### PR TITLE
Add specific error handling for update conflicts; improve edit page

### DIFF
--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -133,7 +133,8 @@
 <clr-modal [(clrModalOpen)]="workspaceUpdateConflictError">
   <h3 class="modal-title">Conflicting update:</h3>
   <div class="modal-body">
-    Workspace has been modified since the beginning of this editing session.
+    Another client has modified this workspace since the beginning of this
+    editing session. Please reload to avoid overwriting those changes.
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-primary" (click)="reloadConflictingWorkspace()">Reload Workspace</button>

--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -1,4 +1,5 @@
-<h2>Create a new Workspace</h2>
+<h2 *ngIf="adding">Create a new Workspace</h2>
+<h2 *ngIf="!adding">Edit workspace "{{workspace.name}}"</h2>
 <div>* is a required field</div>
 <div class="form-area">
   <div class="name-area" [class.validation-error]="nameNotEntered">
@@ -118,6 +119,24 @@
   <div class="modal-body">Could not create workspace.</div>
   <div class="modal-footer">
     <button type="button" class="btn btn-primary" (click)="navigateBack()">Cancel Creation</button>
-    <button type="button" class="btn btn-primary" (click)="resetWorkspaceCreation()">Keep Editing</button>
+    <button type="button" class="btn btn-primary" (click)="resetWorkspaceEditor()">Keep Editing</button>
+  </div>
+</clr-modal>
+<clr-modal [(clrModalOpen)]="workspaceUpdateError">
+  <h3 class="modal-title">Error:</h3>
+  <div class="modal-body">Could not update workspace.</div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="navigateBack()">Cancel Edits</button>
+    <button type="button" class="btn btn-primary" (click)="resetWorkspaceEditor()">Keep Editing</button>
+  </div>
+</clr-modal>
+<clr-modal [(clrModalOpen)]="workspaceUpdateConflictError">
+  <h3 class="modal-title">Conflicting update:</h3>
+  <div class="modal-body">
+    Workspace has been modified since the beginning of this editing session.
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="reloadConflictingWorkspace()">Reload Workspace</button>
+    <button type="button" class="btn btn-primary" (click)="resetWorkspaceEditor()">Keep Editing</button>
   </div>
 </clr-modal>

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -1,6 +1,7 @@
 import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
 import {Router, ActivatedRoute} from '@angular/router';
+import {Observable} from 'rxjs/Observable';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {WorkspaceComponent} from 'app/views/workspace/component';
@@ -58,14 +59,8 @@ export class WorkspaceEditComponent implements OnInit {
     } else {
       this.oldWorkspaceNamespace = this.route.snapshot.params['ns'];
       this.oldWorkspaceName = this.route.snapshot.params['wsid'];
-      this.workspacesService.getWorkspace(this.oldWorkspaceNamespace,
-          this.oldWorkspaceName)
-        .subscribe((workspace) => {
-          this.workspace = workspace;
-        }
-      );
+      this.loadWorkspace();
     }
-
   }
 
   addWorkspace(): void {
@@ -87,17 +82,22 @@ export class WorkspaceEditComponent implements OnInit {
       }
     }
   }
+
+  loadWorkspace(): Observable<Workspace> {
+    const obs: Observable<Workspace> = this.workspacesService.getWorkspace(
+      this.oldWorkspaceNamespace, this.oldWorkspaceName);
+    obs.subscribe((workspace) => {
+        this.workspace = workspace;
+    });
+    return obs;
+  }
+
   navigateBack(): void {
     this.locationService.back();
   }
 
   reloadConflictingWorkspace(): void {
-    this.workspacesService.getWorkspace(this.oldWorkspaceNamespace,
-                                        this.oldWorkspaceName)
-      .subscribe((workspace) => {
-        this.workspace = workspace;
-      });
-    this.resetWorkspaceEditor();
+    this.loadWorkspace().subscribe(() => this.resetWorkspaceEditor());
   }
 
   resetWorkspaceEditor(): void {

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -23,6 +23,8 @@ export class WorkspaceEditComponent implements OnInit {
   savingWorkspace = false;
   nameNotEntered = false;
   workspaceCreationError = false;
+  workspaceUpdateError = false;
+  workspaceUpdateConflictError = false;
 
   constructor(
       private errorHandlingService: ErrorHandlingService,
@@ -89,8 +91,19 @@ export class WorkspaceEditComponent implements OnInit {
     this.locationService.back();
   }
 
-  resetWorkspaceCreation(): void {
+  reloadConflictingWorkspace(): void {
+    this.workspacesService.getWorkspace(this.oldWorkspaceNamespace,
+                                        this.oldWorkspaceName)
+      .subscribe((workspace) => {
+        this.workspace = workspace;
+      });
+    this.resetWorkspaceEditor();
+  }
+
+  resetWorkspaceEditor(): void {
     this.workspaceCreationError = false;
+    this.workspaceUpdateError = false;
+    this.workspaceUpdateConflictError = false;
     this.savingWorkspace = false;
   }
 
@@ -110,7 +123,11 @@ export class WorkspaceEditComponent implements OnInit {
               this.navigateBack();
             },
             (error) => {
-              this.workspaceCreationError = true;
+              if (error.status === 409) {
+                this.workspaceUpdateConflictError = true;
+              } else {
+                this.workspaceUpdateError = true;
+              }
             });
       }
     }


### PR DESCRIPTION
- The conflicting update modal has a "reload" option instead of going back, this seems like the most likely action one would want to take.
- Updated the wording in a few places for "edit mode" vs create mode.