### PR TITLE
Deploy scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build_and_test_api:
+  build_and_test_and_deploy_api:
     docker:
       - image: circleci/openjdk:8-jdk
     working_directory: ~/workbench
@@ -22,6 +22,12 @@ jobs:
             - ~/.m2
             - ~/workbench/api/build/exploded-api/WEB-INF/lib/
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - deploy:
+          name: Deploy to gcloud test project
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ./ci/deploy.sh api
+            fi
   build_and_test_ui:
     docker:
         - image: circleci/node:latest-browsers
@@ -47,5 +53,5 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_and_test_api
+      - build_and_test_and_deploy_api
       - build_and_test_ui

--- a/ci/activate_creds.sh
+++ b/ci/activate_creds.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Creates credentials file $1 from two environment variables (see
+# below) which combine to decrypt the keys for a service account.
+# Does gcloud auth using the result.
+
+echo $GCLOUD_CREDENTIALS | \
+     openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k $GCLOUD_CREDENTIALS_KEY \
+     > $1
+
+gcloud auth activate-service-account --key-file $1
+

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+./ci/install_gcloud.sh && source ~/.bashrc
+./ci/activate_creds.sh ~/gcloud-credentials.key
+
+gcloud components install app-engine-java
+
+./tools/deploy.py \
+  --target $1 \
+  --skip-confirmation \
+  --project all-of-us-workbench-test \
+  --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com
+

--- a/ci/install_gcloud.sh
+++ b/ci/install_gcloud.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+# Install gcloud
+
+cd
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-162.0.1-linux-x86_64.tar.gz -O gcloud.tgz
+tar -xf gcloud.tgz
+./google-cloud-sdk/install.sh  --quiet
+echo "export PATH=~/google-cloud-sdk/bin:$PATH" > ~/.bashrc

--- a/ci/upload_cloud_creds.sh
+++ b/ci/upload_cloud_creds.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run this script to upload service-account keys for gcloud on Circle CI.
+# Arg: [path to gcloud service account key JSON file]
+# Requires CI_TOKEN environment variable containing a valid Circle CI token.
+
+set -e
+
+function make_circle_envvar {
+    curl -s -X DELETE \
+        https://circleci.com/api/v1.1/project/$1/$2/$3/envvar/$4?circle-token=$CI_TOKEN
+
+    curl -s -X POST  --header "Content-Type: application/json" \
+        https://circleci.com/api/v1.1/project/$1/$2/$3/envvar?circle-token=$CI_TOKEN \
+        -d "{\"name\": \"$4\", \"value\": \"$5\"}"
+}
+
+GCLOUD_CREDENTIALS_KEY=$(openssl rand -base64 32)
+GCLOUD_CREDENTIALS=$(openssl enc -md sha256 -aes-256-cbc -in $1 -base64 -A  -k $GCLOUD_CREDENTIALS_KEY)
+
+VCS_TYPE=github
+CI_USERNAME=all-of-us
+CI_PROJECT=workbench
+
+echo "----- Environment vars to set in Circle CI Admin UI:"
+
+echo "GCLOUD_CREDENTIALS=$GCLOUD_CREDENTIALS"
+echo "GCLOUD_CREDENTIALS_KEY=$GCLOUD_CREDENTIALS_KEY"
+
+make_circle_envvar $VCS_TYPE $CI_USERNAME $CI_PROJECT GCLOUD_CREDENTIALS $GCLOUD_CREDENTIALS
+make_circle_envvar $VCS_TYPE $CI_USERNAME $CI_PROJECT GCLOUD_CREDENTIALS_KEY $GCLOUD_CREDENTIALS_KEY
+
+echo "----- Created vars:"
+curl https://circleci.com/api/v1.1/project/$VCS_TYPE/$CI_USERNAME/$CI_PROJECT/envvar?circle-token=$CI_TOKEN
+
+echo "----- Decryption command:"
+echo 'echo $GCLOUD_CREDENTIALS | openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k $GCLOUD_CREDENTIALS_KEY'

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -17,7 +17,8 @@ def deploy(args):
   targets = (
       _TargetChoices.ALL_TARGETS if args.target == _TargetChoices.ALL
       else (args.target,))
-  get_confirmation('Deploy to %r (%s)?' % (args.project, ', '.join(targets)))
+  if not args.skip_confirmation:
+    get_confirmation('Deploy to %r (%s)?' % (args.project, ', '.join(targets)))
 
   if _TargetChoices.API in targets:
     logging.info('Deploying API')
@@ -71,6 +72,10 @@ if __name__ == '__main__':
       '-t', '--target',
       default=_TargetChoices.ALL, choices=_TargetChoices.ALL_TARGET_CHOICES,
       help='Which part of the Workbench to deploy.')
+  parser.add_argument(
+      '-s', '--skip-confirmation',
+      action='store_true',
+      help='Skip confirmation (for automated deploys)')
   # Set auth/project here for general usage, but also pass them explicitly
   # to commands that support it as a safeguard against other gcloud commands
   # altering the configured values (which would cause a race condition).


### PR DESCRIPTION
These cover auto-deployment of the API server. To handle deployment of the UI as well, we will want to choose among:

1. **Selected, see #19**: Split the "build" task into a "workflow" with two tasks, one for API and one for UI
~~2. Use a customer Docker image that has java *and* node installed~~
~~3. Start from the default Docker image (with java) and install node each time we need it (slow :/)~~

I'd like to merge in this state, so we have working auto-deploy for the API server on merge-to-master.