### PR TITLE
Implement py client authentication.

### DIFF
--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -34,7 +34,11 @@ _token_expiration = 0  # Epoch seconds when the token is expired. Default to som
 
 
 def get_authenticated_swagger_client(force=False):
-    """Caches returned value and lazily re-authenticates as tokens expire."""
+    """Returns a Swagger ApiClient set up to make authenticated calls to the Workbench API.
+
+    This function caches the client until its OAuth token expires, so prefer calling this function
+    frequently to get a refreshed client, rather than keeping a reference to the client locally.
+    """
     global _cached_client
     global _token_expiration
     if _cached_client is None:

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -1,0 +1,70 @@
+"""OAuth against the AoU Workbench API using bearer tokens provided by gcloud."""
+
+import json
+import logging
+import subprocess
+import time
+import urllib2
+
+from swagger_client.api_client import ApiClient
+
+
+_METADATA_URL = (
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token')
+_METADATA_HEADER = {'Metadata-Flavor': 'Google'}
+_TOKEN_INFO_URL_T = 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=%s'
+
+
+# Note that we use custom cache management because cachetools.TTLCache (for example) uses a
+# constant / whole-cache TTL, whereas we want a varying expiration time.
+_cached_client = None
+_token_expiration = 0  # Epoch seconds when the token is expired. Default to some time in the past.
+
+
+def get_authenticated_swagger_client(force=False):
+  """Caches returned value and lazily re-authenticates as tokens expire."""
+  global _cached_client
+  global _token_expiration
+  if _cached_client is None:
+    _cached_client = ApiClient()
+  if force or (time.time() >= _token_expiration_time):
+    token, _token_expiration = _get_bearer_token_and_expiration()
+    _cached_client.set_default_header(name, value)
+  return _cached_client
+
+
+def _get_bearer_token_and_expiration():
+  """Fetches a new token. Returns (token string, expiration time epoch seconds)."""
+  try:
+    return _query_metadata_api()
+  except urllib2.URLError as e:
+    logging.warning('Metadata API query failed: %s', e)
+    return _run_print_access_token()
+
+
+def _query_metadata_api():
+  # Conservatively estimate token expiration time by recording token fetch time before initiating
+  # the request.
+  t = int(time.time())
+
+  respones = urllib2.urlopen(urllib2.Request(url=_METADATA_URL, headers=_METADATA_HEADER))
+  response_json = json.loads(response.read())
+  return response_json['access_token'], t + response_json['expires_in']
+
+
+def _run_print_access_token():
+  logging.warning('Falling back to print-access-token (should be used for debugging only).')
+  token = subprocess.check_output(['gcloud', 'auth', 'print-access-token']).strip()
+
+  # Get details about the token, including expiration time.
+  t = time.time()
+  response = urllib2.urlopen(_TOKEN_INFO_URL_T % token)
+  token_info_json = json.loads(response.read())
+  return token, t + token_info_json['expires_in']
+
+
+def clear_cache():
+  global _cached_client
+  global _token_expiration
+  _cached_client = None
+  _token_expiration = 0

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -86,6 +86,9 @@ if __name__ == '__main__':
     print _run_print_access_token()
 
     # Make an example API call.
-    from swagger_client.apis.profile_api import ProfileApi
-    profile_client = ProfileApi(api_client=get_authenticated_swagger_client())
-    print profile_client.get_me()
+    from swagger_client.apis.workspaces_api import WorkspacesApi
+    client = WorkspacesApi(api_client=get_authenticated_swagger_client())
+    workspace_list = client.get_workspaces()
+    print 'Workspaces:'
+    for ws in workspace_list.items:
+        print '%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description)

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -10,7 +10,8 @@ from swagger_client.api_client import ApiClient
 
 
 _METADATA_URL = (
-    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token')
+        'http://metadata.google.internal/computeMetadata/v1/'
+        'instance/service-accounts/default/token')
 _METADATA_HEADER = {'Metadata-Flavor': 'Google'}
 _TOKEN_INFO_URL_T = 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=%s'
 
@@ -22,49 +23,49 @@ _token_expiration = 0  # Epoch seconds when the token is expired. Default to som
 
 
 def get_authenticated_swagger_client(force=False):
-  """Caches returned value and lazily re-authenticates as tokens expire."""
-  global _cached_client
-  global _token_expiration
-  if _cached_client is None:
-    _cached_client = ApiClient()
-  if force or (time.time() >= _token_expiration_time):
-    token, _token_expiration = _get_bearer_token_and_expiration()
-    _cached_client.set_default_header(name, value)
-  return _cached_client
+    """Caches returned value and lazily re-authenticates as tokens expire."""
+    global _cached_client
+    global _token_expiration
+    if _cached_client is None:
+        _cached_client = ApiClient()
+    if force or (time.time() >= _token_expiration_time):
+        token, _token_expiration = _get_bearer_token_and_expiration()
+        _cached_client.set_default_header(name, value)
+    return _cached_client
 
 
 def _get_bearer_token_and_expiration():
-  """Fetches a new token. Returns (token string, expiration time epoch seconds)."""
-  try:
-    return _query_metadata_api()
-  except urllib2.URLError as e:
-    logging.warning('Metadata API query failed: %s', e)
-    return _run_print_access_token()
+    """Fetches a new token. Returns (token string, expiration time epoch seconds)."""
+    try:
+        return _query_metadata_api()
+    except urllib2.URLError as e:
+        logging.warning('Metadata API query failed: %s', e)
+        return _run_print_access_token()
 
 
 def _query_metadata_api():
-  # Conservatively estimate token expiration time by recording token fetch time before initiating
-  # the request.
-  t = int(time.time())
+    # Conservatively estimate token expiration time by recording token fetch time before initiating
+    # the request.
+    t = int(time.time())
 
-  respones = urllib2.urlopen(urllib2.Request(url=_METADATA_URL, headers=_METADATA_HEADER))
-  response_json = json.loads(response.read())
-  return response_json['access_token'], t + response_json['expires_in']
+    respones = urllib2.urlopen(urllib2.Request(url=_METADATA_URL, headers=_METADATA_HEADER))
+    response_json = json.loads(response.read())
+    return response_json['access_token'], t + response_json['expires_in']
 
 
 def _run_print_access_token():
-  logging.warning('Falling back to print-access-token (should be used for debugging only).')
-  token = subprocess.check_output(['gcloud', 'auth', 'print-access-token']).strip()
+    logging.warning('Falling back to print-access-token (should be used for debugging only).')
+    token = subprocess.check_output(['gcloud', 'auth', 'print-access-token']).strip()
 
-  # Get details about the token, including expiration time.
-  t = time.time()
-  response = urllib2.urlopen(_TOKEN_INFO_URL_T % token)
-  token_info_json = json.loads(response.read())
-  return token, t + token_info_json['expires_in']
+    # Get details about the token, including expiration time.
+    t = time.time()
+    response = urllib2.urlopen(_TOKEN_INFO_URL_T % token)
+    token_info_json = json.loads(response.read())
+    return token, t + token_info_json['expires_in']
 
 
 def clear_cache():
-  global _cached_client
-  global _token_expiration
-  _cached_client = None
-  _token_expiration = 0
+    global _cached_client
+    global _token_expiration
+    _cached_client = None
+    _token_expiration = 0

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -9,10 +9,9 @@ For local development using a private key file:
   GOOGLE_APPLICATION_CREDENTIALS=`pwd`/api/sa-key.json python client/py/aou_workbench_client/auth.py
 """
 
-import logging
 import time
 
-from oauth2client.client import GoogleCredentials, ApplicationDefaultCredentialsError
+from oauth2client.client import GoogleCredentials
 
 from swagger_client.api_client import ApiClient
 

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -15,7 +15,7 @@ _METADATA_URL = (
 _METADATA_HEADER = {'Metadata-Flavor': 'Google'}
 _TOKEN_INFO_URL_T = 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=%s'
 # TODO(markfickett) Get workbench host dynamically based on environment.
-_WORKBENCH_API_HOST = 'https://all-of-us-workbench-test.appspot.com/'
+_WORKBENCH_API_HOST = 'https://api-dot-all-of-us-workbench-test.appspot.com/'
 
 
 # Note that we use custom cache management because cachetools.TTLCache (for example) uses a

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -28,7 +28,7 @@ def get_authenticated_swagger_client(force=False):
     global _token_expiration
     if _cached_client is None:
         _cached_client = ApiClient()
-    if force or (time.time() >= _token_expiration_time):
+    if force or (time.time() >= _token_expiration):
         token, _token_expiration = _get_bearer_token_and_expiration()
         _cached_client.set_default_header(name, value)
     return _cached_client
@@ -48,7 +48,7 @@ def _query_metadata_api():
     # the request.
     t = int(time.time())
 
-    respones = urllib2.urlopen(urllib2.Request(url=_METADATA_URL, headers=_METADATA_HEADER))
+    response = urllib2.urlopen(urllib2.Request(url=_METADATA_URL, headers=_METADATA_HEADER))
     response_json = json.loads(response.read())
     return response_json['access_token'], t + response_json['expires_in']
 
@@ -69,3 +69,14 @@ def clear_cache():
     global _token_expiration
     _cached_client = None
     _token_expiration = 0
+
+
+if __name__ == '__main__':
+    # Self-test: Print tokens from each source.
+    print 'Metadata API'
+    try:
+        print _query_metadata_api()
+    except urllib2.URLError as e:
+        print 'unavailable:', e
+    print 'print-access-token'
+    print _run_print_access_token()

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -19,7 +19,6 @@ from swagger_client.api_client import ApiClient
 CLIENT_OAUTH_SCOPES = (
       'https://www.googleapis.com/auth/userinfo.profile',
       'https://www.googleapis.com/auth/userinfo.email',
-      'https://www.googleapis.com/auth/cloud-billing',
 )
 
 

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -77,18 +77,18 @@ def clear_cache():
 # Self-test / simple example.
 if __name__ == '__main__':
     # Print tokens from each source.
-    print 'Metadata API'
+    print 'Trying to get token via Metadata API (works only in VM).'
     try:
         print _query_metadata_api()
     except urllib2.URLError as e:
         print 'unavailable:', e
-    print 'print-access-token'
+    print 'Trying print-access-token (works when `gcloud auth login` is done previously).'
     print _run_print_access_token()
 
     # Make an example API call.
+    print 'Listing workspaces via authenticated API:'
     from swagger_client.apis.workspaces_api import WorkspacesApi
     client = WorkspacesApi(api_client=get_authenticated_swagger_client())
     workspace_list = client.get_workspaces()
-    print 'Workspaces:'
     for ws in workspace_list.items:
         print '%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description)

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -6,7 +6,10 @@ The credentials are obtained by oauth2client, from one of:
 
 For local development using a private key file:
   api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
-  GOOGLE_APPLICATION_CREDENTIALS=`pwd`/api/sa-key.json python client/py/aou_workbench_client/auth.py
+  GOOGLE_APPLICATION_CREDENTIALS=`pwd`/api/sa-key.json
+  python client/py/aou_workbench_client/auth.py
+TODO(RW-32) Once available, switch to fetching the user's pet service account key (as will be used
+in notebooks), instead of the application service account key.
 """
 
 import time

--- a/client/py/requirements.txt
+++ b/client/py/requirements.txt
@@ -1,0 +1,1 @@
+oauth2client>=4.0.0


### PR DESCRIPTION
This is a first sketch of how auth will work. I think metadata API + fallback on gcloud will stay, but it might well move around. This lets us exercise the Swagger-generated Python client lib and verify that it can talk to the API (from dev workstations or from GCP VMs).

I plan to add tests before submitting, but would like y'all's feedback on the approach.