### PR TITLE
Drop guava dep from build.gradle to fix GCS access

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -207,7 +207,6 @@ dependencies {
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile 'com.google.guava:guava:+'
   compile 'com.blockscore:blockscore-java:4.0.2'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502


### PR DESCRIPTION
Without removal, I see the following when creating a new account (which attempts to read invite keys from GCS):

```
api_1                    | Caused by: java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;
api_1                    | 	at com.google.api.gax.retrying.BasicRetryingFuture.<init>(BasicRetryingFuture.java:77)
api_1                    | 	at com.google.api.gax.retrying.DirectRetryingExecutor.createFuture(DirectRetryingExecutor.java:73)
api_1                    | 	at com.google.cloud.RetryHelper.run(RetryHelper.java:73)
api_1                    | 	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:51)
api_1                    | 	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:194)
api_1                    | 	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:186)
api_1                    | 	at org.pmiops.workbench.google.CloudStorageServiceImpl.readToString(CloudStorageServiceImpl.java:34)
api_1                    | 	at org.pmiops.workbench.google.CloudStorageServiceImpl.readInvitationKey(CloudStorageServiceImpl.java:21)
api_1                    | 	at org.pmiops.workbench.api.ProfileController.createAccount(ProfileController.java:262)
api_1                    | 	at org.pmiops.workbench.api.ProfileApiController.createAccount(ProfileApiController.java:41)
api_1                    | 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
api_1                    | 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
api_1                    | 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
api_1                    | 	at java.lang.reflect.Method.invoke(Method.java:498)
api_1                    | 	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
api_1                    | 	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:133)
api_1                    | 	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:97)
api_1                    | 	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:827)
api_1                    | 	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:738)
api_1                    | 	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:85)
api_1                    | 	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:963)
```

Presumably something in here is having a bad interaction with app engine (or our particular set of deps).

This was added with cohort materialization, but I wasn't able to reproduce any issues after removal (something may come up later in this area).