### PR TITLE
Johnstill/rw 255 typechecked linting

### DIFF
--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -122,7 +122,7 @@ def dev_up(*args)
 end
 
 def run_linter()
-  Common.new.run_inline %W{docker-compose run --rm ui npm run ng lint}
+  Common.new.run_inline %W{docker-compose run --rm ui npm run lint}
 end
 
 def rebuild_image()

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1253,6 +1253,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3074,6 +3075,910 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -8003,7 +8908,7 @@
         "resolve": "1.4.0",
         "semver": "5.4.1",
         "tslib": "1.7.1",
-        "tsutils": "2.8.0"
+        "tsutils": "2.12.2"
       },
       "dependencies": {
         "optimist": {
@@ -8019,9 +8924,9 @@
       }
     },
     "tsutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
-      "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
+      "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test --sourcemaps=false",
-    "lint": "ng lint",
+    "lint": "ng lint --type-check",
     "e2e": "ng e2e",
     "codegen-clean": "rm -rf src/generated",
     "codegen": "npm run codegen-clean && java -jar ../libproject/swagger-codegen-cli.jar generate --lang typescript-angular --input-spec ../api/src/main/resources/workbench.yaml --output src/generated --additional-properties ngVersion=2"
@@ -57,7 +57,7 @@
     "karma-webdriver-launcher": "^1.0.5",
     "protractor": "~5.1.2",
     "ts-node": "~3.0.4",
-    "tslint": "~5.3.2",
+    "tslint": "^5.3.2",
     "typescript": "~2.3.3"
   }
 }

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -11,9 +11,9 @@ import {RouterModule, Routes} from '@angular/router';
 import {CohortEditComponent} from 'app/views/cohort-edit/component';
 import {HomePageComponent} from 'app/views/home-page/component';
 import {ReviewComponent} from 'app/views/review/component';
-import {WorkspaceComponent} from 'app/views/workspace/component';
 import {WorkspaceEditComponent} from 'app/views/workspace-edit/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
+import {WorkspaceComponent} from 'app/views/workspace/component';
 
 // tslint:enable:max-line-length
 

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,8 +1,3 @@
-// Import all the pieces of the app centrally.
-
-// TODO: Remove the lint-disable comment once we can selectively ignore import lines.
-// https://github.com/palantir/tslint/pull/3099
-// tslint:disable:max-line-length
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {HttpModule} from '@angular/http';
@@ -10,30 +5,35 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from 'clarity-angular';
 
-/* Our Components */
-import {AccountCreationComponent} from 'app/views/account-creation/component';
-import {AppComponent} from 'app/views/app/component';
-import {BugReportComponent} from 'app/views/bug-report/component';
-import {CohortEditComponent} from 'app/views/cohort-edit/component';
-import {ErrorHandlerComponent} from 'app/views/error-handler/component';
-import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {HomePageComponent} from 'app/views/home-page/component';
-import {ReviewComponent} from 'app/views/review/component';
-import {SignInService} from 'app/services/sign-in.service';
-import {WorkspaceComponent} from 'app/views/workspace/component';
-import {WorkspaceEditComponent} from 'app/views/workspace-edit/component';
-import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
+import {ErrorHandlingService} from './services/error-handling.service';
+import {SignInService} from './services/sign-in.service';
+
+import {AccountCreationComponent} from './views/account-creation/component';
+import {AppComponent} from './views/app/component';
+import {BugReportComponent} from './views/bug-report/component';
+import {CohortEditComponent} from './views/cohort-edit/component';
+import {ErrorHandlerComponent} from './views/error-handler/component';
+import {HomePageComponent} from './views/home-page/component';
+import {ReviewComponent} from './views/review/component';
+import {WorkspaceEditComponent} from './views/workspace-edit/component';
+import {WorkspaceShareComponent} from './views/workspace-share/component';
+import {WorkspaceComponent} from './views/workspace/component';
+
 import {environment} from 'environments/environment';
 
 /* Our Modules */
-import {AppRoutingModule} from 'app/app-routing.module';
-import {CohortSearchModule} from './cohort-search/cohort-search.module';
+import {AppRoutingModule} from './app-routing.module';
 import {CohortReviewModule} from './cohort-review/cohort-review.module';
+import {CohortSearchModule} from './cohort-search/cohort-search.module';
 
-import {BugReportService, CohortsService, Configuration, ConfigurationParameters, ProfileService, WorkspacesService} from 'generated';
-import {ClusterService} from 'generated';
-// tslint:enable:max-line-length
-
+import {
+  BugReportService,
+  ClusterService,
+  CohortsService,
+  Configuration,
+  ProfileService,
+  WorkspacesService
+} from 'generated';
 
 // "Configuration" means Swagger API Client configuration.
 export function getConfiguration(signInService: SignInService): Configuration {
@@ -42,8 +42,6 @@ export function getConfiguration(signInService: SignInService): Configuration {
       accessToken: () => signInService.currentAccessToken
     });
 }
-
-
 
 @NgModule({
   imports: [

--- a/ui/src/app/cohort-review/cohort-review.module.ts
+++ b/ui/src/app/cohort-review/cohort-review.module.ts
@@ -1,12 +1,12 @@
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 import {ClarityModule} from 'clarity-angular';
 
 import {AnnotationsComponent} from './annotations/annotations.component';
 import {CohortReviewComponent} from './cohort-review/cohort-review.component';
 import {MedicationsComponent} from './medications/medications.component';
-import {SubjectListComponent} from './subject-list/subject-list.component';
 import {SubjectDetailComponent} from './subject-detail/subject-detail.component';
+import {SubjectListComponent} from './subject-list/subject-list.component';
 
 import {CohortReviewRouter} from './router.module';
 
@@ -20,8 +20,8 @@ import {CohortReviewRouter} from './router.module';
     AnnotationsComponent,
     CohortReviewComponent,
     MedicationsComponent,
-    SubjectListComponent,
     SubjectDetailComponent,
+    SubjectListComponent,
   ]
 })
 export class CohortReviewModule {}

--- a/ui/src/app/cohort-review/cohort-review/cohort-review.component.ts
+++ b/ui/src/app/cohort-review/cohort-review/cohort-review.component.ts
@@ -1,17 +1,8 @@
-import { Component, OnInit } from '@angular/core';
-import { StringFilter } from 'clarity-angular';
-import { Subject } from '../model/subject';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-cohort-review',
   templateUrl: './cohort-review.component.html',
   styleUrls: ['./cohort-review.component.css']
 })
-export class CohortReviewComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class CohortReviewComponent {}

--- a/ui/src/app/cohort-review/router.module.ts
+++ b/ui/src/app/cohort-review/router.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from '@angular/core';
-import {RouterModule, Routes} from '@angular/router';
+import {RouterModule} from '@angular/router';
 
 import {CohortReviewComponent} from './cohort-review/cohort-review.component';
 

--- a/ui/src/app/cohort-review/subject-list/subject-list.component.ts
+++ b/ui/src/app/cohort-review/subject-list/subject-list.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
-import { StringFilter } from 'clarity-angular';
-import { Subject } from '../model';
+import {Component, OnInit} from '@angular/core';
+import {StringFilter} from 'clarity-angular';
+
+import {Subject} from '../model';
 
 class SubjectFilter implements StringFilter<Subject> {
   accepts(subject: Subject, search: string): boolean {
@@ -18,9 +19,8 @@ export class SubjectListComponent implements OnInit {
 
   public subjects: Subject[];
 
+  /* tslint:disable-next-line:no-unused-variable */
   private subjectFilter = new SubjectFilter();
-
-  constructor() { }
 
   ngOnInit() {
     this.subjects = [new Subject(127736, 'NR'),

--- a/ui/src/app/cohort-search/charts/charts.component.ts
+++ b/ui/src/app/cohort-search/charts/charts.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ChangeDetectionStrategy} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {List, Map, Set} from 'immutable';
 
 type Datum = Map<string, any>;
@@ -102,12 +102,13 @@ const combinationDataTable = (cleanData: Data): any[] => {
       border: 1px solid #d7d7d7;
     }
   `],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ChartsComponent {
   private rawData: Data;
 
   private genderData: any[];
+
+  /* tslint:disable-next-line:no-unused-variable */
   private readonly genderOpts = {
     title: 'Results By Gender',
     chartArea: {width: '80%'},
@@ -121,6 +122,8 @@ export class ChartsComponent {
   };
 
   private combinationData: any[];
+
+  /* tslint:disable-next-line:no-unused-variable */
   private readonly combinationOpts = {
     title: 'Results by Gender, Age, and Race',
     chartArea: {width: '75%'},

--- a/ui/src/app/cohort-search/charts/charts.module.ts
+++ b/ui/src/app/cohort-search/charts/charts.module.ts
@@ -1,8 +1,8 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
-import {GoogleChartDirective} from './google-chart.directive';
 import {ChartsComponent} from './charts.component';
+import {GoogleChartDirective} from './google-chart.directive';
 
 @NgModule({
   imports: [
@@ -12,8 +12,8 @@ import {ChartsComponent} from './charts.component';
     ChartsComponent
   ],
   declarations: [
-    GoogleChartDirective,
     ChartsComponent,
+    GoogleChartDirective,
   ]
 })
 export class ChartsModule {}

--- a/ui/src/app/cohort-search/cohort-search.module.ts
+++ b/ui/src/app/cohort-search/cohort-search.module.ts
@@ -1,28 +1,22 @@
-// tslint:disable:max-line-length
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {ClarityModule} from 'clarity-angular';
 import {NgReduxModule} from '@angular-redux/store';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ClarityModule} from 'clarity-angular';
 
 /* Components */
 import {CohortSearchComponent} from './cohort-search/cohort-search.component';
 import {OverviewComponent} from './overview/overview.component';
-import {SearchGroupComponent} from './search-group/search-group.component';
 import {SearchGroupItemComponent} from './search-group-item/search-group-item.component';
 import {SearchGroupListComponent} from './search-group-list/search-group-list.component';
+import {SearchGroupComponent} from './search-group/search-group.component';
 
 /* Other Objects */
 import {ChartsModule} from './charts/charts.module';
 import {CriteriaWizardModule} from './criteria-wizard/criteria-wizard.module';
+import {CohortSearchActions, CohortSearchEpics, ConfigureStore} from './redux';
 import {CohortSearchRouter} from './router.module';
-import {
-  CohortSearchActions,
-  CohortSearchEpics,
-  ConfigureStore,
-} from './redux';
-import {CohortBuilderService} from 'generated';
 
-// tslint:enable:max-line-length
+import {CohortBuilderService} from 'generated';
 
 @NgModule({
   imports: [

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
@@ -1,24 +1,17 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-} from '@angular/core';
-import {NgRedux, select} from '@angular-redux/store';
-import {Router, ActivatedRoute} from '@angular/router';
-import {Observable} from 'rxjs/Observable';
-import {Subscription} from 'rxjs/Subscription';
+import {select} from '@angular-redux/store';
+import {Component} from '@angular/core';
 import {List} from 'immutable';
+import {Observable} from 'rxjs/Observable';
 
 import {
-  CohortSearchActions,
-  CohortSearchState,
   activeCriteriaType,
-  includeGroups,
-  excludeGroups,
-  wizardOpen,
-  totalCount,
-  isRequstingTotal,
   chartData,
+  CohortSearchActions,
+  excludeGroups,
+  includeGroups,
+  isRequstingTotal,
+  totalCount,
+  wizardOpen,
 } from '../redux';
 
 @Component({
@@ -26,7 +19,7 @@ import {
   templateUrl: './cohort-search.component.html',
   styleUrls: ['./cohort-search.component.css'],
 })
-export class CohortSearchComponent implements OnInit, OnDestroy {
+export class CohortSearchComponent {
 
   @select(includeGroups) includeGroups$: Observable<List<any>>;
   @select(excludeGroups) excludeGroups$: Observable<List<any>>;
@@ -36,30 +29,6 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
   @select(isRequstingTotal) isRequesting$: Observable<boolean>;
   @select(activeCriteriaType) criteriaType$: Observable<string>;
 
-  private adding = false;
-  private subscriptions: Subscription[];
-
-  constructor(
-    private actions: CohortSearchActions,
-    private router: Router,
-    private route: ActivatedRoute
-  ) {}
-
-  ngOnInit() {
-    if (this.route.snapshot.url[5] === undefined) {
-      this.adding = true;
-    }
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.forEach(sub => sub.unsubscribe());
-  }
-
-  save(): void {
-    if (this.adding) {
-      this.router.navigate(['../create'], {relativeTo : this.route});
-    } else {
-      this.router.navigate(['../edit'], {relativeTo : this.route});
-    }
-  }
+  /* tslint:disable-next-line:no-unused-variable */
+  constructor(private actions: CohortSearchActions) {}
 }

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/age-form.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/age-form.component.ts
@@ -1,13 +1,15 @@
-import {Component, OnInit, OnDestroy, Output, EventEmitter} from '@angular/core';
-import {FormGroup, FormControl, Validators} from '@angular/forms';
 import {select} from '@angular-redux/store';
+import {Component, EventEmitter, OnDestroy, OnInit, Output} from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {fromJS, List} from 'immutable';
 import {Subscription} from 'rxjs/Subscription';
-import {List, Map, fromJS} from 'immutable';
 
-import {environment} from 'environments/environment';
 import {activeParameterList} from '../../redux';
 import {AttributeFormComponent} from './attributes.interface';
+
+import {environment} from 'environments/environment';
 import {Attribute} from 'generated';
+
 
 const OPERATORS = {
   'between': 'In Range',
@@ -71,10 +73,15 @@ export class AgeFormComponent implements AttributeFormComponent, OnInit, OnDestr
   @select(activeParameterList) parameterSelection$;
   private selected: List<string>;
   private subscription: Subscription;
+
+  /* tslint:disable:no-unused-variable */
+  /* All are used in the template */
   private readonly operators = OPERATORS;
   private readonly opCodes = Object.keys(OPERATORS);
   private readonly maxAge = MAX_AGE;
   private readonly minAge = MIN_AGE;
+  /* tslint:enable:no-unused-variable */
+
   @Output() attribute = new EventEmitter<Attribute | null>();
 
   ngOnInit() {

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
@@ -1,17 +1,15 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {By} from '@angular/platform-browser';
-import {ClarityModule} from 'clarity-angular';
-import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, fromJS} from 'immutable';
 import {NgRedux} from '@angular-redux/store';
+import {MockNgRedux} from '@angular-redux/store/testing';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS, Map} from 'immutable';
 
 import {CohortSearchActions} from '../../redux';
 import {AttributesComponent} from '../attributes/attributes.component';
+
 import {CohortBuilderService} from 'generated';
 
-class MockActions {
-}
+class MockActions {}
 
 describe('AttributesComponent', () => {
   let fixture: ComponentFixture<AttributesComponent>;

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.ts
@@ -6,13 +6,13 @@ import {
   OnDestroy,
   ViewChild,
 } from '@angular/core';
+import {fromJS, List, Map} from 'immutable';
 import {Observable} from 'rxjs/Observable';
-import {List, Map, fromJS} from 'immutable';
 import {Subscription} from 'rxjs/Subscription';
 
 import {CohortSearchActions} from '../../redux';
-import {AttributesDirective} from './attributes.directive';
 import {AgeFormComponent} from './age-form.component';
+import {AttributesDirective} from './attributes.directive';
 
 import {Attribute} from 'generated';
 

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.interface.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.interface.ts
@@ -1,5 +1,7 @@
+/* tslint:disable:no-unused-variable */
 import {EventEmitter} from '@angular/core';
 import {Attribute} from 'generated';
+/* tslint:enable:no-unused-variable */
 
 export interface AttributeFormComponent {
   attribute: EventEmitter<Attribute | null>;

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.module.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.module.ts
@@ -1,11 +1,11 @@
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {ClarityModule} from 'clarity-angular';
+import {NgModule} from '@angular/core';
 import {ReactiveFormsModule} from '@angular/forms';
+import {ClarityModule} from 'clarity-angular';
 
-import {AttributesDirective} from './attributes.directive';
-import {AttributesComponent} from './attributes.component';
 import {AgeFormComponent} from './age-form.component';
+import {AttributesComponent} from './attributes.component';
+import {AttributesDirective} from './attributes.directive';
 
 @NgModule({
   imports: [
@@ -17,9 +17,9 @@ import {AgeFormComponent} from './age-form.component';
     AttributesComponent,
   ],
   declarations: [
-    AttributesDirective,
-    AttributesComponent,
     AgeFormComponent,
+    AttributesComponent,
+    AttributesDirective,
   ],
   entryComponents: [
     AgeFormComponent,

--- a/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
@@ -1,7 +1,9 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ReactiveFormsModule} from '@angular/forms';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from 'clarity-angular';
+
 
 import {AlertsComponent} from './alerts/alerts.component';
 import {AttributesModule} from './attributes/attributes.module';
@@ -20,6 +22,7 @@ import {WizardComponent} from './wizard/wizard.component';
 @NgModule({
   imports: [
     AttributesModule,
+    BrowserAnimationsModule,
     CommonModule,
     ClarityModule,
     ReactiveFormsModule,

--- a/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
@@ -1,17 +1,17 @@
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ClarityModule} from 'clarity-angular';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ReactiveFormsModule} from '@angular/forms';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ClarityModule} from 'clarity-angular';
 
-import {AttributesModule} from './attributes/attributes.module';
 import {AlertsComponent} from './alerts/alerts.component';
+import {AttributesModule} from './attributes/attributes.module';
 import {ExplorerComponent} from './explorer/explorer.component';
 import {LeafComponent} from './leaf/leaf.component';
-import {QuickSearchComponent} from './quicksearch/quicksearch.component';
 import {
   QuickSearchResultsComponent
 } from './quicksearch-results/quicksearch-results.component';
+import {QuickSearchComponent} from './quicksearch/quicksearch.component';
 import {RootSpinnerComponent} from './root-spinner/root-spinner.component';
 import {SelectionComponent} from './selection/selection.component';
 import {TreeComponent} from './tree/tree.component';

--- a/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/criteria-wizard.module.ts
@@ -1,7 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ReactiveFormsModule} from '@angular/forms';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from 'clarity-angular';
 
 import {AlertsComponent} from './alerts/alerts.component';
@@ -21,7 +20,6 @@ import {WizardComponent} from './wizard/wizard.component';
 @NgModule({
   imports: [
     AttributesModule,
-    BrowserAnimationsModule,
     CommonModule,
     ClarityModule,
     ReactiveFormsModule,

--- a/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
@@ -1,14 +1,15 @@
-import {Component, OnInit, Input} from '@angular/core';
-import {NgRedux, select} from '@angular-redux/store';
+import {NgRedux} from '@angular-redux/store';
+import {Component, Input, OnInit} from '@angular/core';
+import {fromJS, Map} from 'immutable';
 import {Observable} from 'rxjs/Observable';
-import {Map, fromJS} from 'immutable';
 
 import {
   CohortSearchActions,
+  /* tslint:disable-next-line:no-unused-variable */
   CohortSearchState,
-  isCriteriaLoading,
   criteriaLoadErrors,
   focusedCriterion,
+  isCriteriaLoading,
 } from '../../redux';
 
 import {CohortBuilderService} from 'generated';
@@ -36,9 +37,11 @@ export class ExplorerComponent implements OnInit {
   private nodeInFocus$: Observable<Map<any, any>>;
 
   constructor(
+    /* tslint:disable:no-unused-variable */
     private ngRedux: NgRedux<CohortSearchState>,
     private actions: CohortSearchActions,
     private api: CohortBuilderService,
+    /* tslint:enable:no-unused-variable */
   ) {}
 
   ngOnInit() {

--- a/ui/src/app/cohort-search/criteria-wizard/quicksearch-results/quicksearch-results.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/quicksearch-results/quicksearch-results.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
 import {select} from '@angular-redux/store';
-import {Observable} from 'rxjs/Observable';
+import {Component, Input} from '@angular/core';
 import {List} from 'immutable';
+import {Observable} from 'rxjs/Observable';
 
 import {activeParameterList} from '../../redux';
 

--- a/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
 @Component({
@@ -8,6 +8,7 @@ import {FormControl} from '@angular/forms';
 })
 export class QuickSearchComponent {
   private fuzzyFinder = new FormControl();
+  /* tslint:disable-next-line:no-unused-variable */
   private isFocused = false;
   @Output() value = new EventEmitter<string>();
 

--- a/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
@@ -1,19 +1,21 @@
+import {dispatch, NgRedux} from '@angular-redux/store';
+import {MockNgRedux} from '@angular-redux/store/testing';
 import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ClarityModule} from 'clarity-angular';
-import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, List, fromJS} from 'immutable';
-import {NgRedux, dispatch} from '@angular-redux/store';
+import {fromJS} from 'immutable';
 
 import {
   activeCriteriaType,
   activeParameterList,
   CohortSearchActions,
+  /* tslint:disable-next-line:no-unused-variable */
   CohortSearchState,
   REMOVE_PARAMETER,
   removeParameter,
 } from '../../redux';
 import {SelectionComponent} from './selection.component';
+
 import {CohortBuilderService} from 'generated';
 
 const TYPE_ICD9 = 'icd9';
@@ -30,34 +32,6 @@ const SELECTION_ICD9 = fromJS([
     name: 'CodeB',
     id: 'CodeB',
     parameterId: 'CodeB',
-  }
-]);
-
-const SELECTION_DEMO = fromJS([
-  {
-    type: 'DEMO',
-    subtype: 'GEN',
-    name: 'Female',
-    code: 'F',
-    id: 0,
-    parameterId: 'Code0',
-  }, {
-    type: 'DEMO',
-    subtype: 'RACE',
-    name: 'African American',
-    code: 'A',
-    id: 1,
-    parameterId: 'Code1',
-  }, {
-    type: 'DEMO',
-    subtype: 'AGE',
-    id: 2,
-    parameterId: 'Code0',
-  }, {
-    type: 'DEMO',
-    subtype: 'DEC',
-    id: 3,
-    parameterId: 'Code0',
   }
 ]);
 
@@ -104,7 +78,7 @@ describe('SelectionComponent', () => {
         activeCriteriaType);
 
     listStub = MockNgRedux
-      .getSelectorStub<CohortSearchState, List<any>>(
+      .getSelectorStub<CohortSearchState, any>(
         activeParameterList);
 
     fixture.detectChanges();

--- a/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.ts
@@ -1,17 +1,12 @@
-import {Component} from '@angular/core';
 import {select} from '@angular-redux/store';
+import {Component} from '@angular/core';
 import {List} from 'immutable';
 
 import {
-  CohortSearchActions,
-  activeGroupId,
-  activeRole,
   activeCriteriaType,
   activeParameterList,
+  CohortSearchActions,
 } from '../../redux';
-
-import {Criteria} from 'generated';
-
 
 @Component({
   selector: 'crit-selection',

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
@@ -1,16 +1,16 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {ClarityModule} from 'clarity-angular';
-import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, fromJS} from 'immutable';
 import {NgRedux} from '@angular-redux/store';
+import {MockNgRedux} from '@angular-redux/store/testing';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS, Map} from 'immutable';
 
 import {
-  CohortSearchActions,
   BEGIN_CRITERIA_REQUEST,
+  CohortSearchActions,
 } from '../../redux';
 import {LeafComponent} from '../leaf/leaf.component';
 import {TreeComponent} from './tree.component';
+
 import {CohortBuilderService} from 'generated';
 
 describe('TreeComponent', () => {

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
@@ -1,22 +1,16 @@
-import {
-  Component,
-  OnDestroy,
-  OnInit,
-  Input,
-  ViewEncapsulation,
-} from '@angular/core';
 import {NgRedux, select} from '@angular-redux/store';
-import {Observable} from 'rxjs/Observable';
+import {Component, Input, OnInit} from '@angular/core';
 import {List} from 'immutable';
+import {Observable} from 'rxjs/Observable';
 
-import {needsAttributes} from '../utils';
 import {
-  CohortSearchActions,
-  CohortSearchState,
   activeParameterList,
-  isCriteriaLoading,
+  CohortSearchActions,
+  /* tslint:disable-next-line:no-unused-variable */
+  CohortSearchState,
   criteriaChildren,
   criteriaError,
+  isCriteriaLoading,
 } from '../../redux';
 
 @Component({

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
@@ -1,11 +1,9 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {By} from '@angular/platform-browser';
-import {ClarityModule} from 'clarity-angular';
-import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, fromJS} from 'immutable';
 import {NgRedux} from '@angular-redux/store';
+import {MockNgRedux} from '@angular-redux/store/testing';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS} from 'immutable';
 
 import {
   CohortSearchActions,
@@ -13,17 +11,18 @@ import {
   WIZARD_FINISH,
 } from '../../redux';
 
-import {AttributesModule} from '../attributes/attributes.module';
-import {AlertsComponent} from '../alerts/alerts.component';
-import {ExplorerComponent} from '../explorer/explorer.component';
-import {LeafComponent} from '../leaf/leaf.component';
-import {QuickSearchComponent} from '../quicksearch/quicksearch.component';
-import {QuickSearchResultsComponent
-} from '../quicksearch-results/quicksearch-results.component';
-import {RootSpinnerComponent} from '../root-spinner/root-spinner.component';
-import {SelectionComponent} from '../selection/selection.component';
-import {TreeComponent} from '../tree/tree.component';
-import {WizardComponent} from './wizard.component';
+import {AlertsComponent} from './alerts/alerts.component';
+import {AttributesModule} from './attributes/attributes.module';
+import {ExplorerComponent} from './explorer/explorer.component';
+import {LeafComponent} from './leaf/leaf.component';
+import {
+  QuickSearchResultsComponent
+} from './quicksearch-results/quicksearch-results.component';
+import {QuickSearchComponent} from './quicksearch/quicksearch.component';
+import {RootSpinnerComponent} from './root-spinner/root-spinner.component';
+import {SelectionComponent} from './selection/selection.component';
+import {TreeComponent} from './tree/tree.component';
+import {WizardComponent} from './wizard/wizard.component';
 
 import {CohortBuilderService} from 'generated';
 
@@ -55,7 +54,6 @@ describe('WizardComponent', () => {
         ],
         imports: [
           AttributesModule,
-          BrowserAnimationsModule,
           ClarityModule,
           ReactiveFormsModule,
         ],

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
@@ -2,6 +2,7 @@ import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
 import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS} from 'immutable';
 
@@ -54,6 +55,7 @@ describe('WizardComponent', () => {
         ],
         imports: [
           AttributesModule,
+          BrowserAnimationsModule,
           ClarityModule,
           ReactiveFormsModule,
         ],

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
@@ -11,18 +11,18 @@ import {
   WIZARD_FINISH,
 } from '../../redux';
 
-import {AlertsComponent} from './alerts/alerts.component';
-import {AttributesModule} from './attributes/attributes.module';
-import {ExplorerComponent} from './explorer/explorer.component';
-import {LeafComponent} from './leaf/leaf.component';
+import {AlertsComponent} from '../alerts/alerts.component';
+import {AttributesModule} from '../attributes/attributes.module';
+import {ExplorerComponent} from '../explorer/explorer.component';
+import {LeafComponent} from '../leaf/leaf.component';
 import {
   QuickSearchResultsComponent
-} from './quicksearch-results/quicksearch-results.component';
-import {QuickSearchComponent} from './quicksearch/quicksearch.component';
-import {RootSpinnerComponent} from './root-spinner/root-spinner.component';
-import {SelectionComponent} from './selection/selection.component';
-import {TreeComponent} from './tree/tree.component';
-import {WizardComponent} from './wizard/wizard.component';
+} from '../quicksearch-results/quicksearch-results.component';
+import {QuickSearchComponent} from '../quicksearch/quicksearch.component';
+import {RootSpinnerComponent} from '../root-spinner/root-spinner.component';
+import {SelectionComponent} from '../selection/selection.component';
+import {TreeComponent} from '../tree/tree.component';
+import {WizardComponent} from './wizard.component';
 
 import {CohortBuilderService} from 'generated';
 

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.ts
@@ -1,15 +1,6 @@
 import {Component, Input, ViewEncapsulation} from '@angular/core';
-import {NgRedux} from '@angular-redux/store';
 
-import {
-  CohortSearchActions,
-  CohortSearchState,
-  activeParameterList,
-  activeRole,
-  activeGroupId,
-  activeItem,
-} from '../../redux';
-
+import {CohortSearchActions} from '../../redux';
 
 @Component({
   selector: 'app-criteria-wizard',
@@ -21,10 +12,7 @@ export class WizardComponent {
   @Input() open: boolean;
   @Input() criteriaType: string;
 
-  constructor(
-    private ngRedux: NgRedux<CohortSearchState>,
-    private actions: CohortSearchActions,
-  ) {}
+  constructor(private actions: CohortSearchActions) {}
 
   get critPageTitle() {
     let _type = this.criteriaType;

--- a/ui/src/app/cohort-search/overview/overview.component.spec.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.spec.ts
@@ -1,19 +1,17 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {DebugElement} from '@angular/core';
-import {ClarityModule} from 'clarity-angular';
-import {NgRedux, dispatch} from '@angular-redux/store';
+import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, List, fromJS} from 'immutable';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS} from 'immutable';
 import {Observable} from 'rxjs/Observable';
 
+import {ChartsModule} from '../charts/charts.module';
 import {CohortSearchActions} from '../redux';
 import {OverviewComponent} from './overview.component';
-import {ChartsModule} from '../charts/charts.module';
+
 import {CohortBuilderService} from 'generated';
 
-class MockActions {
-}
+class MockActions {}
 
 describe('OverviewComponent', () => {
   let fixture: ComponentFixture<OverviewComponent>;

--- a/ui/src/app/cohort-search/overview/overview.component.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input} from '@angular/core';
-import {Observable} from 'rxjs/Observable';
 import {List} from 'immutable';
+import {Observable} from 'rxjs/Observable';
 
 import {CohortSearchActions} from '../redux';
 
@@ -14,6 +14,7 @@ export class OverviewComponent {
   @Input() total$: Observable<number>;
   @Input() isRequesting$: Observable<boolean>;
 
+  /* tslint:disable-next-line:no-unused-variable */
   constructor(private actions: CohortSearchActions) {}
 
   save() {

--- a/ui/src/app/cohort-search/redux/actions/creators.ts
+++ b/ui/src/app/cohort-search/redux/actions/creators.ts
@@ -1,4 +1,4 @@
-import {List} from 'immutable';
+/* tslint:disable:ordered-imports */
 import {
   BEGIN_CRITERIA_REQUEST,
   LOAD_CRITERIA_RESULTS,
@@ -29,8 +29,9 @@ import {
   SET_WIZARD_CONTEXT,
   ActionTypes,
 } from './types';
+/* tslint:enable:ordered-imports */
 
-import {Criteria, SearchRequest, ChartInfo} from 'generated';
+import {ChartInfo, Criteria, SearchRequest} from 'generated';
 
 /**
  * Criteria loading mgmt

--- a/ui/src/app/cohort-search/redux/actions/service.spec.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.spec.ts
@@ -1,12 +1,12 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {List, fromJS} from 'immutable';
+import {fromJS, List} from 'immutable';
 
-import {initialState, CohortSearchState, SR_ID} from '../store';
+/* tslint:disable-next-line:no-unused-variable */
+import {CohortSearchState, initialState, SR_ID} from '../store';
 import {CohortSearchActions} from './service';
 
 import {CohortBuilderService} from 'generated';
-import {isUndefined} from 'util';
 
 /**
  * Dummy objects / mock state peices

--- a/ui/src/app/cohort-search/redux/actions/service.spec.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.spec.ts
@@ -6,8 +6,6 @@ import {fromJS, List} from 'immutable';
 import {CohortSearchState, initialState, SR_ID} from '../store';
 import {CohortSearchActions} from './service';
 
-import {CohortBuilderService} from 'generated';
-
 /**
  * Dummy objects / mock state peices
  */

--- a/ui/src/app/cohort-search/redux/actions/service.spec.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.spec.ts
@@ -84,7 +84,6 @@ describe('CohortSearchActions', () => {
     mockReduxInst.getState = () => dummyState;
     actions = new CohortSearchActions(
       mockReduxInst as NgRedux<CohortSearchState>,
-      {} as CohortBuilderService,
     );
   });
 

--- a/ui/src/app/cohort-search/redux/actions/service.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.ts
@@ -1,40 +1,40 @@
+import {dispatch, NgRedux} from '@angular-redux/store';
 import {Injectable} from '@angular/core';
-import {NgRedux, dispatch} from '@angular-redux/store';
-import {AnyAction} from 'redux';
-import {List, Map, Set, isCollection, isImmutable} from 'immutable';
+import {isImmutable, List, Map, Set} from 'immutable';
 
 import {environment} from 'environments/environment';
 
 import {
-  CohortSearchState,
-  isCriteriaLoading,
-  isRequesting,
-  includeGroups,
-  getItem,
-  getGroup,
-  getSearchRequest,
-  SR_ID,
-  activeRole,
   activeGroupId,
   activeItem,
   activeParameterList,
+  activeRole,
+  /* tslint:disable-next-line:no-unused-variable */
+  CohortSearchState,
+  getGroup,
+  getItem,
+  getSearchRequest,
+  includeGroups,
+  isCriteriaLoading,
+  isRequesting,
+  SR_ID,
 } from '../store';
 import * as ActionFuncs from './creators';
 
 import {
-  Criteria,
-  CohortBuilderService,
-  SearchRequest,
-  SearchParameter,
   SearchGroup,
   SearchGroupItem,
+  SearchParameter,
+  SearchRequest,
 } from 'generated';
 
 
 @Injectable()
 export class CohortSearchActions {
-  constructor(private ngRedux: NgRedux<CohortSearchState>,
-              private service: CohortBuilderService) {}
+  constructor(
+    /* tslint:disable-next-line:no-unused-variable */
+    private ngRedux: NgRedux<CohortSearchState>,
+  ) {}
 
   /*
    * Auto-dispatched action creators:

--- a/ui/src/app/cohort-search/redux/actions/types.ts
+++ b/ui/src/app/cohort-search/redux/actions/types.ts
@@ -1,5 +1,4 @@
-import {List} from 'immutable';
-import {Criteria, SearchRequest, ChartInfo} from 'generated';
+import {ChartInfo, Criteria, SearchRequest} from 'generated';
 
 export const BEGIN_CRITERIA_REQUEST = 'BEGIN_CRITERIA_REQUEST';
 export const LOAD_CRITERIA_RESULTS = 'LOAD_CRITERIA_RESULTS';

--- a/ui/src/app/cohort-search/redux/epics.ts
+++ b/ui/src/app/cohort-search/redux/epics.ts
@@ -1,23 +1,23 @@
-import {ActionsObservable, Epic} from 'redux-observable';
 import {Injectable} from '@angular/core';
+import {Map} from 'immutable';
+import {Epic} from 'redux-observable';
 import {Observable} from 'rxjs/Observable';
-import {List, Map} from 'immutable';
+
+/* tslint:disable:ordered-imports */
 import {
   BEGIN_CRITERIA_REQUEST,
   CANCEL_CRITERIA_REQUEST,
-  CRITERIA_REQUEST_ERROR,
 
   BEGIN_COUNT_REQUEST,
   CANCEL_COUNT_REQUEST,
-  COUNT_REQUEST_ERROR,
 
   BEGIN_CHARTS_REQUEST,
   CANCEL_CHARTS_REQUEST,
-  CHARTS_REQUEST_ERROR,
 
   RootAction,
   ActionTypes,
 } from './actions/types';
+
 import {
   loadCriteriaRequestResults,
   criteriaRequestError,
@@ -28,7 +28,10 @@ import {
   loadChartsRequestResults,
   chartsRequestError,
 } from './actions/creators';
+
 import {CohortSearchState} from './store';
+/* tslint:enable:ordered-imports */
+
 import {CohortBuilderService} from 'generated';
 
 type CSEpic = Epic<RootAction, CohortSearchState>;
@@ -36,6 +39,7 @@ type CritRequestAction = ActionTypes[typeof BEGIN_CRITERIA_REQUEST];
 type CountRequestAction = ActionTypes[typeof BEGIN_COUNT_REQUEST];
 type ChartRequestAction = ActionTypes[typeof BEGIN_CHARTS_REQUEST];
 const compare = (obj) => (action) => Map(obj).isSubset(Map(action));
+
 /**
  * CohortSearchEpics
  *

--- a/ui/src/app/cohort-search/redux/index.ts
+++ b/ui/src/app/cohort-search/redux/index.ts
@@ -1,18 +1,26 @@
+import {DevToolsExtension, NgRedux} from '@angular-redux/store';
 import {Injectable} from '@angular/core';
-import {createEpicMiddleware, combineEpics} from 'redux-observable';
-import {NgReduxModule, NgRedux, DevToolsExtension} from '@angular-redux/store';
+import {combineEpics, createEpicMiddleware} from 'redux-observable';
+
 import {environment} from 'environments/environment';
 
-import {initialState, CohortSearchState} from './store';
 import {CohortSearchEpics} from './epics';
 import {rootReducer} from './reducer';
+import {
+  /* tslint:disable-next-line:no-unused-variable */
+  CohortSearchState,
+  initialState,
+} from './store';
 
 @Injectable()
 export class ConfigureStore {
+
   constructor(
+    /* tslint:disable:no-unused-variable */
     private ngRedux: NgRedux<CohortSearchState>,
     private epics: CohortSearchEpics,
-    private devTools: DevToolsExtension
+    private devTools: DevToolsExtension,
+    /* tslint:enable:no-unused-variable */
   ) {
 
     let storeEnhancers = [];

--- a/ui/src/app/cohort-search/redux/reducer.ts
+++ b/ui/src/app/cohort-search/redux/reducer.ts
@@ -1,16 +1,16 @@
+import {fromJS, List, Map, Set} from 'immutable';
 import {Reducer} from 'redux';
-import {Map, List, Set, fromJS} from 'immutable';
 
 import {
-  initialState,
-  CohortSearchState,
-  SR_ID,
-  activeCriteriaType,
   activeGroupId,
   activeItem,
   activeParameterList,
+  CohortSearchState,
+  initialState,
+  SR_ID,
 } from './store';
 
+/* tslint:disable:ordered-imports */
 import {
   BEGIN_CRITERIA_REQUEST,
   LOAD_CRITERIA_RESULTS,
@@ -41,6 +41,7 @@ import {
   SET_WIZARD_CONTEXT,
   RootAction,
 } from './actions/types';
+/* tslint:enable:ordered-imports */
 
 /**
  * The root Reducer.  Handles synchronous changes to application State

--- a/ui/src/app/cohort-search/redux/store/selectors.ts
+++ b/ui/src/app/cohort-search/redux/store/selectors.ts
@@ -1,7 +1,9 @@
-import {Map, List} from 'immutable';
-import {Criteria, SearchRequest} from 'generated';
+import {List, Map} from 'immutable';
 
 import {SR_ID} from './initial';
+
+import {SearchRequest} from 'generated';
+
 
 
 /**

--- a/ui/src/app/cohort-search/router.module.ts
+++ b/ui/src/app/cohort-search/router.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from '@angular/core';
-import {RouterModule, Routes} from '@angular/router';
+import {RouterModule} from '@angular/router';
 
 import {CohortSearchComponent} from './cohort-search/cohort-search.component';
 

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
@@ -1,19 +1,20 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {DebugElement} from '@angular/core';
-import {ClarityModule} from 'clarity-angular';
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, List, fromJS} from 'immutable';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS, List} from 'immutable';
 
 import {
+  CohortSearchActions,
+  /* tslint:disable-next-line:no-unused-variable */
+  CohortSearchState,
   getItem,
   parameterList,
-  CohortSearchActions,
-  CohortSearchState,
   REOPEN_WIZARD,
 } from '../redux';
 import {SearchGroupItemComponent} from './search-group-item.component';
+
 import {CohortBuilderService} from 'generated';
 
 const baseItem = fromJS({
@@ -81,7 +82,7 @@ describe('SearchGroupItemComponent', () => {
     comp.itemId = 'item001';
 
     itemStub = MockNgRedux
-      .getSelectorStub<CohortSearchState, Map<any, any>>(
+      .getSelectorStub<CohortSearchState, any>(
         getItem(comp.itemId));
 
     codeStub = MockNgRedux

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.ts
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input, OnInit, OnDestroy} from '@angular/core';
 import {NgRedux} from '@angular-redux/store';
-import {Subscription} from 'rxjs/Subscription';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {List, Map} from 'immutable';
+import {Subscription} from 'rxjs/Subscription';
 
 import {
   CohortSearchActions,
@@ -9,6 +9,7 @@ import {
   getItem,
   parameterList
 } from '../redux';
+
 import {SearchRequest} from 'generated';
 
 
@@ -16,7 +17,6 @@ const getDisplayName = (criteria: Map<any, any>): string =>
   criteria.get('type', '').match(/^DEMO.*/i)
     ?  criteria.get('name', 'N/A')
     : criteria.get('code', 'N/A');
-
 
 @Component({
   selector: 'app-search-group-item',

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
@@ -1,10 +1,8 @@
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {DebugElement} from '@angular/core';
-import {ClarityModule} from 'clarity-angular';
-import {NgRedux, dispatch} from '@angular-redux/store';
+import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {List, fromJS} from 'immutable';
+import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ClarityModule} from 'clarity-angular';
+import {fromJS, List} from 'immutable';
 import {Observable} from 'rxjs/Observable';
 
 import {
@@ -12,11 +10,11 @@ import {
   INIT_SEARCH_GROUP,
   initGroup
 } from '../redux';
-import {SearchGroupComponent} from '../search-group/search-group.component';
 import {SearchGroupItemComponent} from '../search-group-item/search-group-item.component';
-import {CohortBuilderService} from 'generated';
-
+import {SearchGroupComponent} from '../search-group/search-group.component';
 import {SearchGroupListComponent} from './search-group-list.component';
+
+import {CohortBuilderService} from 'generated';
 
 class MockActions {
   @dispatch() initGroup = initGroup;

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.ts
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.ts
@@ -1,8 +1,9 @@
 import {Component, Input} from '@angular/core';
-import {Observable} from 'rxjs/Observable';
 import {List} from 'immutable';
+import {Observable} from 'rxjs/Observable';
 
 import {CohortSearchActions} from '../redux';
+
 import {SearchRequest} from 'generated';
 
 @Component({

--- a/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
@@ -1,23 +1,25 @@
+import {dispatch, NgRedux} from '@angular-redux/store';
+import {MockNgRedux} from '@angular-redux/store/testing';
 import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {DebugElement} from '@angular/core';
 import {ClarityModule} from 'clarity-angular';
-import {NgRedux, dispatch} from '@angular-redux/store';
-import {MockNgRedux} from '@angular-redux/store/testing';
-import {Map, List, fromJS} from 'immutable';
+import {fromJS} from 'immutable';
 
 import {
   CohortSearchActions,
+  /* tslint:disable-next-line:no-unused-variable */
   CohortSearchState,
-  openWizard,
   OPEN_WIZARD,
-  removeGroup,
+  openWizard,
   REMOVE_GROUP,
+  removeGroup,
 } from '../redux';
-import {SearchGroupComponent} from './search-group.component';
 import {SearchGroupItemComponent} from '../search-group-item/search-group-item.component';
+import {SearchGroupComponent} from './search-group.component';
+
 import {CohortBuilderService} from 'generated';
 
+/* tslint:disable-next-line:no-unused-variable */
 const itemA = fromJS({
   id: 'itemA',
   count: null,
@@ -27,6 +29,7 @@ const itemA = fromJS({
   modifiers: [],
 });
 
+/* tslint:disable-next-line:no-unused-variable */
 const itemB = fromJS({
   id: 'itemB',
   count: null,

--- a/ui/src/app/cohort-search/search-group/search-group.component.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.ts
@@ -2,6 +2,7 @@ import {Component, Input} from '@angular/core';
 import {List} from 'immutable';
 
 import {CohortSearchActions} from '../redux';
+
 import {SearchRequest} from 'generated';
 
 const CRITERIA_TYPES = [

--- a/ui/src/app/services/error-handling.service.ts
+++ b/ui/src/app/services/error-handling.service.ts
@@ -8,6 +8,7 @@ export class ErrorHandlingService {
   public noServerResponse: boolean;
   public serverBusy: boolean;
 
+  /* tslint:disable-next-line:no-unused-variable */
   constructor(private zone: NgZone) {
     this.serverError = false;
     this.noServerResponse = false;

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -1,12 +1,13 @@
 /**
  * OAuth2 via GAPI sign-in.
  */
-
 import 'rxjs/Rx';
-import {Injectable, NgZone} from '@angular/core';
-import {Observable} from 'rxjs/Observable';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
+import {Injectable, NgZone} from '@angular/core';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {Observable} from 'rxjs/Observable';
+
+/* tslint:disable-next-line:no-unused-variable */
 declare const gapi: any;
 
 const SIGNED_IN_USER = 'signedInUser';

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 import {SignInService} from 'app/services/sign-in.service';
 import {DataAccessLevel} from 'generated';
 import {Profile} from 'generated';

--- a/ui/src/app/views/app/component.spec.ts
+++ b/ui/src/app/views/app/component.spec.ts
@@ -1,20 +1,18 @@
-import {TestBed, async} from '@angular/core/testing';
+import {async, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {Title} from '@angular/platform-browser';
 import {RouterTestingModule} from '@angular/router/testing';
 
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {ClarityModule} from 'clarity-angular';
 
-import {AccountCreationComponent} from 'app/views/account-creation/component';
-import {AppComponent} from 'app/views/app/component';
-import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {SignInService} from 'app/services/sign-in.service';
+import {ErrorHandlingService} from '../../services/error-handling.service';
+import {SignInService} from '../../services/sign-in.service';
+import {AccountCreationComponent} from '../account-creation/component';
+import {AppComponent} from '../app/component';
+
 import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
 import {ProfileServiceStub} from 'testing/stubs/profile-service-stub';
 
-import {CohortsService} from 'generated';
-import {ProfileService} from 'generated';
+import {CohortsService, ProfileService} from 'generated';
 
 describe('AppComponent', () => {
 

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -1,19 +1,19 @@
 // UI Component framing the overall app (title and nav).
 // Content is in other Components.
 
-import {ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 
 import {Observable} from 'rxjs/Observable';
 
+import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {SignInDetails, SignInService} from 'app/services/sign-in.service';
 import {environment} from 'environments/environment';
-import {ErrorHandlingService} from 'app/services/error-handling.service';
 
-import {Authority} from 'generated';
-import {CohortsService, Configuration, ConfigurationParameters, ProfileService} from 'generated';
+import {Authority, ProfileService} from 'generated';
 
+/* tslint:disable-next-line:no-unused-variable */
 declare const gapi: any;
 
 @Component({
@@ -29,7 +29,6 @@ export class AppComponent implements OnInit {
 
   constructor(
       private activatedRoute: ActivatedRoute,
-      private cohortsService: CohortsService,
       private errorHandlingService: ErrorHandlingService,
       private profileService: ProfileService,
       private router: Router,

--- a/ui/src/app/views/bug-report/component.spec.ts
+++ b/ui/src/app/views/bug-report/component.spec.ts
@@ -1,9 +1,8 @@
-import {Component, DebugElement} from '@angular/core';
-import {TestBed, async, tick, fakeAsync, ComponentFixture} from '@angular/core/testing';
+import {DebugElement} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {Title, By} from '@angular/platform-browser';
+import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from 'clarity-angular';
 
@@ -12,10 +11,9 @@ import {BugReportComponent} from 'app/views/bug-report/component';
 import {BugReportServiceStub} from 'testing/stubs/bug-report-service-stub';
 import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
 import {ProfileServiceStub, ProfileStubVariables} from 'testing/stubs/profile-service-stub';
-import {updateAndTick, simulateInput} from 'testing/test-helpers';
+import {simulateInput, updateAndTick} from 'testing/test-helpers';
 
-import {BugReportService} from 'generated';
-import {ProfileService} from 'generated';
+import {BugReportService, ProfileService} from 'generated';
 
 
 class BugReportPage {

--- a/ui/src/app/views/cohort-edit/component.spec.ts
+++ b/ui/src/app/views/cohort-edit/component.spec.ts
@@ -1,18 +1,17 @@
-import {Component, DebugElement} from '@angular/core';
-import {TestBed, async, tick, fakeAsync, ComponentFixture} from '@angular/core/testing';
+import {DebugElement} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {Title, By} from '@angular/platform-browser';
+import {By} from '@angular/platform-browser';
 import {ActivatedRoute, UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from 'clarity-angular';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {CohortEditComponent} from 'app/views/cohort-edit/component';
 import {WorkspaceComponent} from 'app/views/workspace/component';
-import {DEFAULT_COHORT_ID, CohortsServiceStub} from 'testing/stubs/cohort-service-stub';
+import {CohortsServiceStub, DEFAULT_COHORT_ID} from 'testing/stubs/cohort-service-stub';
 import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
-import {updateAndTick, simulateInput} from 'testing/test-helpers';
+import {simulateInput, updateAndTick} from 'testing/test-helpers';
 
 import {CohortsService} from 'generated';
 

--- a/ui/src/app/views/cohort-edit/component.ts
+++ b/ui/src/app/views/cohort-edit/component.ts
@@ -1,11 +1,9 @@
 import {Component, OnInit} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {WorkspaceComponent} from 'app/views/workspace/component';
 
-import {Cohort} from 'generated';
-import {CohortsService} from 'generated';
+import {Cohort, CohortsService} from 'generated';
 
 @Component({
   styleUrls: ['./component.css'],

--- a/ui/src/app/views/error-handler/component.ts
+++ b/ui/src/app/views/error-handler/component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import 'clarity-icons';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';

--- a/ui/src/app/views/home-page/component.spec.ts
+++ b/ui/src/app/views/home-page/component.spec.ts
@@ -1,17 +1,15 @@
-import {Component, DebugElement} from '@angular/core';
-import {TestBed, async, tick, fakeAsync, ComponentFixture} from '@angular/core/testing';
-import {Title, By} from '@angular/platform-browser';
-import {ActivatedRoute, UrlSegment} from '@angular/router';
+import {DebugElement} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
-import {FormsModule} from '@angular/forms';
 import {ClarityModule} from 'clarity-angular';
 
-import {HomePageComponent} from 'app/views/home-page/component';
-import {WorkspaceComponent} from 'app/views/workspace/component';
-import {updateAndTick, simulateInput} from 'testing/test-helpers';
-import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {ErrorHandlingService} from 'app/services/error-handling.service';
+import {HomePageComponent} from 'app/views/home-page/component';
 import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
+import {updateAndTick} from 'testing/test-helpers';
 
 import {WorkspacesService} from 'generated';
 

--- a/ui/src/app/views/home-page/component.ts
+++ b/ui/src/app/views/home-page/component.ts
@@ -1,13 +1,11 @@
-import {Component, OnInit, Inject} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
-import {DOCUMENT} from '@angular/platform-browser';
-import {StringFilter, Comparator} from 'clarity-angular';
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Comparator, StringFilter} from 'clarity-angular';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {WorkspaceComponent} from 'app/views/workspace/component';
 
-import {Workspace} from 'generated';
-import {WorkspacesService} from 'generated';
+import {Workspace, WorkspacesService} from 'generated';
+
 /*
 * Search filters used by the workspace data table to
 * determine which of the cohorts loaded into client side memory
@@ -38,9 +36,13 @@ class WorkspaceResearchPurposeFilter implements StringFilter<Workspace> {
   templateUrl: './component.html',
 })
 export class HomePageComponent implements OnInit {
+
+  /* tslint:disable:no-unused-variable */
   private workspaceNameFilter = new WorkspaceNameFilter();
   private workspaceResearchPurposeFilter = new WorkspaceResearchPurposeFilter();
   private workspaceNameComparator = new WorkspaceNameComparator();
+  /* tslint:enable:no-unused-variable */
+
   workspaceList: Workspace[] = [];
   workspacesLoading = false;
   constructor(
@@ -48,7 +50,6 @@ export class HomePageComponent implements OnInit {
       private errorHandlingService: ErrorHandlingService,
       private router: Router,
       private workspacesService: WorkspacesService,
-      @Inject(DOCUMENT) private document: any
   ) {}
   ngOnInit(): void {
     this.workspacesLoading = true;

--- a/ui/src/app/views/review/component.ts
+++ b/ui/src/app/views/review/component.ts
@@ -1,14 +1,12 @@
-import {Component, OnInit, Inject} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
-import {StringFilter, Comparator} from 'clarity-angular';
-import {DOCUMENT} from '@angular/platform-browser';
-import {Observable} from 'rxjs/Observable';
+import {Component, OnInit} from '@angular/core';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 
-import {Workspace} from 'generated';
-import {WorkspacesService} from 'generated';
-import {ResearchPurposeReviewRequest} from 'generated';
+import {
+  ResearchPurposeReviewRequest,
+  Workspace,
+  WorkspacesService,
+} from 'generated';
 
 
 /**
@@ -25,7 +23,6 @@ export class ReviewComponent implements OnInit {
   contentLoaded = false;
 
   constructor(
-      private router: Router,
       private errorHandlingService: ErrorHandlingService,
       private workspacesService: WorkspacesService
   ) {}

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -1,14 +1,16 @@
 import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
+import {ActivatedRoute} from '@angular/router';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {WorkspaceComponent} from 'app/views/workspace/component';
 import {isBlank} from 'app/utils';
 
-import {DataAccessLevel} from 'generated';
-import {Workspace} from 'generated';
-import {ProfileService, WorkspacesService} from 'generated';
+import {
+  DataAccessLevel,
+  ProfileService,
+  Workspace,
+  WorkspacesService
+} from 'generated';
 
 @Component({
   styleUrls: ['./component.css'],
@@ -27,7 +29,6 @@ export class WorkspaceEditComponent implements OnInit {
   constructor(
       private errorHandlingService: ErrorHandlingService,
       private locationService: Location,
-      private router: Router,
       private route: ActivatedRoute,
       private workspacesService: WorkspacesService,
       private profileService: ProfileService,

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -1,11 +1,9 @@
 import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
+import {ActivatedRoute} from '@angular/router';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
-import {isBlank} from 'app/utils';
 
-import {DataAccessLevel} from 'generated';
 import {ProfileService} from 'generated';
 import {UserRole} from 'generated';
 import {UserRoleList} from 'generated';
@@ -27,7 +25,6 @@ export class WorkspaceShareComponent implements OnInit {
   constructor(
       private errorHandlingService: ErrorHandlingService,
       private locationService: Location,
-      private router: Router,
       private route: ActivatedRoute,
       private profileService: ProfileService,
       private workspacesService: WorkspacesService,

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -1,7 +1,6 @@
-import {Component, DebugElement} from '@angular/core';
-import {TestBed, async, tick, fakeAsync, ComponentFixture} from '@angular/core/testing';
-import {FormsModule} from '@angular/forms';
-import {Title, By} from '@angular/platform-browser';
+import {DebugElement} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {ActivatedRoute, UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from 'clarity-angular';
@@ -11,7 +10,7 @@ import {WorkspaceComponent} from 'app/views/workspace/component';
 import {CohortsServiceStub} from 'testing/stubs/cohort-service-stub';
 import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
 import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
-import {updateAndTick, simulateInput} from 'testing/test-helpers';
+import {updateAndTick} from 'testing/test-helpers';
 
 import {ClusterService} from 'generated';
 import {CohortsService} from 'generated';

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -1,17 +1,20 @@
-import {Component, OnInit, Inject} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
-import {StringFilter, Comparator} from 'clarity-angular';
+import {Component, Inject, OnInit} from '@angular/core';
 import {DOCUMENT} from '@angular/platform-browser';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Comparator, StringFilter} from 'clarity-angular';
 import {Observable} from 'rxjs/Observable';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 
-import {Cluster} from 'generated';
-import {ClusterService} from 'generated';
-import {Cohort} from 'generated';
-import {CohortsService} from 'generated';
-import {Workspace} from 'generated';
-import {WorkspacesService} from 'generated';
+import {
+  Cluster,
+  ClusterService,
+  Cohort,
+  CohortsService,
+  Workspace,
+  WorkspacesService,
+} from 'generated';
+
 // TODO: use a real swagger generated class for this.
 class Notebook {
   constructor(public name: string, public description: string, public url: string) {}
@@ -76,6 +79,9 @@ export class WorkspaceComponent implements OnInit {
   public static DEFAULT_WORKSPACE_NS = 'defaultNamespace';
   public static DEFAULT_WORKSPACE_NAME = 'defaultWorkspace';
   public static DEFAULT_WORKSPACE_ID = '1';
+
+  /* tslint:disable:no-unused-variable */
+  /* All these are used in the template, not the class */
   private cohortNameFilter = new CohortNameFilter();
   private cohortDescriptionFilter = new CohortDescriptionFilter();
   private notebookNameFilter = new NotebookNameFilter();
@@ -84,6 +90,8 @@ export class WorkspaceComponent implements OnInit {
   private cohortDescriptionComparator = new CohortDescriptionComparator();
   private notebookNameComparator = new NotebookNameComparator();
   private notebookDescriptionComparator = new NotebookDescriptionComparator();
+  /* tslint:enable:no-unused-variable */
+
   workspace: Workspace;
   wsId: string;
   wsNamespace: string;
@@ -104,6 +112,7 @@ export class WorkspaceComponent implements OnInit {
       private clusterService: ClusterService,
       private errorHandlingService: ErrorHandlingService,
       private workspacesService: WorkspacesService,
+      /* tslint:disable-next-line:no-unused-variable */
       @Inject(DOCUMENT) private document: any
   ) {}
   ngOnInit(): void {

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -1,4 +1,5 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+// tslint:disable
 
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';

--- a/ui/src/testing/stubs/cohort-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-service-stub.ts
@@ -1,9 +1,6 @@
-
 import {WorkspaceComponent} from 'app/views/workspace/component';
 import {Cohort, CohortListResponse, Workspace} from 'generated';
-
 import {Observable} from 'rxjs/Observable';
-import {Observer} from 'rxjs/Observer';
 
 export let DEFAULT_COHORT_ID = '1';
 

--- a/ui/src/testing/stubs/workspace-service-stub.ts
+++ b/ui/src/testing/stubs/workspace-service-stub.ts
@@ -1,9 +1,6 @@
-
 import {WorkspaceComponent} from 'app/views/workspace/component';
 import {Workspace, WorkspaceListResponse} from 'generated';
-
 import {Observable} from 'rxjs/Observable';
-import {Observer} from 'rxjs/Observer';
 
 export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_DESCRIPTION = 'Stub workspace';

--- a/ui/src/testing/test-helpers.ts
+++ b/ui/src/testing/test-helpers.ts
@@ -1,7 +1,5 @@
 import {Component, DebugElement} from '@angular/core';
-import {tick, ComponentFixture} from '@angular/core/testing';
-
-
+import {ComponentFixture, tick} from '@angular/core/testing';
 
 export function updateAndTick(fixture: any) {
   fixture.detectChanges();

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -10,7 +10,7 @@
       true,
       "check-space"
     ],
-    "curly": true,
+    "curly": [true, "as-needed"],
     "eofline": true,
     "forin": true,
     "import-blacklist": [
@@ -52,6 +52,7 @@
     ],
     "no-construct": true,
     "no-debugger": true,
+    "no-duplicate-imports": true,
     "no-duplicate-super": true,
     "no-empty": false,
     "no-empty-interface": true,
@@ -69,6 +70,7 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
+    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
@@ -79,6 +81,7 @@
       "check-else",
       "check-whitespace"
     ],
+    "ordered-imports": true,
     "prefer-const": [true, {"destructuring": "all"}],
     "quotemark": [
       true,

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -52,7 +52,6 @@
     ],
     "no-construct": true,
     "no-debugger": true,
-    "no-duplicate-imports": true,
     "no-duplicate-super": true,
     "no-empty": false,
     "no-empty-interface": true,


### PR DESCRIPTION
Enables and enforces type checking in our Angular linter and adds two rules: `no-unused-variable` and `ordered-imports`.

There is a bug in the version of TypeScript we're pinned to by Angular where (sometimes) names that refer to interfaces or types which are only used as generics improperly trigger the `no-unused-variable` rule; similarly Angular's tendency to split things across files means that attributes defined on a class but only used in the template may also give a false positive, and finally arguments to a Component constructor that are auto-magically attached to the instance by angular's DI mechanism may give false positives.  In all these cases the lines

```
/* tslint:disable-next-line:no-unused-variable */
```
or
```
/* tslint:disable:no-unused-variable */
// code...
/* tslint:enable:no-unused-variable */
```

May be used to silence the false positives.

Import _statements_ are sorted alphabetically within each import group (import groups are separated by newlines) by the module being imported from.  Imported _names_ are then sorted alphabetically within each import statement. Imported _names_ are **not** sorted across _statements_. All sorts are case-insensitive. 

EDIT: all the reviewers are tagged because they have already / will probably need to write Angular code, not necessarily because I want all of you to approve before merging.