### PR TITLE
[RW-220] Remove superfluous Java declaration of index for User.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -19,8 +19,7 @@ import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
-@Table(name = "user",
-    indexes = {  @Index(name = "idx_user_email", columnList = "email", unique = true)})
+@Table(name = "user")
 public class User {
 
   private long userId;


### PR DESCRIPTION
Exists in XML as:
```
    <createIndex
        indexName="idx_user_email"
        tableName="user"
        unique="true">
      <column name="email"/>
```