### PR TITLE
Changing dev-up to run as all-of-us-workbench-test@appspot.gserviceaccount.com.

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -87,12 +87,8 @@ end
 def get_service_account_creds_file(project, account, creds_file)
   common = Common.new
   service_account = "#{project}@appspot.gserviceaccount.com"
-  account_flag = ""
-  if account != nil
-    account_flag = "--account=#{account}"
-  end
   common.run_inline %W{gcloud iam service-accounts keys create #{creds_file.path}
-    --iam-account=#{service_account} --project=#{project} #{account_flag}}
+    --iam-account=#{service_account} --project=#{project} --account=#{account}}
 end
 
 def delete_service_accounts_creds(project, account, creds_file)


### PR DESCRIPTION
With reuse of code.

Note: we should consider uploading some shared creds for all-of-us-workbench-test@ into our credentials bucket, and using those, so we don't have to have every developer holding on to a separate key while their server is running. But for now, this works.