### PR TITLE
Remove "api" from API URLs

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -88,7 +88,7 @@ parameters:
 
 paths:
 
-  /api/v1/config:
+  /v1/config:
     get:
       tags:
         - config
@@ -104,7 +104,7 @@ paths:
 
    # User methods ########################################################################
 
-  /api/v1/me:
+  /v1/me:
     get:
       tags:
         - profile
@@ -116,7 +116,7 @@ paths:
           schema:
             $ref: "#/definitions/Profile"
 
-  /api/v1/sendBugReport:
+  /v1/sendBugReport:
     post:
       tags:
         - bugReport
@@ -138,7 +138,7 @@ paths:
 
   # TODO(dmohs): If the username is not present in the query string, this responds with 500 Server
   # Error. It should respond with 400 Bad Request.
-  /api/v1/is-username-taken:
+  /v1/is-username-taken:
     get:
       tags:
         - profile
@@ -156,7 +156,7 @@ paths:
           schema:
             $ref: "#/definitions/UsernameTakenResponse"
 
-  /api/v1/invitation-key-verification:
+  /v1/invitation-key-verification:
     post:
       tags:
         - profile
@@ -177,7 +177,7 @@ paths:
             $ref: "#/definitions/ErrorResponse"
 
 
-  /api/v1/google-account:
+  /v1/google-account:
     post:
       tags:
         - profile
@@ -207,7 +207,7 @@ paths:
         204:
           description: Account deleted successfully.
 
-  /api/v1/id-verification:
+  /v1/id-verification:
     post:
       tags:
         - profile
@@ -224,7 +224,7 @@ paths:
           schema:
             $ref: "#/definitions/Profile"
 
-  /api/v1/update-profile:
+  /v1/update-profile:
     post:
       tags:
         - profile
@@ -241,7 +241,7 @@ paths:
           description: Request received.
 
   # TODO: add signature / other state?
-  /api/v1/account/accept-terms-of-service:
+  /v1/account/accept-terms-of-service:
     post:
       tags:
         - profile
@@ -254,7 +254,7 @@ paths:
             $ref: "#/definitions/Profile"
 
   # TODO: add other state pertaining to ethics training?
-  /api/v1/account/complete-ethics-training:
+  /v1/account/complete-ethics-training:
     post:
       tags:
         - profile
@@ -267,7 +267,7 @@ paths:
             $ref: "#/definitions/Profile"
 
   # TODO: add demographic survey response data
-  /api/v1/account/submit-demographic-survey:
+  /v1/account/submit-demographic-survey:
     post:
       tags:
         - profile
@@ -279,7 +279,7 @@ paths:
           schema:
             $ref: "#/definitions/Profile"
 
-  /api/v1/auth-domain/{groupName}:
+  /v1/auth-domain/{groupName}:
     post:
       tags:
         - authDomain
@@ -297,7 +297,7 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
-  /api/v1/auth-domain/{groupName}/users:
+  /v1/auth-domain/{groupName}/users:
     post:
       tags:
         - authDomain
@@ -363,7 +363,7 @@ paths:
 
   # Notebook clusters ####################################################################
 
-  /api/v1/clusters:
+  /v1/clusters:
     get:
       summary: List all clusters
       description: List all clusters, optionally filtering on a set of labels
@@ -395,7 +395,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorReport'
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cluster/:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cluster/:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -460,7 +460,7 @@ paths:
 
   # Billing projects #####################################################################
 
-  /api/v1/billingProjects:
+  /v1/billingProjects:
     get:
       tags:
         - Profile
@@ -480,7 +480,7 @@ paths:
 
   # Workspaces ###########################################################################
 
-  /api/v1/workspaces:
+  /v1/workspaces:
     get:
       tags:
         - workspaces
@@ -508,7 +508,7 @@ paths:
           schema:
             $ref: "#/definitions/Workspace"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -552,7 +552,7 @@ paths:
 
             $ref: '#/definitions/EmptyResponse'
 
-  /api/v1/workspaces/review:
+  /v1/workspaces/review:
     get:
       tags:
         - workspaces
@@ -566,7 +566,7 @@ paths:
           schema:
             $ref: "#/definitions/WorkspaceListResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -587,7 +587,7 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -608,7 +608,7 @@ paths:
           schema:
             $ref: "#/definitions/ShareWorkspaceResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/clone:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/clone:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -636,7 +636,7 @@ paths:
 
   # Cohorts ##############################################################################
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -667,7 +667,7 @@ paths:
           schema:
             $ref: "#/definitions/Cohort"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -711,7 +711,7 @@ paths:
           schema:
             $ref: '#/definitions/EmptyResponse'
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/materializeCohort:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/materializeCohort:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -733,7 +733,7 @@ paths:
             $ref: "#/definitions/MaterializeCohortResponse"
 
   # Cohort Builder #######################################################################
-  /api/v1/cohortbuilder/criteria/{type}/{parentId}:
+  /v1/cohortbuilder/criteria/{type}/{parentId}:
     get:
       tags:
         - cohortBuilder
@@ -757,7 +757,7 @@ paths:
           schema:
             $ref: "#/definitions/CriteriaListResponse"
 
-  /api/v1/cohortbuilder/search:
+  /v1/cohortbuilder/search:
     post:
       tags:
         - cohortBuilder
@@ -777,7 +777,7 @@ paths:
             type: integer
             format: int64
 
-  /api/v1/cohortbuilder/chartinfo:
+  /v1/cohortbuilder/chartinfo:
     post:
       tags:
         - cohortBuilder
@@ -797,7 +797,7 @@ paths:
             $ref: "#/definitions/ChartInfoListResponse"
 
 
-  /api/v1/cohortbuilder/quicksearch/{type}/{value}:
+  /v1/cohortbuilder/quicksearch/{type}/{value}:
     get:
       tags:
         - cohortBuilder
@@ -821,7 +821,7 @@ paths:
             $ref: "#/definitions/CriteriaListResponse"
 
   # Cohort Review  #######################################################################
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -900,7 +900,7 @@ paths:
           schema:
             $ref: "#/definitions/CohortReview"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/status/{participantId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/status/{participantId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -934,7 +934,7 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantCohortStatus"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/charts/{domain}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/charts/{domain}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -957,7 +957,7 @@ paths:
           schema:
             $ref: "#/definitions/CohortSummaryListResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -991,7 +991,7 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantCohortAnnotationListResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations/{annotationId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations/{annotationId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -1032,7 +1032,7 @@ paths:
             $ref: '#/definitions/EmptyResponse'
 
   # Cohort Annotation Definition Controller ###################################################
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -1065,7 +1065,7 @@ paths:
           schema:
             $ref: "#/definitions/CohortAnnotationDefinitionListResponse"
 
-  /api/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions/{annotationDefinitionId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions/{annotationDefinitionId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
@@ -1114,7 +1114,7 @@ paths:
             $ref: '#/definitions/EmptyResponse'
 
   # Data Browser #######################################################################
-  /api/v1/databrowser/search-concepts:
+  /v1/databrowser/search-concepts:
     get:
       security: []
       tags:
@@ -1154,7 +1154,7 @@ paths:
           schema:
             $ref: "#/definitions/ConceptListResponse"
 
-  /api/v1/databrowser/analysis-results:
+  /v1/databrowser/analysis-results:
     get:
       security: []
       tags:
@@ -1185,7 +1185,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisResultListResponse"
 
-  /api/v1/databrowser/analyses:
+  /v1/databrowser/analyses:
     get:
       security: []
       tags:
@@ -1200,7 +1200,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisListResponse"
 
-  /api/v1/databrowser/participant-count:
+  /v1/databrowser/participant-count:
     get:
       security: []
       tags:
@@ -1215,7 +1215,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisResult"
 
-  /api/v1/databrowser/concept-count:
+  /v1/databrowser/concept-count:
     get:
       security: []
       tags:
@@ -1235,7 +1235,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisResultListResponse"
 
-  /api/v1/databrowser/concept-count-by-gender:
+  /v1/databrowser/concept-count-by-gender:
     get:
       security: []
       tags:
@@ -1255,7 +1255,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisResultListResponse"
 
-  /api/v1/databrowser/concept-count-by-age:
+  /v1/databrowser/concept-count-by-age:
     get:
       security: []
       tags:
@@ -1275,7 +1275,7 @@ paths:
           schema:
             $ref: "#/definitions/AnalysisResultListResponse"
 
-  /api/v1/databrowser/db-domains:
+  /v1/databrowser/db-domains:
     get:
       security: []
       tags:
@@ -1290,7 +1290,7 @@ paths:
           schema:
             $ref: "#/definitions/DbDomainListResponse"
 
-  /api/v1/databrowser/child-concepts:
+  /v1/databrowser/child-concepts:
     get:
       security: []
       tags:
@@ -1311,7 +1311,7 @@ paths:
           schema:
             $ref: "#/definitions/ConceptListResponse"
 
-  /api/v1/databrowser/parent-concepts:
+  /v1/databrowser/parent-concepts:
       get:
         security: []
         tags:


### PR DESCRIPTION
Our current plan is to deploy our UI at something.org and our API at api.something.org. URLs are important for usability, so ours should be as short and meaningful as possible. Given the aforementioned scheme, the "api" part is redundant, so this PR removes it.