### PR TITLE
[RW-28] Add Python client stub and rules to generate Swagger Python client, installable via PIP.

### DIFF
--- a/client/libproject/devstart.rb
+++ b/client/libproject/devstart.rb
@@ -18,6 +18,7 @@ def swagger_regen()
   FileUtils.remove_dir('py/tmp')
   # TODO(markfickett) Automatically check out generated-py-client when running the above.
   common.status "Only commit generated files on the generated-py-client branch."
+  common.status "Publish a version with `git tag pyclient-vN-N-rcN` and `git push --tags`."
 end
 
 Common.register_command({

--- a/client/libproject/devstart.rb
+++ b/client/libproject/devstart.rb
@@ -7,7 +7,6 @@ def swagger_regen()
   Workbench::Swagger.download_swagger_codegen_cli
 
   common = Common.new
-  #check out py-client branch
   common.run_inline %W{
       java -jar #{Workbench::Swagger::SWAGGER_CODEGEN_CLI_JAR}
       generate --lang python --input-spec #{Workbench::Swagger::SWAGGER_SPEC} --output py/tmp}
@@ -17,6 +16,8 @@ def swagger_regen()
   FileUtils.mv('py/tmp/README.md', 'py/README.swagger.md', move_opts)
   FileUtils.mv('py/tmp/requirements.txt', 'py/swagger-requirements.txt', move_opts)
   FileUtils.remove_dir('py/tmp')
+  # TODO(markfickett) Automatically check out generated-py-client when running the above.
+  common.status "Only commit generated files on the generated-py-client branch."
 end
 
 Common.register_command({

--- a/client/libproject/devstart.rb
+++ b/client/libproject/devstart.rb
@@ -1,4 +1,5 @@
 require "optparse"
+require "fileutils"
 require_relative "../../libproject/utils/common"
 require_relative "../../libproject/swagger"
 
@@ -6,9 +7,15 @@ def swagger_regen()
   Workbench::Swagger.download_swagger_codegen_cli
 
   common = Common.new
+  #check out py-client branch
   common.run_inline %W{
       java -jar #{Workbench::Swagger::SWAGGER_CODEGEN_CLI_JAR}
-      generate --lang python --input-spec #{Workbench::Swagger::SWAGGER_SPEC} --output py/}
+      generate --lang python --input-spec #{Workbench::Swagger::SWAGGER_SPEC} --output py/tmp}
+  FileUtils.mv('py/tmp/swagger_client', 'py/aou_workbench_client/')
+  FileUtils.mv('py/tmp/docs', 'py/swagger_docs')
+  FileUtils.mv('py/tmp/README.md', 'py/README.swagger.md')
+  FileUtils.mv('py/tmp/requirements.txt', 'py/swagger-requirements.txt')
+  FileUtils.remove_dir('py/tmp')
 end
 
 Common.register_command({

--- a/client/libproject/devstart.rb
+++ b/client/libproject/devstart.rb
@@ -11,10 +11,11 @@ def swagger_regen()
   common.run_inline %W{
       java -jar #{Workbench::Swagger::SWAGGER_CODEGEN_CLI_JAR}
       generate --lang python --input-spec #{Workbench::Swagger::SWAGGER_SPEC} --output py/tmp}
-  FileUtils.mv('py/tmp/swagger_client', 'py/aou_workbench_client/')
-  FileUtils.mv('py/tmp/docs', 'py/swagger_docs')
-  FileUtils.mv('py/tmp/README.md', 'py/README.swagger.md')
-  FileUtils.mv('py/tmp/requirements.txt', 'py/swagger-requirements.txt')
+  move_opts = {:force => true, :verbose => true}
+  FileUtils.mv('py/tmp/swagger_client', 'py/aou_workbench_client/', move_opts)
+  FileUtils.mv('py/tmp/docs', 'py/swagger_docs', move_opts)
+  FileUtils.mv('py/tmp/README.md', 'py/README.swagger.md', move_opts)
+  FileUtils.mv('py/tmp/requirements.txt', 'py/swagger-requirements.txt', move_opts)
   FileUtils.remove_dir('py/tmp')
 end
 

--- a/client/py/.gitignore
+++ b/client/py/.gitignore
@@ -1,0 +1,4 @@
+README.swagger.md
+swagger_docs
+swagger-requirements.txt
+swagger_client/

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -4,7 +4,10 @@ Usage:
 
   virtualenv venv
   . venv/bin/activate
+  # Install HEAD from a branch:
   pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-client#egg=aou_workbench_client&subdirectory=client/py'
+  # or install a tagged version (which also avoids downloading all history):
+  pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-0-rc0.zip#egg=aou_workbench_client&subdirectory=client/py'
 
 then
 

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -2,8 +2,11 @@
 
 Usage:
 
-  pip install -e 'git:https://github.com/all-of-us/workbench.git@mwf/py-client#egg=aou_workbench_client&subdirectory=client/py'
+  virtualenv venv
+  . venv/bin/activate
+  pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-client#egg=aou_workbench_client&subdirectory=client/py'
 
 then
 
   import aou_workbench_client
+  from aou_workbench_client import swagger_client

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -7,7 +7,7 @@ Usage:
   # Install HEAD from a branch:
   pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-client#egg=aou_workbench_client&subdirectory=client/py'
   # or install a tagged version (which also avoids downloading all history):
-  pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-0-rc0.zip#egg=aou_workbench_client&subdirectory=client/py'
+  pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-0-rc1.zip#egg=aou_workbench_client&subdirectory=client/py'
 
 then
 

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -1,0 +1,9 @@
+# Python client for All of Us Workbench Jupyter Notebooks
+
+Usage:
+
+  pip install -e 'git:https://github.com/all-of-us/workbench.git@mwf/py-client#egg=aou_workbench_client&subdirectory=client/py'
+
+then
+
+  import aou_workbench_client

--- a/client/py/aou_workbench_client/__init__.py
+++ b/client/py/aou_workbench_client/__init__.py
@@ -1,0 +1,6 @@
+"""AoU Workbench Python Client
+
+This module contains convenience wrappers for researchers to use.
+
+The swagger_client submodule contains a generated API client.
+"""

--- a/client/py/setup.py
+++ b/client/py/setup.py
@@ -1,0 +1,30 @@
+"""A setuptools based module for PIP installation of the AoU Workbench Python client."""
+# Docs/example setup.py: https://github.com/pypa/sampleproject/blob/master/setup.py
+
+import os
+from setuptools import setup
+
+
+client_dir = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(client_dir, 'README.md')) as readme:
+  readme_contents = readme.read()
+with open(os.path.join(client_dir, 'README.swagger.md')) as swagger_readme:
+  readme_contents += '\n\n' + swagger_readme.read()
+with open(os.path.join(client_dir, 'requirements.txt')) as requirements:
+  requirements_list = [l.strip() for l in requirements.readlines()]
+with open(os.path.join(client_dir, 'swagger-requirements.txt')) as swagger_requirements:
+  requirements_list += [l.strip() for l in swagger_requirements.readlines()]
+
+
+setup(
+    # This is what people 'pip install'.
+    name='aou-workbench-client',
+
+    long_description=readme_contents,
+    url='https://github.com/all-of-us/workbench',
+
+    # These packages may be imported after the egg is installed.
+    packages=['aou_workbench_client'],
+
+    install_requires=requirements_list,
+)

--- a/client/py/setup.py
+++ b/client/py/setup.py
@@ -20,6 +20,9 @@ setup(
     # This is what people 'pip install'.
     name='aou-workbench-client',
 
+    # TODO(markfickett) Provide a version string here. Automatically bump when publishing (maybe
+    # from swagger-regen).
+
     long_description=readme_contents,
     url='https://github.com/all-of-us/workbench',
 

--- a/client/py/setup.py
+++ b/client/py/setup.py
@@ -23,8 +23,9 @@ setup(
     long_description=readme_contents,
     url='https://github.com/all-of-us/workbench',
 
-    # These packages may be imported after the egg is installed.
-    packages=['aou_workbench_client'],
+    # These packages may be imported after the egg is installed. (We want all Python packages
+    # rooted under client/py, so we use automatic discovery.)
+    packages=setuptools.find_packages(),
 
     install_requires=requirements_list,
 )


### PR DESCRIPTION
From client/py/README.md, to try it out:

```
virtualenv venv
. venv/bin/activate
pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-0-rc1.zip#egg=aou_workbench_client&subdirectory=client/py'
python -c 'from aou_workbench_client import swagger_client; print swagger_client'
```

This provides a PIP-installable, versioned Python client with the Swagger client as a submodule. I expect to mostly wrap the swagger client, to provide easier functionality. Still TODO is all that wrapping. To publish the client, we'll run `./project.rb swagger-regen`, commit it to the `generated-py-client` branch, and tag it.