### PR TITLE
[RW-82] Convert px to rem in stylesheets.

### DIFF
--- a/ui/src/app/views/app/component.css
+++ b/ui/src/app/views/app/component.css
@@ -12,7 +12,7 @@
 .sign-in-inner-container {
   margin-top: 30vh;
   background-color: #fcfcfc;
-  border-radius: 4px;
+  border-radius: 0.3rem;
 }
 
 .page-container {

--- a/ui/src/app/views/bug-report/component.css
+++ b/ui/src/app/views/bug-report/component.css
@@ -1,7 +1,7 @@
 .bug-report {
   position: fixed;
-  bottom: 0px;
-  right: 0px;
+  bottom: 0;
+  right: 0;
 }
 
 .input {

--- a/ui/src/app/views/cohort-builder/search/cohort-builder/cohort-builder.component.css
+++ b/ui/src/app/views/cohort-builder/search/cohort-builder/cohort-builder.component.css
@@ -4,10 +4,10 @@
 }
 
 .my-border {
-    border-radius: 3px;
+    border-radius: 0.2rem;
     border: 1px solid #d7d7d7;
-    padding-right: 10px;
-    padding-left: 10px;
+    padding-right: 1rem;
+    padding-left: 1rem;
     background-color: #e9f0f1;
 }
 

--- a/ui/src/app/views/cohort-builder/search/wizard-modal/wizard-modal.component.css
+++ b/ui/src/app/views/cohort-builder/search/wizard-modal/wizard-modal.component.css
@@ -46,6 +46,6 @@
 }
 
 /*.text-truncate {*/
-  /*width: 230px;*/
+  /*width: 15rem;*/
 /*}*/
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -39,8 +39,8 @@ button {
   font-family: Arial;
   background-color: #eee;
   border: none;
-  padding: 5px 10px;
-  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
   cursor: pointer;
   cursor: hand;
 }


### PR DESCRIPTION
I did not convert px in:
 - 1px borders. I think the notion here is 'the thinnest solid line'. I'm not sure if there's a better unit.
 - Shadow offset of 1px (similar).
 - @media rules in Cohort Browser. Some of these aren't used, also.
Tangentially, I removed any units from 0 values. I also left `vh` alone (new to me, seems fine).

Demo: https://20170922t173307-dot-all-of-us-workbench-test.appspot.com