### PR TITLE
Update Python client docs: describe releasing and auth details; split out example script.

### DIFF
--- a/client/py/README.md
+++ b/client/py/README.md
@@ -1,6 +1,6 @@
 # Python client for All of Us Workbench Jupyter Notebooks
 
-The client uses `python3`, to match Jupyter environments.
+The client uses Python 2.7, to match FireCloud Jupyter environments.
 
 ## Local testing
 
@@ -28,7 +28,6 @@ key.
 ```Shell
 api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
 export GOOGLE_APPLICATION_CREDENTIALS=.../path/to/sa-key.json
-python3 client/py/aou_workbench_client/auth.py
 ```
 
 ### Run examples

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -21,18 +21,19 @@ pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-clie
 For local development, you can specify a local key file instead of using
 application default credentials.
 
-TODO(RW-32) Once available, switch to fetching the user's pet service account
-key (as will be used in notebooks), instead of the application service account
-key.
+TODO(RW-32) Once available, switch the below to fetching the user's pet service
+account key (as will be used in notebooks), instead of the application service
+account key.
 
 ```Shell
-api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
+api/project.rb get-service-creds --project all-of-us-workbench-test \
+    --account $USER@pmi-ops.org
 export GOOGLE_APPLICATION_CREDENTIALS=.../path/to/sa-key.json
 ```
 
 ### Run examples
 
-Authenticate as above, then run (example.py)[example.py]:
+Authenticate as above, then run [example.py](example.py):
 
 ```Shell
 workbench/client$ ./project.rb swagger-regen
@@ -47,7 +48,7 @@ To publish a new version:
     `generated-py-client` for this).
 *   Tag them as `pyclient-vN-N-rcN`, and push the tag.
 
-Also, edit (setup.py)[setup.py] and update `version=` (or else pip will not
+Also, edit [setup.py](setup.py) and update `version=` (or else pip will not
 overwrite old installed versions).
 
 ```Shell

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -1,6 +1,6 @@
 # Python client for All of Us Workbench Jupyter Notebooks
 
-Usage:
+Usage for local testing:
 
 ```Shell
 virtualenv venv
@@ -8,7 +8,7 @@ virtualenv venv
 # Install HEAD from a branch:
 pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-client#egg=aou_workbench_client&subdirectory=client/py'
 # or install a tagged version (which also avoids downloading all history):
-pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-0-rc1.zip#egg=aou_workbench_client&subdirectory=client/py'
+pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-1-rc1.zip#egg=aou_workbench_client&subdirectory=client/py'
 ```
 
 then
@@ -16,4 +16,24 @@ then
 ```Python
 import aou_workbench_client
 from aou_workbench_client import swagger_client
+```
+
+To publish a new version:
+*   Regenerate Python Swagger client files.
+*   Check them in on an arbitrary working branch (you can reuse
+    `generated-py-client` for this).
+*   Tag them as `pyclient-vN-N-rcN`, and push the tag.
+
+```Shell
+PYCLIENT_VERSION=pyclient-v0-N-rcN  # your version here
+git checkout master
+git pull
+git checkout generated-py-client
+git reset --hard master
+git cherry-pick 2d1b2db97560cae505326ac2b157eaba2945829d  # remove gitignores
+client/project.rb swagger-regen
+git add client/py  # includes swagger_client, generated docs and requirements
+git commit -a -m "Add auto-generated Python Swagger client ${PYCLIENT_VERSION}."
+git tag ${PYCLIENT_VERSION}
+git push --tags
 ```

--- a/client/py/README.md
+++ b/client/py/README.md
@@ -1,28 +1,55 @@
 # Python client for All of Us Workbench Jupyter Notebooks
 
-Usage for local testing:
+The client uses `python3`, to match Jupyter environments.
+
+## Local testing
+
+### Install
 
 ```Shell
 virtualenv venv
 . venv/bin/activate
-# Install HEAD from a branch:
+# Install a tagged version (preferred; also avoids downloading all history):
+export PYCLIENT_VERSION=pyclient-v0-N-rcN  # your version here
+pip install 'https://github.com/all-of-us/workbench/archive/${PYCLIENT_VERSION}.zip#egg=aou_workbench_client&subdirectory=client/py'
+# Or install HEAD from a branch:
 pip install -e 'git+https://github.com/all-of-us/workbench.git@generated-py-client#egg=aou_workbench_client&subdirectory=client/py'
-# or install a tagged version (which also avoids downloading all history):
-pip install 'https://github.com/all-of-us/workbench/archive/pyclient-v0-1-rc1.zip#egg=aou_workbench_client&subdirectory=client/py'
 ```
 
-then
+### Authenticate
 
-```Python
-import aou_workbench_client
-from aou_workbench_client import swagger_client
+For local development, you can specify a local key file instead of using
+application default credentials.
+
+TODO(RW-32) Once available, switch to fetching the user's pet service account
+key (as will be used in notebooks), instead of the application service account
+key.
+
+```Shell
+api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
+export GOOGLE_APPLICATION_CREDENTIALS=.../path/to/sa-key.json
+python3 client/py/aou_workbench_client/auth.py
 ```
+
+### Run examples
+
+Authenticate as above, then run (example.py)[example.py]:
+
+```Shell
+workbench/client$ ./project.rb swagger-regen
+workbench/client$ py/example.py
+```
+
+## Releases
 
 To publish a new version:
 *   Regenerate Python Swagger client files.
 *   Check them in on an arbitrary working branch (you can reuse
     `generated-py-client` for this).
 *   Tag them as `pyclient-vN-N-rcN`, and push the tag.
+
+Also, edit (setup.py)[setup.py] and update `version=` (or else pip will not
+overwrite old installed versions).
 
 ```Shell
 PYCLIENT_VERSION=pyclient-v0-N-rcN  # your version here

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -8,9 +8,11 @@ GoogleCredentials.create_scoped() is a noop for application-default credentials.
 used when GOOGLE_APPLICATION_CREDENTIALS is defined and they key is read from a file.) For
 application default credentials, the service account's scopes are set ahead of time, like:
 
+  SCOPES="https://www.googleapis.com/auth/userinfo.profile"
+  SCOPES+=",https://www.googleapis.com/auth/userinfo.email"
   gcloud compute instances set-service-account $INSTANCE_ID --zone us-west1-b \
       --service-account $PET_SA_NAME@$PROJECT.iam.gserviceaccount.com \
-      --scopes "https://www.googleapis.com/auth/userinfo.profile","https://www.googleapis.com/auth/userinfo.email"
+      --scopes "$SCOPES"
 
 See https://www.googleapis.com/oauth2/v3/tokeninfo?access_token= for debugging.
 """

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -3,20 +3,13 @@
 The credentials are obtained by oauth2client, from one of:
 *   Google application default credentials (expected case, from notebook servers).
 *   A private key file, path specified in GOOGLE_APPLICATION_CREDENTIALS environment variable.
-
-For local development using a private key file:
-  api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
-  export GOOGLE_APPLICATION_CREDENTIALS=.../path/to/sa-key.json
-  python3 client/py/aou_workbench_client/auth.py
-TODO(RW-32) Once available, switch to fetching the user's pet service account key (as will be used
-in notebooks), instead of the application service account key.
 """
 
 import time
 
 from oauth2client.client import GoogleCredentials
 
-from swagger_client.api_client import ApiClient
+from .swagger_client.api_client import ApiClient
 
 
 CLIENT_OAUTH_SCOPES = (
@@ -72,13 +65,3 @@ def clear_cache():
     global _token_expiration
     _cached_client = None
     _token_expiration = 0
-
-
-# Self-test / simple example: Make a simple authenticated API call.
-if __name__ == '__main__':
-    print('Listing workspaces via authenticated API:')
-    from swagger_client.apis.workspaces_api import WorkspacesApi
-    client = WorkspacesApi(api_client=get_authenticated_swagger_client())
-    workspace_list = client.get_workspaces()
-    for ws in workspace_list.items:
-        print('%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description))

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -6,8 +6,8 @@ The credentials are obtained by oauth2client, from one of:
 
 For local development using a private key file:
   api/project.rb get-service-creds --project all-of-us-workbench-test --account $USER@pmi-ops.org
-  GOOGLE_APPLICATION_CREDENTIALS=`pwd`/api/sa-key.json
-  python client/py/aou_workbench_client/auth.py
+  export GOOGLE_APPLICATION_CREDENTIALS=.../path/to/sa-key.json
+  python3 client/py/aou_workbench_client/auth.py
 TODO(RW-32) Once available, switch to fetching the user's pet service account key (as will be used
 in notebooks), instead of the application service account key.
 """
@@ -76,9 +76,9 @@ def clear_cache():
 
 # Self-test / simple example: Make a simple authenticated API call.
 if __name__ == '__main__':
-    print 'Listing workspaces via authenticated API:'
+    print('Listing workspaces via authenticated API:')
     from swagger_client.apis.workspaces_api import WorkspacesApi
     client = WorkspacesApi(api_client=get_authenticated_swagger_client())
     workspace_list = client.get_workspaces()
     for ws in workspace_list.items:
-        print '%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description)
+        print('%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description))

--- a/client/py/aou_workbench_client/auth.py
+++ b/client/py/aou_workbench_client/auth.py
@@ -3,6 +3,16 @@
 The credentials are obtained by oauth2client, from one of:
 *   Google application default credentials (expected case, from notebook servers).
 *   A private key file, path specified in GOOGLE_APPLICATION_CREDENTIALS environment variable.
+
+GoogleCredentials.create_scoped() is a noop for application-default credentials. (However, it is
+used when GOOGLE_APPLICATION_CREDENTIALS is defined and they key is read from a file.) For
+application default credentials, the service account's scopes are set ahead of time, like:
+
+  gcloud compute instances set-service-account $INSTANCE_ID --zone us-west1-b \
+      --service-account $PET_SA_NAME@$PROJECT.iam.gserviceaccount.com \
+      --scopes "https://www.googleapis.com/auth/userinfo.profile","https://www.googleapis.com/auth/userinfo.email"
+
+See https://www.googleapis.com/oauth2/v3/tokeninfo?access_token= for debugging.
 """
 
 import time
@@ -12,6 +22,7 @@ from oauth2client.client import GoogleCredentials
 from .swagger_client.api_client import ApiClient
 
 
+# These are sometimes ignored, see module doc.
 CLIENT_OAUTH_SCOPES = (
       'https://www.googleapis.com/auth/userinfo.profile',
       'https://www.googleapis.com/auth/userinfo.email',
@@ -53,7 +64,8 @@ def _get_bearer_token_and_expiration():
 
     # The default, unscoped credentials provide an access token.
     creds = GoogleCredentials.get_application_default()
-    # Scoped credentials provide the bearer token we need.
+    # Scoped credentials provide the bearer token we need. However, create_scoped is sometimes
+    # ignored, see the module doc.
     scoped_creds = creds.create_scoped(CLIENT_OAUTH_SCOPES)
     token_info = scoped_creds.get_access_token()
 

--- a/client/py/example.py
+++ b/client/py/example.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Self-test / simple example: Make a simple authenticated API call."""
+
+
+from aou_workbench_client.auth import get_authenticated_swagger_client
+from aou_workbench_client.swagger_client.apis.workspaces_api import WorkspacesApi
+
+
+if __name__ == '__main__':
+    print('Listing workspaces via authenticated API:')
+    client = WorkspacesApi(api_client=get_authenticated_swagger_client())
+    workspace_list = client.get_workspaces()
+    for ws in workspace_list.items:
+        print('%s/%s\t%s\t%s' % (ws.namespace, ws.id, ws.name, ws.description))

--- a/client/py/example.py
+++ b/client/py/example.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Self-test / simple example: Make a simple authenticated API call."""
 
+from __future__ import print_function
 
 from aou_workbench_client.auth import get_authenticated_swagger_client
 from aou_workbench_client.swagger_client.apis.workspaces_api import WorkspacesApi

--- a/client/py/example.py
+++ b/client/py/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Self-test / simple example: Make a simple authenticated API call."""
 
 

--- a/client/py/setup.py
+++ b/client/py/setup.py
@@ -20,8 +20,9 @@ setup(
         # This is what people 'pip install'.
         name='aou-workbench-client',
 
-        # TODO(markfickett) Provide a version string here. Automatically bump when publishing (maybe
-        # from swagger-regen).
+        # TODO(markfickett) Automatically provide a version string here, bumped when publishing
+        # (maybe from swagger-regen).
+        version='0.1.2',
 
         long_description=readme_contents,
         url='https://github.com/all-of-us/workbench',


### PR DESCRIPTION
This is the process I've been using. I'm open to suggestions for a simpler workflow, and/or glad to turn this into a `project.rb` script if it looks like a suitably durable process.

My goals are:
* Produce a git tag which can be used for versioned installation via PIP.
* On the master branch, .gitignore the Swagger-generated files.