### PR TITLE
Change top bar to have our active logic.

### DIFF
--- a/ui/src/app/views/app/component.css
+++ b/ui/src/app/views/app/component.css
@@ -42,13 +42,13 @@
   display: flex;
 }
 
-.btn.tab-link {
+.tab-link {
   border-radius: 0;
   margin: 0;
   border: 1px solid #00537d;
 }
 
-.btn.tab-link.active {
+.tab-link.active {
   border-bottom: 3px solid black;
   font-weight: bold;
 }

--- a/ui/src/app/views/app/component.css
+++ b/ui/src/app/views/app/component.css
@@ -36,3 +36,19 @@
 .image-link-wrapper {
   text-decoration: none;
 }
+
+.top-nav {
+  border-bottom: 1px solid #ccc;
+  display: flex;
+}
+
+.btn.tab-link {
+  border-radius: 0;
+  margin: 0;
+  border: 1px solid #00537d;
+}
+
+.btn.tab-link.active {
+  border-bottom: 3px solid black;
+  font-weight: bold;
+}

--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -43,9 +43,6 @@
         routerLink="/">My Workspaces</button>
     <button class="btn tab-link"
         [class.active]="reviewActive"
-        routerLink="/review">Review</button>
-    <button class="btn tab-link"
-        [class.active]="reviewActive"
         *ngIf="hasReviewResearchPurpose"
         routerLink="/review">Review Research Purposes</button>
   </div>

--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -37,13 +37,18 @@
       <button (click)="signOut()" class="btn">Sign Out</button>
     </div>
   </div>
-  <clr-tabs>
-    <clr-tab>
-      <button clrTabLink routerLink="/" routerLinkActive="active">My Workspaces</button>
-      <button *ngIf="hasReviewResearchPurpose" clrTabLink routerLink="/review"
-          routerLinkActive="active">Review Research Purposes</button>
-    </clr-tab>
-  </clr-tabs>
+  <div class="top-nav btn-primary">
+    <button class="btn tab-link"
+        [class.active]="workspacesActive"
+        routerLink="/">My Workspaces</button>
+    <button class="btn tab-link"
+        [class.active]="reviewActive"
+        routerLink="/review">Review</button>
+    <button class="btn tab-link"
+        [class.active]="reviewActive"
+        *ngIf="hasReviewResearchPurpose"
+        routerLink="/review">Review Research Purposes</button>
+  </div>
   <div>
     <!--
       Angular's builtin Router module will attach specific views here

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -1,6 +1,6 @@
 // UI Component framing the overall app (title and nav).
 // Content is in other Components.
-
+import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
@@ -32,6 +32,7 @@ export class AppComponent implements OnInit {
   constructor(
       private activatedRoute: ActivatedRoute,
       private errorHandlingService: ErrorHandlingService,
+      private locationService: Location,
       private profileService: ProfileService,
       private router: Router,
       private signInService: SignInService,
@@ -40,7 +41,6 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.overriddenUrl = localStorage.getItem(overriddenUrlKey);
-
     window['setAllOfUsApiUrl'] = (url: string) => {
       if (url) {
         if (!url.match(/^https?:[/][/][a-z0-9.:-]+$/)) {
@@ -111,5 +111,13 @@ export class AppComponent implements OnInit {
     this.profileService.deleteAccount().subscribe(() => {
       this.signInService.signOut();
     });
+  }
+
+  get reviewActive(): boolean {
+    return this.locationService.path().startsWith('/review');
+  }
+
+  get workspacesActive(): boolean {
+    return !this.reviewActive;
   }
 }


### PR DESCRIPTION
Rationale: Clarity's top-nav content had some undesireable behavior
around reloading the page, where it reset which tab it had highlighted,
so I did a quick re-implementation there, so that we have control
over what is active