### PR TITLE
Blrubenstein/fc sharing

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -12,10 +12,13 @@ import org.springframework.stereotype.Service;
 
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.db.model.WorkspaceUserRole;
+import org.pmiops.workbench.firecloud.FireCloudService;
 
 public interface WorkspaceService {
   public WorkspaceDao getDao();
   public void setDao(WorkspaceDao workspaceDao);
+  public FireCloudService getFireCloudService();
+  public void setFireCloudService(FireCloudService fireCloudService);
   public Workspace get(String ns, String id);
   public Workspace getRequired(String ns, String id);
   public List<Workspace> findForReview();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -120,6 +120,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         currentUserRole.setRole(mapValue.getRole());
         userRoleMap.remove(currentUserRole.getUser().getUserId());
       } else {
+        // This is how to remove a user from the FireCloud ACL:
+        // Pass along an update request with NO ACCESS as the given access level.
         WorkspaceACLUpdate removedUser = new WorkspaceACLUpdate();
         removedUser.setEmail(currentUserRole.getUser().getEmail());
         removedUser.setCanCompute(false);
@@ -151,7 +153,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       updateACLRequestList.add(currentUpdate);
     }
     try {
-      WorkspaceACLUpdateResponseList fireCloudResponse = fireCloudService.updateWorkspaceACL(ns, id, false, updateACLRequestList);
+      WorkspaceACLUpdateResponseList fireCloudResponse = fireCloudService.updateWorkspaceACL(ns, id, updateACLRequestList);
       if (fireCloudResponse.getUsersNotFound().size() != 0) {
         String usersNotFound = "";
         for (int i = 0; i < fireCloudResponse.getUsersNotFound().size(); i++) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -23,6 +23,7 @@ import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.exceptions.ServerUnavailableException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
@@ -172,8 +173,10 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         throw new BadRequestException(e.getResponseBody());
       } else if (e.getCode() == 404) {
         throw new NotFoundException("Workspace not found.");
-      } else {
+      } else if (e.getCode() == 500) {
         throw new ServerErrorException(e);
+      } else {
+        throw new ServerUnavailableException(e);
       }
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -171,7 +171,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       if (e.getCode() == 400) {
         throw new BadRequestException(e.getResponseBody());
       } else if (e.getCode() == 404) {
-        throw new BadRequestException("Workspace not found.");
+        throw new NotFoundException("Workspace not found.");
       } else {
         throw new ServerErrorException(e);
       }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -162,13 +162,19 @@ public class WorkspaceServiceImpl implements WorkspaceService {
           }
           usersNotFound += fireCloudResponse.getUsersNotFound().get(i).getEmail();
         }
-        throw new ServerErrorException("Could not find users: " + usersNotFound);
+        throw new BadRequestException(usersNotFound);
       }
       // TODO(calbach): This save() is not technically necessary but included to
       // workaround RW-252. Remove either this, or @Transactional.
       workspaceDao.save(dbWorkspace);
     } catch(org.pmiops.workbench.firecloud.ApiException e) {
-      throw new ServerErrorException(e);
+      if (e.getCode() == 400) {
+        throw new BadRequestException(e.getResponseBody());
+      } else if (e.getCode() == 404) {
+        throw new BadRequestException("Workspace not found.");
+      } else {
+        throw new ServerErrorException(e);
+      }
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.firecloud;
 
 import java.util.List;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 
 /**
  * Encapsulate Firecloud API interaction details and provide a simple/mockable interface
@@ -41,4 +43,6 @@ public interface FireCloudService {
    * Retrieves all billing project memberships for the user from FireCloud.
    */
   List<BillingProjectMembership> getBillingProjectMemberships() throws ApiException;
+
+  WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, Boolean inviteUsersNotFound, List<WorkspaceACLUpdate> aclUpdates) throws ApiException;
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -44,5 +44,5 @@ public interface FireCloudService {
    */
   List<BillingProjectMembership> getBillingProjectMemberships() throws ApiException;
 
-  WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, Boolean inviteUsersNotFound, List<WorkspaceACLUpdate> aclUpdates) throws ApiException;
+  WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, List<WorkspaceACLUpdate> aclUpdates) throws ApiException;
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -110,9 +110,9 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, Boolean inviteUsersNotFound, List<WorkspaceACLUpdate> aclUpdates) throws ApiException {
+  public WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, List<WorkspaceACLUpdate> aclUpdates) throws ApiException {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     // TODO: set authorization domain here
-    return workspacesApi.updateWorkspaceACL(projectName, workspaceName, inviteUsersNotFound, aclUpdates);
+    return workspacesApi.updateWorkspaceACL(projectName, workspaceName, false, aclUpdates);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -11,6 +11,8 @@ import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
 import org.pmiops.workbench.firecloud.model.CreateRawlsBillingProjectFullRequest;
 import org.pmiops.workbench.firecloud.model.Me;
 import org.pmiops.workbench.firecloud.model.Profile;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.firecloud.model.WorkspaceIngest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -105,5 +107,12 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   private boolean isTrue(Boolean b) {
     return b != null && b == true;
+  }
+
+  @Override
+  public WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, Boolean inviteUsersNotFound, List<WorkspaceACLUpdate> aclUpdates) throws ApiException {
+    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    // TODO: set authorization domain here
+    return workspacesApi.updateWorkspaceACL(projectName, workspaceName, inviteUsersNotFound, aclUpdates);
   }
 }

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -228,6 +228,40 @@ paths:
         500:
           description: Internal Server Error
 
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/acl:
+    patch:
+      tags:
+        - Workspaces
+      operationId: updateWorkspaceACL
+      summary: Update workspace ACL
+      parameters:
+        - $ref: '#/parameters/workspaceNamespaceParam'
+        - $ref: '#/parameters/workspaceNameParam'
+        - in: query
+          description: true to invite unregistered users, false to ignore
+          name: inviteUsersNotFound
+          required: true
+          default: false
+          type: boolean
+        - name: aclUpdates
+          description: Series of ACL updates for workspace
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/WorkspaceACLUpdate'
+          in: body
+      responses:
+        200:
+          description: Successful Request
+          schema:
+            $ref: '#/definitions/WorkspaceACLUpdateResponseList'
+        400:
+          description: Can't set ACL for workspace
+        404:
+          description: Workspace not found
+        500:
+          description: Internal Server Error
   /me:
     get:
       tags:
@@ -589,3 +623,65 @@ definitions:
       runningSubmissionsCount:
         type: integer
         description: Count of all the running submissions
+  WorkspaceACLUpdate:
+    description: ''
+    required:
+      - email
+      - accessLevel
+    type: object
+    properties:
+      email:
+        type: string
+        description: email address of the user or group whose permissions will be changed
+      accessLevel:
+        type: string
+        description: The access level to grant to this user or group (OWNER, READER, WRITER, NO ACCESS)
+      canShare:
+        type: boolean
+        description: Set to true if you want this user to be able to share the workspace with other users, only meaningful for readers and writers, default false
+      canCompute:
+        type: boolean
+        description: Set to true if you want this user to be able to launch compute in this workspace, may not be true for readers, default false for reader, true otherwise
+  WorkspaceACLUpdateResponse:
+    description: ''
+    required:
+      - subjectId
+      - accessLevel
+    type: object
+    properties:
+      subjectId:
+        type: string
+        description: id of the user or group whose permissions will be changed
+      accessLevel:
+        type: string
+        description: The access level granted to this user or group (OWNER, READER, WRITER, NO ACCESS)
+
+  WorkspaceACLUpdateResponseList:
+    description: ''
+    required:
+      - usersUpdated
+      - invitesSent
+      - invitesUpdated
+      - usersNotFound
+    type: object
+    properties:
+      usersUpdated:
+        type: array
+        description: the users or groups who were updated
+        items:
+          $ref: '#/definitions/WorkspaceACLUpdateResponse'
+      invitesSent:
+        type: array
+        description: the list of invites that were sent
+        items:
+          $ref: '#/definitions/WorkspaceACLUpdate'
+      invitesUpdated:
+        type: array
+        description: the list of invites that were updated
+        items:
+          $ref: '#/definitions/WorkspaceACLUpdate'
+      usersNotFound:
+        type: array
+        description: the users or groups who were not found
+        items:
+          $ref: '#/definitions/WorkspaceACLUpdate'

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -786,7 +786,7 @@ definitions:
 
   WorkspaceAccessLevel:
     type: string
-    description: levels of access to workspace
+    description: levels of access to workspace, NO ACCESS is akin to removing a user from a workspace ACL
     enum: [NO ACCESS, READER, WRITER, OWNER]
 
   ResearchPurpose:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -787,7 +787,7 @@ definitions:
   WorkspaceAccessLevel:
     type: string
     description: levels of access to workspace
-    enum: [reader, writer, owner]
+    enum: [NO ACCESS, READER, WRITER, OWNER]
 
   ResearchPurpose:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -74,6 +74,7 @@ public class WorkspacesControllerTest {
     User user = new User();
     user.setEmail("bob@gmail.com");
     user.setUserId(123L);
+    user.setFreeTierBillingProjectName("TestBillingProject1");
     user = userDao.save(user);
     when(userProvider.get()).thenReturn(user);
 
@@ -81,6 +82,7 @@ public class WorkspacesControllerTest {
     // DAO and creating the service directly.
     workspaceService = new WorkspaceServiceImpl();
     workspaceService.setDao(workspaceDao);
+    workspaceService.setFireCloudService(fireCloudService);
 
     this.workspacesController = new WorkspacesController(workspaceService, cdrVersionDao,
         userDao, userProvider, fireCloudService,
@@ -285,10 +287,14 @@ public class WorkspacesControllerTest {
     User writerUser = new User();
     writerUser.setEmail("writerfriend@gmail.com");
     writerUser.setUserId(124L);
+    writerUser.setFreeTierBillingProjectName("TestBillingProject2");
+
     writerUser = userDao.save(writerUser);
     User readerUser = new User();
     readerUser.setEmail("readerfriend@gmail.com");
     readerUser.setUserId(125L);
+    readerUser.setFreeTierBillingProjectName("TestBillingProject3");
+
     readerUser = userDao.save(readerUser);
     Workspace workspace = createDefaultWorkspace();
     workspacesController.createWorkspace(workspace);
@@ -337,10 +343,12 @@ public class WorkspacesControllerTest {
     User writerUser = new User();
     writerUser.setEmail("writerfriend@gmail.com");
     writerUser.setUserId(124L);
+    writerUser.setFreeTierBillingProjectName("TestBillingProject2");
     writerUser = userDao.save(writerUser);
     User readerUser = new User();
     readerUser.setEmail("readerfriend@gmail.com");
     readerUser.setUserId(125L);
+    readerUser.setFreeTierBillingProjectName("TestBillingProject3");
     readerUser = userDao.save(readerUser);
     Workspace workspace = createDefaultWorkspace();
     workspacesController.createWorkspace(workspace);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.fail;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -313,7 +315,10 @@ public class WorkspacesControllerTest {
     reader.setEmail("readerfriend@gmail.com");
     reader.setRole(WorkspaceAccessLevel.READER);
     updatedUserRoles.addItemsItem(reader);
-    when(fireCloudService.updateWorkspaceACL("namespace", "name", new ArrayList<WorkspaceACLUpdate>())).thenReturn(new WorkspaceACLUpdateResponseList());
+
+    WorkspaceACLUpdateResponseList responseValue = new WorkspaceACLUpdateResponseList();
+
+    when(fireCloudService.updateWorkspaceACL(anyString(), anyString(), anyListOf(WorkspaceACLUpdate.class))).thenReturn(responseValue);
     workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
     Workspace workspace2 =
         workspacesController.getWorkspace("namespace", "name")
@@ -368,42 +373,15 @@ public class WorkspacesControllerTest {
     reader.setRole(WorkspaceAccessLevel.READER);
     updatedUserRoles.addItemsItem(reader);
 
-
-    List<WorkspaceACLUpdate> firecloudUpdates = new ArrayList<WorkspaceACLUpdate>();
-    WorkspaceACLUpdate creatorFirecloud = new WorkspaceACLUpdate();
-    creatorFirecloud.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
-    creatorFirecloud.setEmail("bob@gmail.com");
-    creatorFirecloud.setCanShare(true);
-    creatorFirecloud.setCanCompute(false);
-    WorkspaceACLUpdate writerFirecloud = new WorkspaceACLUpdate();
-    writerFirecloud.setAccessLevel(WorkspaceAccessLevel.WRITER.toString());
-    writerFirecloud.setEmail("writerfriend@gmail.com");
-    writerFirecloud.setCanShare(false);
-    writerFirecloud.setCanCompute(false);
-    WorkspaceACLUpdate readerFirecloud = new WorkspaceACLUpdate();
-    readerFirecloud.setAccessLevel(WorkspaceAccessLevel.READER.toString());
-    readerFirecloud.setEmail("readerfriend@gmail.com");
-    readerFirecloud.setCanShare(false);
-    readerFirecloud.setCanCompute(false);
-    firecloudUpdates.add(creatorFirecloud);
-    firecloudUpdates.add(writerFirecloud);
-    firecloudUpdates.add(readerFirecloud);
-
     WorkspaceACLUpdateResponseList responseValue = new WorkspaceACLUpdateResponseList();
     responseValue.setUsersNotFound(new ArrayList<WorkspaceACLUpdate>());
 
-    when(fireCloudService.updateWorkspaceACL("namespace", "name", org.mockito.Mockito.Matchers.anyList())).thenReturn(responseValue);
+    when(fireCloudService.updateWorkspaceACL(anyString(), anyString(), anyListOf(WorkspaceACLUpdate.class))).thenReturn(responseValue);
     workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
     updatedUserRoles = new UserRoleList();
     updatedUserRoles.addItemsItem(creator);
     updatedUserRoles.addItemsItem(writer);
 
-    firecloudUpdates = new ArrayList<WorkspaceACLUpdate>();
-    readerFirecloud.setAccessLevel(WorkspaceAccessLevel.NO_ACCESS.toString());
-    firecloudUpdates.add(creatorFirecloud);
-    firecloudUpdates.add(writerFirecloud);
-    firecloudUpdates.add(readerFirecloud);
-    when(fireCloudService.updateWorkspaceACL("namespace", "name", firecloudUpdates)).thenReturn(responseValue);
     workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
     Workspace workspace2 =
         workspacesController.getWorkspace("namespace", "name")

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -61,7 +61,9 @@ sourceSets {
                    'org/pmiops/workbench/model/Authority.java',
                    'org/pmiops/workbench/model/DataAccessLevel.java',
                    'org/pmiops/workbench/model/ErrorResponse.java',
-                   'org/pmiops/workbench/model/WorkspaceAccessLevel.java' ]
+                   'org/pmiops/workbench/model/WorkspaceAccessLevel.java']
+       excludes = ['org/pmiops/workbench/db/dao/WorkspaceService.java',
+                   'org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java']
     }
   }
 }

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -56,11 +56,11 @@ export class WorkspaceShareComponent implements OnInit {
   setAccess(dropdownSelected: string): void {
     this.selectedPermission = dropdownSelected;
     if (dropdownSelected === 'Owner') {
-      this.accessLevel = WorkspaceAccessLevel.Owner;
+      this.accessLevel = WorkspaceAccessLevel.OWNER;
     } else if (dropdownSelected === 'Writer') {
-      this.accessLevel = WorkspaceAccessLevel.Writer;
+      this.accessLevel = WorkspaceAccessLevel.WRITER;
     } else {
-      this.accessLevel = WorkspaceAccessLevel.Reader;
+      this.accessLevel = WorkspaceAccessLevel.READER;
     }
   }
 


### PR DESCRIPTION
This is technically functional sharing in FireCloud, there are just two things that I want to check on. 
1) I'm not super happy with the exceptions getting thrown here, and would love some advice exception message, codes, and new exception classes?
2) We don't yet have enough granular permissions in FC to make owners not have canCompute. I am planning on talking to the FC team about this, but also had the idea of making all sharing on the Workspace happen with a superUser in our API, and that's what has 'owner' permission in FC. And then people who are owners in AoU land are technically just writers in FC. This would allow us to ensure that all sharing happens from the AoU UI, rather than from FC, in AoU workspaces. Thoughts on this? I think its considerably more complicated, but could be worth it if we wanted more technical control? The disadvantage would be that our ACL wouldn't line up with the FC ACL.