### PR TITLE
GET and PUT participant statuses from the same endpoint

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -911,6 +911,45 @@ paths:
             $ref: "#/definitions/CohortReview"
 
   /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/status/{participantId}:
+    get:
+      tags:
+        - cohortReview
+      description: This endpoint will return a ParticipantCohortStatus
+      operationId: "getParticipantCohortStatus"
+      parameters:
+        - in: path
+          name: workspaceNamespace
+          type: string
+          required: true
+          description: specifies which workspace namespace
+        - in: path
+          name: workspaceId
+          type: string
+          required: true
+          description: specifies which workspace
+        - in: path
+          name: cohortId
+          type: integer
+          format: int64
+          required: true
+          description: specifies which cohort
+        - in: path
+          name: cdrVersionId
+          type: integer
+          format: int64
+          required: true
+          description: specifies which cdr version
+        - in: path
+          name: participantId
+          type: integer
+          format: int64
+          required: true
+          description: specifies which participant
+      responses:
+        "200":
+          description: The ParticipantCohortStatus definition
+          schema:
+            $ref: "#/definitions/ParticipantCohortStatus"
     put:
       tags:
         - cohortReview
@@ -994,40 +1033,6 @@ paths:
           description: A collection of CohortSummary
           schema:
             $ref: "#/definitions/CohortSummaryListResponse"
-
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}:
-    get:
-      tags:
-        - cohortReview
-      description: This endpoint will return a ParticipantCohortStatus
-      operationId: "getParticipantCohortStatus"
-      parameters:
-        - in: path
-          name: workspaceNamespace
-          type: string
-          required: true
-        - in: path
-          name: workspaceId
-          type: string
-          required: true
-          description: specifies which workspace
-        - in: path
-          name: cohortReviewId
-          type: integer
-          format: int64
-          required: true
-          description: specifies which review
-        - in: path
-          name: participantId
-          type: integer
-          format: int64
-          required: true
-          description: specifies which participant
-      responses:
-        "200":
-          description: The ParticipantCohortStatus definition
-          schema:
-            $ref: "#/definitions/ParticipantCohortStatus"
 
   /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations:
     post:


### PR DESCRIPTION
The existing GET and PUT methods for `ParticipantCohortStatus` objects did not share an endpoint; now they do.