### PR TITLE
Add provisional Attribute defn to Swagger

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1077,10 +1077,15 @@ definitions:
         type: "array"
         items:
           type: string
-    example:
-      name: "age_at_event"
-      operator: "GTE"
-      operands: [ "Arg1", "Arg2" ]
+    examples:
+      singleValued:
+        name: "age_at_event"
+        operator: "GTE"
+        value: "20"
+      multiValued:
+        name: "age_at_event"
+        operator: "BETWEEN"
+        operands: ["18", "35"]
 
   # Mirrors notebooks definitions ###############################################
   ErrorReport:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1045,23 +1045,28 @@ definitions:
     type: object
     required:
       - operator
+      - operands
     properties:
       operator:
         type: string
-      value:
-        description: Unary operators use value
-        type: string
       operands:
-        description: N-ary operators use operands
         type: "array"
         items:
           type: string
+    examples:
+      singleValued:
+        operator: "GTE"
+        operands: ["20"]
+      multiValued:
+        operator: "BETWEEN"
+        operands: ["18", "35"]
 
   Modifier:
     type: object
     required:
       - name
       - operator
+      - operands
     properties:
       name:
         description: Semantic name of the operator
@@ -1069,11 +1074,7 @@ definitions:
       operator:
         description: Machine name of the operator
         type: string
-      value:
-        description: Unary operators use value
-        type: string
       operands:
-        description: N-ary operators use operands
         type: "array"
         items:
           type: string
@@ -1081,7 +1082,7 @@ definitions:
       singleValued:
         name: "age_at_event"
         operator: "GTE"
-        value: "20"
+        operands: ["20"]
       multiValued:
         name: "age_at_event"
         operator: "BETWEEN"

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1028,6 +1028,11 @@ definitions:
         description: The concept id that maps to concept table.
         type: integer
         format: int64
+      attributes:
+        description: Any applicable arguments that complete the sense of the parameter
+        type: "array"
+        items:
+          $ref: "#/definitions/Attribute"
     examples:
       leafExample:
         value: "E9293"
@@ -1036,24 +1041,45 @@ definitions:
         value: "E979-E979.9"
         domainId: null
 
+  Attribute:
+    type: object
+    required:
+      - operator
+    properties:
+      operator:
+        type: string
+      value:
+        description: Unary operators use value
+        type: string
+      operands:
+        description: N-ary operators use operands
+        type: "array"
+        items:
+          type: string
+
   Modifier:
     type: object
     required:
       - name
       - operator
-      - values
     properties:
       name:
+        description: Semantic name of the operator
         type: string
       operator:
+        description: Machine name of the operator
+        type: string
+      value:
+        description: Unary operators use value
         type: string
       operands:
+        description: N-ary operators use operands
         type: "array"
         items:
           type: string
     example:
       name: "age_at_event"
-      operator: "GTE >="
+      operator: "GTE"
       operands: [ "Arg1", "Arg2" ]
 
   # Mirrors notebooks definitions ###############################################


### PR DESCRIPTION
Adds a definition for `Attributes` to the swagger files, provisionally - this should be considered subject to change as we explore what's needed here.

The difference between an `Attribute` and a `Modifier` is both semantic and a difference of scope - an attribute applies to a single criterion (i.e. a Medication code may need extra information about dosage to make sense) and a modifier applies to a whole grouping (a `SearchGroupItem`, technically) - e.g., equivalent to "select from these five codes everyone who is in some age range".