### PR TITLE
[RW-183] Create WorkspaceService to handle research purpose review.

### DIFF
--- a/api/db/changelog/db.changelog-8-ws-index.xml
+++ b/api/db/changelog/db.changelog-8-ws-index.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="markfickett" id="changelog-8-ws-index">
+    <createIndex
+        indexName="idx_workspace_rp"
+        tableName="workspace"
+        unique="true">
+      <column name="rp_review_requested"/>
+      <column name="rp_approved"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -15,4 +15,5 @@
   <include file="changelog/db.changelog-5-authority.xml"/>
   <include file="changelog/db.changelog-6.xml"/>
   <include file="changelog/db.changelog-7.xml"/>
+  <include file="changelog/db.changelog-8-ws-index.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/Application.java
+++ b/api/src/main/java/org/pmiops/workbench/Application.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class Application {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.db.dao.CohortDao;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -61,15 +61,18 @@ public class CohortsController implements CohortsApiDelegate {
         }
       };
 
-  private final WorkspaceDao workspaceDao;
+  private final WorkspaceService workspaceService;
   private final CohortDao cohortDao;
   private final Provider<User> userProvider;
   private final Clock clock;
 
   @Autowired
-  CohortsController(WorkspaceDao workspaceDao, CohortDao cohortDao, Provider<User> userProvider,
+  CohortsController(
+      WorkspaceService workspaceService,
+      CohortDao cohortDao,
+      Provider<User> userProvider,
       Clock clock) {
-    this.workspaceDao = workspaceDao;
+    this.workspaceService = workspaceService;
     this.cohortDao = cohortDao;
     this.userProvider = userProvider;
     this.clock = clock;
@@ -78,7 +81,7 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> createCohort(String workspaceNamespace, String workspaceId,
       Cohort cohort) {
-    Workspace workspace = getDbWorkspace(workspaceNamespace, workspaceId);
+    Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     org.pmiops.workbench.db.model.Cohort dbCohort = FROM_CLIENT_COHORT.apply(cohort);
     dbCohort.setCreator(userProvider.get());
@@ -118,7 +121,7 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<CohortListResponse> getCohortsInWorkspace(String workspaceNamespace,
       String workspaceId) {
-    Workspace workspace = getDbWorkspace(workspaceNamespace, workspaceId);
+    Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
     CohortListResponse response = new CohortListResponse();
     List<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
     if (cohorts != null) {
@@ -151,23 +154,9 @@ public class CohortsController implements CohortsApiDelegate {
     return ResponseEntity.ok(TO_CLIENT_COHORT.apply(dbCohort));
   }
 
-  /**
-   * Gets or creates a workspace with the given namespace and ID.
-   * (In future it will throw NotFoundException if the workspace wasn't created previously.)
-   */
-  private Workspace getDbWorkspace(String workspaceNamespace, String workspaceId) {
-    Workspace workspace = workspaceDao.findByWorkspaceNamespaceAndFirecloudName(workspaceNamespace,
-        workspaceId);
-    if (workspace == null) {
-      throw new NotFoundException("No workspace with name {0}/{1}"
-          .format(workspaceNamespace, workspaceId));
-    }
-    return workspace;
-  }
-
   private org.pmiops.workbench.db.model.Cohort getDbCohort(String workspaceName,
       String workspaceId, String cohortId) {
-    Workspace workspace = getDbWorkspace(workspaceName, workspaceId);
+    Workspace workspace = workspaceService.getRequired(workspaceName, workspaceId);
 
     org.pmiops.workbench.db.model.Cohort cohort =
         cohortDao.findOne(convertCohortId(cohortId));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -196,7 +196,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
     FirecloudWorkspaceId workspaceId = generateFirecloudWorkspaceId(workspace.getNamespace(),
         workspace.getName());
-    org.pmiops.workbench.db.model.Workspace existingWorkspace = workspaceService.dao.get(
+    org.pmiops.workbench.db.model.Workspace existingWorkspace = workspaceService.get(
         workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
     if (existingWorkspace != null) {
       throw new BadRequestException(String.format(
@@ -292,8 +292,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
   public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
     WorkspaceListResponse response = new WorkspaceListResponse();
-    List<org.pmiops.workbench.db.model.Workspace> workspaces =
-        workspaceService.dao.findForReview();
+    List<org.pmiops.workbench.db.model.Workspace> workspaces = workspaceService.findForReview();
     response.setItems(workspaces.stream().map(TO_CLIENT_WORKSPACE).collect(Collectors.toList()));
     return ResponseEntity.ok(response);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -10,6 +10,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
@@ -18,6 +24,7 @@ import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -25,9 +32,6 @@ import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.Workspace.DataAccessLevelEnum;
 import org.pmiops.workbench.model.WorkspaceListResponse;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
@@ -278,14 +282,14 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   /** Record approval or rejection of research purpose. */
-  // Auth
+  @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
   public ResponseEntity<EmptyResponse> reviewWorkspace(
       String ns, String id, ResearchPurposeReviewRequest review) {
     workspaceService.setResearchPurposeApproved(ns, id, review.getApproved());
     return ResponseEntity.ok(new EmptyResponse());
   }
 
-  // Auth
+  @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
   public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
     WorkspaceListResponse response = new WorkspaceListResponse();
     List<org.pmiops.workbench.db.model.Workspace> workspaces =

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -289,6 +289,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     return ResponseEntity.ok(new EmptyResponse());
   }
 
+
+  // Note we do not paginate the workspaces list, since we expect few workspaces
+  // to require review.
+  //
+  // We can add pagination in the DAO by returning Slice<Workspace> if we want the method to return
+  // pagination information (e.g. are there more workspaces to get), and Page<Workspace> if we
+  // want the method to return both pagination information and a total count.
   @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
   public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
     WorkspaceListResponse response = new WorkspaceListResponse();

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -293,7 +293,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
     WorkspaceListResponse response = new WorkspaceListResponse();
     List<org.pmiops.workbench.db.model.Workspace> workspaces =
-        = workspaceService.dao.findForReview();
+        workspaceService.dao.findForReview();
     response.setItems(workspaces.stream().map(TO_CLIENT_WORKSPACE).collect(Collectors.toList()));
     return ResponseEntity.ok(response);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -158,13 +158,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       try {
         CdrVersion cdrVersion = cdrVersionDao.findOne(Long.parseLong(workspace.getCdrVersionId()));
         if (cdrVersion == null) {
-          throw new BadRequestException("CDR version with ID {0} not found"
-              .format(workspace.getCdrVersionId()));
+          throw new BadRequestException(
+              String.format("CDR version with ID %s not found", workspace.getCdrVersionId()));
         }
         dbWorkspace.setCdrVersion(cdrVersion);
       } catch (NumberFormatException e) {
-        throw new BadRequestException("Invalid cdr version ID: {0}"
-            .format(workspace.getCdrVersionId()));
+        throw new BadRequestException(String.format(
+            "Invalid cdr version ID: %s", workspace.getCdrVersionId()));
       }
     }
   }
@@ -195,7 +195,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     org.pmiops.workbench.db.model.Workspace existingWorkspace = workspaceService.dao.get(
         workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
     if (existingWorkspace != null) {
-      throw new BadRequestException("Workspace {0}/{1} already exists".format(
+      throw new BadRequestException(String.format(
+          "Workspace %s/%s already exists",
           workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName()));
     }
     try {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -18,7 +18,9 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.Workspace.DataAccessLevelEnum;
 import org.pmiops.workbench.model.WorkspaceListResponse;
@@ -189,8 +191,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
     FirecloudWorkspaceId workspaceId = generateFirecloudWorkspaceId(workspace.getNamespace(),
         workspace.getName());
-    org.pmiops.workbench.db.model.Workspace existingWorkspace =
-        workspaceService.get(workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
+    org.pmiops.workbench.db.model.Workspace existingWorkspace = workspaceService.dao.get(
+        workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
     if (existingWorkspace != null) {
       throw new BadRequestException("Workspace {0}/{1} already exists".format(
           workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName()));
@@ -273,9 +275,17 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     return ResponseEntity.ok(TO_CLIENT_WORKSPACE.apply(dbWorkspace));
   }
 
+  /** Record approval or rejection of research purpose. */
   public ResponseEntity<EmptyResponse> reviewWorkspace(
       String ns, String id, ResearchPurposeReviewRequest review) {
     workspaceService.setResearchPurposeApproved(ns, id, review.getApproved());
     return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
+    WorkspaceListResponse response = new WorkspaceListResponse();
+    // FIXME
+    //response.setItems(workspaces.stream().map(TO_CLIENT_WORKSPACE).collect(Collectors.toList()));
+    return ResponseEntity.ok(response);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -278,16 +278,19 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   /** Record approval or rejection of research purpose. */
+  // Auth
   public ResponseEntity<EmptyResponse> reviewWorkspace(
       String ns, String id, ResearchPurposeReviewRequest review) {
     workspaceService.setResearchPurposeApproved(ns, id, review.getApproved());
     return ResponseEntity.ok(new EmptyResponse());
   }
 
+  // Auth
   public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
     WorkspaceListResponse response = new WorkspaceListResponse();
-    // FIXME
-    //response.setItems(workspaces.stream().map(TO_CLIENT_WORKSPACE).collect(Collectors.toList()));
+    List<org.pmiops.workbench.db.model.Workspace> workspaces =
+        = workspaceService.dao.findForReview();
+    response.setItems(workspaces.stream().map(TO_CLIENT_WORKSPACE).collect(Collectors.toList()));
     return ResponseEntity.ok(response);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/README.md
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/README.md
@@ -1,2 +1,6 @@
 DAOs' query implementations are
 [automatically derived](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.details).
+
+Services implement custom behavior which can't be auto-generated. Where both a
+Service and a DAO are available, inject the Service and use its public dao field
+where necessary. [Design doc](https://docs.google.com/document/d/1uNf6_5TZxnQt8BP_wWoGxPcGwaIZAhZswW3bXwbswHU).

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -10,15 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 /**
  * Declaration of automatic query methods for Workspaces. The methods declared here are
  * automatically interpreted by Spring Data (see README).
+ *
+ * Use of @Query is discouraged; if desired, define aliases in WorkspaceService.
  */
 public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
-  @Query("SELECT w FROM Workspace w WHERE w.workspaceNamespace = ?1 AND w.firecloudName = ?2")
-  Workspace get(String workspaceNamespace, String firecloudName);
-
+  Workspace findByWorkspaceNamespaceAndFirecloudName(
+      String workspaceNamespace, String firecloudName);
   List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
-
   List<Workspace> findByCreatorOrderByNameAsc(User creator);
-
-  @Query("SELECT w FROM Workspace w WHERE w.approved IS NULL AND w.reviewRequested = true")
-  List<Workspace> findForReview();
+  List<Workspace> findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -11,8 +11,10 @@ import org.springframework.data.repository.CrudRepository;
  * automatically interpreted by Spring Data (see README).
  */
 public interface WorkspaceDao extends CrudRepository<Workspace, Long>, WorkspaceDaoCustom {
+  @Query("SELECT w FROM Workspace w WHERE w.workspaceNamespace = ?1 AND w.firecloudName = ?2")
+  Workspace get(String workspaceNamespace, String firecloudName);
+
   List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
-  Workspace findByWorkspaceNamespaceAndFirecloudName(String workspaceNamespace,
-      String firecloudName);
+
   List<Workspace> findByCreatorOrderByNameAsc(User creator);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -19,6 +19,6 @@ public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
 
   List<Workspace> findByCreatorOrderByNameAsc(User creator);
 
-  @Query("SELECT w FROM Workspace w WHERE w.approved IS NULL AND w.reviewRequested = true");
+  @Query("SELECT w FROM Workspace w WHERE w.approved IS NULL AND w.reviewRequested = true")
   List<Workspace> findForReview();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -5,7 +5,12 @@ import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.data.repository.CrudRepository;
 
-public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
+
+/**
+ * Declaration of automatic query methods for Workspaces. The methods declared here are
+ * automatically interpreted by Spring Data (see README).
+ */
+public interface WorkspaceDao extends CrudRepository<Workspace, Long>, WorkspaceDaoCustom {
   List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
   Workspace findByWorkspaceNamespaceAndFirecloudName(String workspaceNamespace,
       String firecloudName);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -4,13 +4,14 @@ import java.util.List;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 /**
  * Declaration of automatic query methods for Workspaces. The methods declared here are
  * automatically interpreted by Spring Data (see README).
  */
-public interface WorkspaceDao extends CrudRepository<Workspace, Long>, WorkspaceDaoCustom {
+public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
   @Query("SELECT w FROM Workspace w WHERE w.workspaceNamespace = ?1 AND w.firecloudName = ?2")
   Workspace get(String workspaceNamespace, String firecloudName);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -18,4 +18,7 @@ public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
   List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
 
   List<Workspace> findByCreatorOrderByNameAsc(User creator);
+
+  @Query("SELECT w FROM Workspace w WHERE w.approved IS NULL AND w.reviewRequested = true");
+  List<Workspace> findForReview();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -1,17 +1,20 @@
 package org.pmiops.workbench.db.dao;
 
+import java.util.List;
 import java.util.logging.Logger;
-import org.pmiops.workbench.db.model.Workspace;
-import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.exceptions.NotFoundException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.NotFoundException;
+
 
 /**
  * Workspace manipulation and shared business logic which can't be represented by automatic query
- * generation in WorkspaceDao or @Query annotations.
+ * generation in WorkspaceDao, or convenience aliases.
  *
  * TODO(RW-215) Add versioning to detect/prevent concurrent edits.
  */
@@ -30,12 +33,20 @@ public class WorkspaceService {
     this.dao = workspaceDao;
   }
 
+  public Workspace get(String ns, String id) {
+    return dao.findByWorkspaceNamespaceAndFirecloudName(ns, id);
+  }
+
   public Workspace getRequired(String ns, String id) {
-    Workspace workspace = dao.get(ns, id);
+    Workspace workspace = get(ns, id);
     if (workspace == null) {
       throw new NotFoundException(String.format("Workspace %s/%s not found.", ns, id));
     }
     return workspace;
+  }
+
+  public List<Workspace> findForReview() {
+    return dao.findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();
   }
 
   // FIXME @Version instead? Bean instantiation v. @Transactional?

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -33,7 +33,7 @@ public class WorkspaceService {
   public Workspace getRequired(String ns, String id) {
     Workspace workspace = dao.get(ns, id);
     if (workspace == null) {
-      throw new NotFoundException("Workspace {0}/{1} not found".format(ns, id));
+      throw new NotFoundException(String.format("Workspace %s/%s not found.", ns, id));
     }
     return workspace;
   }
@@ -43,10 +43,12 @@ public class WorkspaceService {
   public void setResearchPurposeApproved(String ns, String id, boolean approved) {
     Workspace workspace = getRequired(ns, id);
     if (workspace.getReviewRequested() == null || !workspace.getReviewRequested()) {
-      throw new BadRequestException("No review requested for workspace {0}/{1}.".format(ns, id));
+      throw new BadRequestException(String.format(
+          "No review requested for workspace %s/%s.", ns, id));
     }
     if (workspace.getApproved() != null) {
-      throw new BadRequestException("Workspace {0}/{1} already {3}.".format(
+      throw new BadRequestException(String.format(
+          "Workspace %s/%s already %s.",
           ns, id, workspace.getApproved() ? "approved" : "rejected"));
     }
     workspace.setApproved(approved);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -43,7 +43,7 @@ public class WorkspaceService {
     if (workspace.getReviewRequested() == null || !workspace.getReviewRequested()) {
       throw new BadRequestException("No review requested for workspace {0}/{1}.".format(ns, id));
     }
-    if (workspace.getApproved != null) {
+    if (workspace.getApproved() != null) {
       throw new BadRequestException("Workspace {0}/{1} already {3}.".format(
           ns, id, workspace.getApproved() ? "approved" : "rejected"));
     }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -26,7 +26,7 @@ public class WorkspaceService {
   public final WorkspaceDao dao;
 
   @Autowired
-  WorkspaceService(WorkspaceDao workspaceDao) {
+  public WorkspaceService(WorkspaceDao workspaceDao) {
     this.dao = workspaceDao;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -1,0 +1,42 @@
+package org.pmiops.workbench.api;
+
+import java.util.logging.Logger;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+/**
+ * Workspace manipulation and shared business logic which can't be represented by automatic query
+ * generation in WorkspaceDao or @Query annotations.
+ */
+public class WorkspaceService {
+  private static final Logger log = Logger.getLogger(WorkspaceService.class.getName());
+
+  /**
+   * Clients wishing to use the auto-generated methods from the DAO interface may directly access
+   * it here.
+   */
+  public final WorkspaceDao dao;
+
+  @Autowired
+  WorkspaceService(WorkspaceDao workspaceDao) {
+    this.dao = workspaceDao;
+  }
+
+  public Workspace get(String workspaceNamespace, String workspaceId) {
+    return dao.findByWorkspaceNamespaceAndFirecloudName(workspaceNamespace, workspaceId);
+  }
+
+  public Workspace getRequired(String ns, String id) {
+    Workspace workspace = get(ns, id);
+    if (workspace == null) {
+      throw new NotFoundException("Workspace {0}/{1} not found".format(ns, id));
+    }
+    return workspace;
+  }
+
+  public void setResearchPurposeApproved(String ns, String id, boolean approved) {
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -5,6 +5,7 @@ import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * TODO(RW-215) Add versioning to detect/prevent concurrent edits.
  */
+@Service
 public class WorkspaceService {
   private static final Logger log = Logger.getLogger(WorkspaceService.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -38,7 +38,8 @@ public class WorkspaceService {
     return workspace;
   }
 
-  @Transactional
+  // FIXME @Version instead? Bean instantiation v. @Transactional?
+  //@Transactional
   public void setResearchPurposeApproved(String ns, String id, boolean approved) {
     Workspace workspace = getRequired(ns, id);
     if (workspace.getReviewRequested() == null || !workspace.getReviewRequested()) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -1,7 +1,6 @@
-package org.pmiops.workbench.api;
+package org.pmiops.workbench.db.dao;
 
 import java.util.logging.Logger;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -292,20 +292,6 @@ public class Workspace {
     this.approved = approved;
   }
 
-  /**
-   * Record research purpose approval. Throw if already approved/denied.
-   * Use setApproved(boolean) for access with minimal validation (ex: backfill scripts).
-   */
-  public void setApprovedUnique(boolean approved) {
-    if (getReviewRequested() == null || getReviewRequested()) {
-      throw new IllegalStateException("No review requsted for research purpose.");
-    }
-    if (dbWorkspace.getApproved() != null) {
-      throw new IllegalStateException("Research purpose approval already recorded.");
-    }
-    setApproved(approved);
-  }
-
   @Column(name = "rp_time_requested")
   public Timestamp getTimeRequested() {
     return this.timeRequested;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -292,6 +292,20 @@ public class Workspace {
     this.approved = approved;
   }
 
+  /**
+   * Record research purpose approval. Throw if already approved/denied.
+   * Use setApproved(boolean) for access with minimal validation (ex: backfill scripts).
+   */
+  public void setApprovedUnique(boolean approved) {
+    if (getReviewRequested() == null || getReviewRequested()) {
+      throw new IllegalStateException("No review requsted for research purpose.");
+    }
+    if (dbWorkspace.getApproved() != null) {
+      throw new IllegalStateException("Research purpose approval already recorded.");
+    }
+    setApproved(approved);
+  }
+
   @Column(name = "rp_time_requested")
   public Timestamp getTimeRequested() {
     return this.timeRequested;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -17,9 +17,15 @@ import javax.persistence.Transient;
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
-@Table(name = "workspace",
-  indexes = {  @Index(name = "idx_workspace_fc_name", columnList = "firecloud_name",
-      unique = true)})
+@Table(
+    name = "workspace",
+    indexes = {
+        @Index(name = "idx_workspace_fc_name", columnList = "firecloud_name", unique = true),
+        @Index(
+            name = "idx_workspace_rp",
+            columnList = "rp_review_requested,rp_approved",
+            unique = true)
+    })
 public class Workspace {
 
   public static class FirecloudWorkspaceId {

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -17,15 +17,7 @@ import javax.persistence.Transient;
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
-@Table(
-    name = "workspace",
-    indexes = {
-        @Index(name = "idx_workspace_fc_name", columnList = "firecloud_name", unique = true),
-        @Index(
-            name = "idx_workspace_rp",
-            columnList = "rp_review_requested,rp_approved",
-            unique = true)
-    })
+@Table(name = "workspace")
 public class Workspace {
 
   public static class FirecloudWorkspaceId {

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -380,7 +380,42 @@ paths:
           type: string
           required: true
           description: ID of the workspace containing the cohort definition
-
+  /api/v1/workspaces/review:
+    get:
+      tags:
+        - workspaces
+      description: >
+          Returns workspaces that need research purpose review. Requires
+          REVIEW_RESEARCH_PURPOSE authority.
+      operationId: getWorkspacesForReview
+      responses:
+        "200":
+          schema:
+            $ref: "#/definitions/WorkspaceListResponse"
+  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review:
+    post:
+      tags:
+        - workspaces
+      description: Sets a research purpose review result.
+      operationId: reviewWorkspace
+      parameters:
+        - in: path
+          name: workspaceNamespace
+          type: string
+          required: true
+        - in: path
+          name: workspaceId
+          type: string
+          required: true
+        - in: body
+          name: review
+          description: result of the research purpose review
+          schema:
+            $ref: "#/definitions/ResearchPurposeReviewRequest"
+      responses:
+        "200":
+          schema:
+            $ref: "#/definitions/EmptyResponse"
 
   # Cohorts ##############################################################################
 
@@ -703,6 +738,14 @@ definitions:
         description: Milliseconds since the UNIX epoch.
       additionalNotes:
         type: string
+
+  ResearchPurposeReviewRequest:
+    description: Approve or reject a workspace's research purpose.
+    type: object
+    required: approve
+    properties:
+      approve:
+        type: boolean
 
   CohortListResponse:
     type: object
@@ -1063,6 +1106,7 @@ definitions:
         description: stack trace
         items:
           $ref: '#/definitions/StackTraceElement'
+
   StackTraceElement:
     description: ''
     required:
@@ -1083,6 +1127,7 @@ definitions:
       lineNumber:
         type: integer
         description: line number
+
   # TODO: Clean up the client representation of the cluster
   Cluster:
     description: ''
@@ -1111,6 +1156,7 @@ definitions:
       labels:
         type: object
         description: The labels to be placed on the cluster. Of type Map[String,String]
+
   ClusterListResponse:
     type: object
     required:
@@ -1120,6 +1166,7 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Cluster"
+
   UsernameTakenResponse:
     type: object
     required:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -742,9 +742,9 @@ definitions:
   ResearchPurposeReviewRequest:
     description: Approve or reject a workspace's research purpose.
     type: object
-    required: approve
+    required: approved
     properties:
-      approve:
+      approved:
         type: boolean
 
   CohortListResponse:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -33,8 +34,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 @AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 public class WorkspacesControllerTest {
 
-  @Autowired
   WorkspaceService workspaceService;
+  @Autowired
+  WorkspaceDao workspaceDao;
   @Autowired
   CdrVersionDao cdrVersionDao;
   @Autowired
@@ -56,6 +58,10 @@ public class WorkspacesControllerTest {
     user.setUserId(123L);
     user = userDao.save(user);
     when(userProvider.get()).thenReturn(user);
+
+    // Injecting WorkspaceService fails in the test environment. Work around it by injecting the
+    // DAO and creating the service directly.
+    workspaceService = new WorkspaceService(workspaceDao);
 
     this.workspacesController = new WorkspacesController(workspaceService, cdrVersionDao,
         userProvider, fireCloudService, Clock.fixed(NOW, ZoneId.systemDefault()));

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -34,7 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class WorkspacesControllerTest {
 
   @Autowired
-  WorkspaceDao workspaceDao;
+  WorkspaceService workspaceService;
   @Autowired
   CdrVersionDao cdrVersionDao;
   @Autowired
@@ -57,7 +57,7 @@ public class WorkspacesControllerTest {
     user = userDao.save(user);
     when(userProvider.get()).thenReturn(user);
 
-    this.workspacesController = new WorkspacesController(workspaceDao, cdrVersionDao,
+    this.workspacesController = new WorkspacesController(workspaceService, cdrVersionDao,
         userProvider, fireCloudService, Clock.fixed(NOW, ZoneId.systemDefault()));
   }
 

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -55,8 +55,12 @@ sourceSets {
        srcDirs = ['src/main/java', '../src/main/java', '../src/generated/java']
        includes = ['org/pmiops/workbench/tools/**/*.java',
                    'org/pmiops/workbench/db/**/*.java',
+                   // In general, command-line tools won't need access to
+                   // org.pmiops.workbench.model (Swagger-generated classes),
+                   // so we selectively whitelist as needed.
                    'org/pmiops/workbench/model/Authority.java',
-                   'org/pmiops/workbench/model/DataAccessLevel.java' ]
+                   'org/pmiops/workbench/model/DataAccessLevel.java',
+                   'org/pmiops/workbench/model/ErrorResponse.java' ]
     }
   }
 }


### PR DESCRIPTION
* Factor out WorkspaceService (wrapping WorkspaceDao).
* Combine copies of 'get workspace and throw if it doesn not exist'.
* Add methods for research purpose review, and associated tests.
* Incidental fix of string formatting in exception messages (in WS files only).

Following discussion captured in https://docs.google.com/document/d/1uNf6_5TZxnQt8BP_wWoGxPcGwaIZAhZswW3bXwbswHU about how to make more complicated stuff than Spring-Data repositories are set up for. Glad for feedback on that -- are the right things `@Query`s, using model objects, etc? Also curious what people think about doc links in READMEs.

This leaves a major TODO of RW-215, adding transactionality / entity versioning. I think that's likely to cause some further changes (especially in tests) because of how Spring annotation / instantiation works. We may also want to change it following more discussion of how to approach SQL. But, it should unblock development of UI for research purpose review (I don't expect the models or API to change substantially).