### PR TITLE
Reduce memory usage in tests

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -275,6 +275,14 @@ tasks.withType(Test) {
   }
 }
 
+test {
+  // Starting with a smaller minimum seems to help this task use memory more slowly. When Gradle
+  // runs out of memory, it fails with this message:
+  //   Process 'Gradle Test Executor 1' finished with non-zero exit value 137
+  // and literally nothing else in terms of helpful debugging information.
+  minHeapSize = '128m'
+}
+
 integration {
   // These tests should always run when requested since they consume and produce side-effects.
   outputs.upToDateWhen { false }


### PR DESCRIPTION
It appears that Gradle forks the JVM when running tasks. According to `top`, when running tests, our memory usage steadily increases. This change causes the JVM forks to start with less memory so that the tests finish before the memory usage grows beyond the upper bound.

Helpful info on solution:
https://discuss.gradle.org/t/travis-ci-org-gradle-launcher-daemon-client-daemondisappearedexception-gradle-build-daemon-disappeared-unexpectedly-it-may-have-been-killed-or-may-have-crashed/13106/3