### PR TITLE
Exclude slf4j as per:

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -167,6 +167,7 @@ dependencies {
   compile 'com.google.appengine:appengine-api-1.0-sdk:+'
   compile('org.springframework.boot:spring-boot-starter-web:+') {
     exclude module: 'spring-boot-starter-tomcat'
+    exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
   compile 'org.springframework.boot:spring-boot-starter-actuator:+'
   compile 'org.springframework.security:spring-security-web:+'


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/appengine-standard-java8/springboot-appengine-standard

Hopefully this will get Spring Boot startup logging going to Cloud Console.