### PR TITLE
Use UrlFetchTransport as HttpTransport for Google client library

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.config;
 
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import java.time.Clock;
@@ -18,7 +18,7 @@ public class CommonConfig {
 
   @Bean
   HttpTransport httpTransport() {
-    return new ApacheHttpTransport();
+    return UrlFetchTransport.getDefaultInstance();
   }
 
   @Bean

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -1,8 +1,8 @@
 package org.pmiops.workbench.google;
 
 import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
-import static com.google.api.client.googleapis.util.Utils.getDefaultTransport;
 
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.admin.directory.Directory;
@@ -52,7 +52,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     GoogleCredential googleCredential = googleCredentialProvider.get();
     String gSuiteDomain = configProvider.get().googleDirectoryService.gSuiteDomain;
     return new GoogleCredential.Builder()
-        .setTransport(getDefaultTransport())
+        .setTransport(UrlFetchTransport.getDefaultInstance())
         .setJsonFactory(getDefaultJsonFactory())
         // Must be an admin user in the GSuite domain.
         .setServiceAccountUser("directory-service@"+gSuiteDomain)
@@ -65,7 +65,7 @@ public class DirectoryServiceImpl implements DirectoryService {
   }
 
   private Directory getGoogleDirectoryService() {
-    return new Directory.Builder(getDefaultTransport(), getDefaultJsonFactory(),
+    return new Directory.Builder(UrlFetchTransport.getDefaultInstance(), getDefaultJsonFactory(),
           createCredentialWithImpersonation())
         .setApplicationName(APPLICATION_NAME)
         .build();


### PR DESCRIPTION
This [1] says:
> - Google App Engine: use com.google.api.client.extensions.appengine.http.UrlFetchTransport.
>   - com.google.api.client.apache.ApacheHttpTransport doesn't work on App Engine because the Apache HTTP Client opens its own sockets (though in theory there are ways to hack it to work on App Engine that might work).
>   - com.google.api.client.javanet.NetHttpTransport is discouraged due to a bug in the App Engine SDK itself in how it parses HTTP headers in the response.

[1] https://developers.google.com/api-client-library/java/google-http-java-client/reference/1.19.0/com/google/api/client/http/HttpTransport

`com.google.api.client.googleapis.util.Utils.getDefaultTransport` returns `com.google.api.client.javanet.NetHttpTransport`. This PR uses `UrlFetchTransport` in both places.