### PR TITLE
Shorten billing project prefix, to avoid 30-character limit from GCP.

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -2,7 +2,7 @@
 {
   "firecloud": {
     "debugEndpoints": false,
-    "billingProjectPrefix": "all-of-us-free-test-"
+    "billingProjectPrefix": "aou-free-test-"
   },
   "bigquery": {
     "dataSetId": "synpuf",

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -123,6 +123,8 @@ public class ProfileController implements ProfileApiDelegate {
       // should consider switching the prefix.)
       suffix = user.getUserId();
     }
+    // GCP billing project names must be <= 30 characters. The per-user hash, an integer,
+    // is <= 10 chars.
     String billingProjectNamePrefix = workbenchConfig.firecloud.billingProjectPrefix + suffix;
     String billingProjectName = billingProjectNamePrefix;
     int numAttempts = 0;


### PR DESCRIPTION
Tested:
```
workbench$ api/project.rb update-cloud-config --account mark.fickett@pmi-ops.org --project all-of-us-workbench-test
...
:tools:loadConfig (Thread[Task worker,5,main]) completed. Took 9.975 secs.
BUILD SUCCESSFUL in 36s
```