### PR TITLE
Send bearer token with UI's outgoing requests.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.interceptors;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.services.oauth2.model.Userinfoplus;
+import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
@@ -36,9 +37,20 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     }
 
     String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authorizationHeader == null) {
+      Enumeration<String> headerNames = request.getHeaderNames();
+      String foundHeaders = "";
+      while (headerNames.hasMoreElements()) {
+        foundHeaders += " " + headerNames.nextElement();
+      }
+      log.warning("No " + HttpHeaders.AUTHORIZATION + " header found in request, found: "
+          + foundHeaders + ".");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      return false;
+    }
 
-    if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-      log.warning("No bearer token found in request");
+    if (!authorizationHeader.startsWith("Bearer ")) {
+      log.warning("No bearer token found in authorization header: " + authorizationHeader);
       response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
       return false;
     }

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -2,10 +2,11 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {HttpModule} from '@angular/http';
+import {HttpModule, RequestOptions, XHRBackend} from '@angular/http';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {AllOfUsService} from 'app/services/all-of-us.service';
+import {AuthorizedHttp} from 'app/services/authorized-http.service';
 import {AppRoutingModule} from 'app/app-routing.module';
 import {AppComponent} from 'app/views/app/component';
 import {CohortBuilderComponent} from 'app/views/cohort-builder/component';
@@ -25,6 +26,11 @@ export function getVaadin(): VaadinNs {
   }
 }
 
+export function getAuthorizedHttp(
+    xhrBackend: XHRBackend, requestOptions: RequestOptions): AuthorizedHttp {
+  return new AuthorizedHttp(xhrBackend, requestOptions);
+}
+
 @NgModule({
   imports:      [
     AppRoutingModule,
@@ -40,6 +46,7 @@ export function getVaadin(): VaadinNs {
   ],
   providers: [
     AllOfUsService,
+    {provide: AuthorizedHttp, useFactory: getAuthorizedHttp, deps: [XHRBackend, RequestOptions]},
     UserService,
     RepositoryService,
     {provide: VAADIN_CLIENT, useFactory: getVaadin}

--- a/ui/src/app/services/all-of-us.service.ts
+++ b/ui/src/app/services/all-of-us.service.ts
@@ -3,14 +3,14 @@
 
 import 'rxjs/add/operator/toPromise';
 
-import {Http} from '@angular/http';
 import {Injectable} from '@angular/core';
 
 import {environment} from 'environments/environment';
+import {AuthorizedHttp} from 'app/services/authorized-http.service';
 
 @Injectable()
 export class AllOfUsService {
-  constructor(private http: Http) {}
+  constructor(private http: AuthorizedHttp) {}
 
   // Gets a "hello world" value from the server (a test endpoint).
   getHelloWorld(): Promise<String> {

--- a/ui/src/app/services/authorized-http.service.ts
+++ b/ui/src/app/services/authorized-http.service.ts
@@ -1,6 +1,5 @@
 import {Injectable} from '@angular/core';
-import {Http, Headers, RequestOptionsArgs, Request, Response, ConnectionBackend, RequestOptions}
-    from '@angular/http';
+import {Http, Headers, RequestOptionsArgs, Request, Response, ConnectionBackend, RequestOptions} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
 // Subclass of Http which adds bearer token auth to all requests.

--- a/ui/src/app/services/authorized-http.service.ts
+++ b/ui/src/app/services/authorized-http.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
-import {Http, Headers, RequestOptionsArgs, Request, Response, ConnectionBackend, RequestOptions} from '@angular/http';
+import {Http, Headers, Request, Response, ConnectionBackend, RequestOptions} from '@angular/http';
+import {RequestOptionsArgs} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
 // Subclass of Http which adds bearer token auth to all requests.
@@ -25,7 +26,7 @@ export class AuthorizedHttp extends Http {
       // Requests coming from Http.get() will have a Request object. To support a string URL in
       // place of a request, add the headers on the RequestOptionsArgs instead (as in the original
       // SO example).
-      throw new NotImplementedException('AuthorizedHttp.request(url: string) unimplemented.');
+      throw new Error('AuthorizedHttp.request(url: string) unimplemented.');
     }
     this._setAuthHeader(request);
     return super.request(request, options);

--- a/ui/src/app/services/authorized-http.service.ts
+++ b/ui/src/app/services/authorized-http.service.ts
@@ -1,0 +1,34 @@
+import {Injectable} from '@angular/core';
+import {Http, Headers, RequestOptionsArgs, Request, Response, ConnectionBackend, RequestOptions}
+    from '@angular/http';
+import {Observable} from 'rxjs/Observable';
+
+// Subclass of Http which adds bearer token auth to all requests.
+// Adapted from https://stackoverflow.com/a/40913003 .
+@Injectable()
+export class AuthorizedHttp extends Http {
+  // To get a test token, `gcloud auth login` and then `gcloud auth print-access-token`.
+  private bearerToken = 'TODO get from gapi.';
+
+  _addAuthHeader(headers: Headers) {
+    headers.append('Authorization', `Bearer ${this.bearerToken}`);
+  }
+
+  _setAuthHeader(request: Request) {
+    if (!request.headers) {
+      request.headers = new Headers()
+    }
+    this._addAuthHeader(request.headers);
+  }
+
+  request(request: string|Request, options?: RequestOptionsArgs): Observable<Response> {
+    if (typeof request === 'string') {
+      // Requests coming from Http.get() will have a Request object. To support a string URL in
+      // place of a request, add the headers on the RequestOptionsArgs instead (as in the original
+      // SO example).
+      throw new NotImplementedException('AuthorizedHttp.request(url: string) unimplemented.');
+    }
+    this._setAuthHeader(request);
+    return super.request(request, options);
+  }
+}

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   displayTag: 'Local',
-  allOfUsApiUrl: 'http://localhost:8080/api/'
+  allOfUsApiUrl: 'http://localhost:8081/api/'
 };


### PR DESCRIPTION
* Add an AuthorizedHttp service which subclasses Http and adds tokens to all requests.
* Incidental increased logging in API's interceptor. Dan, is this too much? Useful when debugging.

Since this may not go in before I go on vacation, feel free to merge it, ignore, patch + edit, commit more to this branch and then merge it, or whatever's most convenient.

David, my guess is that AuthorizedHttp will inject whatever your new service is, and then call DmohsLoginService.getBearerToken() to pass into these requests.