### PR TITLE
Added loading spinners to datatables

### DIFF
--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -14,7 +14,7 @@
       <button class="btn btn-link" (click)="addCohort()">Add a Cohort</button>
     </div>
     <div class="indented">
-      <clr-datagrid>
+      <clr-datagrid [clrDgLoading]="cohortsLoading">
         <clr-dg-column>
           Name
           <clr-dg-string-filter [clrDgStringFilter]="cohortNameFilter"></clr-dg-string-filter>
@@ -44,7 +44,7 @@
       <button class="btn btn-link">Launch Notebook Server</button>
     </div>
     <div class="indented">
-      <clr-datagrid>
+      <clr-datagrid [clrDgLoading]="notebooksLoading">
         <clr-dg-column>
           Name
           <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -50,7 +50,8 @@ export class WorkspaceComponent implements OnInit {
   private cohortDescriptionFilter = new CohortDescriptionFilter();
   private notebookNameFilter = new NotebookNameFilter();
   private notebookDescriptionFilter = new NotebookDescriptionFilter();
-
+  cohortsLoading = true;
+  notebooksLoading = false;
   repositories: Repository[] = [];
   user: User;  // to detect if logged in
   cohortList: Cohort[] = [];
@@ -79,6 +80,7 @@ export class WorkspaceComponent implements OnInit {
               for (const coho of cohortsReceived.items) {
                 this.cohortList.push(coho);
               }
+              this.cohortsLoading = false;
             });
 
   }


### PR DESCRIPTION
I didn't deploy an example, because the current wait time is fast enough that you can't really see it, but if you grab the branch and add a settimeout before it sets cohortsLoading to false, you can see what the behavior looks like.