### PR TITLE
Setting version in deploy.py.

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -23,4 +23,5 @@ fi
   --target $1 \
   --skip-confirmation \
   --project all-of-us-workbench-test \
-  --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com
+  --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+  --version $VERSION

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,5 +1,16 @@
 #!/bin/bash -e
 
+if [ -n "${CIRCLE_TAG}" ]
+then
+  # For a tagged commit, deploy a version matching that tag. We tag some commits
+  # on master to tell CircleCI to deploy them as named versions.
+  VERSION=${CIRCLE_TAG}
+else
+  # On test, CircleCI automatically deploys all commits to master, for testing.
+  # These versions need not persist, so give them all the same name.
+  VERSION=circle-ci-test
+fi
+
 ./ci/activate_creds.sh ~/gcloud-credentials.key
 if [ "$1" == "api" ]
 then

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -71,7 +71,8 @@ if __name__ == '__main__':
     configure_logging()
     parser = get_parser()
     parser.add_argument(
-            '-v', '--version', help='Version name for Workbench to deploy')
+            '-v', '--version', help='Version name for Workbench to deploy',
+            required=True)
     parser.add_argument(
             '-t', '--target',
             default=_TargetChoices.ALL, choices=_TargetChoices.ALL_TARGET_CHOICES,

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -49,6 +49,8 @@ def deploy(args):
                     args.project,
                     '--account',
                     args.account,
+                    '--version',
+                    args.version
                 ],
                 cwd=paths.get_ui_dir())
     else:
@@ -68,6 +70,8 @@ class _TargetChoices(object):
 if __name__ == '__main__':
     configure_logging()
     parser = get_parser()
+    parser.add_argument(
+            '-v', '--version', help='Version name for Workbench to deploy')
     parser.add_argument(
             '-t', '--target',
             default=_TargetChoices.ALL, choices=_TargetChoices.ALL_TARGET_CHOICES,


### PR DESCRIPTION
This avoids creating a new version in AppEngine on every deploy, and gives us the capability to name versions.