### PR TITLE
Cleanup in API Ruby: Use Dir.chdir context guard, common.run_inline. Use spawn() for all of Workbench.

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -10,9 +10,11 @@ require "fileutils"
 class Options < OpenStruct
 end
 
-def create_parser(command)
+# Creates a default command-line argument parser.
+# command_name: For help text.
+def create_parser(command_name)
   OptionParser.new do |parser|
-    parser.banner = "Usage: ./project.rb #{command} [options]"
+    parser.banner = "Usage: ./project.rb #{command_name} [options]"
     parser
   end
 end
@@ -244,8 +246,8 @@ def get_auth_login_account()
   return `gcloud config get-value account`.strip()
 end
 
-def run_with_creds(args, command, proc)
-  parser = create_parser(command)
+def run_with_creds(args, command_name, proc)
+  parser = create_parser(command_name)
   options = Options.new
   add_default_options parser, options
   parser.parse args
@@ -290,8 +292,8 @@ def do_run_with_creds(project, account, creds_file, proc)
   end
 end
 
-def run_with_cloud_sql_proxy(args, command, proc)
-  run_with_creds(args, command, lambda { |project, account, creds_file|
+def run_with_cloud_sql_proxy(args, command_name, proc)
+  run_with_creds(args, command_name, lambda { |project, account, creds_file|
     pid = run_cloud_sql_proxy(project, creds_file)
     begin
       proc.call(project, account, creds_file)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -220,8 +220,10 @@ def do_run_migrations(creds_file, project)
   end
   ENV["DB_PORT"] = "3307"
   puts "Upgrading database..."
-  unless system("cd db && ../gradlew --info update && cd ..")
-    raise("Error upgrading database. Exiting.")
+  Dir.chdir("db") do
+    unless system("../gradlew --info update")
+      raise("Error upgrading database. Exiting.")
+    end
   end
 end
 
@@ -307,8 +309,10 @@ def register_service_account(*args)
   run_with_creds(args, "register-service-account", lambda { |project, account, creds_file|
     common = Common.new
     ENV["GOOGLE_APPLICATION_CREDENTIALS"] = creds_file
-    system("cd ../firecloud-tools &&  ./run.sh " \
-      "register_service_account/register_service_account.py -j #{creds_file} -o #{account}")
+    Dir.chdir("../firecloud-tools") do
+      system("./run.sh " \
+        "register_service_account/register_service_account.py -j #{creds_file} -o #{account}")
+    end
   })
 end
 
@@ -330,8 +334,10 @@ def update_cloud_config(*args)
   run_with_cloud_sql_proxy(args, "connect-to-cloud-db", lambda { |project, account, creds_file|
     read_db_vars(creds_file, project)
     ENV["DB_PORT"] = "3307"
-    unless system("cd tools && ../gradlew --info loadConfig && cd ..")
-        raise("Error updating configuration. Exiting.")
+    Dir.chdir("tools") do
+      unless system("../gradlew --info loadConfig")
+          raise("Error updating configuration. Exiting.")
+      end
     end
   })
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1,6 +1,6 @@
 # Calls to common.run_inline in this file may use a quoted string purposefully
-# to cause system() to run the command in a shell. Calls with %W{..} are not
-# run in a shell, which can break usage of the CloudSQL proxy.
+# to cause system() or spawn() to run the command in a shell. Calls with arrays
+# are not run in a shell, which can break usage of the CloudSQL proxy.
 
 require_relative "../../libproject/utils/common"
 require_relative "../../libproject/workbench"

--- a/libproject/workbench.rb
+++ b/libproject/workbench.rb
@@ -25,6 +25,7 @@ module Workbench
   module_function :ensure_git_hooks
 
   def handle_argv_or_die(main_filename)
+    ENV["PROJECTRB_DEBUG"] = "true"  # Use spawn() instead of system() so stderr shows up.
     common = Common.new
     Dir.chdir(File.dirname(main_filename))
 


### PR DESCRIPTION
Clean rollforward of #184, rolled back in #186. (I believe the error was actually caused by #181, fixed separately in #187.)