### PR TITLE
Adding config framework.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 /api/out/*
 /api/src/main/webapp/WEB-INF/appengine-web.xml
 /api/src/generated
+/api/tools/build/*
+/api/tools/.gradle/*
 /build/*
 /ui/ui.iml
 /ui/.idea/*

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -1,0 +1,5 @@
+{
+  "firecloud": {
+    "debugEndpoints": "false"
+  }
+}

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -1,5 +1,5 @@
 {
   "firecloud": {
-    "debugEndpoints": "false"
+    "debugEndpoints": false
   }
 }

--- a/api/db/changelog/db.changelog-3.xml
+++ b/api/db/changelog/db.changelog-3.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="danrodney" id="changelog-3">
+
+    <createTable tableName="config">
+      <column name="config_id" type="varchar(80)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="configuration" type="CLOB">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -10,4 +10,5 @@
   </preConditions>
   <include file="changelog/db.changelog-1.xml"/>
   <include file="changelog/db.changelog-2.xml"/>
+  <include file="changelog/db.changelog-3.xml"/>
 </databaseChangeLog>

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -31,6 +31,18 @@ services:
     command: wait-for db:3306 -- ./run-migrations.sh
     env_file:
       - db/vars.env
+  config:
+    build:
+     context: ./src/dev/server
+    depends_on:
+      - db-migration
+    working_dir: /w/tools
+    volumes:
+      - gradle-cache:/root/.gradle
+      - .:/w:cached
+    command: wait-for db:3306 -- ../gradlew loadConfig
+    env_file:
+      - db/vars.env
 volumes:
   db:
   gradle-cache:

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -31,11 +31,9 @@ services:
     command: wait-for db:3306 -- ./run-migrations.sh
     env_file:
       - db/vars.env
-  config:
+  update-config:
     build:
      context: ./src/dev/server
-    depends_on:
-      - db-migration
     working_dir: /w/tools
     volumes:
       - gradle-cache:/root/.gradle

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -259,6 +259,16 @@ def connect_to_cloud_db(*args)
   })
 end
 
+def update_cloud_config(*args)
+  run_with_cloud_sql_proxy(args, "connect-to-cloud-db", lambda { |project, account, creds_file|
+    read_db_vars(project)
+    ENV["DB_PORT"] = "3307"
+    unless system("cd tools && ../gradlew --info loadConfig && cd ..")
+        raise("Error updating configuration. Exiting.")
+    end
+  })
+end
+
 def run_cloud_migrations(*args)
   run_with_cloud_sql_proxy(args, "run-cloud-migrations", lambda { |project, account, creds_file|
     puts "Running migrations..."
@@ -374,4 +384,10 @@ Common.register_command({
   :invocation => "register-service-account",
   :description => "Registers a service account with Firecloud; do this once per account we use.",
   :fn => lambda { |*args| register_service_account(*args) }
+})
+
+Common.register_command({
+  :invocation => "update-cloud-config",
+  :description => "Updates configuration in Cloud SQL database for the specified project.",
+  :fn => lambda { |*args| update_cloud_config(*args) }
 })

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -56,6 +56,8 @@ def dev_up(*args)
   common.run_inline %W{docker-compose up -d db}
   common.status "Running database migrations..."
   common.run_inline %W{docker-compose run db-migration}
+  common.status "Updating configuration..."
+  common.run_inline %W{docker-compose run update-config}
   at_exit { FileUtils.rm("sa-key.json") }
   do_run_with_creds("all-of-us-workbench-test", account, nil, lambda { |project, account, creds_file|
     FileUtils.cp(creds_file, "sa-key.json")

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,0 +1,1 @@
+include ":tools"

--- a/api/src/main/java/org/pmiops/workbench/config/CacheConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CacheConfig.java
@@ -3,6 +3,9 @@ package org.pmiops.workbench.config;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.pmiops.workbench.db.dao.ConfigDao;
@@ -15,22 +18,37 @@ import org.springframework.web.context.annotation.RequestScope;
 @Configuration
 public class CacheConfig {
 
+  private static final Map<String, Class<?>> CONFIG_CLASS_MAP = new HashMap<>();
+
+  static {
+    CONFIG_CLASS_MAP.put(Config.MAIN_CONFIG_ID, WorkbenchConfig.class);
+  }
+
   @Bean
-  LoadingCache<String, Config> getConfigCache(ConfigDao configDao) {
+  LoadingCache<String, Object> getConfigCache(ConfigDao configDao) {
     // Cache configuration in memory for ten minutes.
     return CacheBuilder.<String, Config>newBuilder()
         .expireAfterWrite(10, TimeUnit.MINUTES)
-        .build(new CacheLoader<String, Config>() {
+        .build(new CacheLoader<String, Object>() {
           @Override
-          public Config load(String key) {
-            return configDao.findOne(key);
+          public Object load(String key) {
+            Class<?> configClass = CONFIG_CLASS_MAP.get(key);
+            if (configClass == null) {
+              throw new IllegalArgumentException("Invalid config key: " + key);
+            }
+            Config config = configDao.findOne(key);
+            if (config == null) {
+              return null;
+            }
+            Gson gson = new Gson();
+            return gson.fromJson(config.getConfiguration(), configClass);
           }
         });
   }
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  Config getMainConfig(LoadingCache<String, Config> configCache) throws ExecutionException {
-    return configCache.get(Config.MAIN_CONFIG_ID);
+  WorkbenchConfig getWorkbenchConfig(LoadingCache<String, Object> configCache) throws ExecutionException {
+    return (WorkbenchConfig) configCache.get(Config.MAIN_CONFIG_ID);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/CacheConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CacheConfig.java
@@ -1,0 +1,36 @@
+package org.pmiops.workbench.config;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.pmiops.workbench.db.dao.ConfigDao;
+import org.pmiops.workbench.db.model.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Configuration
+public class CacheConfig {
+
+  @Bean
+  LoadingCache<String, Config> getConfigCache(ConfigDao configDao) {
+    // Cache configuration in memory for ten minutes.
+    return CacheBuilder.<String, Config>newBuilder()
+        .expireAfterWrite(10, TimeUnit.MINUTES)
+        .build(new CacheLoader<String, Config>() {
+          @Override
+          public Config load(String key) {
+            return configDao.findOne(key);
+          }
+        });
+  }
+
+  @Bean
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  Config getMainConfig(LoadingCache<String, Config> configCache) throws ExecutionException {
+    return configCache.get(Config.MAIN_CONFIG_ID);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -2,13 +2,13 @@ package org.pmiops.workbench.config;
 
 /**
  * A class representing the main workbench configuration; parsed from JSON stored in the database.
- * See {@link CacheConfig}.
+ * See {@link CacheConfig}. This should be kept in sync with files in the config/ directory.
  */
 public class WorkbenchConfig {
 
   public static class FireCloudConfig {
-    public static boolean debugging;
+    public boolean debugEndpoints;
   }
 
-  public static FireCloudConfig firecloud;
+  public FireCloudConfig firecloud;
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -1,0 +1,14 @@
+package org.pmiops.workbench.config;
+
+/**
+ * A class representing the main workbench configuration; parsed from JSON stored in the database.
+ * See {@link CacheConfig}.
+ */
+public class WorkbenchConfig {
+
+  public static class FireCloudConfig {
+    public static boolean debugging;
+  }
+
+  public static FireCloudConfig firecloud;
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConfigDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConfigDao.java
@@ -1,0 +1,7 @@
+package org.pmiops.workbench.db.dao;
+
+import org.pmiops.workbench.db.model.Config;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ConfigDao extends CrudRepository<Config, String> {
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/Config.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Config.java
@@ -1,0 +1,35 @@
+package org.pmiops.workbench.db.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "config")
+public class Config {
+
+  public static final String MAIN_CONFIG_ID = "main";
+
+  private String configId;
+  private String configuration;
+
+  @Id
+  @Column(name = "config_id")
+  public String getConfigId() {
+    return configId;
+  }
+
+  public void setConfigId(String configId) {
+    this.configId = configId;
+  }
+
+  @Column(name = "configuration")
+  public String getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(String configuration) {
+    this.configuration = configuration;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -4,8 +4,8 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.logging.Logger;
-import org.pmiops.workbench.api.ProfileController;
 import org.pmiops.workbench.auth.UserAuthentication;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
@@ -30,17 +30,17 @@ public class FireCloudConfig {
 
   @Bean(name=END_USER_API_CLIENT)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public ApiClient fireCloudApiClient(UserAuthentication userAuthentication) {
+public ApiClient fireCloudApiClient(UserAuthentication userAuthentication,
+      WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(userAuthentication.getCredentials());
-    // Uncomment to enable REST API debugging.
-    //apiClient.setDebugging(true);
+    apiClient.setDebugging(workbenchConfig.firecloud.debugging);
     return apiClient;
   }
 
   @Bean(name=ALL_OF_US_API_CLIENT)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public ApiClient allOfUsApiClient() {
+  public ApiClient allOfUsApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     try {
       GoogleCredential credential = GoogleCredential.getApplicationDefault()
@@ -48,8 +48,7 @@ public class FireCloudConfig {
       credential.refreshToken();
       String accessToken = credential.getAccessToken();
       apiClient.setAccessToken(accessToken);
-      // Uncomment to enable REST API debugging.
-      // apiClient.setDebugging(true);
+      apiClient.setDebugging(workbenchConfig.firecloud.debugging);
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -30,11 +30,11 @@ public class FireCloudConfig {
 
   @Bean(name=END_USER_API_CLIENT)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-public ApiClient fireCloudApiClient(UserAuthentication userAuthentication,
+  public ApiClient fireCloudApiClient(UserAuthentication userAuthentication,
       WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(userAuthentication.getCredentials());
-    apiClient.setDebugging(workbenchConfig.firecloud.debugging);
+    apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
     return apiClient;
   }
 
@@ -48,7 +48,7 @@ public ApiClient fireCloudApiClient(UserAuthentication userAuthentication,
       credential.refreshToken();
       String accessToken = credential.getAccessToken();
       apiClient.setAccessToken(accessToken);
-      apiClient.setDebugging(workbenchConfig.firecloud.debugging);
+      apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -16,6 +16,7 @@ task loadConfig(type: JavaExec) {
       'spring.datasource.username': '${workbench_db_user}',
       'spring.datasource.password': '${workbench_db_password}'
     ]
+    args config_file
 }
 
 
@@ -48,6 +49,7 @@ repositories {   // repositories for Jar's you access in your code
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
     compile 'joda-time:joda-time:+'
+    compile 'com.github.fge:json-patch:+'
     compile 'io.swagger:swagger-annotations:1.5.9'
     compile 'com.google.cloud.sql:mysql-socket-factory:+'
     compile rootProject

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'org.springframework.boot'
+
+def db_host = System.getenv("DB_HOST")
+def db_port = System.getenv("DB_PORT")
+def workbench_db_user = System.getenv("WORKBENCH_DB_USER")
+def workbench_db_password = System.getenv("WORKBENCH_DB_PASSWORD")
+
+task loadConfig(type: JavaExec) {
+    classpath sourceSets.main.runtimeClasspath
+    main = "org.pmiops.workbench.tools.ConfigLoader"
+    systemProperties = [
+      'spring.datasource.driver-class-name': 'com.mysql.jdbc.Driver',
+      'spring.datasource.url': 'jdbc:mysql://${db_host}:${db_port}/workbench',
+      'spring.datasource.username': '${workbench_db_user}',
+      'spring.datasource.password': '${workbench_db_password}'
+    ]
+}
+
+
+buildscript {    // Configuration for building
+    repositories {
+        jcenter()    // Bintray's repository - a fast Maven Central mirror & more
+    }
+    dependencies {
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.3.RELEASE'
+    }
+}
+
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', '../src/main/java', '../src/generated/java']
+            includes = ['org/pmiops/workbench/tools/**/*.java',
+                        'org/pmiops/workbench/db/**/*.java',
+                        'org/pmiops/workbench/model/DataAccessLevel.java' ]
+        }
+    }
+}
+
+repositories {   // repositories for Jar's you access in your code
+    jcenter()
+}
+
+
+dependencies {
+    compile 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compile 'joda-time:joda-time:+'
+    compile 'io.swagger:swagger-annotations:1.5.9'
+    compile 'com.google.cloud.sql:mysql-socket-factory:+'
+    compile rootProject
+}

--- a/api/tools/gradle.properties
+++ b/api/tools/gradle.properties
@@ -1,0 +1,1 @@
+config_file=../config/config_test.json

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
@@ -1,0 +1,31 @@
+package org.pmiops.workbench.tools;
+
+import org.pmiops.workbench.db.dao.ConfigDao;
+import org.pmiops.workbench.db.model.Config;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.stereotype.Component;
+
+@SpringBootApplication
+@EnableJpaRepositories("org.pmiops.workbench.db.dao")
+@EntityScan("org.pmiops.workbench.db.model")
+public class ConfigLoader {
+
+  @Bean
+  public CommandLineRunner run(ConfigDao configDao) {
+    return (args) -> {
+      throw new Exception("Config = " + configDao.findOne(Config.MAIN_CONFIG_ID));
+    };
+  }
+  public static void main(String[] args) throws Exception {
+    new SpringApplicationBuilder(ConfigLoader.class).web(false).run(args);
+  }
+
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
@@ -1,29 +1,57 @@
 package org.pmiops.workbench.tools;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import java.io.FileInputStream;
+import java.util.logging.Logger;
 import org.pmiops.workbench.db.dao.ConfigDao;
 import org.pmiops.workbench.db.model.Config;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 @EnableJpaRepositories("org.pmiops.workbench.db.dao")
 @EntityScan("org.pmiops.workbench.db.model")
 public class ConfigLoader {
 
+  private static final Logger log = Logger.getLogger(ConfigLoader.class.getName());
+
   @Bean
   public CommandLineRunner run(ConfigDao configDao) {
     return (args) -> {
-      throw new Exception("Config = " + configDao.findOne(Config.MAIN_CONFIG_ID));
+      if (args.length != 1) {
+        throw new IllegalArgumentException("Must pass filename of config file");
+      }
+      ObjectMapper jackson = new ObjectMapper();
+      JsonNode newJson = jackson.readTree(new FileInputStream(args[0]));
+      Config existingConfig = configDao.findOne(Config.MAIN_CONFIG_ID);
+      if (existingConfig == null) {
+        log.info("No configuration exists, creating one.");
+        Config config = new Config();
+        config.setConfigId(Config.MAIN_CONFIG_ID);
+        config.setConfiguration(newJson.toString());
+        configDao.save(config);
+      } else {
+        JsonNode existingJson = jackson.readTree(existingConfig.getConfiguration());
+        JsonNode diff = JsonDiff.asJson(existingJson, newJson);
+        if (diff.size() == 0) {
+          log.info("No change in configuration; exiting.");
+        } else {
+          log.info("Updating configuration:");
+          log.info(diff.toString());
+          existingConfig.setConfiguration(newJson.toString());
+          configDao.save(existingConfig);
+        }
+      }
+      log.info("Done.");
     };
   }
+
   public static void main(String[] args) throws Exception {
     new SpringApplicationBuilder(ConfigLoader.class).web(false).run(args);
   }


### PR DESCRIPTION
Workbench config gets written to row in config database table using ConfigLoader tool, parsed into WorkbenchConfig object and cached in memory for ten minutes.

Adding "run-api" target that skips db-migration and update-config (speeds up startup time when everything is up to date.)


