### PR TITLE
[RW-215] Add etag support to ShareWorkspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -141,11 +141,12 @@ public class CohortsController implements CohortsApiDelegate {
       String cohortId, Cohort cohort) {
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
-    if(!Strings.isNullOrEmpty(cohort.getEtag())) {
-      int version = Etags.toVersion(cohort.getEtag());
-      if (dbCohort.getVersion() != version) {
-        throw new ConflictException("Attempted to modify outdated cohort version");
-      }
+    if(Strings.isNullOrEmpty(cohort.getEtag())) {
+      throw new BadRequestException("missing required update field 'cohort'");
+    }
+    int version = Etags.toVersion(cohort.getEtag());
+    if (dbCohort.getVersion() != version) {
+      throw new ConflictException("Attempted to modify outdated cohort version");
     }
     if (cohort.getType() != null) {
       dbCohort.setType(cohort.getType());

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -142,7 +142,7 @@ public class CohortsController implements CohortsApiDelegate {
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     if(Strings.isNullOrEmpty(cohort.getEtag())) {
-      throw new BadRequestException("missing required update field 'cohort'");
+      throw new BadRequestException("missing required update field 'etag'");
     }
     int version = Etags.toVersion(cohort.getEtag());
     if (dbCohort.getVersion() != version) {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -5,7 +5,6 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -16,12 +15,12 @@ import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
-import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;
+import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -31,14 +30,13 @@ import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
+import org.pmiops.workbench.model.ShareWorkspaceRequest;
+import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceListResponse;
-import org.pmiops.workbench.model.UserRole;
-import org.pmiops.workbench.model.UserRoleList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -266,9 +264,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     dbWorkspace.addWorkspaceUserRole(permissions);
 
     dbWorkspace = workspaceService.getDao().save(dbWorkspace);
-
-
-
     return ResponseEntity.ok(TO_CLIENT_WORKSPACE.apply(dbWorkspace));
   }
 
@@ -309,12 +304,12 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       Workspace workspace) {
     org.pmiops.workbench.db.model.Workspace dbWorkspace = workspaceService.getRequired(
         workspaceNamespace, workspaceId);
-    // TODO(calbach): Require etag once client supplies it.
-    if(!Strings.isNullOrEmpty(workspace.getEtag())) {
-      int version = Etags.toVersion(workspace.getEtag());
-      if (dbWorkspace.getVersion() != version) {
-        throw new ConflictException("Attempted to modify outdated workspace version");
-      }
+    if (Strings.isNullOrEmpty(workspace.getEtag())) {
+      throw new BadRequestException("Missing required update field 'etag'");
+    }
+    int version = Etags.toVersion(workspace.getEtag());
+    if (dbWorkspace.getVersion() != version) {
+      throw new ConflictException("Attempted to modify outdated workspace version");
     }
     if(workspace.getDataAccessLevel() != null &&
         !dbWorkspace.getDataAccessLevel().equals(workspace.getDataAccessLevel())){
@@ -328,27 +323,27 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
     // TODO: handle research purpose
     setCdrVersionId(workspace, dbWorkspace);
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    dbWorkspace.setLastModifiedTime(now);
-
-    try {
-      // The version asserted on save is the same as the one we read via
-      // getRequired() above, see RW-215 for details.
-      dbWorkspace = workspaceService.getDao().save(dbWorkspace);
-    } catch (ObjectOptimisticLockingFailureException e) {
-      log.log(Level.WARNING, "version conflict for workspace update", e);
-      throw new ConflictException("Failed due to concurrent workspace modification");
-    }
+    // The version asserted on save is the same as the one we read via
+    // getRequired() above, see RW-215 for details.
+    dbWorkspace = workspaceService.saveWithLastModified(dbWorkspace);
     return ResponseEntity.ok(TO_CLIENT_WORKSPACE.apply(dbWorkspace));
   }
 
   @Override
   public ResponseEntity<EmptyResponse> shareWorkspace(String workspaceNamespace, String workspaceId,
-      UserRoleList userRoleList) {
-    // TODO(calbach): Attempt to factor this into updateWorkspace() in order to
-    // share etag/versioning logic.
+      ShareWorkspaceRequest request) {
+    if (Strings.isNullOrEmpty(request.getWorkspaceEtag())) {
+      throw new BadRequestException("Missing required update field 'workspaceEtag'");
+    }
+
+    org.pmiops.workbench.db.model.Workspace dbWorkspace =
+        workspaceService.getRequired(workspaceNamespace, workspaceId);
+    int version = Etags.toVersion(request.getWorkspaceEtag());
+    if (dbWorkspace.getVersion() != version) {
+      throw new ConflictException("Attempted to modify outdated workspace version");
+    }
     Set<WorkspaceUserRole> dbUserRoles = new HashSet<WorkspaceUserRole>();
-    for (UserRole user : userRoleList.getItems()) {
+    for (UserRole user : request.getItems()) {
       WorkspaceUserRole newUserRole = new WorkspaceUserRole();
       User newUser = userDao.findUserByEmail(user.getEmail());
       if (newUser == null) {
@@ -360,7 +355,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       newUserRole.setRole(user.getRole());
       dbUserRoles.add(newUserRole);
     }
-    workspaceService.updateUserRoles(workspaceNamespace, workspaceId, dbUserRoles);
+    workspaceService.updateUserRoles(dbWorkspace, dbUserRoles);
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -11,7 +11,8 @@ public interface WorkspaceService {
   public FireCloudService getFireCloudService();
   public Workspace get(String ns, String id);
   public Workspace getRequired(String ns, String id);
+  public Workspace saveWithLastModified(Workspace workspace);
   public List<Workspace> findForReview();
   public void setResearchPurposeApproved(String ns, String id, boolean approved);
-  public void updateUserRoles(String ns, String id, Set<WorkspaceUserRole> userRoleSet);
+  public void updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -14,5 +14,5 @@ public interface WorkspaceService {
   public Workspace saveWithLastModified(Workspace workspace);
   public List<Workspace> findForReview();
   public void setResearchPurposeApproved(String ns, String id, boolean approved);
-  public void updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
+  public Workspace updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -16,23 +16,16 @@ import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.firecloud.ApiException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.auditing.AuditingHandler;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import org.pmiops.workbench.db.model.Workspace;
-import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.ServerUnavailableException;
+import org.pmiops.workbench.firecloud.ApiException;
+import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
-import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.exceptions.ServerUnavailableException;
-import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
 
 
 /**
@@ -111,7 +104,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
-  public void updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet) {
+  public Workspace updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet) {
     Map<Long, WorkspaceUserRole> userRoleMap = new HashMap<Long, WorkspaceUserRole>();
     for (WorkspaceUserRole userRole : userRoleSet) {
       userRole.setWorkspace(workspace);
@@ -184,6 +177,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         throw new ServerUnavailableException(e);
       }
     }
-    this.saveWithLastModified(workspace);
+    return this.saveWithLastModified(workspace);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -1,10 +1,13 @@
 package org.pmiops.workbench.db.dao;
 
+import java.sql.Timestamp;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -13,7 +16,9 @@ import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.firecloud.ApiException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +49,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   // Boot due to https://jira.spring.io/browse/SPR-15600. See RW-256.
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private FireCloudService fireCloudService;
+  @Autowired private Clock clock;
 
   /**
    * Clients wishing to use the auto-generated methods from the DAO interface may directly access
@@ -61,6 +67,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   public Workspace get(String ns, String id) {
     return workspaceDao.findByWorkspaceNamespaceAndFirecloudName(ns, id);
   }
+
   @Override
   public Workspace getRequired(String ns, String id) {
     Workspace workspace = get(ns, id);
@@ -69,6 +76,19 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     }
     return workspace;
   }
+
+  @Override
+  public Workspace saveWithLastModified(Workspace workspace) {
+    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+    workspace.setLastModifiedTime(now);
+    try {
+      return workspaceDao.save(workspace);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      log.log(Level.WARNING, "version conflict for workspace update", e);
+      throw new ConflictException("Failed due to concurrent workspace modification");
+    }
+  }
+
   @Override
   public List<Workspace> findForReview() {
     return workspaceDao.findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();
@@ -87,26 +107,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
           ns, id, workspace.getApproved() ? "approved" : "rejected"));
     }
     workspace.setApproved(approved);
-    try {
-      workspaceDao.save(workspace);
-    } catch (ObjectOptimisticLockingFailureException e) {
-      log.log(Level.WARNING, "version conflict for workspace update", e);
-      throw new ConflictException("Failed due to concurrent workspace modification");
-    }
+    saveWithLastModified(workspace);
   }
 
   @Override
-  @Transactional
-  public void updateUserRoles(String ns, String id, Set<WorkspaceUserRole> userRoleSet) {
-    org.pmiops.workbench.db.model.Workspace dbWorkspace = getRequired(
-        ns, id);
+  public void updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet) {
     Map<Long, WorkspaceUserRole> userRoleMap = new HashMap<Long, WorkspaceUserRole>();
     for (WorkspaceUserRole userRole : userRoleSet) {
-      userRole.setWorkspace(dbWorkspace);
+      userRole.setWorkspace(workspace);
       userRoleMap.put(userRole.getUser().getUserId(), userRole);
     }
     ArrayList<WorkspaceACLUpdate> updateACLRequestList = new ArrayList<WorkspaceACLUpdate>();
-    Iterator<WorkspaceUserRole> dbUserRoles = dbWorkspace.getWorkspaceUserRoles().iterator();
+    Iterator<WorkspaceUserRole> dbUserRoles = workspace.getWorkspaceUserRoles().iterator();
     while (dbUserRoles.hasNext()) {
       boolean resolved = false;
       WorkspaceUserRole currentUserRole = dbUserRoles.next();
@@ -128,11 +140,11 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       }
     }
 
-    for (Map.Entry<Long, WorkspaceUserRole> remainingRole : userRoleMap.entrySet()) {
-      dbWorkspace.getWorkspaceUserRoles().add(remainingRole.getValue());
+    for (Entry<Long, WorkspaceUserRole> remainingRole : userRoleMap.entrySet()) {
+      workspace.getWorkspaceUserRoles().add(remainingRole.getValue());
     }
 
-    for(WorkspaceUserRole currentWorkspaceUser : dbWorkspace.getWorkspaceUserRoles()) {
+    for(WorkspaceUserRole currentWorkspaceUser : workspace.getWorkspaceUserRoles()) {
       WorkspaceACLUpdate currentUpdate = new WorkspaceACLUpdate();
       currentUpdate.setEmail(currentWorkspaceUser.getUser().getEmail());
       currentUpdate.setCanCompute(false);
@@ -149,7 +161,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       updateACLRequestList.add(currentUpdate);
     }
     try {
-      WorkspaceACLUpdateResponseList fireCloudResponse = fireCloudService.updateWorkspaceACL(ns, id, updateACLRequestList);
+      WorkspaceACLUpdateResponseList fireCloudResponse = fireCloudService.updateWorkspaceACL(
+          workspace.getWorkspaceNamespace(), workspace.getFirecloudName(), updateACLRequestList);
       if (fireCloudResponse.getUsersNotFound().size() != 0) {
         String usersNotFound = "";
         for (int i = 0; i < fireCloudResponse.getUsersNotFound().size(); i++) {
@@ -160,10 +173,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         }
         throw new BadRequestException(usersNotFound);
       }
-      // TODO(calbach): This save() is not technically necessary but included to
-      // workaround RW-252. Remove either this, or @Transactional.
-      workspaceDao.save(dbWorkspace);
-    } catch(org.pmiops.workbench.firecloud.ApiException e) {
+    } catch(ApiException e) {
       if (e.getCode() == 400) {
         throw new BadRequestException(e.getResponseBody());
       } else if (e.getCode() == 404) {
@@ -174,5 +184,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         throw new ServerUnavailableException(e);
       }
     }
+    this.saveWithLastModified(workspace);
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -434,10 +434,10 @@ paths:
             type: string
             required: true
           - in: body
-            name: usersAndRoles
+            name: body
             description: users to share the workspace with
             schema:
-              $ref: "#/definitions/UserRoleList"
+              $ref: "#/definitions/ShareWorkspaceRequest"
       responses:
         "200":
           schema:
@@ -774,11 +774,17 @@ definitions:
       role:
         $ref: "#/definitions/WorkspaceAccessLevel"
 
-  UserRoleList:
+  ShareWorkspaceRequest:
     type: object
     required:
      - items
     properties:
+      workspaceEtag:
+        type: string
+        description: >
+          Associated workspace etag retrieved via reading the workspaces API. If provided,
+          validates that the workspace (and its user roles) has not been modified since this
+          etag was retrieved.
       items:
         type: "array"
         items:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -441,7 +441,7 @@ paths:
       responses:
         "200":
           schema:
-            $ref: "#/definitions/EmptyResponse"
+            $ref: "#/definitions/ShareWorkspaceResponse"
 
   # Cohorts ##############################################################################
 
@@ -789,6 +789,14 @@ definitions:
         type: "array"
         items:
            $ref: "#/definitions/UserRole"
+
+  ShareWorkspaceResponse:
+    type: object
+    properties:
+      workspaceEtag:
+        type: string
+        description: >
+          Updated workspace etag after the share request has been applied.
 
   WorkspaceAccessLevel:
     type: string

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -48,13 +49,18 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class CohortsControllerTest {
+  private static final Instant NOW = Instant.now();
+  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
+
   @TestConfiguration
   @Import(WorkspaceServiceImpl.class)
   @MockBean(FireCloudService.class)
-  static class Configuration {}
-
-  private static final Instant NOW = Instant.now();
-  private static final Clock CLOCK = FakeClock.fixed(NOW, ZoneId.systemDefault());
+  static class Configuration {
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+  }
 
   Workspace workspace;
   @Autowired
@@ -86,10 +92,10 @@ public class CohortsControllerTest {
     workspace.setDataAccessLevel(DataAccessLevel.PROTECTED);
     workspace.setResearchPurpose(new ResearchPurpose());
 
+    CLOCK.setInstant(NOW);
     WorkspacesController workspacesController = new WorkspacesController(workspaceService,
         cdrVersionDao, userDao, userProvider, fireCloudService, CLOCK);
     workspace = workspacesController.createWorkspace(workspace).getBody();
-
     this.cohortsController = new CohortsController(
         workspaceService, cohortDao, userProvider, CLOCK);
   }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -121,13 +121,6 @@ public class CohortsControllerTest {
     cohort.setEtag(updated.getEtag());
     assertThat(updated).isEqualTo(cohort);
 
-    // Verify that we can update without an etag.
-    cohort.setEtag(null);
-    cohort.setName("updated-name3");
-    updated = cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(), cohort).getBody();
-    cohort.setEtag(updated.getEtag());
-    assertThat(updated).isEqualTo(cohort);
-
     Cohort got = cohortsController.getCohort(workspace.getNamespace(), workspace.getId(), cohort.getId()).getBody();
     assertThat(got).isEqualTo(cohort);
   }
@@ -151,7 +144,7 @@ public class CohortsControllerTest {
     cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
 
     // TODO: Refactor to be a @Parameterized test case.
-    List<String> cases = ImmutableList.of("hello, world", "\"\"", "\"\"1234\"\"", "\"-1\"");
+    List<String> cases = ImmutableList.of("", "hello, world", "\"\"", "\"\"1234\"\"", "\"-1\"");
     for (String etag : cases) {
       try {
         cohortsController.updateCohort(workspace.getNamespace(), workspace.getId(), cohort.getId(),

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
+import org.pmiops.workbench.model.ShareWorkspaceRequest;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.UserRoleList;
 import org.pmiops.workbench.model.Workspace;
@@ -42,6 +44,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -56,10 +59,19 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class WorkspacesControllerTest {
+  private static final Instant NOW = Instant.now();
+  private static final long NOW_TIME = Timestamp.from(NOW).getTime();
+  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
+
   @TestConfiguration
   @Import(WorkspaceServiceImpl.class)
   @MockBean(FireCloudService.class)
-  static class Configuration {}
+  static class Configuration {
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+  }
 
   @Autowired
   FireCloudService fireCloudService;
@@ -74,9 +86,6 @@ public class WorkspacesControllerTest {
 
   private WorkspacesController workspacesController;
 
-  private static final Instant NOW = Instant.now();
-  private static final long NOW_TIME = Timestamp.from(NOW).getTime();
-
   @Before
   public void setUp() {
     User user = new User();
@@ -86,8 +95,9 @@ public class WorkspacesControllerTest {
     user = userDao.save(user);
     when(userProvider.get()).thenReturn(user);
 
+    CLOCK.setInstant(NOW);
     this.workspacesController = new WorkspacesController(workspaceService, cdrVersionDao,
-        userDao, userProvider, fireCloudService, FakeClock.fixed(NOW, ZoneId.systemDefault()));
+        userDao, userProvider, fireCloudService, CLOCK);
   }
 
   public Workspace createDefaultWorkspace() {
@@ -186,13 +196,6 @@ public class WorkspacesControllerTest {
     assertThat(updated).isEqualTo(ws);
 
     ws.setName("updated-name2");
-    updated = workspacesController.updateWorkspace(ws.getNamespace(), ws.getId(), ws).getBody();
-    ws.setEtag(updated.getEtag());
-    assertThat(updated).isEqualTo(ws);
-
-    // Verify that we can update without an etag.
-    ws.setEtag(null);
-    ws.setName("updated-name3");
     updated = workspacesController.updateWorkspace(ws.getNamespace(), ws.getId(), ws).getBody();
     ws.setEtag(updated.getEtag());
     assertThat(updated).isEqualTo(ws);
@@ -298,25 +301,27 @@ public class WorkspacesControllerTest {
 
     readerUser = userDao.save(readerUser);
     Workspace workspace = createDefaultWorkspace();
-    workspacesController.createWorkspace(workspace);
-    UserRoleList updatedUserRoles = new UserRoleList();
+    workspace = workspacesController.createWorkspace(workspace).getBody();
+    ShareWorkspaceRequest shareWorkspaceRequest = new ShareWorkspaceRequest();
+    shareWorkspaceRequest.setWorkspaceEtag(workspace.getEtag());
     UserRole creator = new UserRole();
     creator.setEmail("bob@gmail.com");
     creator.setRole(WorkspaceAccessLevel.OWNER);
-    updatedUserRoles.addItemsItem(creator);
+    shareWorkspaceRequest.addItemsItem(creator);
     UserRole writer = new UserRole();
     writer.setEmail("writerfriend@gmail.com");
     writer.setRole(WorkspaceAccessLevel.WRITER);
-    updatedUserRoles.addItemsItem(writer);
+    shareWorkspaceRequest.addItemsItem(writer);
     UserRole reader = new UserRole();
     reader.setEmail("readerfriend@gmail.com");
     reader.setRole(WorkspaceAccessLevel.READER);
-    updatedUserRoles.addItemsItem(reader);
+    shareWorkspaceRequest.addItemsItem(reader);
 
+    // Simulate time between API calls to trigger last-modified/@Version changes.
+    CLOCK.increment(1000);
     WorkspaceACLUpdateResponseList responseValue = new WorkspaceACLUpdateResponseList();
-
     when(fireCloudService.updateWorkspaceACL(anyString(), anyString(), anyListOf(WorkspaceACLUpdate.class))).thenReturn(responseValue);
-    workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
+    workspacesController.shareWorkspace("namespace", "name", shareWorkspaceRequest);
     Workspace workspace2 =
         workspacesController.getWorkspace("namespace", "name")
             .getBody();
@@ -340,6 +345,7 @@ public class WorkspacesControllerTest {
     assertThat(numOwners).isEqualTo(1);
     assertThat(numWriters).isEqualTo(1);
     assertThat(numReaders).isEqualTo(1);
+    assertThat(workspace.getEtag()).isNotEqualTo(workspace2.getEtag());
   }
 
   @Test
@@ -355,40 +361,47 @@ public class WorkspacesControllerTest {
     readerUser.setFreeTierBillingProjectName("TestBillingProject3");
     readerUser = userDao.save(readerUser);
     Workspace workspace = createDefaultWorkspace();
-    workspacesController.createWorkspace(workspace);
-    UserRoleList updatedUserRoles = new UserRoleList();
+    workspace = workspacesController.createWorkspace(workspace).getBody();
+    ShareWorkspaceRequest shareWorkspaceRequest = new ShareWorkspaceRequest();
+    shareWorkspaceRequest.setWorkspaceEtag(workspace.getEtag());
     UserRole creator = new UserRole();
     creator.setEmail("bob@gmail.com");
     creator.setRole(WorkspaceAccessLevel.OWNER);
-    updatedUserRoles.addItemsItem(creator);
+    shareWorkspaceRequest.addItemsItem(creator);
     UserRole writer = new UserRole();
     writer.setEmail("writerfriend@gmail.com");
     writer.setRole(WorkspaceAccessLevel.WRITER);
-    updatedUserRoles.addItemsItem(writer);
+    shareWorkspaceRequest.addItemsItem(writer);
     UserRole reader = new UserRole();
     reader.setEmail("readerfriend@gmail.com");
     reader.setRole(WorkspaceAccessLevel.READER);
-    updatedUserRoles.addItemsItem(reader);
+    shareWorkspaceRequest.addItemsItem(reader);
 
     WorkspaceACLUpdateResponseList responseValue = new WorkspaceACLUpdateResponseList();
     responseValue.setUsersNotFound(new ArrayList<WorkspaceACLUpdate>());
 
+    // Simulate time between API calls to trigger last-modified/@Version changes.
+    CLOCK.increment(1000);
     when(fireCloudService.updateWorkspaceACL(anyString(), anyString(), anyListOf(WorkspaceACLUpdate.class))).thenReturn(responseValue);
-    workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
-    updatedUserRoles = new UserRoleList();
-    updatedUserRoles.addItemsItem(creator);
-    updatedUserRoles.addItemsItem(writer);
+    workspacesController.shareWorkspace("namespace", "name", shareWorkspaceRequest);
 
-    workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
-    Workspace workspace2 =
+    CLOCK.increment(1000);
+    Workspace workspace2 = workspacesController.getWorkspace(workspace.getNamespace(), workspace.getId()).getBody();
+    shareWorkspaceRequest = new ShareWorkspaceRequest();
+    shareWorkspaceRequest.setWorkspaceEtag(workspace2.getEtag());
+    shareWorkspaceRequest.addItemsItem(creator);
+    shareWorkspaceRequest.addItemsItem(writer);
+
+    workspacesController.shareWorkspace("namespace", "name", shareWorkspaceRequest);
+    Workspace workspace3 =
         workspacesController.getWorkspace("namespace", "name")
             .getBody();
 
-    assertThat(workspace2.getUserRoles().size()).isEqualTo(2);
+    assertThat(workspace3.getUserRoles().size()).isEqualTo(2);
     int numOwners = 0;
     int numWriters = 0;
     int numReaders = 0;
-    for (UserRole userRole : workspace2.getUserRoles()) {
+    for (UserRole userRole : workspace3.getUserRoles()) {
       if (userRole.getRole().equals(WorkspaceAccessLevel.OWNER)) {
         assertThat(userRole.getEmail()).isEqualTo("bob@gmail.com");
         numOwners++;
@@ -403,21 +416,23 @@ public class WorkspacesControllerTest {
     assertThat(numOwners).isEqualTo(1);
     assertThat(numWriters).isEqualTo(1);
     assertThat(numReaders).isEqualTo(0);
+    assertThat(workspace.getEtag()).isNotEqualTo(workspace2.getEtag());
+    assertThat(workspace2.getEtag()).isNotEqualTo(workspace3.getEtag());
   }
 
   @Test(expected = BadRequestException.class)
   public void testUnableToShareWithNonExistantUser() throws Exception {
     Workspace workspace = createDefaultWorkspace();
     workspacesController.createWorkspace(workspace);
-    UserRoleList updatedUserRoles = new UserRoleList();
+    ShareWorkspaceRequest shareWorkspaceRequest = new ShareWorkspaceRequest();
     UserRole creator = new UserRole();
     creator.setEmail("bob@gmail.com");
     creator.setRole(WorkspaceAccessLevel.OWNER);
-    updatedUserRoles.addItemsItem(creator);
+    shareWorkspaceRequest.addItemsItem(creator);
     UserRole writer = new UserRole();
     writer.setEmail("writerfriend@gmail.com");
     writer.setRole(WorkspaceAccessLevel.WRITER);
-    updatedUserRoles.addItemsItem(writer);
-    workspacesController.shareWorkspace("namespace", "name", updatedUserRoles);
+    shareWorkspaceRequest.addItemsItem(writer);
+    workspacesController.shareWorkspace("namespace", "name", shareWorkspaceRequest);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -35,7 +35,6 @@ import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
 import org.pmiops.workbench.model.ShareWorkspaceRequest;
 import org.pmiops.workbench.model.ShareWorkspaceResponse;
 import org.pmiops.workbench.model.UserRole;
-import org.pmiops.workbench.model.UserRoleList;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.test.FakeClock;

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -6,7 +6,7 @@ import {ErrorHandlingService} from 'app/services/error-handling.service';
 
 import {ProfileService} from 'generated';
 import {UserRole} from 'generated';
-import {UserRoleList} from 'generated';
+import {ShareWorkspaceResponse} from 'generated';
 import {Workspace} from 'generated';
 import {WorkspaceAccessLevel} from 'generated';
 import {WorkspacesService} from 'generated';
@@ -63,12 +63,13 @@ export class WorkspaceShareComponent implements OnInit {
 
   addCollaborator(): void {
     this.workspace.userRoles.push({email: this.toShare, role: this.accessLevel});
-    const userRoleList: UserRoleList = {items: this.workspace.userRoles};
-    this.workspacesService.shareWorkspace(this.workspace.namespace,
-        this.workspace.id, userRoleList).subscribe(
-      () => {
-      }
-    );
+    this.workspacesService.shareWorkspace(
+      this.workspace.namespace, this.workspace.id, {
+        workspaceEtag: this.workspace.etag,
+        items: this.workspace.userRoles
+      }).subscribe((resp: ShareWorkspaceResponse) => {
+        this.workspace.etag = resp.workspaceEtag;
+      });
   }
 
   removeCollaborator(user: UserRole): void {
@@ -80,11 +81,12 @@ export class WorkspaceShareComponent implements OnInit {
       }
     });
     this.workspace.userRoles.splice(position, 1);
-    const userRoleList: UserRoleList = {items: this.workspace.userRoles};
-    this.workspacesService.shareWorkspace(this.workspace.namespace,
-        this.workspace.id, userRoleList).subscribe(
-      () => {
-      }
-    );
+    this.workspacesService.shareWorkspace(
+      this.workspace.namespace, this.workspace.id, {
+        workspaceEtag: this.workspace.etag,
+        items: this.workspace.userRoles
+      }).subscribe((resp: ShareWorkspaceResponse) => {
+        this.workspace.etag = resp.workspaceEtag;
+      });
   }
 }


### PR DESCRIPTION
- `ShareWorkspace` now accepts and returns a `workspaceEtag`
- `updateUserRoles` now increments the `workspace.version` column by advancing `workspace.lastModified`; it is worth noting that this is not bullet-proof as there is no global consistency for a server-side `new Instant()` call, however it is still very unlikely for that two servers would generate the exact same millisecond timestamp, especially since we expect concurrent modification to be a rare user-driven occurrence.
  - Another option here is to force a version increment via `auditingHandler.markModified()`; we'd need to switch to \@EnableJpaAuditing and refactor our lastModified columns to get this (it does not work in isolation with \@Version from my testing). Didn't pursue this further as there may be other implications and it requires larger changes.
- Update client code to refresh the etag after applying a "share"
- Require etag for all endpoints that accept them, per previous discussion

Alternatives considered:
1. Refactor `ShareWorkspace` into `UpdateWorkspace`; rejected for now due to (1) workspace may not be the right place for these ACLs - a fairly common pattern which we may eventually want is to allow certain users to see a Workspace resource, but not its associated ACLs (or edit those ACLs) and (2) concerns around accidental modification of ACLs or metadata or vice-versa from separate endpoints as currently most of these API endpoints are fairly tightly coupled to the UI
1. Refactor userRoles off of the `Workspace`, e.g. /workspaces/../../{get,set}Policy. IMO this is probably the cleaner solution (see point above about viewing ACLs), but is a slightly larger refactoring. We'd also likely want to maintain a custom policyVersion column and allow it to have an etag independent of the workspace.