### PR TITLE
Clean old generated files before generating

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,6 +6,7 @@ def swaggerSourceFile = 'src/main/resources/workbench.yaml'
 def swaggerTargetFolder = 'src/generated/java'
 
 task generateApi {
+  delete("${projectDir}/$swaggerTargetFolder")
   inputs.file("$projectDir/$swaggerSourceFile")
   outputs.dir("$projectDir/$swaggerTargetFolder")
   doLast {


### PR DESCRIPTION
David Mohs and I ran into an issue where if a swagger definition was removed, but the generated files weren't manually cleaned, then it wouldn't run the API. This remedies that issue.