### PR TITLE
remove redundant interface

### DIFF
--- a/ui/src/app/data-browser/ConceptClasses.ts
+++ b/ui/src/app/data-browser/ConceptClasses.ts
@@ -1,8 +1,7 @@
-
-  // Concept Classes
+// Concept Classes
 import {Criteria} from '../../generated/model/criteria';
 
-  export interface IConcept {
+export class Concept {
   concept_name: string;
   prevalence: string;
   concept_id: number;
@@ -11,45 +10,26 @@ import {Criteria} from '../../generated/model/criteria';
   vocabulary_id: string;
   domain_id: string;
   count_value: number;
-  children: IConcept [];
-  parents: IConcept [];
-  id: number; // icd concepts have id for tree info
-  is_group: boolean;
-  is_selectable: boolean;
-  color: string;
-  moreInfo(): string;
-}
-
-
-export class Concept implements IConcept {
-  concept_name: string;
-  prevalence: string;
-  concept_id: number;
-  concept_class_id: string;
-  concept_code: string;
-  vocabulary_id: string;
-  domain_id: string;
-  count_value: number;
-  children: IConcept[];
-  parents: IConcept[];
+  children: Concept[];
+  parents: Concept[];
   id: number ; // icd concepts have id for tree info
   is_group: boolean;
   is_selectable: boolean;
   color: string;
 
   static conceptFromCriteria(obj: Criteria):  Concept {
-        const concept = new Concept();
-        concept.concept_name = obj.name;
-        concept.concept_id = obj.conceptId;
-        concept.count_value = obj.count;
-        concept.is_group = obj.group;
-        concept.is_selectable = obj.selectable;
-        concept.domain_id = obj.domainId;
-        concept.id = obj.id;
-        concept.concept_code = obj.code;
-        concept.vocabulary_id = obj.type;
-        return concept;
-    }
+    const concept = new Concept();
+    concept.concept_name = obj.name;
+    concept.concept_id = obj.conceptId;
+    concept.count_value = obj.count;
+    concept.is_group = obj.group;
+    concept.is_selectable = obj.selectable;
+    concept.domain_id = obj.domainId;
+    concept.id = obj.id;
+    concept.concept_code = obj.code;
+    concept.vocabulary_id = obj.type;
+    return concept;
+  }
   constructor(obj?: any) {
     this.concept_name = obj && obj.conceptName || '';
     this.concept_class_id = obj && obj.conceptClassId || '';
@@ -66,25 +46,18 @@ export class Concept implements IConcept {
     this.is_selectable = obj && obj.isSelectable || false;
   }
 
-    moreInfo(): string {
-        return 'More information about concept class ' + this.constructor.name;
-    }
-
-
-
-
+  moreInfo(): string {
+    return 'More information about concept class ' + this.constructor.name;
+  }
 }
 
 export class ConceptPpi extends Concept {
   children: Array<any>;
-  // survey: Survey;
-  // Return more info about survey and whatever for this concept
 
   moreInfo(): string {
     return 'ConceptPPI More info on Survey and such';
   }
- // constructing from codebook ppi
- // Todo:
+
   constructor(obj?: any) {
     super(obj);
     this.concept_name = obj && obj.display;
@@ -116,9 +89,8 @@ export class ConceptPpi extends Concept {
       max = Math.floor(max);
       return Math.floor(Math.random() * (max - min)) + min;
     }
-  } // End constructor
+  }
 }
-
 
 export class Survey {
   title: string;

--- a/ui/src/app/data-browser/chart/chart.component.ts
+++ b/ui/src/app/data-browser/chart/chart.component.ts
@@ -2,6 +2,9 @@ import {Component, Input, NgModule, OnChanges} from '@angular/core';
 import { ChartModule } from 'angular2-highcharts';
 import { AchillesService} from '../services/achilles.service';
 
+import { Analysis } from '../AnalysisClasses';
+import { Concept } from '../ConceptClasses';
+
 // This draws a highchart from an analysis object
 // import highcharts and highmaps and add highmaps to it.
 // Note, must import the js/modules/map so it can play nice. See highcharts docs
@@ -18,12 +21,6 @@ ChartModule.forRoot(
 );
 // highmaps(highcharts);  // Call this to add highmaps functionality to highcharts
 
-
-
-
-import { Analysis } from '../AnalysisClasses';
-import { IConcept } from '../ConceptClasses';
-
 @Component({
   selector: 'app-chart',
   templateUrl: './chart.component.html',
@@ -35,7 +32,7 @@ import { IConcept } from '../ConceptClasses';
 export class ChartComponent implements OnChanges {
   @Input() redraw;
   @Input() analysis: Analysis;
-  @Input() concepts: IConcept[];
+  @Input() concepts: Concept[];
   chartType;
   chartOptions;
   chart;

--- a/ui/src/app/data-browser/lazy-tree/lazy-tree.component.ts
+++ b/ui/src/app/data-browser/lazy-tree/lazy-tree.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import {IConcept} from '../ConceptClasses';
+import {Concept} from '../ConceptClasses';
 import { TreeService } from '../services/tree.service';
 @Component({
   selector: 'app-lazy-tree',
@@ -8,7 +8,7 @@ import { TreeService } from '../services/tree.service';
 })
 export class LazyTreeComponent implements OnInit {
   routeId;
-  tree_nodes: IConcept[] = [];
+  tree_nodes: Concept[] = [];
   loading: boolean;
   // Route domain map -- todo , these can be more than one eventually
   routeDomain = {
@@ -20,11 +20,11 @@ export class LazyTreeComponent implements OnInit {
   pageDomainId = null;
 
   @Input() vocabularyId;
-  @Input() parent: IConcept;
+  @Input() parent: Concept;
   @Output() conceptEmit = new EventEmitter;
 
   // Function to return true if we can expand this
-  canExpand(item: IConcept) {
+  canExpand(item: Concept) {
     if (item.is_group) {
       return true;
     }
@@ -35,7 +35,7 @@ export class LazyTreeComponent implements OnInit {
   }
 
   // Function to return true if we can click this
-  canClick(item: IConcept) {
+  canClick(item: Concept) {
     if (item.is_selectable) {
       return true;
     }

--- a/ui/src/app/data-browser/mobile-charts/mobile-charts.component.ts
+++ b/ui/src/app/data-browser/mobile-charts/mobile-charts.component.ts
@@ -6,7 +6,7 @@ import { AchillesService } from '../services/achilles.service';
   styleUrls: ['./mobile-charts.component.css']
 })
 export class MobileChartsComponent implements OnInit {
-  // @Input() newConcept:IConcept; // Last concept added
+  // @Input() newConcept:Concept; // Last concept added
   @Input() redraw;
   @Input() concept;
   @Input() analyses;

--- a/ui/src/app/data-browser/my-concepts/my-concepts.component.ts
+++ b/ui/src/app/data-browser/my-concepts/my-concepts.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output} from '@angular/core';
 import { IAnalysis } from '../AnalysisClasses';
-import { IConcept } from '../ConceptClasses';
+import { Concept } from '../ConceptClasses';
 import { AchillesService } from '../services/achilles.service';
 
 
@@ -10,8 +10,8 @@ import { AchillesService } from '../services/achilles.service';
   styleUrls: ['./my-concepts.component.css']
 })
 export class MyConceptsComponent implements OnInit, OnChanges {
-  @Input() conceptsArray: IConcept[] = [];
-  @Input() newConcept: IConcept; // Last concept added
+  @Input() conceptsArray: Concept[] = [];
+  @Input() newConcept: Concept; // Last concept added
   @Input() route: string;
   @Output() removalEmit = new EventEmitter();
   @Output() resetConcepts = new EventEmitter();
@@ -48,7 +48,7 @@ export class MyConceptsComponent implements OnInit, OnChanges {
   // Add it to the concept array if it is  the drawer.
   // We do this by just emitting to the component (ie search page ),
     // so it can add to its array too and graph it
-  drawerParentSelected(item: IConcept) {
+  drawerParentSelected(item: Concept) {
     this.addEmit.emit(item);
   }
 

--- a/ui/src/app/data-browser/search/search.component.ts
+++ b/ui/src/app/data-browser/search/search.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IConcept } from '../ConceptClasses';
+import { Concept } from '../ConceptClasses';
 import { AchillesService } from '../services/achilles.service';
 
 @Component({
@@ -15,7 +15,7 @@ export class SearchComponent {
   routeId: string;
   colors: ['#262262', '#8bc990', '#6cace4', '#f58771', '#f8c954', '#216fb4'];
   loading = true;
-  clickedConcept: IConcept;
+  clickedConcept: Concept;
   toggleTree: boolean;
   vocabulary_id: string;
   savedSearchString: string;

--- a/ui/src/app/data-browser/services/achilles.service.ts
+++ b/ui/src/app/data-browser/services/achilles.service.ts
@@ -4,7 +4,7 @@ import 'rxjs/add/operator/toPromise';
 import 'rxjs/Rx'; // unlocks all rxjs operators, such as map()
 import { Analysis, AnalysisResult, IAnalysis} from '../AnalysisClasses';
 import { AnalysisDist, AnalysisDistResult } from '../AnalysisSubClasses';
-import { Concept, IConcept } from '../ConceptClasses';
+import { Concept} from '../ConceptClasses';
 import { DomainClass } from '../DomainClasses';
 
 @Injectable()
@@ -26,7 +26,7 @@ export class AchillesService {
   }
   // Return an Analysis object with results for the concepts array.
   // This analysis obj can then be passed to app-chart
-  makeConceptsCountAnalysis(concepts: IConcept[]): Analysis {
+  makeConceptsCountAnalysis(concepts: Concept[]): Analysis {
       const obj = {
           analysisId: 3000,
           analysisName: 'Number of Participants',


### PR DESCRIPTION
The current UI build process generates some warnings caused by a long-standing bug in the Typescript compiler where it has difficultly recognizing a module's exported _types_ when the same module exports concrete objects (classes, constants, etc).

Given that in typescript, a class definition actually generates an interface and may be used as an interface where necessary, the most expedient means by which to remove the build warnings is to remove the extraneous interface triggering them, which I have done.