### PR TITLE
Enforcing that only GSuite domain users get user records.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -210,7 +210,7 @@ dependencies {
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
   compile 'com.blockscore:blockscore-java:4.0.2'
-  compile 'com.google.guava:guava:19.0'
+  compile 'com.google.guava:guava:22.0'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502
   compile 'org.json:json:20160810'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -198,7 +198,9 @@ dependencies {
   compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0'
   compile 'com.google.apis:google-api-services-oauth2:+'
   compile 'com.google.cloud:google-cloud-bigquery:0.30.0-beta'
-  compile 'com.google.cloud:google-cloud-storage:1.8.0'
+  compile ('com.google.cloud:google-cloud-storage:1.8.0') {
+    exclude group: 'com.google.guava', module:'guava-jdk5'
+  }
   compile 'com.google.code.gson:gson:+'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
   compile 'com.squareup.okhttp:okhttp:2.4.0'
@@ -208,6 +210,7 @@ dependencies {
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
   compile 'com.blockscore:blockscore-java:4.0.2'
+  compile 'com.google.guava:guava:19.0'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502
   compile 'org.json:json:20160810'

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -53,6 +53,7 @@ def dev_up(*args)
   common.status "Running database migrations..."
   common.run_inline %W{docker-compose run db-migration}
   common.run_inline %W{docker-compose run db-cdr-migration}
+  common.run_inline %W{docker-compose run db-data-migration}
 
   common.status "Updating configuration..."
   common.run_inline %W{docker-compose run update-config}

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -271,13 +271,9 @@ public class ProfileController implements ProfileApiDelegate {
     // profile, since it can be edited in our UI as well as the Google UI,  and we're fine with
     // that; the expectation is their profile in AofU will be managed in AofU, not in Google.
 
-    User user = new User();
-    user.setDataAccessLevel(DataAccessLevel.UNREGISTERED);
-    user.setEmail(googleUser.getPrimaryEmail());
-    user.setContactEmail(request.getProfile().getContactEmail());
-    user.setFamilyName(request.getProfile().getFamilyName());
-    user.setGivenName(request.getProfile().getGivenName());
-    userDao.save(user);
+    User user = userService.createUser(request.getProfile().getGivenName(),
+        request.getProfile().getFamilyName(),
+        googleUser.getPrimaryEmail(), request.getProfile().getContactEmail());
 
     // TODO(dmohs): This should be 201 Created with no body, but the UI's swagger-generated code
     // doesn't allow this. Fix.

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -66,7 +66,6 @@ public class ProfileController implements ProfileApiDelegate {
 
   private final ProfileService profileService;
   private final Provider<User> userProvider;
-  private final Provider<Userinfoplus> userinfoplusProvider;
   private final UserDao userDao;
   private final Clock clock;
   private final UserService userService;
@@ -79,7 +78,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Autowired
   ProfileController(ProfileService profileService, Provider<User> userProvider,
-      Provider<Userinfoplus> userinfoplusProvider, UserDao userDao,
+      UserDao userDao,
       Clock clock, UserService userService, FireCloudService fireCloudService,
       DirectoryService directoryService,
       CloudStorageService cloudStorageService, BlockscoreService blockscoreService,
@@ -87,7 +86,6 @@ public class ProfileController implements ProfileApiDelegate {
       WorkbenchEnvironment workbenchEnvironment) {
     this.profileService = profileService;
     this.userProvider = userProvider;
-    this.userinfoplusProvider = userinfoplusProvider;
     this.userDao = userDao;
     this.clock = clock;
     this.userService = userService;
@@ -198,24 +196,6 @@ public class ProfileController implements ProfileApiDelegate {
 
   private User initializeUserIfNeeded() {
     User user = userProvider.get();
-    if (user == null) {
-      // For now, this will happen with any account that you sign in with (since we're not
-      // creating Google accounts yet.) Create a user record for the account.
-
-      // After we start requiring that user accounts are in our GSuite domain, this should only
-      // happen if a Google account was created but we failed to write to our
-      // database right after that.
-      // TODO: remove this logic when we start using Gsuite account info, or start storing the
-      // contact email in Google account info so we can use it here. (We don't want User records
-      // without contact emails.)
-      Userinfoplus userInfo = userinfoplusProvider.get();
-      user = new User();
-      user.setDataAccessLevel(DataAccessLevel.UNREGISTERED);
-      user.setEmail(userInfo.getEmail());
-      user.setGivenName(userInfo.getGivenName());
-      user.setFamilyName(userInfo.getFamilyName());
-    }
-
     // On first sign-in, create a FC user, billing project, and set the first sign in time.
     if (user.getFirstSignInTime() == null) {
       if (user.getFreeTierBillingProjectName() == null) {
@@ -224,13 +204,14 @@ public class ProfileController implements ProfileApiDelegate {
       }
 
       user.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
+      try {
+        return userDao.save(user);
+      } catch (ObjectOptimisticLockingFailureException e) {
+        log.log(Level.WARNING, "version conflict for user update", e);
+        throw new ConflictException("Failed due to concurrent modification");
+      }
     }
-    try {
-      return userDao.save(user);
-    } catch (ObjectOptimisticLockingFailureException e) {
-      log.log(Level.WARNING, "version conflict for user update", e);
-      throw new ConflictException("Failed due to concurrent modification");
-    }
+    return user;
   }
 
   private ResponseEntity<Profile> getProfileResponse(User user) {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -352,11 +352,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       throw new BadRequestException("missing required field 'dataAccessLevel'");
     }
     User user = userProvider.get();
-    if (user == null) {
-      // You won't be able to create workspaces prior to creating a user record once our
-      // registration flow is done, so this should never happen.
-      throw new BadRequestException("User is not initialized yet; please register");
-    }
     org.pmiops.workbench.db.model.Workspace existingWorkspace = workspaceService.getByName(
         workspace.getNamespace(), workspace.getName());
     if (existingWorkspace != null) {
@@ -530,11 +525,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       throw new BadRequestException("missing required field 'workspace.researchPurpose'");
     }
     User user = userProvider.get();
-    if (user == null) {
-      // You won't be able to create workspaces prior to creating a user record once our
-      // registration flow is done, so this should never happen.
-      throw new BadRequestException("User is not initialized yet; please register");
-    }
     if (workspaceService.getByName(workspace.getNamespace(), workspace.getName()) != null) {
       throw new ConflictException(String.format(
           "Workspace %s/%s already exists",

--- a/api/src/main/java/org/pmiops/workbench/auth/UserAuthentication.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/UserAuthentication.java
@@ -3,15 +3,18 @@ package org.pmiops.workbench.auth;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import org.pmiops.workbench.db.model.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
 public class UserAuthentication implements Authentication {
 
+  private final User user;
   private final Userinfoplus userInfo;
   private final String bearerToken;
 
-  public UserAuthentication(Userinfoplus userInfo, String bearerToken) {
+  public UserAuthentication(User user, Userinfoplus userInfo, String bearerToken) {
+    this.user = user;
     this.userInfo = userInfo;
     this.bearerToken = bearerToken;
   }
@@ -48,5 +51,9 @@ public class UserAuthentication implements Authentication {
 
   @Override
   public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+  }
+
+  public User getUser() {
+    return user;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
@@ -6,6 +6,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.services.oauth2.Oauth2;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
+import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,6 @@ public class UserInfoService {
     GoogleCredential credential = new GoogleCredential().setAccessToken(token);
     Oauth2 oauth2 = new Oauth2.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName(APPLICATION_NAME).build();
-    return oauth2.userinfo().get().execute();
+    return ExceptionUtils.executeWithRetries(oauth2.userinfo().get());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -9,6 +9,7 @@ import javax.servlet.ServletContext;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.interceptors.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +50,12 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public User user(Userinfoplus userInfo, UserDao userDao) {
-    return userDao.findUserByEmail(userInfo.getEmail());
+    User user = userDao.findUserByEmail(userInfo.getEmail());
+    if (user == null) {
+      throw new NotFoundException(String.format("No user record found for %s",
+          userInfo.getEmail()));
+    }
+    return user;
   }
 
   @Bean

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -49,13 +49,8 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public User user(Userinfoplus userInfo, UserDao userDao) {
-    User user = userDao.findUserByEmail(userInfo.getEmail());
-    if (user == null) {
-      throw new NotFoundException(String.format("No user record found for %s",
-          userInfo.getEmail()));
-    }
-    return user;
+  public User user(UserAuthentication userAuthentication) {
+    return userAuthentication.getUser();
   }
 
   @Bean

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -85,12 +85,8 @@ public class UserService {
       if (user == null) {
         throw e;
       }
-      // If a user already existed, update it in place.
-      user.setDataAccessLevel(DataAccessLevel.UNREGISTERED);
-      user.setContactEmail(contactEmail);
-      user.setFamilyName(familyName);
-      user.setGivenName(givenName);
-      userDao.save(user);
+      // If a user already existed (due to multiple requests trying to create a user simultaneously)
+      // just return it.
     }
     return user;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
@@ -68,6 +69,30 @@ public class UserService {
         user.setDataAccessLevel(DataAccessLevel.REGISTERED);
       }
     }
+  }
+
+  public User createUser(String givenName, String familyName, String email, String contactEmail) {
+    User user = new User();
+    user.setDataAccessLevel(DataAccessLevel.UNREGISTERED);
+    user.setEmail(email);
+    user.setContactEmail(contactEmail);
+    user.setFamilyName(familyName);
+    user.setGivenName(givenName);
+    try {
+      userDao.save(user);
+    } catch (DataIntegrityViolationException e) {
+      user = userDao.findUserByEmail(email);
+      if (user == null) {
+        throw e;
+      }
+      // If a user already existed, update it in place.
+      user.setDataAccessLevel(DataAccessLevel.UNREGISTERED);
+      user.setContactEmail(contactEmail);
+      user.setFamilyName(familyName);
+      user.setGivenName(givenName);
+      userDao.save(user);
+    }
+    return user;
   }
 
   public User setBlockscoreIdVerification(String blockscoreId, boolean blockscoreVerificationIsValid) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -40,9 +40,6 @@ public class UserService {
    */
   private User updateWithRetries(Function<User, User> userModifier) {
     User user = userProvider.get();
-    if (user == null) {
-      throw new NotFoundException("Could not find record for authenticated user");
-    }
     int numAttempts = 0;
     while (true) {
       user = userModifier.apply(user);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -56,7 +56,6 @@ public class FireCloudConfig {
     return apiClient;
   }
 
-
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public ProfileApi profileApi(@Qualifier(END_USER_API_CLIENT) ApiClient apiClient) {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.firecloud;
 
 import java.util.List;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
+import org.pmiops.workbench.firecloud.model.Me;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
@@ -16,6 +17,11 @@ public interface FireCloudService {
    * @return true if the user making the current request is enabled in FireCloud, false otherwise.
    */
   boolean isRequesterEnabledInFirecloud() throws ApiException;
+
+  /**
+   * @return the FireCloud profile for the requesting user.
+   */
+  Me getMe() throws ApiException;
 
   /**
    * Registers the user in Firecloud.

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -62,6 +62,11 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
+  public Me getMe() throws ApiException {
+    return profileApiProvider.get().me();
+  }
+
+  @Override
   public void registerUser(String contactEmail, String firstName, String lastName)
       throws ApiException {
     ProfileApi profileApi = profileApiProvider.get();

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -17,8 +17,10 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpHeaders;
@@ -51,14 +53,17 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
 
   private final UserInfoService userInfoService;
   private final Provider<User> userProvider;
+  private final String gsuiteDomainSuffix;
   private final UserDao userDao;
 
   @Autowired
   public AuthInterceptor(UserInfoService userInfoService, Provider<User> userProvider,
-      UserDao userDao) {
+      WorkbenchConfig workbenchConfig, UserDao userDao) {
     this.userInfoService = userInfoService;
     // Note that this provider isn't usable until after we publish the security context below.
     this.userProvider = userProvider;
+    // We cache this so we don't have to retrieve the config and parse it every request.
+    this.gsuiteDomainSuffix = "@" + workbenchConfig.googleDirectoryService.gSuiteDomain;
     this.userDao = userDao;
   }
 
@@ -112,7 +117,12 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       return false;
     }
 
-    // TODO: get token info and check that as well
+    if (!userInfo.getEmail().endsWith(gsuiteDomainSuffix)) {
+      log.log(Level.INFO, "{0} isn't in {1}, can't access the workbench",
+          new Object[] { userInfo.getEmail(), gsuiteDomainSuffix });
+      response.sendError(HttpServletResponse.SC_FORBIDDEN);
+      return false;
+    }
 
     // TODO: check Google group membership to ensure user is in registered user group
 
@@ -122,7 +132,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     log.log(Level.INFO, "{0} logged in", userInfo.getEmail());
 
     if (!hasRequiredAuthority(method.getMethod(), userProvider.get())) {
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      response.sendError(HttpServletResponse.SC_FORBIDDEN);
       return false;
     }
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -140,9 +140,10 @@ public class AuthInterceptorTest {
     Userinfoplus userInfo = new Userinfoplus();
     userInfo.setEmail("bob@bad-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
-    when(fireCloudService.getMe()).thenThrow(new ApiException());
+    when(fireCloudService.getMe()).thenThrow(
+        new ApiException(HttpServletResponse.SC_NOT_FOUND, "blah"));
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+    verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
   }
 
   @Test
@@ -177,7 +178,7 @@ public class AuthInterceptorTest {
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByEmail("bob@also-bad-domain.org")).thenReturn(null);
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
   }
 
   @Test


### PR DESCRIPTION
Allowing pet SAs to use our API; resolving them to their corresponding user record by calling /me on FireCloud.

Making user records created for GSuite domain users that don't already have them on any API call.

Changing dev-up to run db-data-migration (to insert CDR version row.)

