### PR TITLE
Switch environment script

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -7,8 +7,10 @@ Usage:
 
 import logging
 import subprocess
+import switch-env
 
 from main_util import configure_logging, get_parser, get_confirmation
+from shutil import copyfile
 import paths
 import gcloud_auth
 
@@ -35,9 +37,13 @@ def deploy(args):
     logging.info('Skipping deploy of API.')
 
   if _TargetChoices.UI in targets:
+    environmentPath = '../ui/src/environments/'
+    copyfile(environmentPath + 'environment.ts', environmentPath + 'environment.stash.ts')
+    environmentSwap('test');
+
     logging.info('Building UI using %r', paths.get_ng())
     subprocess.check_call(
-        [paths.get_ng(), 'build', '--environment=test'],
+        [paths.get_ng(), 'build'],
         cwd=paths.get_ui_dir())
     logging.info('Deploying UI')
     subprocess.check_call(
@@ -51,6 +57,7 @@ def deploy(args):
           args.account,
         ],
         cwd=paths.get_ui_dir())
+    environmentSwap('revert')
   else:
     logging.info('Skipping deploy of UI.')
 

--- a/tools/switch-env.py
+++ b/tools/switch-env.py
@@ -1,0 +1,26 @@
+import logging
+import subprocess
+import sys
+import os
+from shutil import copyfile
+from main_util import configure_logging, get_parser, get_confirmation
+
+#Run options: ./switch-env.py test, ./switch-env.py prod
+def environmentSwap(environment):
+    environmentPath = '../ui/src/environments/'
+    if(environment == "test"):
+        copyfile(environmentPath + 'environment.test.ts', environmentPath + 'environment.ts')
+    elif(environment == "prod"):
+        copyfile(environmentPath + 'environment.prod.ts', environmentPath + 'environment.ts')
+    elif(environment == "revert"):
+        os.rename(environmentPath + 'environment.stash.ts', environmentPath + 'environment.ts')
+    else:
+        copyfile(environmentPath + 'environment.dev.ts', environmentPath + 'environment.ts')
+
+environment = 'dev'
+try:
+    environment = sys.argv[1]
+except IndexError:
+    pass
+
+environmentSwap(environment)

--- a/ui/src/environments/environment.dev.ts
+++ b/ui/src/environments/environment.dev.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  displayTag: 'Local',
+  allOfUsApiUrl: 'http://localhost:8081'
+};


### PR DESCRIPTION
This is the work around that I brought up in standup. My thinking is that most people are going to do the majority of their UI development against the dev or test environment anyway, so I'm not too worried about fixing the flag in the `npm run build` or `npm run start` scripts. 

The 'comment' in the script is a WIP, and I'd love suggestions on what people think for that. It may even be self documenting.