### PR TITLE
Jmandel/as-local-user Run docker as local user instead of root

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
   db-migration:
     build:
       context: ./src/dev/server
+    user: ${UID}
     working_dir: /w/db
     volumes:
       - gradle-cache:/.gradle
@@ -37,6 +38,7 @@ services:
   update-config:
     build:
      context: ./src/dev/server
+    user: ${UID}
     working_dir: /w
     volumes:
       - gradle-cache:/.gradle

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -24,6 +24,26 @@ services:
     ports:
       - 8081:8081
       - 8001:8001
+  db-migration:
+    build:
+      context: ./src/dev/server
+    working_dir: /w/db
+    volumes:
+      - gradle-cache:/.gradle
+      - .:/w:cached
+    command: wait-for db:3306 -- ./run-migrations.sh
+    env_file:
+      - db/vars.env
+  update-config:
+    build:
+     context: ./src/dev/server
+    working_dir: /w
+    volumes:
+      - gradle-cache:/.gradle
+      - .:/w:cached
+    command: wait-for db:3306 -- ./gradlew tools:loadConfig
+    env_file:
+      - db/vars.env
 volumes:
   db:
   gradle-cache:

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -9,10 +9,13 @@ services:
   api:
     build:
       context: ./src/dev/server
+    user: ${UID}
     working_dir: /w
+    depends_on:
+      - db
     volumes:
-      - gradle-cache:/root/.gradle
       - .:/w:cached
+      - gradle-cache:/.gradle
     command: ./gradlew appengineRun
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
@@ -21,26 +24,6 @@ services:
     ports:
       - 8081:8081
       - 8001:8001
-  db-migration:
-    build:
-      context: ./src/dev/server
-    working_dir: /w/db
-    volumes:
-      - gradle-cache:/root/.gradle
-      - .:/w:cached
-    command: wait-for db:3306 -- ./run-migrations.sh
-    env_file:
-      - db/vars.env
-  update-config:
-    build:
-     context: ./src/dev/server
-    working_dir: /w
-    volumes:
-      - gradle-cache:/root/.gradle
-      - .:/w:cached
-    command: wait-for db:3306 -- ./gradlew tools:loadConfig
-    env_file:
-      - db/vars.env
 volumes:
   db:
   gradle-cache:

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -11,8 +11,6 @@ services:
       context: ./src/dev/server
     user: ${UID}
     working_dir: /w
-    depends_on:
-      - db
     volumes:
       - .:/w:cached
       - gradle-cache:/.gradle

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -56,16 +56,10 @@ def dev_up(*args)
   common.status "Starting database..."
   common.run_inline %W{docker-compose up -d db}
   common.status "Running database migrations..."
-  common.run_inline [
-    "docker-compose", "run", "--no-deps", "api", "sh", "-c",
-    "cd /w/db && wait-for db:3306 -- ./run-migrations.sh"
-  ]
+  common.run_inline %W{docker-compose run db-migration}
 
   common.status "Updating configuration..."
-  common.run_inline [
-    "docker-compose", "run", "--no-deps", "api", "sh", "-c",
-    "wait-for db:3306 -- ./gradlew tools:loadConfig"
-  ]
+  common.run_inline %W{docker-compose run update-config}
 
   run_api(account)
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1,11 +1,10 @@
 require_relative "../../libproject/utils/common"
+require_relative "../../libproject/workbench"
 require "io/console"
 require "json"
 require "optparse"
 require "tempfile"
 require "fileutils"
-
-ENV["UID"] = "#{Process.euid}"
 
 class ProjectAndAccountOptions
   attr_accessor :project

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -5,6 +5,8 @@ require "optparse"
 require "tempfile"
 require "fileutils"
 
+ENV["UID"] = "#{Process.euid}"
+
 class ProjectAndAccountOptions
   attr_accessor :project
   attr_accessor :account
@@ -45,7 +47,6 @@ end
 def dev_up(*args)
   common = Common.new
   common.docker.requires_docker
-  ENV["UID"] = "#{Process.euid}"
 
   account = get_auth_login_account()
   if account == nil

--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -45,5 +45,9 @@ RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
 RUN curl https://raw.githubusercontent.com/mrako/wait-for/d9699cb9fe8a4622f05c4ee32adf2fd93239d005/wait-for \
   > /usr/local/bin/wait-for && chmod +x /usr/local/bin/wait-for
 
+RUN mkdir /.gradle && chmod a+rwx -R /.gradle
+VOLUME /.gradle
+ENV GRADLE_USER_HOME /.gradle
+
 # It never makes sense for Gradle to run a daemon within a docker container.
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"

--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -45,6 +45,8 @@ RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
 RUN curl https://raw.githubusercontent.com/mrako/wait-for/d9699cb9fe8a4622f05c4ee32adf2fd93239d005/wait-for \
   > /usr/local/bin/wait-for && chmod +x /usr/local/bin/wait-for
 
+# Create a gradle cache directory as a volume that can be read/written by any
+# container (including containers running as any user -- hence the a+rwx)
 RUN mkdir /.gradle && chmod a+rwx -R /.gradle
 VOLUME /.gradle
 ENV GRADLE_USER_HOME /.gradle

--- a/libproject/workbench.rb
+++ b/libproject/workbench.rb
@@ -1,5 +1,7 @@
 require_relative "utils/common"
 
+ENV["UID"] = "#{Process.euid}"
+
 module Workbench
   WORKBENCH_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   ui:
     build:
       context: ./src/dev/server
+    user: ${UID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
@@ -12,6 +13,7 @@ services:
   tests:
     build:
       context: ./src/dev/server
+    user: ${UID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -3,9 +3,7 @@ services:
   ui:
     build:
       context: ./src/dev/server
-      args:
-        - UID=${UID}
-        - GID=${GID}
+    user: ${UID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
@@ -15,9 +13,7 @@ services:
   tests:
     build:
       context: ./src/dev/server
-      args:
-        - UID=${UID}
-        - GID=${GID}
+    user: ${UID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -3,7 +3,9 @@ services:
   ui:
     build:
       context: ./src/dev/server
-    user: ${UID}
+      args:
+        - UID=${UID}
+        - GID=${GID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
@@ -13,7 +15,9 @@ services:
   tests:
     build:
       context: ./src/dev/server
-    user: ${UID}
+      args:
+        - UID=${UID}
+        - GID=${GID}
     working_dir: /w/ui
     volumes:
       - ..:/w:cached

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -5,6 +5,8 @@ require_relative "../../libproject/utils/common"
 require_relative "../../libproject/workbench"
 require_relative "../../libproject/swagger"
 
+ENV["UID"] = "#{Process.euid}"
+
 def install_dependencies()
   common = Common.new
   common.docker.requires_docker
@@ -52,6 +54,7 @@ def dev_up(*args)
 
   ENV["ENV_FLAG"] = options.env == "local" ? "" : "--environment=#{options.env}"
   at_exit { common.run_inline %W{docker-compose down} }
+  swagger_regen()
   common.run_inline %W{docker-compose run -d --service-ports tests}
 
   common.status "Tests started. Open\n"

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -5,8 +5,6 @@ require_relative "../../libproject/utils/common"
 require_relative "../../libproject/workbench"
 require_relative "../../libproject/swagger"
 
-ENV["UID"] = "#{Process.euid}"
-
 def install_dependencies()
   common = Common.new
   common.docker.requires_docker

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -3,4 +3,15 @@ FROM node:alpine
 # Java for Swagger client generation
 RUN apk --no-cache add openjdk8-jre
 
-RUN mkdir /.config &&  mkdir /.npm && chmod a+rwx /.config /.npm
+# These must be populated on either the build command line or via
+# docker-compose
+ARG UID
+ARG GID
+
+# No sudo in the node alpine image, so explicitly change user
+USER 0
+RUN mkdir /.config /.npm
+RUN chmod a+rwx /.config /.npm
+RUN chown -R $UID:$GID /.config /.npm
+# and reset user to local user's ID and group ID
+USER $UID:$GID

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -2,3 +2,5 @@ FROM node:alpine
 
 # Java for Swagger client generation
 RUN apk --no-cache add openjdk8-jre
+
+RUN mkdir /.config &&  mkdir /.npm && chmod a+rwx /.config /.npm

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -3,15 +3,4 @@ FROM node:alpine
 # Java for Swagger client generation
 RUN apk --no-cache add openjdk8-jre
 
-# These must be populated on either the build command line or via
-# docker-compose
-ARG UID
-ARG GID
-
-# No sudo in the node alpine image, so explicitly change user
-USER 0
-RUN mkdir /.config /.npm
-RUN chmod a+rwx /.config /.npm
-RUN chown -R $UID:$GID /.config /.npm
-# and reset user to local user's ID and group ID
-USER $UID:$GID
+RUN mkdir /.config &&  mkdir /.npm && chmod a+rwx /.config /.npm


### PR DESCRIPTION
To try this, check out the branch locally and

* remove all volumes (`docker-compose down -v`)
* remove all root-owned files (`sudo rm -rf src/generated build db/.gradle tools/build src/main/webapp/WEB-INF/appengine-web.xml`)

At this point you should see no files owned by root:

```
$ find . -user root | wc -l
0
```

And you should see no old volumes hanging around:

```
$ docker volume ls | grep gradle-cache | wc -l
      0       0       0 -
```

Then you can try building and running with local user priviliges:

```
docker-compose build
./project.rb dev-up
```
