### PR TITLE
Update UI deployment to match API; rename script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Deploy to gcloud test project
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./ci/deploy.sh ui
+              ./ci/deploy_ui.sh
             fi
   test_client:
     docker:

--- a/ci/deploy_ui.sh
+++ b/ci/deploy_ui.sh
@@ -7,13 +7,15 @@ then
   # On test, CircleCI automatically deploys all commits to master, for testing.
   # These versions need not persist, so give them all the same name.
   VERSION=circle-ci-test
+  PROMOTE=--promote
 else
   # For a tagged commit, deploy a version matching that tag. We tag some commits
   # on master to tell CircleCI to deploy them as named versions.
   VERSION=${CIRCLE_TAG}
+  PROMOTE=--no-promote
 fi
 echo "Version: ${VERSION}"
 
 (cd ./ui && ./project.rb deploy-ui --project all-of-us-workbench-test \
   --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
-  --version $VERSION --promote)
+  --version $VERSION $PROMOTE)


### PR DESCRIPTION
Don't promote on git tag CircleCI runs. AFAIK we're not using git tags for anything and I'm not sure if CircleCI is configured to run on git tags anyways, so this is just for consistency going forward.