### PR TITLE
Check for required env var before use, report error in activate_creds.sh.

### DIFF
--- a/ci/activate_creds.sh
+++ b/ci/activate_creds.sh
@@ -3,9 +3,14 @@
 # Creates credentials file $1 from two environment variables (see
 # below) which combine to decrypt the keys for a service account.
 # Does gcloud auth using the result.
+if [ ! "${GCLOUD_CREDENTIALS}" ]
+then
+  echo "No GCLOUD_CREDENTIALS env var defined, aborting creds activation."
+  exit 1
+fi
 
 echo $GCLOUD_CREDENTIALS | \
-     openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k $GCLOUD_CREDENTIALS_KEY \
+     openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k "${GCLOUD_CREDENTIALS_KEY}" \
      > $1
 
 gcloud auth activate-service-account --key-file $1


### PR DESCRIPTION
I ran into this while debugging deployment; not our issue I don't think, just making it clearer when things go wrong.