### PR TITLE
Add error message if db setup script is run from the wrong directory.

### DIFF
--- a/api/db/setup_local_database.sh
+++ b/api/db/setup_local_database.sh
@@ -7,7 +7,12 @@
 # If you have an environment variable named "MYSQL_ROOT_PASSWORD" it will be
 # used as the password to connect to the database; by default, the password
 # "root" will be used.
-#
+
+if [ ! -f setup_local_vars.sh ]
+then
+  echo Script must be run from local db/ directory.
+  exit 1
+fi
 
 CREATE_DB_FILE=/tmp/create_db.sql
 


### PR DESCRIPTION
Otherwise you just get an error that setup_local_vars.sh cannot be found, but not an indication of where it is / should be.