### PR TITLE
Serve all paths as index.html to accommodate ng routes

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -1,15 +1,16 @@
 runtime: python27
 api_version: 1
 threadsafe: true
+default_expiration: "2m"
 
 handlers:
-- url: /
-  static_files: dist/index.html
-  upload: dist/index.html
-  secure: always
-- url: /(.*)
+- url: /(.*\.(css|eot|gz|html|ico|js|map|png|svg|ttf|woff|woff2))
   static_files: dist/\1
   upload: dist/(.*)
+  secure: always
+- url: /.*
+  static_files: dist/index.html
+  upload: dist/index.html
   secure: always
 
 # If a file (relative path under ui/) matches this regex, do not upload it.


### PR DESCRIPTION
This ensures that URLs like `login` work in our "single page app" design, by serving the same default `index.html` no matter what url is requested.

Before this fix:
https://20170717t223357-dot-all-of-us-workbench-test.appspot.com/login

After:
https://20170718t205535-dot-all-of-us-workbench-test.appspot.com/login
