### PR TITLE
Revert "Shorten billing prefix and add comment. (#256)"

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -2,8 +2,7 @@
 {
   "firecloud": {
     "debugEndpoints": false,
-    "billingProjectPrefix": "aou-free-test-",
-    "#": "GCP billing project names must be <= 30 characters. Per-user hash is <= 10 chars."
+    "billingProjectPrefix": "all-of-us-free-test-"
   },
   "bigquery": {
     "dataSetId": "synpuf",


### PR DESCRIPTION
This reverts commit 7084ee8a7430ee5df9c266d6d817be99be2f9a8e.

This broke CircleCI on master, see for example https://circleci.com/gh/all-of-us/workbench/2743 (:tools:loadConfig fails).

Submitting TBR since it's a clean rollback and CircleCI is broken (after a retry as well).