### PR TITLE
Removing external ID from cohort DB representation.

### DIFF
--- a/api/db/changelog/db.changelog-1.xml
+++ b/api/db/changelog/db.changelog-1.xml
@@ -116,9 +116,6 @@
       <column name="description" type="clob">
         <constraints nullable="false"/>
       </column>
-      <column name="external_id" type="varchar(80)">
-        <constraints nullable="false"/>
-      </column>
       <column name="criteria" type="blob">
         <constraints nullable="false"/>
       </column>
@@ -132,13 +129,6 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
-    <createIndex
-        indexName="idx_cohort_workspace_id_external_id"
-        tableName="cohort"
-        unique="true">
-      <column name="workspace_id"/>
-      <column name="external_id"/>
-    </createIndex>
     <addForeignKeyConstraint baseColumnNames="creator_id"
         baseTableName="cohort"
         constraintName="fk_cohort_creator_id"

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
@@ -4,6 +4,4 @@ import org.pmiops.workbench.db.model.Cohort;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CohortDao extends CrudRepository<Cohort, Long> {
-
-  Cohort findByWorkspaceIdAndExternalId(long workspaceId, String externalId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
@@ -5,15 +5,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "cohort",
-    indexes = {  @Index(name = "idx_cohort_workspace_id_external_id",
-        columnList = "workspace_id,external_id", unique = true)})
+@Table(name = "cohort")
 public class Cohort {
 
   private long cohortId;
@@ -64,15 +61,6 @@ public class Cohort {
 
   public void setDescription(String description) {
     this.description = description;
-  }
-
-  @Column(name = "external_id")
-  public String getExternalId() {
-    return externalId;
-  }
-
-  public void setExternalId(String externalId) {
-    this.externalId = externalId;
   }
 
   @Column(name = "workspace_id")

--- a/api/src/main/java/org/pmiops/workbench/exceptions/BadRequestException.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/BadRequestException.java
@@ -1,0 +1,16 @@
+package org.pmiops.workbench.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+
+  public BadRequestException() {
+    super();
+  }
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+}

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -197,7 +197,6 @@ definitions:
   Cohort:
     type: "object"
     required:
-      - "id"
       - "name"
       - "criteria"
       - "type"


### PR DESCRIPTION
Changing ID used for cohorts in external API to be the numeric database ID, assigned by the server on creation.