### PR TITLE
Add Swagger codegen in angular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules
 /ui/dist/**
 /ui/**/*.map
 /ui/**/*.js
+tools/*.jar
+/ui/src/generated/*

--- a/README.md
+++ b/README.md
@@ -56,11 +56,23 @@ local API server under http://localhost:8081/api/.
 From the `ui/` subdirectory:
 
 ```Shell
-ng serve
+npm run start
 ```
 
 After webpack finishes the build, you can view your local UI server at
 http://localhost:4200/.
+
+#### You can regenerate classes from swagger with
+
+```Shell
+npm run codegen
+```
+
+#### You can build the UI with
+
+```Shell
+npm run build
+```
 
 ## Running in Docker
 

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -36,6 +36,12 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Cohort"
+      security:
+        - aou_oauth: []
+securityDefinitions:
+  aou_oauth:
+    type: oauth2
+    flow: accessCode
 definitions:
   Cohort:
     type: "object"

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -8,4 +8,4 @@ echo Installing UI project dependencies.
 npm install
 
 cd ../tools
-wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
+wget https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.3.0-SNAPSHOT/swagger-codegen-cli-2.3.0-20170716.142514-29.jar -O swagger-codegen-cli.jar

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -6,3 +6,6 @@ echo Installing the Angular command-line tool, to serve/build the UI.
 sudo npm install -g @angular/cli
 echo Installing UI project dependencies.
 npm install
+
+cd ../tools
+wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "codegen": "java -jar ../tools/swagger-codegen-cli.jar generate --lang typescript-angular2 --input-spec ../api/src/main/resources/workbench.yaml  --output src/generated"
+    "codegen": "java -jar ../tools/swagger-codegen-cli.jar generate --lang typescript-angular  --input-spec ../api/src/main/resources/workbench.yaml  --output src/generated --additional-properties ngVersion=2"
   },
   "private": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "npm run codegen && ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "codegen": "java -jar ../tools/swagger-codegen-cli.jar generate --lang typescript-angular2 --input-spec ../api/src/main/resources/workbench.yaml  --output src/generated"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This is a PR on top of yours @danqrodney, taking a quick look at codegen in angular2.

There's no obvious/clear framework-sanctioned way to hook a codegen step into the build process, so here I add an explicit `npm run codegen` script, and call it automatically when doing `npm run build`, which should help prevent things from getting too far out of sync. 

For examples of the generated files:
https://gist.github.com/jmandel/c951f5d685d097c7d39e8cc5304a6a78

The files are reasonable, including magic like:

        constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {

which allows you to inject different base URLs into the service depending on which environment you're using. I've tried this technique with success (but not included in this PR, because I don't want to clutter up with experimental code).