### PR TITLE
[RW-235] Add test-while-idle db options.

### DIFF
--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -16,6 +16,9 @@
     <!-- NOTE(RW-235) Keep the db connection alive. -->
     <env-var name="spring.datasource.dbcp.test-on-borrow" value="true" />
     <env-var name="spring.datasource.dbcp.validationQuery" value="SELECT 1" />
+    <env-var name="spring.datasource.dbcp.test-while-idle" value="true" />
+    <env-var name="spring.datasource.dbcp.time-between-eviction-runs-millis" value="3600000" />
+    <env-var name="spring.datasource.dbcp.validation-query" value="SELECT 1" />
   </env-variables>
 
   <resource-files>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -15,7 +15,6 @@
     <env-var name="spring.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
     <!-- NOTE(RW-235) Keep the db connection alive. -->
     <env-var name="spring.datasource.dbcp.test-on-borrow" value="true" />
-    <env-var name="spring.datasource.dbcp.validationQuery" value="SELECT 1" />
     <env-var name="spring.datasource.dbcp.test-while-idle" value="true" />
     <env-var name="spring.datasource.dbcp.time-between-eviction-runs-millis" value="3600000" />
     <env-var name="spring.datasource.dbcp.validation-query" value="SELECT 1" />


### PR DESCRIPTION
From deploying a test to all-of-us-workbench-test, I think this avoids remaining db connection staleness. However, I'm still seeing plenty of socket exceptions.