### PR TITLE
Freemabd1/local schema data migration task

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ database with a 10 minute expiration.
 
 ## API Server Database Updates
 
+Loading of local tables/data for both schemas (workbench/cdr) happens in a manual goal(creates tables in both schemas and insert any app data needed for local development):
+
+```./project.rb run-local-all-migrations```
+
+Local tables loaded with data are:
+  * **workbench** - cdr_version
+  * **cdr** - criteria, achilles_analysis, concept, concept_relationship, vocabulary, domain, achilles_results, achilles_results_concept and db_domain
+
 When editing database models, you must write a new changelog XML file. See
 [Liquibase change docs](http://www.liquibase.org/documentation/changes/index.html),
 such as [createTable](http://www.liquibase.org/documentation/changes/create_table.html).
@@ -214,14 +222,6 @@ CDR schema lives in `api/db-cdr` --> all cdr/cohort builder related activities a
 ## Cohort Builder
 
 During ```./project dev-up``` the schema activity is the only activity run, which only creates tables for the cdr schema. 
-
-Loading of local data for the criteria trees happens in a manual goal(deletes and inserts tree data into the criteria table):
-
-```./project.rb run-local-data-migrations```
-
-Local tables loaded from the goal are:
-  * **workbench** - cdr_version
-  * **cdr** - criteria, achilles_analysis, concept, concept_relationship, vocabulary, domain, achilles_results, achilles_results_concept and db_domain
 
 Loading of cloud data for the criteria trees and cdr version happens in a manual goal(deletes and inserts tree data into the criteria table):
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ From the `api/` directory:
 ```
 
 When the console displays "Dev App Server is now running", you can hit your
-local API server under http://localhost:8081/api/.
+local API server under http://localhost:8081/api/. 
+
+**Note:** If you haven't loaded any data locally for the app, please run the goal below. Also, this will not run while dev-up is running, so please kill dev-up first.
+```Shell
+./project.rb run-local-data-migrations
+```
+
 
 Other available operations may be discovered by running:
 ```Shell

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -307,6 +307,13 @@ def run_local_all_migrations(*args)
   common.run_inline %W{docker-compose run db-data-migration}
 end
 
+def run_local_data_migrations(*args)
+  common = Common.new
+
+  common.run_inline %W{docker-compose run db-cdr-data-migration}
+  common.run_inline %W{docker-compose run db-data-migration}
+end
+
 def run_drop_cdr_db(*args)
   common = Common.new
 
@@ -601,6 +608,12 @@ Common.register_command({
   :invocation => "run-local-all-migrations",
   :description => "Runs local data/schema migrations for cdr/workbench schemas.",
   :fn => lambda { |*args| run_local_all_migrations(*args) }
+})
+
+Common.register_command({
+  :invocation => "run-local-data-migrations",
+  :description => "Runs local data migrations for cdr/workbench schemas.",
+  :fn => lambda { |*args| run_local_data_migrations(*args) }
 })
 
 Common.register_command({

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -298,9 +298,11 @@ def drop_cloud_cdr(*args)
   end
 end
 
-def run_local_data_migrations(*args)
+def run_local_all_migrations(*args)
   common = Common.new
 
+  common.run_inline %W{docker-compose run db-migration}
+  common.run_inline %W{docker-compose run db-cdr-migration}
   common.run_inline %W{docker-compose run db-cdr-data-migration}
   common.run_inline %W{docker-compose run db-data-migration}
 end
@@ -596,9 +598,9 @@ Common.register_command({
 })
 
 Common.register_command({
-  :invocation => "run-local-data-migrations",
-  :description => "Runs database migrations for cdr schema on the Cloud SQL database for the specified project.",
-  :fn => lambda { |*args| run_local_data_migrations(*args) }
+  :invocation => "run-local-all-migrations",
+  :description => "Runs local data/schema migrations for cdr/workbench schemas.",
+  :fn => lambda { |*args| run_local_all_migrations(*args) }
 })
 
 Common.register_command({


### PR DESCRIPTION
`./project.rb run-local-all-migrations`

This goal will allow for creation of tables and data in one goal after a `./project.rb docker-clean` has been run.
It will do the following:
1) create workbench schema/tables
2) create cdr schema/tables
3) insert cdr app initialization data
4) insert workbench app initialization data