### PR TITLE
Removed extra slash at the end of prod and test environments

### DIFF
--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment: object = {
   displayTag: null,
-  allOfUsApiUrl: 'https://all-of-us-workbench.appspot.com/api/v1/'
+  allOfUsApiUrl: 'https://all-of-us-workbench.appspot.com/api/v1'
 };

--- a/ui/src/environments/environment.test.ts
+++ b/ui/src/environments/environment.test.ts
@@ -1,4 +1,4 @@
 export const environment = {
   displayTag: 'Test',
-  allOfUsApiUrl: 'https://all-of-us-workbench-test.appspot.com/api/v1/'
+  allOfUsApiUrl: 'https://all-of-us-workbench-test.appspot.com/api/v1'
 };


### PR DESCRIPTION
API calls on the test and prod environments had an extra /.