### PR TITLE
Update billing project prefix

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -3,7 +3,7 @@
   "firecloud": {
     "debugEndpoints": false,
     "billingAccountId": "001A68-D1B344-975E93",
-    "billingProjectPrefix": "aou-test-free-"
+    "billingProjectPrefix": "aou-test-free1-"
   },
   "bigquery": {
     "dataSetId": "synpuf",


### PR DESCRIPTION
Test env is currently broken, as it appears that all DB rows were dropped as of last night (12/19) around 9PM PST (more likely, the tables were deleted then recreated).

Workbench currently fails on user initialization (required for most calls), as it cannot create new billing projects for any user that already has one.