### PR TITLE
Remove multiple codegens on UI startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           working_directory: ~/workbench/ui
           command: |
-            npm test  -- --no-watch
+            npm codegen && npm test  -- --no-watch
       - deploy:
           name: Deploy to gcloud test project
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           working_directory: ~/workbench/ui
           command: |
-            npm codegen && npm test  -- --no-watch
+            npm run codegen && npm test  -- --no-watch
       - deploy:
           name: Deploy to gcloud test project
           command: |

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
-    command: npm start -- --host=0.0.0.0 ${ENV_FLAG}
+    command: npm run ng serve -- --host=0.0.0.0 ${ENV_FLAG}
     ports:
       - 4200:4200
   tests:
@@ -17,6 +17,6 @@ services:
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
-    command: npm test
+    command: npm run ng test
     ports:
       - 9876:9876

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
-    command: npm run ng serve -- --host=0.0.0.0 ${ENV_FLAG}
+    command: npm start -- --host=0.0.0.0 ${ENV_FLAG}
     ports:
       - 4200:4200
   tests:
@@ -17,6 +17,6 @@ services:
     working_dir: /w/ui
     volumes:
       - ..:/w:cached
-    command: npm run ng test
+    command: npm test
     ports:
       - 9876:9876

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,9 +4,9 @@
   "license": "BSD",
   "scripts": {
     "ng": "ng",
-    "start": "npm run codegen && ng serve",
-    "build": "npm run codegen && ng build",
-    "test": "npm run codegen && ng test",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "codegen-clean": "rm -rf src/generated",


### PR DESCRIPTION
We had previously been running our swagger codegen three times on startup, once in the ruby script, and then once on each of `npm start` and `npm test`. This fixes that issue.