### PR TITLE
SignIn service using Observable

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -12,7 +12,6 @@ import {CohortBuilderComponent} from 'app/views/cohort-builder/component';
 import {LoginComponent} from 'app/views/login/component';
 import {RepositoryService} from 'app/services/repository.service';
 import {SelectRepositoryComponent} from 'app/views/select-repository/component';
-import {SignInComponent} from 'app/views/sign-in/component'
 import {SignInService} from 'app/services/sign-in.service';
 import {UserService} from 'app/services/user.service';
 import {VAADIN_CLIENT} from 'app/vaadin-client';
@@ -39,7 +38,6 @@ export function getVaadin(): VaadinNs {
     LoginComponent,
     SelectRepositoryComponent,
     CohortBuilderComponent,
-    SignInComponent
   ],
   providers: [
     AllOfUsService,

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -1,87 +1,103 @@
-import {Injectable} from '@angular/core';
+import 'rxjs/Rx';
+import {Injectable, NgZone} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {User} from 'app/models/user';
 
 declare const gapi: any;
 
+interface BasicProfile {
+  id: string,
+  name: string,
+  givenName: string,
+  familyName: string,
+  imageUrl: string,
+  email: string
+}
+
+export interface SignInDetails {
+  isSignedIn: boolean;
+  id?: string;
+  hostedDomain?: string;
+  grantedScopes?: Array<string>;
+  basicProfile?: BasicProfile;
+  authRespones?: object;
+}
+
 @Injectable()
 export class SignInService {
-  constructor() {
-    // console.log('In SignInService constructor.');
-    // console.log(this.isAuth2Loaded());
-    // this.initAuth2();
+
+  // Expose the gapi.auth2 object warpped in a Promise
+  public auth2: Promise<any>;
+  // Expose "current user details" as an Observable
+  public user: Observable<SignInDetails>;
+
+  constructor(private zone: NgZone) {
+    this.zone = zone;
+    this.auth2 = this.makeAuth2();
+    this.user = this.makeUserSubject();
   }
 
-  private isAuth2Loaded(): boolean {
-    return typeof gapi.auth2 != 'undefined';
+  public signIn(): void {
+    this.auth2.then(auth2 => auth2.getAuthInstance().signIn());
   }
 
-  private isAuth2Initialized(): boolean {
-    return gapi.auth2.getAuthInstance() != null;
+  public signOut(): void {
+    this.auth2.then(auth2 => auth2.getAuthInstance().signOut());
   }
 
-  private loadAuth2(): Promise<void> {
-    if (this.isAuth2Loaded()) {
-      return Promise.resolve(null);
-    } else {
-      return new Promise<void>(function(resolve) {
-        gapi.load('auth2', () => resolve(null));
+  private makeAuth2(): Promise<any> {
+    const zone = this.zone;
+    return new Promise(function(resolve){
+      gapi.load('auth2', function(){
+        gapi.auth2.init({
+            client_id: '887440561153-pb9gmue2cbbs2gbn9nkr35g0ifpvb8g5.apps.googleusercontent.com',
+            hosted_domain: 'pmi-ops.org'
+        });
+        resolve(gapi.auth2);
       });
+    });
+  }
+
+  private makeUserSubject(): Observable<SignInDetails> {
+     return new Observable<SignInDetails>((subscriber) => {
+      this.auth2.then(auth2 => {
+          gapi.auth2.getAuthInstance().currentUser.listen((e: any) => {
+            const currentUser = gapi.auth2.getAuthInstance().currentUser.get();
+            const details = this.extractSignInDetails(currentUser);
+
+            // Without this, Angular views won't "notice" the externally-triggered
+            // event, though the Angular models will update... so the change
+            // won't propagate to UI automatically. Calling `zone.run`
+            // ensures Angular notices as soon as the change occurs.
+            this.zone.run(() => subscriber.next(details));
+          });
+      });
+    }).share().startWith({isSignedIn: false});
+  }
+
+  private extractSignInDetails(currentUser: any): SignInDetails {
+    if (!currentUser.isSignedIn()) {
+      return {
+        isSignedIn: false
+      }
+    }
+
+    const basicProfile = currentUser.getBasicProfile();
+    return {
+      isSignedIn: true,
+      id: currentUser.getId(),
+      hostedDomain: currentUser.getHostedDomain(),
+      grantedScopes: currentUser.getGrantedScopes().split(/\s+/),
+      basicProfile: {
+        id: basicProfile.getId(),
+        name: basicProfile.getName(),
+        givenName:  basicProfile.getGivenName(),
+        familyName: basicProfile.getFamilyName(),
+        imageUrl: basicProfile.getImageUrl(),
+        email: basicProfile.getEmail()
+      },
+      authRespones: currentUser.getAuthResponse()
     }
   }
 
-  private initAuth2(): Promise<void> {
-    if (this.isAuth2Initialized()) {
-      return Promise.resolve(null);
-    } else {
-      return new Promise<void>(
-        // Google doesn't know how to make real promises, so attempting to use the returned promise
-        // leads to an infinite loop.
-        (resolve) => gapi.auth2.init({
-          client_id: '887440561153-pb9gmue2cbbs2gbn9nkr35g0ifpvb8g5.apps.googleusercontent.com',
-          hosted_domain: 'pmi-ops.org'
-      }).then(() => resolve(null)));
-    }
-  }
-
-  getCurrentUser(): Promise<any> {
-    return this.loadAuth2()
-      .then(() => this.initAuth2())
-      .then(() => gapi.auth2.getAuthInstance().currentUser);
-  }
-
-  isSignedIn(): Promise<boolean> {
-    return this.getCurrentUser().then((user) => user.get().isSignedIn());
-  }
-
-  listenForUserDidChange(didChange): void {
-    this.getCurrentUser().then((user) => user.listen(didChange));
-  }
-
-  // handleAuth2Initialized(): void {
-  //   // gapi.auth2.getAuthInstance().currentUser.listen(this.handleUserDidChange.bind(this))
-  //   // this.isSignedIn = gapi.auth2.getAuthInstance().currentUser.get().isSignedIn();
-  //   // this.cdRef.detectChanges();
-  // }
-
-  handleAuth2Error(e: Error): void {
-    console.error(e);
-  }
-
-  // handleUserDidChange(user: any): void {
-  //   this.isSignedIn = user.isSignedIn();
-  //   this.cdRef.detectChanges();
-  // }
-
-  // getLoggedInUser(): Promise<User> {
-  //   return Promise.resolve(this.user);
-  // }
-  //
-  // logIn(name: string, permission: PermissionLevel): Promise<User> {
-  //   this.user = {id: 42, name: name, permission: permission};
-  //   return this.getLoggedInUser();
-  // }
-  //
-  // logOut(): Promise<void> {
-  //   this.user = null;
-  //   return Promise.resolve(null);
-  // }
 }

--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -12,12 +12,12 @@
   Angular's builtin Router module will attach specific views here
   based on clicking routerLink elements (above) or router.navigate calls.
 -->
-<div *ngIf="isSignedIn | async">
+<div *ngIf="(user | async).isSignedIn">
   <router-outlet></router-outlet>
 </div>
-<div *ngIf="!(isSignedIn | async)">
+<div *ngIf="!(user | async).isSignedIn">
   <button (click)="signIn()">Sign In</button>
 </div>
-<div *ngIf="isSignedIn | async">
+<div *ngIf="(user | async).isSignedIn">
   <button (click)="signOut()">Sign Out</button>
 </div>

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -4,8 +4,9 @@
 import {environment} from 'environments/environment';
 import {ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {Router, NavigationEnd, ActivatedRoute} from '@angular/router';
-import {SignInService} from 'app/services/sign-in.service';
+import {SignInService, SignInDetails} from 'app/services/sign-in.service';
 import {Title} from '@angular/platform-browser';
+import {Observable} from 'rxjs/Observable';
 
 declare const gapi: any;
 
@@ -16,10 +17,9 @@ declare const gapi: any;
 })
 export class AppComponent implements OnInit {
   private baseTitle: string;
-  isSignedIn: Promise<boolean>;
+  user: Observable<SignInDetails>;
 
   constructor(
-      private cdRef: ChangeDetectorRef,
       private titleService: Title,
       private activatedRoute: ActivatedRoute,
       private router: Router,
@@ -49,22 +49,18 @@ export class AppComponent implements OnInit {
         }
       }
     });
+    this.user = this.signInService.user;
 
-    this.signInService.listenForUserDidChange(function(user) {
-      this.isSignedIn = Promise.resolve(user.isSignedIn());
-      this.isSignedIn.then((x) => console.log(x));
-      this.cdRef.detectChanges();
-    }.bind(this));
-    this.signInService.isSignedIn()
-      .then((isSignedIn) => this.isSignedIn = Promise.resolve(isSignedIn));
+    this.user.subscribe(u => {
+      console.log('USER', u);
+    })
   }
 
-
   signIn(e: Event): void {
-    gapi.auth2.getAuthInstance().signIn();
+    this.signInService.signIn();
   }
 
   signOut(e: Event): void {
-    gapi.auth2.getAuthInstance().signOut();
+    this.signInService.signOut();
   }
 }


### PR DESCRIPTION
Hey @dmohs  — I wanted to share some ideas about how to structure the sign-in service. One challenge with using Promises for data that will not just *arrive* but will also change over time, is that the "subscription" pattern is hard to express. Instead, here I'm suggesting a way to accomplish this with the rxjs `Observable` API (specifically, by creating a share observable that starts with a default non-logged-in state, followed by a potential stream of status updates over time).

I think this is actually a good way to handle this case, but if you find it distasteful, I should also say: the one tidbit that you need to make your current approach work is wrapping your gapi-to-angular bridge calls with `zone.run` as you'll see in this PR.

_Note: This is structured as a PR against your current PR, in case you want to incorporate it..._