### PR TITLE
Don't redeploy the test API server on every CircleCI run

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -730,10 +730,10 @@ def with_cloud_proxy_and_db_env(cmd_name, args)
 end
 
 def circle_deploy(cmd_name, args)
-  if ENV.has_key("CIRCLE_BRANCH") and ENV.has_key("CIRCLE_TAG")
+  if ENV.has_key?("CIRCLE_BRANCH") and ENV.has_key?("CIRCLE_TAG")
     raise("expected exactly one of CIRCLE_BRANCH and CIRCLE_TAG env vars to be set")
   end
-  if ENV.fetch("CIRCLE_BRANCH", "") != "master" and !ENV.has_key("CIRCLE_TAG")
+  if ENV.fetch("CIRCLE_BRANCH", "") != "master" and !ENV.has_key?("CIRCLE_TAG")
     common.status "not master or a git tag, nothing to deploy"
     return
   end
@@ -761,7 +761,7 @@ def circle_deploy(cmd_name, args)
 
   promote = ""
   version = ""
-  if ENV.fetch("CIRCLE_BRANCH", "") == "master":
+  if ENV.fetch("CIRCLE_BRANCH", "") == "master"
     # Note that --promote will generally be a no-op, as we expect
     # circle-ci-test to always be serving 100% traffic. Pushing to an existing
     # live version will immediately make those changes live. In the event that
@@ -769,7 +769,7 @@ def circle_deploy(cmd_name, args)
     # will restore us to the expected circle-ci-test version on the next commit.
     promote = "--promote"
     version = "circle-ci-test"
-  elsif ENV.has_key("CIRCLE_TAG")
+  elsif ENV.has_key?("CIRCLE_TAG")
     promote = "--no-promote"
     version = ENV["CIRCLE_TAG"]
   end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -751,9 +751,20 @@ def circle_deploy(cmd_name, args)
     end
   end
 
-  version = ENV.fetch("CIRCLE_TAG", "circle-ci-test")
-  promote = ENV["CIRCLE_BRANCH"] == "master" ? "--promote" : "--no-promote"
-  deploy(cmd_name, args + %W{--version #{version} #{promote}})
+  default_version = "circle-ci-test"
+  promote = "--no-promote"
+  if ENV["CIRCLE_BRANCH"] == "master":
+    # Note that --promote will generally be a no-op, as we expect
+    # circle-ci-master to always be serving 100% traffic. Pushing to an existing
+    # live version will immediately make those changes live. In the event that
+    # someone mistakenly pushes a different version manually, this --promote
+    # will restore us to the expected circle-ci-master version on the next
+    # commit.
+    promote = "--promote"
+    default_version = "circle-ci-master"
+  version = ENV.fetch("CIRCLE_TAG", default_version)
+
+  deploy(cmd_name, args + %W{--version #{version}})
 end
 
 def run_cloud_migrations(cmd_name, args)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -763,11 +763,10 @@ def circle_deploy(cmd_name, args)
   version = ""
   if ENV.fetch("CIRCLE_BRANCH", "") == "master":
     # Note that --promote will generally be a no-op, as we expect
-    # circle-ci-master to always be serving 100% traffic. Pushing to an existing
+    # circle-ci-test to always be serving 100% traffic. Pushing to an existing
     # live version will immediately make those changes live. In the event that
     # someone mistakenly pushes a different version manually, this --promote
-    # will restore us to the expected circle-ci-master version on the next
-    # commit.
+    # will restore us to the expected circle-ci-test version on the next commit.
     promote = "--promote"
     version = "circle-ci-test"
   elsif ENV.has_key("CIRCLE_TAG")

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -753,7 +753,7 @@ def circle_deploy(cmd_name, args)
 
   default_version = "circle-ci-test"
   promote = "--no-promote"
-  if ENV["CIRCLE_BRANCH"] == "master":
+  if ENV["CIRCLE_BRANCH"] == "master"
     # Note that --promote will generally be a no-op, as we expect
     # circle-ci-master to always be serving 100% traffic. Pushing to an existing
     # live version will immediately make those changes live. In the event that

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -762,6 +762,7 @@ def circle_deploy(cmd_name, args)
     # commit.
     promote = "--promote"
     default_version = "circle-ci-master"
+  end
   version = ENV.fetch("CIRCLE_TAG", default_version)
 
   deploy(cmd_name, args + %W{--version #{version}})


### PR DESCRIPTION
Previous behavior:
- Every time CircleCI runs, we redeploy the `circle-ci-test` GAE version
- The `circle-ci-test` is serving 100% traffic
- There is no distinction between `--promote` vs `--no-promote` in this scenario, since the `circle-ci-test` version is already serving traffic. If it weren't serving traffic, then `--promote` would switch traffic over to it.

New behavior:
- For master pushes, we redeploy the `circle-ci-test` GAE version, which should always serve 100% traffic
- For git tag pushes, we deploy a GAE version with that tag name, but don't promote (AFAIK no one is using this currently, but may be useful later for releases).
- For everything else, we don't touch the GAE deployment

The UI server was not affected here, as it already only repushes for master commits.