### PR TITLE
Start containers separately for easier debugging

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -24,8 +24,6 @@ services:
     build:
       context: ./src/dev/server
     working_dir: /w/db
-    depends_on:
-      - api
     volumes:
       - gradle-cache-migration:/root/.gradle
       - .:/w:cached


### PR DESCRIPTION
Also adds a `docker-clean` command and documentation about when it's useful.