### PR TITLE
[RW-215] Add workspace/cohort/users versions and etags

### DIFF
--- a/api/db/changelog/db.changelog-11-version.xml
+++ b/api/db/changelog/db.changelog-11-version.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="calbach" id="changelog-11-version">
+    <addColumn tableName="workspace">
+      <column name="version" type="smallint" defaultValue="1">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="cohort">
+      <column name="version" type="smallint" defaultValue="1">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="user">
+      <column name="version" type="smallint" defaultValue="1">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -18,4 +18,5 @@
   <include file="changelog/db.changelog-8-ws-index.xml"/>
   <include file="changelog/db.changelog-9-ws-index-fix.xml"/>
   <include file="changelog/db.changelog-10-userworkspace.xml"/>
+  <include file="changelog/db.changelog-11-version.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/api/Etags.java
+++ b/api/src/main/java/org/pmiops/workbench/api/Etags.java
@@ -1,0 +1,28 @@
+package org.pmiops.workbench.api;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.pmiops.workbench.exceptions.BadRequestException;
+
+/**
+ * Utility class for creating API etags, to prevent versioning issues during
+ * read-modify-write cycles for API clients.
+ */
+public final class Etags {
+  private static final String ETAG_FORMAT = "\"%d\"";
+  private static final Pattern ETAG_PATTERN = Pattern.compile("^\"(\\d+)\"$");
+
+  private Etags() {}
+
+  public static String fromVersion(int version) {
+    return String.format(ETAG_FORMAT, version);
+  }
+
+  public static int toVersion(String etag) {
+    Matcher m = ETAG_PATTERN.matcher(etag);
+    if (!m.matches()) {
+      throw new BadRequestException(String.format("Invalid etag provided: %s", etag));
+    }
+    return Integer.parseInt(m.group(1));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -309,6 +309,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       Workspace workspace) {
     org.pmiops.workbench.db.model.Workspace dbWorkspace = workspaceService.getRequired(
         workspaceNamespace, workspaceId);
+    // TODO(calbach): Require etag once client supplies it.
     if(!Strings.isNullOrEmpty(workspace.getEtag())) {
       int version = Etags.toVersion(workspace.getEtag());
       if (dbWorkspace.getVersion() != version) {
@@ -344,6 +345,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   @Override
   public ResponseEntity<EmptyResponse> shareWorkspace(String workspaceNamespace, String workspaceId,
       UserRoleList userRoleList) {
+    // TODO(calbach): Attempt to factor this into updateWorkspace() in order to
+    // share etag/versioning logic.
     Set<WorkspaceUserRole> dbUserRoles = new HashSet<WorkspaceUserRole>();
     for (UserRole user : userRoleList.getItems()) {
       WorkspaceUserRole newUserRole = new WorkspaceUserRole();

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.base.Strings;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -13,11 +14,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
-
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.WorkspaceService;
@@ -27,6 +23,7 @@ import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.Authority;
@@ -39,6 +36,10 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceListResponse;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.UserRoleList;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
@@ -82,6 +83,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
             researchPurpose.timeReviewed(workspace.getTimeReviewed().getTime());
           }
           Workspace result = new Workspace()
+              .etag(Etags.fromVersion(workspace.getVersion()))
               .lastModifiedTime(workspace.getLastModifiedTime().getTime())
               .creationTime(workspace.getCreationTime().getTime())
               .dataAccessLevel(workspace.getDataAccessLevel())
@@ -253,6 +255,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     dbWorkspace.setCreator(user);
     dbWorkspace.setCreationTime(now);
     dbWorkspace.setLastModifiedTime(now);
+    dbWorkspace.setVersion(1);
     setCdrVersionId(workspace, dbWorkspace);
 
     org.pmiops.workbench.db.model.WorkspaceUserRole permissions = new org.pmiops.workbench.db.model.WorkspaceUserRole();
@@ -306,7 +309,14 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       Workspace workspace) {
     org.pmiops.workbench.db.model.Workspace dbWorkspace = workspaceService.getRequired(
         workspaceNamespace, workspaceId);
-    if(!dbWorkspace.getDataAccessLevel().equals(workspace.getDataAccessLevel())){
+    if(!Strings.isNullOrEmpty(workspace.getEtag())) {
+      int version = Etags.toVersion(workspace.getEtag());
+      if (dbWorkspace.getVersion() != version) {
+        throw new ConflictException("Attempted to modify outdated workspace version");
+      }
+    }
+    if(workspace.getDataAccessLevel() != null &&
+        !dbWorkspace.getDataAccessLevel().equals(workspace.getDataAccessLevel())){
       throw new BadRequestException("Attempted to change data access level");
     }
     if (workspace.getDescription() != null) {
@@ -319,8 +329,15 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     setCdrVersionId(workspace, dbWorkspace);
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     dbWorkspace.setLastModifiedTime(now);
-    // TODO: add version, check it here
-    dbWorkspace = workspaceService.getDao().save(dbWorkspace);
+
+    try {
+      // The version asserted on save is the same as the one we read via
+      // getRequired() above, see RW-215 for details.
+      dbWorkspace = workspaceService.getDao().save(dbWorkspace);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      log.log(Level.WARNING, "version conflict for workspace update", e);
+      throw new ConflictException("Failed due to concurrent workspace modification");
+    }
     return ResponseEntity.ok(TO_CLIENT_WORKSPACE.apply(dbWorkspace));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -2,8 +2,12 @@ package org.pmiops.workbench.db.dao;
 
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 import org.pmiops.workbench.db.model.Workspace;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -109,6 +109,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     for (Map.Entry<Long, WorkspaceUserRole> remainingRole : userRoleMap.entrySet()) {
       dbWorkspace.getWorkspaceUserRoles().add(remainingRole.getValue());
     }
+    // TODO(calbach): This save() is not technically necessary but included to
+    // workaround RW-252. Remove either this, or @Transactional.
     workspaceDao.save(dbWorkspace);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -6,9 +6,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +25,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
  * generation in WorkspaceDao, or convenience aliases.
  *
  * This needs to implement an interface to support Transactional
- *
- * TODO(RW-215) Add versioning to detect/prevent concurrent edits.
  */
 @Service
 public class WorkspaceServiceImpl implements WorkspaceService {
@@ -60,8 +61,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     return workspaceDao.findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();
   }
 
-  // FIXME @Version instead? Bean instantiation v. @Transactional?
-  //@Transactional
   @Override
   public void setResearchPurposeApproved(String ns, String id, boolean approved) {
     Workspace workspace = getRequired(ns, id);
@@ -75,7 +74,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
           ns, id, workspace.getApproved() ? "approved" : "rejected"));
     }
     workspace.setApproved(approved);
-    workspaceDao.save(workspace);
+    try {
+      workspaceDao.save(workspace);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      log.log(Level.WARNING, "version conflict for workspace update", e);
+      throw new ConflictException("Failed due to concurrent workspace modification");
+    }
   }
 
   @Override
@@ -105,5 +109,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     for (Map.Entry<Long, WorkspaceUserRole> remainingRole : userRoleMap.entrySet()) {
       dbWorkspace.getWorkspaceUserRoles().add(remainingRole.getValue());
     }
+    workspaceDao.save(dbWorkspace);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
@@ -8,12 +8,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 @Entity
 @Table(name = "cohort")
 public class Cohort {
 
   private long cohortId;
+  private int version;
   private String name;
   private String type;
   private String description;
@@ -35,6 +37,14 @@ public class Cohort {
   public void setCohortId(long cohortId) {
     this.cohortId = cohortId;
   }
+
+  @Version
+  @Column(name = "version")
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) { this.version = version; }
 
   @Column(name = "name")
   public String getName() {

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -15,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import javax.persistence.Version;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.DataAccessLevel;
 
@@ -23,6 +24,7 @@ import org.pmiops.workbench.model.DataAccessLevel;
 public class User {
 
   private long userId;
+  private int version;
   // The Google email address that the user signs in with.
   private String email;
   // The email address that can be used to contact the user.
@@ -46,6 +48,12 @@ public class User {
   public void setUserId(long userId) {
     this.userId = userId;
   }
+
+  @Version
+  @Column(name = "version")
+  public int getVersion() { return version; }
+
+  public void setVersion(int version) { this.version = version; }
 
   @Column(name = "email")
   public String getEmail() {

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -19,6 +19,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.persistence.Version;
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
@@ -59,6 +60,7 @@ public class Workspace {
   }
 
   private long workspaceId;
+  private int version;
   private String name;
   private String description;
   private String workspaceNamespace;
@@ -98,6 +100,14 @@ public class Workspace {
   public void setWorkspaceId(long workspaceId) {
     this.workspaceId = workspaceId;
   }
+
+  @Version
+  @Column(name = "version")
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) { this.version = version; }
 
   @Column(name = "name")
   public String getName() {

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ConflictException.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ConflictException.java
@@ -1,0 +1,30 @@
+package org.pmiops.workbench.exceptions;
+
+import org.pmiops.workbench.model.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+
+  private ErrorResponse errorResponse;
+
+  public ConflictException(String message) {
+    this(errorResponse(message));
+  }
+
+  public ConflictException(ErrorResponse errorResponse) {
+    super(errorResponse.getMessage());
+    this.errorResponse = errorResponse;
+  }
+
+  public ErrorResponse getErrorResponse() {
+    return errorResponse;
+  }
+
+  private static ErrorResponse errorResponse(String message) {
+    ErrorResponse response = new ErrorResponse();
+    response.setMessage(message);
+    return response;
+  }
+}

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -707,6 +707,12 @@ definitions:
     properties:
       id:
         type: string
+      etag:
+        type: string
+        description: >
+          Entity tag for optimistic concurrency control. To be set during a
+          read-modify-write to ensure that the client has not attempted to
+          modify a changed resource.
       name:
         type: string
       namespace:
@@ -840,6 +846,12 @@ definitions:
     properties:
       id:
         type: string
+      etag:
+        type: string
+        description: >
+          Entity tag for optimistic concurrency control. To be set during a
+          read-modify-write to ensure that the client has not attempted to
+          modify a changed resource.
       name:
         type: string
       criteria:

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -1,0 +1,160 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import javax.inject.Provider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
+import org.pmiops.workbench.db.dao.WorkspaceServiceImpl;
+import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ConflictException;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.Cohort;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.Workspace;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class CohortsControllerTest {
+
+  Workspace workspace;
+  @Autowired
+  WorkspaceDao workspaceDao;
+  @Autowired
+  CdrVersionDao cdrVersionDao;
+  @Autowired
+  CohortDao cohortDao;
+  @Autowired
+  UserDao userDao;
+  @Mock
+  Provider<User> userProvider;
+  @Mock
+  FireCloudService fireCloudService;
+
+  private CohortsController cohortsController;
+
+  private static final Instant NOW = Instant.now();
+  private static final long NOW_TIME = Timestamp.from(NOW).getTime();
+
+  @Before
+  public void setUp() {
+    User user = new User();
+    user.setEmail("bob@gmail.com");
+    user.setUserId(123L);
+    user = userDao.save(user);
+    when(userProvider.get()).thenReturn(user);
+
+    workspace = new Workspace();
+    workspace.setName("test");
+    workspace.setNamespace("ns");
+    workspace.setDataAccessLevel(DataAccessLevel.PROTECTED);
+    workspace.setResearchPurpose(new ResearchPurpose());
+
+    // Injecting WorkspaceService fails in the test environment. Work around it by injecting the
+    // DAO and creating the service directly.
+    WorkspaceService workspaceService = new WorkspaceServiceImpl();
+    workspaceService.setDao(workspaceDao);
+
+    WorkspacesController workspacesController = new WorkspacesController(workspaceService,
+        cdrVersionDao, userDao, userProvider, fireCloudService,
+        Clock.fixed(NOW, ZoneId.systemDefault()));
+    workspace = workspacesController.createWorkspace(workspace).getBody();
+
+    this.cohortsController = new CohortsController(workspaceService, cohortDao,
+        userProvider, Clock.fixed(NOW, ZoneId.systemDefault()));
+  }
+
+  public Cohort createDefaultCohort() {
+    Cohort cohort = new Cohort();
+    cohort.setName("name");
+    return cohort;
+  }
+
+  @Test
+  public void testUpdateCohort() throws Exception {
+    Cohort cohort = createDefaultCohort();
+    cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
+
+    cohort.setName("updated-name");
+    Cohort updated = cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(), cohort).getBody();
+    cohort.setEtag(updated.getEtag());
+    assertThat(updated).isEqualTo(cohort);
+
+    cohort.setName("updated-name2");
+    updated = cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(), cohort).getBody();
+    cohort.setEtag(updated.getEtag());
+    assertThat(updated).isEqualTo(cohort);
+
+    // Verify that we can update without an etag.
+    cohort.setEtag(null);
+    cohort.setName("updated-name3");
+    updated = cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(), cohort).getBody();
+    cohort.setEtag(updated.getEtag());
+    assertThat(updated).isEqualTo(cohort);
+
+    Cohort got = cohortsController.getCohort(workspace.getNamespace(), workspace.getId(), cohort.getId()).getBody();
+    assertThat(got).isEqualTo(cohort);
+  }
+
+  @Test(expected = ConflictException.class)
+  public void testUpdateCohortStaleThrows() throws Exception {
+    Cohort cohort = createDefaultCohort();
+    cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
+
+    cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(),
+        new Cohort().name("updated-name").etag(cohort.getEtag())).getBody();
+
+    // Still using the initial etag.
+    cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(),
+        new Cohort().name("updated-name2").etag(cohort.getEtag())).getBody();
+  }
+
+  @Test
+  public void testUpdateCohortInvalidEtagsThrow() throws Exception {
+    Cohort cohort = createDefaultCohort();
+    cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
+
+    // TODO: Refactor to be a @Parameterized test case.
+    List<String> cases = ImmutableList.of("hello, world", "\"\"", "\"\"1234\"\"", "\"-1\"");
+    for (String etag : cases) {
+      try {
+        cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(),
+            new Cohort().name("updated-name").etag(etag));
+        fail(String.format("expected BadRequestException for etag: %s", etag));
+      } catch(BadRequestException e) {
+        // expected
+      }
+    }
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/WorkspaceDaoTest.java
@@ -1,0 +1,49 @@
+package org.pmiops.workbench.cdr.dao;
+
+import static org.springframework.test.util.AssertionErrors.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class WorkspaceDaoTest {
+  @Autowired
+  WorkspaceDao workspaceDao;
+
+  @Test
+  public void testWorkspaceVersionLocking() {
+    org.pmiops.workbench.db.model.Workspace ws = new org.pmiops.workbench.db.model.Workspace();
+    ws.setVersion(1);
+    ws = workspaceDao.save(ws);
+
+    // Version incremented to 2.
+    ws.setName("foo");
+    ws = workspaceDao.save(ws);
+
+    try {
+      ws.setName("bar");
+      ws.setVersion(1);
+      workspaceDao.save(ws);
+      fail("expected optimistic lock exception on stale version update");
+    } catch(ObjectOptimisticLockingFailureException e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
- Add an `etag` to mutable resources in the workbench API (workspace, cohort) to allow the client to detect attempted stale updates to a changed resource
  - Rationale: set directly in the resource (rather than via HTTP headers) to enable clearer semantics on List/Get, e.g. on ListWorkspace should return a resource that can be used to make an update.
  - Returning an etag directly on the resource is recommended by [Google API style](https://cloud.google.com/apis/design/design_patterns#etags)
- Use of `etag`s during updates are optional; if unset by the client we will apply the update without knowing whether it is "stale"
- Add an @Version version column to these models which is automatically incremented and checked during all updates
- Add versioning to User to detect concurrent modification without corresponding etags as there is no direct update API.