### PR TITLE
[RW-217] Fix calls to String.format.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -94,9 +94,9 @@ public class CohortsController implements CohortsApiDelegate {
     } catch (DataIntegrityViolationException e) {
       // TODO The exception message doesn't show up anywhere; neither logged nor returned to the
       // client by Spring (the client gets a default reason string).
-      throw new BadRequestException(
-          "Cohort \"/%s/%s/%s\" already exists.".format(
-              workspaceNamespace, workspaceId, dbCohort.getCohortId()));
+      throw new BadRequestException(String.format(
+          "Cohort \"/%s/%s/%s\" already exists.",
+          workspaceNamespace, workspaceId, dbCohort.getCohortId()));
     }
     return ResponseEntity.ok(TO_CLIENT_COHORT.apply(dbCohort));
   }
@@ -161,8 +161,8 @@ public class CohortsController implements CohortsApiDelegate {
     org.pmiops.workbench.db.model.Cohort cohort =
         cohortDao.findOne(convertCohortId(cohortId));
     if (cohort == null) {
-      throw new NotFoundException("No cohort with name {0} in workspace {0}".format(cohortId,
-          workspace.getFirecloudName()));
+      throw new NotFoundException(String.format(
+          "No cohort with name %s in workspace %s.", cohortId, workspace.getFirecloudName()));
     }
     return cohort;
   }
@@ -171,7 +171,7 @@ public class CohortsController implements CohortsApiDelegate {
     try {
       return Long.parseLong(cohortId);
     } catch (NumberFormatException e) {
-      throw new BadRequestException("Invalid cohort ID: {0}".format(cohortId));
+      throw new BadRequestException(String.format("Invalid cohort ID: %s", cohortId));
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -106,7 +106,7 @@ public class ProfileController implements ProfileApiDelegate {
       fireCloudService.registerUser(user.getContactEmail(),
           user.getGivenName(), user.getFamilyName());
     } catch (ApiException e) {
-      log.log(Level.SEVERE, "Error registering user: {0}".format(e.getResponseBody()), e);
+      log.log(Level.SEVERE, String.format("Error registering user: %s", e.getResponseBody()), e);
       // We don't expect this to happen.
       throw new ServerErrorException("Error registering user", e);
     }
@@ -145,7 +145,9 @@ public class ProfileController implements ProfileApiDelegate {
             billingProjectName = billingProjectNamePrefix + "-" + numAttempts;
           }
         } else {
-          log.log(Level.SEVERE, "Error creating billing project: {0}".format(e.getResponseBody()),
+          log.log(
+              Level.SEVERE,
+              String.format("Error creating billing project: %s", e.getResponseBody()),
               e);
           throw new ServerErrorException("Error creating billing project", e);
         }
@@ -171,7 +173,7 @@ public class ProfileController implements ProfileApiDelegate {
         throw new ServerErrorException("Unable to add user to billing project", e);
       } else {
         log.log(Level.SEVERE,
-            "Error adding user to billing project: {0}".format(e.getResponseBody()),
+            String.format("Error adding user to billing project: %s", e.getResponseBody()),
             e);
         throw new ServerErrorException("Error adding user to billing project", e);
       }
@@ -313,7 +315,8 @@ public class ProfileController implements ProfileApiDelegate {
     try {
       return ResponseEntity.ok(profileService.getProfile(user));
     } catch (ApiException e) {
-      log.log(Level.SEVERE, "Error getting user profile: {0}".format(e.getResponseBody()), e);
+      log.log(
+          Level.SEVERE, String.format("Error getting user profile: %s", e.getResponseBody()), e);
       return ResponseEntity.status(e.getCode()).build();
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -302,7 +302,8 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Profile> register(RegistrationRequest registrationRequest) {
     User user = initializeUserIfNeeded();
     if (user.getDataAccessLevel() != DataAccessLevel.UNREGISTERED) {
-      throw new BadRequestException("User {0} is already registered".format(user.getEmail()));
+      throw new BadRequestException(String.format(
+          "User %s is already registered", user.getEmail()));
     }
     // TODO: add user to authorization domain for registered access; add pet SA to
     // Google group for CDR access

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -207,8 +207,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       fireCloudService.createWorkspace(workspaceId.getWorkspaceNamespace(),
           workspaceId.getWorkspaceName());
     } catch (org.pmiops.workbench.firecloud.ApiException e) {
-      log.log(Level.SEVERE, "Error creating FC workspace {0}/{1}: {2} ".format(
-          workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName(), e.getResponseBody()),
+      log.log(
+          Level.SEVERE,
+          String.format(
+              "Error creating FC workspace %s/%s: %s",
+              workspaceId.getWorkspaceNamespace(),
+              workspaceId.getWorkspaceName(),
+              e.getResponseBody()),
           e);
       // TODO: figure out what happens if the workspace already exists
       throw new ServerErrorException("Error creating FC workspace", e);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/QueryBuilderFactory.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/QueryBuilderFactory.java
@@ -40,7 +40,10 @@ public class QueryBuilderFactory {
      */
     public static AbstractQueryBuilder getQueryBuilder(FactoryKey key) {
         AbstractQueryBuilder queryBuilder = queryBuilderCache.get(key);
-        if(queryBuilder == null) throw new BadRequestException("Unknown queryBuilder type: {0}".format(key.name()));
+        if (queryBuilder == null) {
+            throw new BadRequestException(String.format(
+                "Unknown queryBuilder type: %s", key.name()));
+        }
         return queryBuilder;
     }
 }


### PR DESCRIPTION
In exceptions and log statements, convert `s.format(p)` to `String.format(s, p)`. `String.format` is a static function, so these instances were ignoring the string it was called on and just returning the first parameter.

This was mostly in exceptions, but also affected `Logger.log` calls which, when including a `Throwable` argument, require a pre-formatted string. (Only `Logger.log(String msg, Object param)` or `Logger.log(String msg, Object[] params)` can use the `Logger`-specific `{N}` style format strings.)