### PR TITLE
Fix git secrets and git hooks

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3,6 +3,13 @@ require "io/console"
 require "optparse"
 require "tempfile"
 
+def ensure_git_hooks()
+  common = Common.new
+  unless common.capture_stdout(%W{git config --get core.hooksPath}).chomp == "hooks"
+    common.run_inline %W{git config core.hooksPath hooks}
+  end
+end
+
 class ProjectAndAccountOptions
   attr_accessor :project
   attr_accessor :account
@@ -44,6 +51,8 @@ end
 def dev_up(args)
   common = Common.new
   common.docker.requires_docker
+
+  ensure_git_hooks
 
   at_exit { common.run_inline %W{docker-compose down} }
   common.run_inline %W{docker-compose up -d db}

--- a/hooks/apply-git-secrets.sh
+++ b/hooks/apply-git-secrets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+{ which git-secrets; } || {
+  echo 'git-secrets required and not found. See README for installation instructions.'
+  echo
+  exit 1
+}
+
+{
+  git config --remove-section secrets 2>/dev/null
+} || {
+  :
+}
+git secrets --add 'private_key'
+git secrets --add 'private_key_id'
+git secrets --add --allowed --literal "git secrets --add 'private_key'"
+git secrets --add --allowed --literal "git secrets --add 'private_key_id'"

--- a/hooks/apply-git-secrets.sh
+++ b/hooks/apply-git-secrets.sh
@@ -17,3 +17,4 @@ git secrets --add 'private_key'
 git secrets --add 'private_key_id'
 git secrets --add --allowed --literal "git secrets --add 'private_key'"
 git secrets --add --allowed --literal "git secrets --add 'private_key_id'"
+git secrets --add --allowed --literal 'tmp_private_key = `grep private_key_id #{creds_file.path} | cut -d\\\" -f4`.strip()'

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-{ which git-secrets; } || {
-  echo 'git-secrets required and not found. See README for installation instructions.'
-  echo
-  exit 1
-}
-
-{
-  git config --remove-section secrets 2>/dev/null
-} || {
-  :
-}
-git secrets --add 'private_key'
-git secrets --add 'private_key_id'
-git secrets --add --allowed --literal "git secrets --add 'private_key'"
-git secrets --add --allowed --literal "git secrets --add 'private_key_id'"
+./hooks/apply-git-secrets.sh
 
 git secrets --commit_msg_hook -- "$@"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-{ which git-secrets; } || {
-  echo 'git-secrets required and not found. See README for installation instructions.'
-  echo
-  exit 1
-}
-
-{
-  git config --remove-section secrets 2>/dev/null
-} || {
-  :
-}
-git secrets --add 'private_key'
-git secrets --add 'private_key_id'
-git secrets --add --allowed --literal "git secrets --add 'private_key'"
-git secrets --add --allowed --literal "git secrets --add 'private_key_id'"
+./hooks/apply-git-secrets.sh
 
 git secrets --pre_commit_hook -- "$@"
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
 # Checks to run before pushing to a remote git repo for review/merging.
 cd ui
 ng lint

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 # Checks to run before pushing to a remote git repo for review/merging.
 cd ui
-ng lint
+docker-compose run ui npm run ng lint

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-{ which git-secrets; } || {
-  echo 'git-secrets required and not found. See README for installation instructions.'
-  echo
-  exit 1
-}
-
-{
-  git config --remove-section secrets 2>/dev/null
-} || {
-  :
-}
-git secrets --add 'private_key'
-git secrets --add 'private_key_id'
-git secrets --add --allowed --literal "git secrets --add 'private_key'"
-git secrets --add --allowed --literal "git secrets --add 'private_key_id'"
+./hooks/apply-git-secrets.sh
 
 git secrets --prepare_commit_msg_hook -- "$@"

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -2,6 +2,13 @@ require "optparse"
 require_relative "download-swagger-codegen-cli"
 require_relative "utils/common"
 
+def ensure_git_hooks()
+  common = Common.new
+  unless common.capture_stdout(%W{git config --get core.hooksPath}).chomp == "hooks"
+    common.run_inline %W{git config core.hooksPath hooks}
+  end
+end
+
 def install_dependencies()
   common = Common.new
   common.docker.requires_docker
@@ -46,6 +53,8 @@ def dev_up(*args)
   common.docker.requires_docker
 
   options = DevUpOptions.new.parse(args)
+
+  ensure_git_hooks
 
   unless Dir.exist?("node_modules")
     install_dependencies

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,7 +52,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-webdriver-launcher": "^1.0.5",
     "protractor": "~5.1.2",
-    "shared-git-hooks": "^1.2.1",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
     "typescript": "~2.3.3"


### PR DESCRIPTION
Git hooks installed by the `shared-git-hooks` NPM module are done within the docker container, so the symlinks are not correct on the host machine. For me, that made them fail silently. Additionally, if I don't start the UI, they don't get installed.

Now they are installed using a local git config (available since version 2.9). I also fixed some other issues and factored out some common code.

When this PR is merged, each developer will want to run
```bash
find .git/hooks -type l -exec rm {} \;
```
to clean out the old hooks.