### PR TITLE
Less noise in Circle test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               api/src/main/webapp/WEB-INF/sa-key.json
       - run:
           working_directory: ~/workbench/api
-          command: gradle test --project-prop verboseTestLogging=yes
+          command: ./project.rb test
       - save_cache:
           paths:
             - ~/.gradle


### PR DESCRIPTION
Our CircleCI test task is so noisy it's hard to even follow the logs. Plus, there is so much logging that you often have to download the log to view it, since Circle will only display the first 400k characters (which should be plenty). This PR makes Circle's web UI useful again.