### PR TITLE
Require validation before codegen

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -147,6 +147,7 @@ sourceSets {
   }
 }
 
+generateApi.dependsOn validateSwagger
 ideaModule.dependsOn generateApi
 compileGeneratedJava.dependsOn generateApi
 ideaModule.dependsOn generateFireCloudClient


### PR DESCRIPTION
Overhead seems negligible:

```
./gradlew generateApi

BUILD SUCCESSFUL in 2s
4 actionable tasks: 2 executed, 2 up-to-date
```