### PR TITLE
mv WorkspaceDaoTest to the proper package

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/db/dao/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/WorkspaceDaoTest.java
@@ -1,10 +1,9 @@
-package org.pmiops.workbench.cdr.dao;
+package org.pmiops.workbench.db.dao;
 
 import static org.springframework.test.util.AssertionErrors.fail;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;


### PR DESCRIPTION
I pattern matched the only directory named "dao". `db/dao` did not yet exist.