### PR TITLE
[RW-235] Set test-on-borrow db property, to avoid db connection timeouts.

### DIFF
--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -13,6 +13,8 @@
     <env-var name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>
     <env-var name="spring.datasource.username" value="${WORKBENCH_DB_USER}"/>
     <env-var name="spring.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
+    <env-var name="spring.datasource.dbcp.test-on-borrow=true" />
+    <env-var name="spring.datasource.dbcp.validationQuery=SELECT 1" />
   </env-variables>
 
   <resource-files>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -13,6 +13,7 @@
     <env-var name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>
     <env-var name="spring.datasource.username" value="${WORKBENCH_DB_USER}"/>
     <env-var name="spring.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
+    <!-- NOTE(RW-235) Keep the db connection alive. -->
     <env-var name="spring.datasource.dbcp.test-on-borrow=true" />
     <env-var name="spring.datasource.dbcp.validationQuery=SELECT 1" />
   </env-variables>


### PR DESCRIPTION
Following advice on https://stackoverflow.com/questions/22684807/spring-boot-jpa-configuring-auto-reconnect/34724168 .

I've deployed a version of the API service with this change. It handles traffic fine.

The lowest "last packet sent successfully to the server" listed in error messages is about 24h, so I could sit on this for a day and submit if there are no errors, or just submit now and keep an eye out for more errors / try different approaches if it's not fixed.