### PR TITLE
[RW-285] Clone cohorts and reviews on workflow clone; fix tests

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -137,7 +137,12 @@ public class CohortReviewController implements CohortReviewApiDelegate {
             throw new BadRequestException(
                     String.format("Invalid Request: Cohort Review size must be between %s and %s", 0, MAX_REVIEW_SIZE));
         }
-        CohortReview cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
+        CohortReview cohortReview = null;
+        try {
+            cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
+        } catch (NotFoundException nfe) {
+            cohortReview = initializeAndSaveCohortReview(workspaceNamespace, workspaceId, cohortId, cdrVersionId);
+        }
         if(cohortReview.getReviewSize() > 0) {
             throw new BadRequestException(
                     String.format("Invalid Request: Cohort Review already created for cohortId: %s, cdrVersionId: %s",

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -4,6 +4,15 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.util.List;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
+import javax.persistence.OptimisticLockException;
 import org.pmiops.workbench.cohorts.CohortMaterializationService;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
@@ -23,8 +32,8 @@ import org.pmiops.workbench.model.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import java.sql.Timestamp;
@@ -148,7 +157,7 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<CohortListResponse> getCohortsInWorkspace(String workspaceNamespace,
       String workspaceId) {
-    Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
+    Workspace workspace = workspaceService.getRequiredWithCohorts(workspaceNamespace, workspaceId);
     CohortListResponse response = new CohortListResponse();
     List<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
     if (cohorts != null) {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -6,7 +6,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import java.sql.Timestamp;
 import java.time.Clock;
-import java.util.List;
+import java.util.Comparator;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -32,7 +33,6 @@ import org.pmiops.workbench.model.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
@@ -159,9 +159,12 @@ public class CohortsController implements CohortsApiDelegate {
       String workspaceId) {
     Workspace workspace = workspaceService.getRequiredWithCohorts(workspaceNamespace, workspaceId);
     CohortListResponse response = new CohortListResponse();
-    List<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
+    Set<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
     if (cohorts != null) {
-      response.setItems(cohorts.stream().map(TO_CLIENT_COHORT).collect(Collectors.toList()));
+      response.setItems(cohorts.stream()
+          .map(TO_CLIENT_COHORT)
+          .sorted(Comparator.comparing(c -> c.getName()))
+          .collect(Collectors.toList()));
     }
     return ResponseEntity.ok(response);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -12,8 +12,6 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import javax.inject.Provider;
-import javax.persistence.OptimisticLockException;
 import org.pmiops.workbench.cohorts.CohortMaterializationService;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
@@ -34,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import java.sql.Timestamp;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import com.google.apphosting.api.ApiProxy;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import java.sql.Timestamp;
@@ -223,7 +225,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   private final WorkspaceService workspaceService;
   private final CdrVersionDao cdrVersionDao;
   private final UserDao userDao;
-  private final Provider<User> userProvider;
+  private Provider<User> userProvider;
   private final FireCloudService fireCloudService;
   private final CloudStorageService cloudStorageService;
   private final Clock clock;
@@ -250,6 +252,11 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     this.clock = clock;
     this.apiHostName = apiHostName;
     this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  @VisibleForTesting
+  void setUserProvider(Provider<User> userProvider) {
+    this.userProvider = userProvider;
   }
 
   private static String generateRandomChars(String candidateChars, int length) {
@@ -600,7 +607,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       dbWorkspace.setDescription(toWorkspace.getDescription());
     }
 
-    // TODO(calbach): Copy cohorts.
     dbWorkspace.setCdrVersion(fromWorkspace.getCdrVersion());
     dbWorkspace.setDataAccessLevel(fromWorkspace.getDataAccessLevel());
 
@@ -611,7 +617,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     dbWorkspace.addWorkspaceUserRole(permissions);
 
-    dbWorkspace = workspaceService.getDao().save(dbWorkspace);
+    dbWorkspace = workspaceService.saveAndCloneCohorts(fromWorkspace, dbWorkspace);
     CloneWorkspaceResponse resp = new CloneWorkspaceResponse();
     resp.setWorkspace(TO_CLIENT_WORKSPACE.apply(dbWorkspace));
     return ResponseEntity.ok(resp);

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -564,7 +564,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
 
     checkWorkspaceReadAccess(workspaceNamespace, workspaceId);
-    org.pmiops.workbench.db.model.Workspace fromWorkspace = workspaceService.getRequired(
+    org.pmiops.workbench.db.model.Workspace fromWorkspace = workspaceService.getRequiredWithCohorts(
         workspaceNamespace, workspaceId);
     if (fromWorkspace == null) {
       throw new NotFoundException(String.format(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.List;
-
 import org.pmiops.workbench.db.model.Cohort;
 import org.springframework.data.repository.CrudRepository;
 
@@ -11,9 +9,4 @@ public interface CohortDao extends CrudRepository<Cohort, Long> {
      * Returns the cohort in the workspace with the specified name, or null if there is none.
      */
     Cohort findCohortByNameAndWorkspaceId(String name, long workspaceId);
-
-    /**
-     * Returns the cohort in the workspace with the specified name, or null if there is none.
-     */
-    List<Cohort> findByWorkspaceId(long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortDao.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
+import java.util.List;
+
 import org.pmiops.workbench.db.model.Cohort;
 import org.springframework.data.repository.CrudRepository;
 
@@ -9,4 +11,9 @@ public interface CohortDao extends CrudRepository<Cohort, Long> {
      * Returns the cohort in the workspace with the specified name, or null if there is none.
      */
     Cohort findCohortByNameAndWorkspaceId(String name, long workspaceId);
+
+    /**
+     * Returns the cohort in the workspace with the specified name, or null if there is none.
+     */
+    List<Cohort> findByWorkspaceId(long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
@@ -3,13 +3,16 @@ package org.pmiops.workbench.db.dao;
 import org.pmiops.workbench.db.model.Cohort;
 import org.pmiops.workbench.db.model.CohortReview;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Service
 public class CohortService {
   // Note: Cannot use an @Autowired constructor with this version of Spring
   // Boot due to https://jira.spring.io/browse/SPR-15600. See RW-256.
   @Autowired private CohortDao cohortDao;
   @Autowired private CohortReviewDao cohortReviewDao;
+  @Autowired private ParticipantCohortStatusDao participantCohortStatusDao;
 
   @Transactional
   public Cohort saveAndCloneReviews(Cohort from, Cohort to) {
@@ -24,7 +27,9 @@ public class CohortService {
       cr.setReviewSize(fromReview.getReviewSize());
       cr.setReviewedCount(fromReview.getReviewedCount());
       cr.setReviewStatus(fromReview.getReviewStatus());
-      cohortReviewDao.save(cr);
+      cr = cohortReviewDao.save(cr);
+      participantCohortStatusDao.bulkCopyByCohortReview(
+          fromReview.getCohortReviewId(), cr.getCohortReviewId());
     }
     return saved;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
@@ -1,0 +1,35 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.logging.Logger;
+
+import org.pmiops.workbench.db.model.Cohort;
+import org.pmiops.workbench.db.model.CohortReview;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class CohortService {
+  private static final Logger log = Logger.getLogger(WorkspaceService.class.getName());
+
+  // Note: Cannot use an @Autowired constructor with this version of Spring
+  // Boot due to https://jira.spring.io/browse/SPR-15600. See RW-256.
+  @Autowired private CohortDao cohortDao;
+  @Autowired private CohortReviewDao cohortReviewDao;
+
+  @Transactional
+  public Cohort saveAndCloneReviews(Cohort from, Cohort to) {
+    Cohort saved = cohortDao.save(to);
+    for (CohortReview fromReview : from.getCohortReviews()) {
+      CohortReview cr = new CohortReview();
+      cr.setCohortId(saved.getCohortId());
+      cr.creationTime(saved.getCreationTime());
+      cr.setLastModifiedTime(saved.getLastModifiedTime());
+      cr.setCdrVersionId(fromReview.getCdrVersionId());
+      cr.setMatchedParticipantCount(fromReview.getMatchedParticipantCount());
+      cr.setReviewSize(fromReview.getReviewSize());
+      cr.setReviewedCount(fromReview.getReviewedCount());
+      cr.setReviewStatus(fromReview.getReviewStatus());
+      cohortReviewDao.save(cr);
+    }
+    return saved;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
@@ -1,15 +1,11 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.logging.Logger;
-
 import org.pmiops.workbench.db.model.Cohort;
 import org.pmiops.workbench.db.model.CohortReview;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 public class CohortService {
-  private static final Logger log = Logger.getLogger(WorkspaceService.class.getName());
-
   // Note: Cannot use an @Autowired constructor with this version of Spring
   // Boot due to https://jira.spring.io/browse/SPR-15600. See RW-256.
   @Autowired private CohortDao cohortDao;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -3,10 +3,25 @@ package org.pmiops.workbench.db.dao;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface ParticipantCohortStatusDao extends CrudRepository<ParticipantCohortStatus, Long>, ParticipantCohortStatusDaoCustom {
+
+  // We use native SQL here as there may be a large number of rows within a
+  // given cohort review; this avoids loading them into memory.
+  @Modifying
+  @Query(
+      value="INSERT INTO participant_cohort_status" +
+      " (cohort_review_id, participant_id, status)" +
+      " SELECT :toCrId, participant_id, pcs.status" +
+      " FROM participant_cohort_status pcs" +
+      " WHERE pcs.cohort_review_id = (:fromCrId)",
+      nativeQuery=true)
+  void bulkCopyByCohortReview(
+      @Param("fromCrId") long fromCohortReviewId, @Param("toCrId") long toCohortReviewId);
 
     Slice<ParticipantCohortStatus> findByParticipantKey_CohortReviewId(@Param("cohortReviewId") long cohortReviewId,
                                                                                Pageable pageRequest);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -16,7 +16,7 @@ public interface ParticipantCohortStatusDao extends CrudRepository<ParticipantCo
   @Query(
       value="INSERT INTO participant_cohort_status" +
       " (cohort_review_id, participant_id, status)" +
-      " SELECT :toCrId, participant_id, pcs.status" +
+      " SELECT (:toCrId), participant_id, pcs.status" +
       " FROM participant_cohort_status pcs" +
       " WHERE pcs.cohort_review_id = (:fromCrId)",
       nativeQuery=true)

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -10,13 +10,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface ParticipantCohortStatusDao extends CrudRepository<ParticipantCohortStatus, Long>, ParticipantCohortStatusDaoCustom {
 
+  // Important: Keep in sync with all DB rows that should be copied.
+  static final String ALL_COLUMNS_EXCEPT_REVIEW_ID =
+      "participant_id, status, gender_concept_id, birth_date, " +
+      "race_concept_id, ethnicity_concept_id";
+
   // We use native SQL here as there may be a large number of rows within a
   // given cohort review; this avoids loading them into memory.
   @Modifying
   @Query(
       value="INSERT INTO participant_cohort_status" +
-      " (cohort_review_id, participant_id, status)" +
-      " SELECT (:toCrId), participant_id, pcs.status" +
+      " (cohort_review_id, " + ALL_COLUMNS_EXCEPT_REVIEW_ID + ")" +
+      " SELECT (:toCrId), " + ALL_COLUMNS_EXCEPT_REVIEW_ID +
       " FROM participant_cohort_status pcs" +
       " WHERE pcs.cohort_review_id = (:fromCrId)",
       nativeQuery=true)

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -1,9 +1,11 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.List;
+
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
 
 
@@ -17,6 +19,10 @@ public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
   Workspace findByWorkspaceNamespaceAndFirecloudName(
       String workspaceNamespace, String firecloudName);
   Workspace findByWorkspaceNamespaceAndName(String workspaceNamespace, String name);
+  @Query("SELECT w FROM Workspace w JOIN FETCH w.cohorts" +
+      " WHERE w.workspaceNamespace = (:ns) AND w.firecloudName = (:fcName)")
+  Workspace findByFirecloudWithEagerCohorts(
+      @Param("ns") String workspaceNamespace, @Param("fcName") String fcName);
   List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
   List<Workspace> findByCreatorOrderByNameAsc(User creator);
   List<Workspace> findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.List;
-
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.data.repository.CrudRepository;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -19,7 +19,7 @@ public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
   Workspace findByWorkspaceNamespaceAndFirecloudName(
       String workspaceNamespace, String firecloudName);
   Workspace findByWorkspaceNamespaceAndName(String workspaceNamespace, String name);
-  @Query("SELECT w FROM Workspace w LEFT JOIN FETCH w.cohorts" +
+  @Query("SELECT w FROM Workspace w LEFT JOIN FETCH w.cohorts c LEFT JOIN FETCH c.cohortReviews" +
       " WHERE w.workspaceNamespace = (:ns) AND w.firecloudName = (:fcName)")
   Workspace findByFirecloudWithEagerCohorts(
       @Param("ns") String workspaceNamespace, @Param("fcName") String fcName);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -19,7 +19,7 @@ public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
   Workspace findByWorkspaceNamespaceAndFirecloudName(
       String workspaceNamespace, String firecloudName);
   Workspace findByWorkspaceNamespaceAndName(String workspaceNamespace, String name);
-  @Query("SELECT w FROM Workspace w JOIN FETCH w.cohorts" +
+  @Query("SELECT w FROM Workspace w LEFT JOIN FETCH w.cohorts" +
       " WHERE w.workspaceNamespace = (:ns) AND w.firecloudName = (:fcName)")
   Workspace findByFirecloudWithEagerCohorts(
       @Param("ns") String workspaceNamespace, @Param("fcName") String fcName);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -16,4 +16,5 @@ public interface WorkspaceService {
   public List<Workspace> findForReview();
   public void setResearchPurposeApproved(String ns, String firecloudName, boolean approved);
   public Workspace updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
+  public Workspace saveAndCloneCohorts(Workspace from, Workspace to);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -12,6 +12,7 @@ public interface WorkspaceService {
   public Workspace get(String ns, String firecloudName);
   public Workspace getByName(String ns, String name);
   public Workspace getRequired(String ns, String firecloudName);
+  public Workspace getRequiredWithCohorts(String ns, String firecloudName);
   public Workspace saveWithLastModified(Workspace workspace);
   public List<Workspace> findForReview();
   public void setResearchPurposeApproved(String ns, String firecloudName, boolean approved);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -87,9 +87,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     if (workspace == null) {
       throw new NotFoundException(String.format("Workspace %s/%s not found.", ns, firecloudName));
     }
-    // TODO(calbach): Use a NamedEntityGraph rather than this hacky populate approach.
-    // Force an eager load of all cohort reviews while we have a session still open.
-    workspace.getCohorts().stream().forEach(c -> c.getCohortReviews().size());
     return workspace;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
@@ -1,12 +1,16 @@
 package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
@@ -26,6 +30,7 @@ public class Cohort {
   private User creator;
   private Timestamp creationTime;
   private Timestamp lastModifiedTime;
+  private List<CohortReview> cohortReviews;
 
   @Id
   @GeneratedValue
@@ -117,5 +122,15 @@ public class Cohort {
 
   public void setLastModifiedTime(Timestamp lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
+  }
+
+  @OneToMany(mappedBy = "cohortId")
+  @OrderBy("cohort_review_id ASC")
+  public List<CohortReview> getCohortReviews() {
+    return cohortReviews;
+  }
+
+  public void setCohortReviews(List<CohortReview> cohortReviews) {
+    this.cohortReviews = cohortReviews;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
@@ -23,8 +23,6 @@ public class Cohort {
   private String name;
   private String type;
   private String description;
-  private String externalId;
-  private Workspace workspace;
   private long workspaceId;
   private String criteria;
   private User creator;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Cohort.java
@@ -1,8 +1,8 @@
 package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
-import java.util.List;
-
+import java.util.Set;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,7 +10,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
@@ -28,7 +27,7 @@ public class Cohort {
   private User creator;
   private Timestamp creationTime;
   private Timestamp lastModifiedTime;
-  private List<CohortReview> cohortReviews;
+  private Set<CohortReview> cohortReviews;
 
   @Id
   @GeneratedValue
@@ -122,13 +121,21 @@ public class Cohort {
     this.lastModifiedTime = lastModifiedTime;
   }
 
-  @OneToMany(mappedBy = "cohortId")
-  @OrderBy("cohort_review_id ASC")
-  public List<CohortReview> getCohortReviews() {
+  @OneToMany(mappedBy = "cohortId", orphanRemoval = true, cascade = CascadeType.ALL)
+  public Set<CohortReview> getCohortReviews() {
     return cohortReviews;
   }
+  
+  public void setCohortReviews(Set<CohortReview> cohortReviews) {
+    if (this.cohortReviews == null) {
+      this.cohortReviews = cohortReviews;
+      return;
+    }
+    this.cohortReviews.clear();
+    this.cohortReviews.addAll(cohortReviews);
+  }
 
-  public void setCohortReviews(List<CohortReview> cohortReviews) {
-    this.cohortReviews = cohortReviews;
+  public void addCohortReview(CohortReview cohortReview) {
+    this.cohortReviews.add(cohortReview);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/ParticipantCohortStatus.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/ParticipantCohortStatus.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 @Table(name = "participant_cohort_status")
 public class ParticipantCohortStatus {
 
+    // Important: Keep fields in sync with ParticipantCohortStatusDao.ALL_COLUMNS_EXCEPT_REVIEW_ID.
     private ParticipantCohortStatusKey participantKey;
     private CohortStatus status;
     private Long genderConceptId;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -3,16 +3,15 @@ package org.pmiops.workbench.db.model;
 import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -20,6 +19,7 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
+
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
@@ -322,7 +322,7 @@ public class Workspace {
     this.timeReviewed = timeReviewed;
   }
 
-  @OneToMany(mappedBy = "workspaceId")
+  @OneToMany(mappedBy = "workspaceId", orphanRemoval = true, cascade = CascadeType.ALL)
   @OrderBy("name ASC")
   public List<Cohort> getCohorts() {
     return cohorts;

--- a/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/Workspace.java
@@ -2,10 +2,8 @@ package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,11 +13,9 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
-
 import org.pmiops.workbench.model.DataAccessLevel;
 
 @Entity
@@ -70,7 +66,7 @@ public class Workspace {
   private User creator;
   private Timestamp creationTime;
   private Timestamp lastModifiedTime;
-  private List<Cohort> cohorts;
+  private Set<Cohort> cohorts = new HashSet<Cohort>();
 
   private boolean diseaseFocusedResearch;
   private String diseaseOfFocus;
@@ -323,13 +319,16 @@ public class Workspace {
   }
 
   @OneToMany(mappedBy = "workspaceId", orphanRemoval = true, cascade = CascadeType.ALL)
-  @OrderBy("name ASC")
-  public List<Cohort> getCohorts() {
+  public Set<Cohort> getCohorts() {
     return cohorts;
   }
 
-  public void setCohorts(List<Cohort> cohorts) {
+  public void setCohorts(Set<Cohort> cohorts) {
     this.cohorts = cohorts;
+  }
+
+  public void addCohort(Cohort cohort) {
+    this.cohorts.add(cohort);
   }
 
   @Transient

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.BigQueryConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.CohortService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.dao.WorkspaceServiceImpl;
@@ -78,7 +79,7 @@ public class CohortsControllerTest {
 
 
   @TestConfiguration
-  @Import(WorkspaceServiceImpl.class)
+  @Import({WorkspaceServiceImpl.class, CohortService.class})
   @MockBean(FireCloudService.class)
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -1,22 +1,17 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-
 import static junit.framework.TestCase.fail;
-
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
-
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-
 import javax.inject.Provider;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -14,7 +14,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Provider;
 
@@ -43,8 +42,6 @@ import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.MaterializeCohortRequest;
 import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.pmiops.workbench.model.ResearchPurpose;
-import org.pmiops.workbench.model.SearchGroup;
-import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchRequest;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -70,7 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(LiquibaseAutoConfiguration.class)
 @AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
-@Transactional(propagation = Propagation.SUPPORTS)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class CohortsControllerTest {
   private static final Instant NOW = Instant.now();
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -611,16 +611,15 @@ public class WorkspacesControllerTest {
         cloned.getNamespace(), cloned.getId(), cohortsByName.get("c1").getId(),
         cdrVersion.getCdrVersionId(), null, null, null, null, null, null).getBody();
     assertThat(gotCr1.getReviewSize()).isEqualTo(cr1.getReviewSize());
-    // TODO(calbach): Compare actual statuses, once fully supported.
-    assertThat(gotCr1.getParticipantCohortStatuses().size())
-        .isEqualTo(cr1.getParticipantCohortStatuses().size());
+    assertThat(gotCr1.getParticipantCohortStatuses())
+        .isEqualTo(cr1.getParticipantCohortStatuses());
 
     CohortReview gotCr2 = cohortReviewController.getParticipantCohortStatuses(
         cloned.getNamespace(), cloned.getId(), cohortsByName.get("c2").getId(),
         cdrVersion.getCdrVersionId(), null, null, null, null, null, null).getBody();
     assertThat(gotCr2.getReviewSize()).isEqualTo(cr2.getReviewSize());
-    assertThat(gotCr2.getParticipantCohortStatuses().size())
-        .isEqualTo(cr2.getParticipantCohortStatuses().size());
+    assertThat(gotCr2.getParticipantCohortStatuses())
+        .isEqualTo(cr2.getParticipantCohortStatuses());
 
     assertThat(ImmutableSet.of(gotCr1.getCohortReviewId(), gotCr2.getCohortReviewId()))
         .containsNoneOf(cr1.getCohortReviewId(), cr2.getCohortId());

--- a/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
@@ -1,17 +1,16 @@
 package org.pmiops.workbench.db.dao;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import com.google.gson.Gson;
-import org.junit.After;
+import java.sql.Timestamp;
+import java.util.Calendar;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.pmiops.workbench.db.model.Cohort;
 import org.pmiops.workbench.db.model.CohortReview;
-import org.pmiops.workbench.db.model.ParticipantCohortStatus;
-import org.pmiops.workbench.db.model.ParticipantCohortStatusKey;
-import org.pmiops.workbench.model.CohortStatus;
+import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -23,10 +22,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Calendar;
-
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @Import(LiquibaseAutoConfiguration.class)
@@ -34,15 +29,26 @@ import java.util.Calendar;
 @Transactional
 public class CohortReviewDaoTest {
 
-    private static long COHORT_ID = 1;
     private static long CDR_VERSION_ID = 1;
 
     @Autowired
+    WorkspaceDao workspaceDao;
+    @Autowired
+    CohortDao cohortDao;
+    @Autowired
     CohortReviewDao cohortReviewDao;
-
     @Autowired
     JdbcTemplate jdbcTemplate;
 
+    private long cohortId;
+    
+    @Before
+    public void setup() throws Exception {
+      Cohort cohort = new Cohort();
+      cohort.setWorkspaceId(workspaceDao.save(new Workspace()).getWorkspaceId());
+      cohortId = cohortDao.save(cohort).getCohortId();
+    }
+    
     @Test
     public void save() throws Exception {
         CohortReview cohortReview = createCohortReview();
@@ -95,7 +101,7 @@ public class CohortReviewDaoTest {
         Gson gson = new Gson();
 
         return new CohortReview()
-                .cohortId(COHORT_ID)
+                .cohortId(cohortId)
                 .cdrVersionId(CDR_VERSION_ID)
                 .creationTime(new Timestamp(Calendar.getInstance().getTimeInMillis()))
                 .lastModifiedTime(new Timestamp(Calendar.getInstance().getTimeInMillis()))

--- a/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
@@ -41,14 +41,14 @@ public class CohortReviewDaoTest {
     JdbcTemplate jdbcTemplate;
 
     private long cohortId;
-    
+
     @Before
     public void setup() throws Exception {
       Cohort cohort = new Cohort();
       cohort.setWorkspaceId(workspaceDao.save(new Workspace()).getWorkspaceId());
       cohortId = cohortDao.save(cohort).getCohortId();
     }
-    
+
     @Test
     public void save() throws Exception {
         CohortReview cohortReview = createCohortReview();

--- a/api/src/test/java/org/pmiops/workbench/db/dao/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/WorkspaceDaoTest.java
@@ -1,7 +1,10 @@
 package org.pmiops.workbench.db.dao;
 
+import static org.springframework.test.util.AssertionErrors.fail;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -13,8 +16,6 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.springframework.test.util.AssertionErrors.fail;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -28,7 +29,7 @@ public class WorkspaceDaoTest {
 
   @Test
   public void testWorkspaceVersionLocking() {
-    org.pmiops.workbench.db.model.Workspace ws = new org.pmiops.workbench.db.model.Workspace();
+    Workspace ws = new Workspace();
     ws.setVersion(1);
     ws = workspaceDao.save(ws);
 


### PR DESCRIPTION
- Clone cohorts and reviews when cloning a workspace.
- Add a `CohortService` to later support a standalone `CloneCohort` method
- `@Autowire` the workspace controller to achieve better similarity to the server environment (this required adding `setUserProvider`, as I couldn't figure out how to bind a dynamic value for user/userProvider in the test configuration).
  