### PR TITLE
Changing /api/v1 to be a part of each endpoint path

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -118,6 +118,7 @@ dependencies {
   compile 'com.google.code.gson:gson:+'
   compile 'joda-time:joda-time:+'
   compile 'javax.inject:javax.inject:1'
+  compile 'io.swagger:swagger-annotations:+'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.+'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -58,7 +58,7 @@ buildscript {    // Configuration for building
     jcenter()    // Bintray's repository - a fast Maven Central mirror & more
   }
   dependencies {
-    classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE'
+    classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.3.RELEASE'
     classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
     classpath 'io.swagger:swagger-codegen:+'
   }
@@ -101,13 +101,14 @@ repositories {   // repositories for Jar's you access in your code
 }
 
 dependencies {
-  providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
+  providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
+
   compile 'com.google.appengine:appengine:+'
   compile('org.springframework.boot:spring-boot-starter-web:+') {
     exclude module: 'spring-boot-starter-tomcat'
   }
   compile 'org.springframework.security:spring-security-web:+'
-  compile 'io.swagger:swagger-codegen:+'
+
   compile 'com.fasterxml.jackson.core:jackson-annotations:+'
   compile 'com.fasterxml.jackson.core:jackson-core:+'
   compile 'com.fasterxml.jackson.core:jackson-databind:+'

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -5,7 +5,6 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.interceptors.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -13,7 +12,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.annotation.RequestScope;
-import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -26,14 +24,6 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
   @Autowired
   private AuthInterceptor authInterceptor;
-
-  @Bean
-  public ServletRegistrationBean dispatcherRegistration(DispatcherServlet dispatcherServlet) {
-    ServletRegistrationBean registration = new ServletRegistrationBean(
-        dispatcherServlet);
-    registration.addUrlMappings("/api/v1/*");
-    return registration;
-  }
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -16,7 +16,6 @@ securityDefinitions:
   aou_oauth:
     type: oauth2
     flow: accessCode
-basePath: "/api/v1"
 schemes:
   - "https"
 produces:
@@ -26,7 +25,7 @@ produces:
 security:
   - aou_oauth: []
 paths:
-  /me:
+  /api/v1/me:
     get:
       tags:
         - profile
@@ -38,7 +37,7 @@ paths:
           schema:
             $ref: "#/definitions/Profile"
 
-  /workspaces/{workspaceNamespace}/{workspaceId}/cohorts:
+  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts:
     get:
       tags:
         - cohorts

--- a/api/src/main/webapp/WEB-INF/web.xml
+++ b/api/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://java.sun.com/xml/ns/javaee"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-    version="2.5">
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
     <display-name>AllOfUs Workbench API</display-name>
 </web-app>


### PR DESCRIPTION
This is necessary because basePath in Swagger isn't used when generating Spring code, and other attempts to set the context root in AppEngine to /api/v1 weren't working.

Switching to servlet 3.1.

Removing stuff from build we didn't need.