### PR TITLE
Dockerized deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_and_test_and_deploy_api:
     docker:
-      - image: allofustest/workbench:buildimage-0.0.8
+      - image: allofustest/workbench:buildimage-0.0.9
     working_directory: ~/workbench
     environment:
       JVM_OPTS: -Xmx3200m
@@ -18,7 +18,7 @@ jobs:
           - api-cache-
       - run:
           working_directory: ~/workbench
-          command: ci/activate_creds.sh circle-sa-key.json
+          command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
           working_directory: ~/workbench
           command: |
@@ -36,10 +36,10 @@ jobs:
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
       - deploy:
           name: Deploy to gcloud test project
+          working_directory: ~/workbench/api
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./ci/deploy.sh api
-            fi
+            ./project.rb circle-deploy \
+              --project all-of-us-workbench-test --creds-file circle-sa-key.json
   build_and_test_and_deploy_ui:
     docker:
       - image: allofustest/workbench:buildimage-0.0.8

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,5 +1,15 @@
 version: "3"
 services:
+  scripts:
+    build:
+      context: ./src/dev/server
+    user: ${UID}
+    working_dir: /w/api
+    volumes:
+      - ..:/w:cached
+      - gradle-cache:/.gradle
+      - ~/.config:/.config:cached
+      - ~/.gsutil:/.gsutil:cached
   db:
     image: mysql:5.7
     env_file:

--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -1,20 +1,27 @@
 require_relative "../../libproject/utils/common"
+require_relative "../../libproject/workbench"
 
 class CloudSqlProxyContext
 
   def initialize(gcc)
+    Workbench::assert_in_docker
     gcc.ensure_service_account
   end
 
   def run()
-    common = Common.new
-    common.run_inline %W{docker-compose up -d cloud-sql-proxy}
+    @ps = fork do
+      exec *%W{
+        cloud_sql_proxy
+          -instances all-of-us-workbench-test:us-central1:workbenchmaindb=tcp:0.0.0.0:3307
+          -credential_file=src/main/webapp/WEB-INF/sa-key.json
+      }
+    end
     begin
       sleep 1 # TODO(dmohs): Detect running better.
       yield
     ensure
-      common.run_inline %W{docker-compose stop cloud-sql-proxy}
-      common.run_inline %W{docker-compose rm --force cloud-sql-proxy}
+      Process.kill "HUP", @ps
+      Process.wait
     end
   end
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -88,10 +88,9 @@ def run_api_and_db(*args)
   run_api(account)
 end
 
-def run_tests(*args)
-  common = Common.new
-
-  common.run_inline %W{docker-compose run --rm api ./gradlew test} + args
+def run_tests(cmd_name, args)
+  ensure_docker cmd_name, args
+  Common.new.run_inline %W{gradle test} + args
 end
 
 def run_integration_tests(*args)
@@ -532,7 +531,7 @@ Common.register_command({
   :invocation => "test",
   :description => "Runs tests. To run a single test, add (for example) " \
       "--tests org.pmiops.workbench.interceptors.AuthInterceptorTest",
-  :fn => lambda { |*args| run_tests(*args) }
+  :fn => lambda { |*args| run_tests("test", args) }
 })
 
 Common.register_command({

--- a/api/libproject/gcloudcontext.rb
+++ b/api/libproject/gcloudcontext.rb
@@ -1,39 +1,53 @@
 require_relative "../../libproject/utils/common"
+require_relative "../../libproject/workbench"
 require "json"
 
 class GcloudContextV2
-  attr_reader :account, :project
+  attr_reader :account, :creds_file, :project
 
   def initialize(options_parser)
+    Workbench::assert_in_docker
+    @options_parser = options_parser
     # We use both gcloud and gsutil commands for various tasks. While gcloud can take arguments,
     # gsutil uses the current gcloud config, so we want to grab and verify the account from there.
     # We do NOT grab the project from gcloud config since that can easily be set to something
     # dangerous, like a production project. Instead, we always require that parameter explicitly.
-    common = Common.new
-    options_parser.add_option(
+    @options_parser.add_option(
       "--project [GOOGLE_PROJECT]",
       lambda {|opts, v| opts.project = v},
       "Google project to act on (e.g. all-of-us-workbench-test)"
     )
-    options_parser.add_validator lambda {|opts| raise ArgumentError unless opts.project}
-    options_parser.parse.validate
-    @project = options_parser.opts.project
-    common.status "Reading glcoud configuration..."
-    configs = common.capture_stdout \
-        %W{docker-compose run --rm api gcloud --format=json config configurations list}
-    active_config = JSON.parse(configs).select{|x| x["is_active"]}.first
-    common.status "Using '#{active_config["name"]}' gcloud configuration"
-    @account = active_config["properties"]["core"]["account"]
-    common.status "  account: #{@account}"
-    unless @account
-      common.error "Account must be set in gcloud config. Try:\n" \
-          "  gcloud auth login your.name@pmi-ops.org"
-      exit 1
-    end
-    unless @account.end_with?("@pmi-ops.org")
-      common.error "Account is not a pmi-ops.org account: #{@account}. Try:\n" \
-          "  gcloud auth login your.name@pmi-ops.org"
-      exit 1
+    @options_parser.add_option(
+      "--creds-file [PATH]",
+      lambda {|opts, v| opts.creds_file = v},
+      "Path to JSON-encoded Google service account file."
+    )
+    @options_parser.add_validator lambda {|opts| raise ArgumentError unless opts.project}
+  end
+
+  def validate()
+    common = Common.new
+    @project = @options_parser.opts.project
+    @creds_file = @options_parser.opts.creds_file
+    if @creds_file
+      common.run_inline %W{gcloud auth activate-service-account --key-file #{@creds_file}}
+    else
+      common.status "Reading glcoud configuration..."
+      configs = common.capture_stdout %W{gcloud --format=json config configurations list}
+      active_config = JSON.parse(configs).select{|x| x["is_active"]}.first
+      common.status "Using '#{active_config["name"]}' gcloud configuration"
+      @account = active_config["properties"]["core"]["account"]
+      common.status "  account: #{@account}"
+      unless @account
+        common.error "Account must be set in gcloud config. Try:\n" \
+            "  gcloud auth login your.name@pmi-ops.org"
+        exit 1
+      end
+      unless @account.end_with?("@pmi-ops.org") || @creds_file
+        common.error "Account is not a pmi-ops.org account: #{@account}. Try:\n" \
+            "  gcloud auth login your.name@pmi-ops.org"
+        exit 1
+      end
     end
   end
 
@@ -41,7 +55,7 @@ class GcloudContextV2
     sa_key_path = "src/main/webapp/WEB-INF/sa-key.json"
     unless File.exist? sa_key_path
       Common.new.run_inline %W{
-        docker-compose run --rm api gsutil cp
+        gsutil cp
           gs://#{@project}-credentials/all-of-us-workbench-test-9b5c623a838e.json
           #{sa_key_path}
       }

--- a/api/libproject/generate_appengine_web_xml.sh
+++ b/api/libproject/generate_appengine_web_xml.sh
@@ -2,13 +2,5 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-CIRCLECI="${CIRCLECI:-false}"
-
-if [[ ! "$CIRCLECI" == "true" ]]; then
-  cd db
-  source vars.env
-  cd ..
-fi
-
 cat src/main/webapp/WEB-INF/appengine-web.xml.template \
   | envsubst > src/main/webapp/WEB-INF/appengine-web.xml

--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -57,3 +57,10 @@ ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 ADD with-uid.sh /usr/local/bin
 
 ENTRYPOINT ["with-uid.sh"]
+
+RUN apk --no-cache add ruby ruby-json ruby-io-console
+
+RUN curl https://services.gradle.org/distributions/gradle-4.3.1-bin.zip -L > /tmp/gradle.zip \
+  && cd /tmp && unzip gradle.zip && rm gradle.zip \
+  && mv gradle-* /gradle
+ENV PATH="$PATH:/gradle/bin"

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -26,6 +26,7 @@ RUN cd && \
   mv node-v6.11.1-linux-x64 node && \
   rm -rf node.tar.xz
 
+RUN sudo apt-get update
 RUN sudo apt-get install gettext ruby mysql-client python-pip
 RUN sudo pip install --upgrade pip
 RUN sudo pip install --upgrade pylint
@@ -34,3 +35,8 @@ ENV PATH=/home/circleci/node/bin:/home/circleci/google-cloud-sdk/bin:$PATH
 
 # It never makes sense for Gradle to run a daemon within a docker container.
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+
+RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > /tmp/cloud_sql_proxy \
+  && sudo mv /tmp/cloud_sql_proxy /usr/local/bin && sudo chmod +x /usr/local/bin/cloud_sql_proxy
+
+RUN sudo apt-get install gradle

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,16 +2,6 @@
 
 ./ci/activate_creds.sh ~/gcloud-credentials.key
 
-if [ "$1" == "api" ]
-then
-  (cd ./api && ./project.rb run-cloud-migrations --project all-of-us-workbench-test \
-    --creds_file ~/gcloud-credentials.key)
-  (cd ./api && ./project.rb run-cloud-cdr-migrations --project all-of-us-workbench-test \
-      --creds_file ~/gcloud-credentials.key)
-  (cd ./api && ./project.rb update-cloud-config --project all-of-us-workbench-test \
-    --creds_file ~/gcloud-credentials.key)
-fi
-
 if [ -z "${CIRCLE_TAG}" ]
 then
   # On test, CircleCI automatically deploys all commits to master, for testing.
@@ -24,13 +14,6 @@ else
 fi
 echo "Version: ${VERSION}"
 
-if [ "$1" == "api" ]
-then
-  (cd ./api && ./project.rb deploy-api --project all-of-us-workbench-test \
-     --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
-     --creds_file ~/gcloud-credentials.key --version $VERSION --promote)
-else
-  (cd ./ui && ./project.rb deploy-ui --project all-of-us-workbench-test \
-    --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
-    --version $VERSION --promote)
-fi
+(cd ./ui && ./project.rb deploy-ui --project all-of-us-workbench-test \
+  --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+  --version $VERSION --promote)

--- a/ci/install_gcloud.sh
+++ b/ci/install_gcloud.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-# Install gcloud
-
-cd
-wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-162.0.1-linux-x86_64.tar.gz -O gcloud.tgz
-tar -xf gcloud.tgz
-./google-cloud-sdk/install.sh  --quiet
-echo "export PATH=~/google-cloud-sdk/bin:$PATH" > ~/.bashrc

--- a/libproject/workbench.rb
+++ b/libproject/workbench.rb
@@ -26,6 +26,16 @@ module Workbench
   end
   module_function :ensure_git_hooks
 
+  def in_docker?()
+    File.exist?("/.dockerenv")
+  end
+  module_function :in_docker?
+
+  def assert_in_docker()
+    raise StandardError.new("Not within a docker container") unless Workbench::in_docker?
+  end
+  module_function :assert_in_docker
+
   # Runs a command (typically project.rb) from the main file's directory.
   def handle_argv_or_die(main_filename)
     common = Common.new
@@ -33,7 +43,7 @@ module Workbench
 
     check_submodules
     ensure_git_hooks
-    unless ENV["CIRCLECI"] == "true"
+    unless in_docker?
       common.docker.requires_docker
     end
 


### PR DESCRIPTION
Decided to improve this since I wanted the functionality in-place so I could test changing the URL for FireCloud to the dev instance. This dockerizes the deploy for developers and also unifies some of the code between what Circle runs and what developers run.