### PR TITLE
Pin com.google.cloud:google-cloud-bigquery to 0.25.0-beta

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -183,7 +183,7 @@ dependencies {
   compile 'joda-time:joda-time:+'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
-  compile 'com.google.cloud:google-cloud-bigquery:+'
+  compile 'com.google.cloud:google-cloud-bigquery:0.25.0-beta'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.+'


### PR DESCRIPTION
Required for now; 0.26 contains breaking changes.