### PR TITLE
Removing entities only refires requests if it has to

### DIFF
--- a/ui/src/app/cohort-search/redux/actions/service.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.ts
@@ -11,6 +11,7 @@ import {
   activeGroupId,
   activeRole,
   isCriteriaLoading,
+  isRequesting,
   getItem,
   getGroup,
   getSearchRequest,
@@ -82,6 +83,9 @@ export class CohortSearchActions {
     return this.ngRedux.getState();
   }
 
+  debugDir(obj) {if (environment.debug) { console.dir(obj); }}
+  debugLog(msg) {if (environment.debug) { console.log(msg); }}
+
   /* Higher order actions - actions composed of other actions or providing
    * alternate interfaces for a simpler action.
    */
@@ -96,43 +100,63 @@ export class CohortSearchActions {
     this.setActiveContext({itemId});
   }
 
-  removeGroup(role: keyof SearchRequest, groupId: string): void {
-    console.log(`Removing Group ${groupId} in ${role}`);
-    const group = getGroup(groupId)(this.state);
-
-    /* Cancel the Group Request Itself */
-    if (group.get('isRequesting', false)) {
-      this.cancelCountRequest('group', groupId);
+  cancelIfRequesting(kind, id) {
+    if (isRequesting(kind, id)(this.state)) {
+      this.cancelCountRequest(kind, id);
     }
+  }
 
-    /* If there are any child items, cancel their requests and delete them */
-    group.get('items', List()).forEach(itemId => {
-      this.removeGroupItem(role, groupId, itemId);
-    });
+  removeGroup(role: keyof SearchRequest, groupId: string): void {
+    const group = getGroup(groupId)(this.state);
+    this.debugLog(`Removing ${groupId} of ${role}:`);
+    this.debugDir(group);
 
-    /* Refires the Totals request without the group */
+    this.cancelIfRequesting('groups', groupId);
+
     this._removeGroup(role, groupId);
     this._removeId(groupId);
-    this.requestTotalCount();
+
+    group.get('items', List()).forEach(itemId => {
+      this.cancelIfRequesting('items', itemId);
+      this._removeGroupItem(groupId, itemId);
+      this._removeId(itemId);
+    });
+
+    const hasItems = !group.get('items', List()).isEmpty();
+    if (hasItems) {
+      this.requestTotalCount();
+    }
   }
 
   removeGroupItem(role: keyof SearchRequest, groupId: string, itemId: string): void {
     const item = getItem(itemId)(this.state);
-    /* Cancel the item request itself */
-    if (item.get('isRequesting', false)) {
-      this.cancelCountRequest('item', itemId);
-    }
+    const hasItems = !item.get('searchParameters', List()).isEmpty();
+    const countIsNonZero = item.get('count') !== 0;
+    // The optimization wherein we only fire the request if the item
+    // has a non-zero count (i.e. it affects its group and hence the total
+    // counts) ONLY WORKS if the item is NOT an only child.
+    const isOnlyChild = (getGroup(groupId)(this.state))
+      .get('items', List())
+      .equals(List([itemId]));
 
-    /* Remove any criterion associated with the item */
+    this.debugLog(`Removing ${itemId} of ${groupId}:`);
+    this.debugDir(item);
+    this.debugLog(
+      `hasItems: ${hasItems}, countIsNonZero: ${countIsNonZero}, isOnlyChild: ${isOnlyChild}`
+    );
+
+    this.cancelIfRequesting('items', itemId);
+    this._removeGroupItem(groupId, itemId);
+    this._removeId(itemId);
+
     item.get('searchParameters', List()).forEach(id => {
       this._removeCriterion(itemId, id);
     });
 
-    /* Refire the group and total requests now without the item */
-    this._removeGroupItem(groupId, itemId);
-    this._removeId(itemId);
-    this.requestGroupCount(role, groupId);
-    this.requestTotalCount();
+    if (hasItems && (countIsNonZero || isOnlyChild)) {
+      this.requestGroupCount(role, groupId);
+      this.requestTotalCount();
+    }
   }
 
   removeCriterion(
@@ -217,6 +241,8 @@ export class CohortSearchActions {
       this.cancelCountRequest('searchRequests', SR_ID);
     }
     const request = this.mapAll();
+    // TODO(jms) if the request is completely empty, the total count will be
+    // zero: just set it to zero
     this.requestCounts('searchRequests', SR_ID, request);
   }
 

--- a/ui/src/app/cohort-search/redux/reducer.ts
+++ b/ui/src/app/cohort-search/redux/reducer.ts
@@ -122,6 +122,7 @@ export const rootReducer: Reducer<CohortSearchState> =
         return state
           .updateIn(
             ['entities', 'groups', action.groupId, 'items'],
+            List(),
             itemList => itemList.filterNot(id => id === action.itemId)
           )
           .deleteIn(['entities', 'items', action.itemId]);
@@ -130,6 +131,7 @@ export const rootReducer: Reducer<CohortSearchState> =
         return state
           .updateIn(
             ['entities', 'searchRequests', SR_ID, action.role],
+            List(),
             groupList => groupList.filterNot(id => id === action.groupId)
           )
           .deleteIn(['entities', 'groups', action.groupId]);
@@ -138,6 +140,7 @@ export const rootReducer: Reducer<CohortSearchState> =
         return state
           .updateIn(
             ['entities', 'items', action.itemId, 'searchParameters'],
+            List(),
             critList => critList.filterNot(id => id === action.criterionId)
           )
           .deleteIn(['entities', 'criteria', action.criterionId]);


### PR DESCRIPTION
Currently requests in the "outer scope" of an entity (SearchGroupItem, SearchGroup) are re-fired upon every addition or removal of a SearchGroupItem or SearchGroup to the SearchRequest. If the count for an removed entity is 0 or if the entity has no constituents (and hence no count) we would rather not fire a request when it is deleted so that we can (A) avoid the network overhead and (B) minimize the amount of time interesting numbers are obscured from the user by spinners - i.e., at the moment removing an empty group obscures the total count.