### PR TITLE
Selectively disable max-line-length rule around long import blocks. Revert to 100 columns.

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -1,6 +1,10 @@
 // Based on the URL mapping in "routes" below, the RouterModule attaches
 // UI Components to the <router-outlet> element in the main AppComponent.
 
+// TODO: Remove the lint-disable comment once we can selectively ignore import lines.
+// https://github.com/palantir/tslint/pull/3099
+// tslint:disable:max-line-length
+
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 
@@ -10,6 +14,8 @@ import {HomePageComponent} from 'app/views/home-page/component';
 import {WorkspaceComponent} from 'app/views/workspace/component';
 import {WorkspaceEditComponent} from 'app/views/workspace-edit/component';
 import { CohortReviewComponent } from 'app/views/cohort-builder/review/cohort-review/cohort-review.component';
+
+// tslint:enable:max-line-length
 
 
 const routes: Routes = [

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,5 +1,9 @@
 // Import all the pieces of the app centrally.
 
+// TODO: Remove the lint-disable comment once we can selectively ignore import lines.
+// https://github.com/palantir/tslint/pull/3099
+// tslint:disable:max-line-length
+
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {HttpModule} from '@angular/http';
@@ -33,6 +37,8 @@ import { WizardSelectComponent } from 'app/views/cohort-builder/search/wizard-se
 import { WizardModalComponent } from 'app/views/cohort-builder/search/wizard-modal/wizard-modal.component';
 import { WizardTreeParentComponent } from './views/cohort-builder/search/wizard-tree-parent/wizard-tree-parent.component';
 import { BroadcastService, SearchService } from './views/cohort-builder/search/service';
+
+// tslint:enable:max-line-length
 
 
 // "Configuration" means Swagger API Client configuration.

--- a/ui/src/app/views/cohort-builder/search/model/search-result.ts
+++ b/ui/src/app/views/cohort-builder/search/model/search-result.ts
@@ -29,7 +29,8 @@ export class SearchResult {
     this.count = -1;
     for (const criteria of this.criteriaList) {
       this.searchType = criteria.type;
-      this.values.push(new SearchParameter(criteria.code, criteria.type.startsWith('DEMO') ? criteria.type : criteria.domainId));
+      this.values.push(new SearchParameter(
+          criteria.code, criteria.type.startsWith('DEMO') ? criteria.type : criteria.domainId));
     }
   }
 

--- a/ui/src/app/views/cohort-builder/search/wizard-modal/wizard-modal.component.ts
+++ b/ui/src/app/views/cohort-builder/search/wizard-modal/wizard-modal.component.ts
@@ -1,8 +1,14 @@
+// TODO: Remove the lint-disable comment once we can selectively ignore import lines.
+// https://github.com/palantir/tslint/pull/3099
+// tslint:disable:max-line-length
+
 import { Component, OnInit, ViewChild, ViewEncapsulation, OnDestroy, ComponentRef } from '@angular/core';
 import { Wizard } from 'clarity-angular/wizard/wizard';
 import { SearchGroup, SearchResult, Criteria, Modifier, SearchRequest } from '../model';
 import { BroadcastService, SearchService } from '../service';
 import { Subscription } from 'rxjs/Subscription';
+
+// tslint:enable:max-line-length
 
 @Component({
   selector: 'app-wizard-modal',
@@ -64,9 +70,11 @@ export class WizardModalComponent implements OnInit, OnDestroy {
 
   updateOrCreateSearchResult() {
     if (this.selectedSearchResult) {
-      this.selectedSearchResult.update(this.criteriaType.toUpperCase() + ' Group', this.criteriaList, this.modifierList);
+      this.selectedSearchResult.update(
+          this.criteriaType.toUpperCase() + ' Group', this.criteriaList, this.modifierList);
     } else {
-      this.selectedSearchResult = new SearchResult(this.criteriaType.toUpperCase() + ' Group', this.criteriaList, this.modifierList);
+      this.selectedSearchResult = new SearchResult(
+          this.criteriaType.toUpperCase() + ' Group', this.criteriaList, this.modifierList);
       this.selectedSearchGroup.results.push(this.selectedSearchResult);
     }
   }

--- a/ui/src/app/views/cohort-builder/search/wizard-select/wizard-select.component.ts
+++ b/ui/src/app/views/cohort-builder/search/wizard-select/wizard-select.component.ts
@@ -1,7 +1,13 @@
+// TODO: Remove the lint-disable comment once we can selectively ignore import lines.
+// https://github.com/palantir/tslint/pull/3099
+// tslint:disable:max-line-length
+
 import { Component, OnInit, ComponentFactoryResolver, ViewChild, ViewContainerRef } from '@angular/core';
 import { CriteriaType } from '../model';
 import { SearchService, BroadcastService } from '../service';
 import { WizardModalComponent } from '../wizard-modal/wizard-modal.component';
+
+// tslint:enable:max-line-length
 
 @Component({
   selector: 'app-wizard-select',
@@ -23,7 +29,8 @@ export class WizardSelectComponent implements OnInit {
   }
 
   openWizard(criteriaType: string) {
-    const wizardModalComponent = this.componentFactoryResolver.resolveComponentFactory(WizardModalComponent);
+    const wizardModalComponent = this.componentFactoryResolver.resolveComponentFactory(
+        WizardModalComponent);
     const wizardModalRef = this.parent.createComponent(wizardModalComponent);
     this.broadcastService.selectCriteriaType(criteriaType);
     wizardModalRef.instance.wizardModalRef = wizardModalRef;

--- a/ui/src/app/views/cohort-builder/search/wizard-tree-parent/wizard-tree-parent.component.ts
+++ b/ui/src/app/views/cohort-builder/search/wizard-tree-parent/wizard-tree-parent.component.ts
@@ -25,7 +25,8 @@ export class WizardTreeParentComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.subscription =
       this.broadcastService.selectedCriteriaType$
-      .mergeMap(criteriaType => this.cohortBuilderService.getCriteriaByTypeAndParentId(criteriaType, '0'))
+      .mergeMap(criteriaType => this.cohortBuilderService.getCriteriaByTypeAndParentId(
+          criteriaType, '0'))
       .subscribe(nodes => {
         this.nodes = nodes.items;
         this.loading = false;

--- a/ui/src/helper-functions.ts
+++ b/ui/src/helper-functions.ts
@@ -4,8 +4,8 @@ interface DateObject {
 
 /**
  * Converts a Swagger-generated date-like object into a real Date. Swagger codegen creates generic
- * objects with properties (millis etc) but no methods. As a workaround and to satisfy the TS compiler,
- * we convert those to equivalent real Date objects.
+ * objects with properties (millis etc) but no methods. As a workaround and to satisfy the TS
+ * compiler, we convert those to equivalent real Date objects.
  */
 export function resetDateObject(date: Date): Date {
   const obj = date as DateObject;

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -26,7 +26,7 @@
     "label-position": true,
     "max-line-length": [
       true,
-      120
+      100
     ],
     "member-access": false,
     "member-ordering": [


### PR DESCRIPTION
I'd like to keep our 100-columns rule in most places, and just disable it around import blocks where statements are too long. I know this puts a little burden on cohort builder folks (since you're likely to be dealing with long imports the most), but hopefully that's OK. This lets us keep the same lint rules elsewhere (where lines were already sneaking by our radar). Followup to #110.