### PR TITLE
Enforce auth domain for all workspaces. (And grab access level for ac…

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -83,11 +83,11 @@ public class ClusterController implements ClusterApiDelegate {
   public ResponseEntity<Cluster> createCluster(String workspaceNamespace,
       String workspaceId) {
 
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+          workspaceId, WorkspaceAccessLevel.WRITER);
     } catch (Exception e) {
       throw e;
     }
@@ -109,11 +109,11 @@ public class ClusterController implements ClusterApiDelegate {
   public ResponseEntity<EmptyResponse> deleteCluster(String workspaceNamespace,
       String workspaceId) {
 
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+          workspaceId, WorkspaceAccessLevel.WRITER);
     } catch (Exception e) {
       throw e;
     }
@@ -134,11 +134,11 @@ public class ClusterController implements ClusterApiDelegate {
   public ResponseEntity<Cluster> getCluster(String workspaceNamespace,
       String workspaceId) {
 
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+          workspaceId, WorkspaceAccessLevel.WRITER);
     } catch (Exception e) {
       throw e;
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.EmailException;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -32,6 +33,7 @@ public class ClusterController implements ClusterApiDelegate {
 
   private final NotebooksService notebooksService;
   private final Provider<User> userProvider;
+  private final WorkspaceService workspaceService;
 
   private static final Function<org.pmiops.workbench.notebooks.model.Cluster, Cluster> TO_ALL_OF_US_CLUSTER =
     new Function<org.pmiops.workbench.notebooks.model.Cluster, Cluster>() {
@@ -71,9 +73,11 @@ public class ClusterController implements ClusterApiDelegate {
 
   @Autowired
   ClusterController(NotebooksService notebooksService,
-      Provider<User> userProvider) {
+      Provider<User> userProvider,
+      WorkspaceService workspaceService) {
     this.notebooksService = notebooksService;
     this.userProvider = userProvider;
+    this.workspaceService = workspaceService;
   }
 
   public ResponseEntity<Cluster> createCluster(String workspaceNamespace,
@@ -83,7 +87,7 @@ public class ClusterController implements ClusterApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -109,7 +113,7 @@ public class ClusterController implements ClusterApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -134,7 +138,7 @@ public class ClusterController implements ClusterApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -84,13 +84,9 @@ public class ClusterController implements ClusterApiDelegate {
       String workspaceId) {
 
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-          workspaceId, WorkspaceAccessLevel.WRITER);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+        workspaceId, WorkspaceAccessLevel.WRITER);
+
 
     Cluster createdCluster;
 
@@ -110,13 +106,8 @@ public class ClusterController implements ClusterApiDelegate {
       String workspaceId) {
 
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-          workspaceId, WorkspaceAccessLevel.WRITER);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+        workspaceId, WorkspaceAccessLevel.WRITER);
 
     String clusterName = this.convertClusterName(workspaceId);
     try {
@@ -135,13 +126,8 @@ public class ClusterController implements ClusterApiDelegate {
       String workspaceId) {
 
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-          workspaceId, WorkspaceAccessLevel.WRITER);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
+        workspaceId, WorkspaceAccessLevel.WRITER);
 
     String clusterName = this.convertClusterName(workspaceId);
     Cluster cluster;

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -30,7 +30,6 @@ public class ClusterController implements ClusterApiDelegate {
   // This will currently only work inside the Broad's network.
   private static final Logger log = Logger.getLogger(BugReportController.class.getName());
 
-  private final FireCloudService fireCloudService;
   private final NotebooksService notebooksService;
   private final Provider<User> userProvider;
 
@@ -71,10 +70,8 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   @Autowired
-  ClusterController(FireCloudService fireCloudService,
-      NotebooksService notebooksService,
+  ClusterController(NotebooksService notebooksService,
       Provider<User> userProvider) {
-    this.fireCloudService = fireCloudService;
     this.notebooksService = notebooksService;
     this.userProvider = userProvider;
   }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -13,9 +13,12 @@ import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.EmailException;
-import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterListResponse;
+import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.ApiException;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +30,7 @@ public class ClusterController implements ClusterApiDelegate {
   // This will currently only work inside the Broad's network.
   private static final Logger log = Logger.getLogger(BugReportController.class.getName());
 
+  private final FireCloudService fireCloudService;
   private final NotebooksService notebooksService;
   private final Provider<User> userProvider;
 
@@ -67,14 +71,26 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   @Autowired
-  ClusterController(NotebooksService notebooksService,
+  ClusterController(FireCloudService fireCloudService,
+      NotebooksService notebooksService,
       Provider<User> userProvider) {
+    this.fireCloudService = fireCloudService;
     this.notebooksService = notebooksService;
     this.userProvider = userProvider;
   }
 
   public ResponseEntity<Cluster> createCluster(String workspaceNamespace,
       String workspaceId) {
+
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
+
     Cluster createdCluster;
 
     String clusterName = this.convertClusterName(workspaceId);
@@ -91,6 +107,16 @@ public class ClusterController implements ClusterApiDelegate {
 
   public ResponseEntity<EmptyResponse> deleteCluster(String workspaceNamespace,
       String workspaceId) {
+
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
+
     String clusterName = this.convertClusterName(workspaceId);
     try {
       // TODO: Replace with real workspaceNamespace/billing-project
@@ -106,6 +132,16 @@ public class ClusterController implements ClusterApiDelegate {
 
   public ResponseEntity<Cluster> getCluster(String workspaceNamespace,
       String workspaceId) {
+
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
+
     String clusterName = this.convertClusterName(workspaceId);
     Cluster cluster;
     try {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
@@ -69,6 +69,14 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                                        String workspaceId,
                                                                                        Long cohortId,
                                                                                        CohortAnnotationDefinition request) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -97,6 +105,14 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                           String workspaceId,
                                                                           Long cohortId,
                                                                           Long annotationDefinitionId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -114,6 +130,14 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                                     String workspaceId,
                                                                                     Long cohortId,
                                                                                     Long annotationDefinitionId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -128,6 +152,14 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
     public ResponseEntity<CohortAnnotationDefinitionListResponse> getCohortAnnotationDefinitions(String workspaceNamespace,
                                                                                                  String workspaceId,
                                                                                                  Long cohortId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -148,6 +180,14 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                      Long cohortId,
                                      Long annotationDefinitionId,
                                      ModifyCohortAnnotationDefinitionRequest modifyCohortAnnotationDefinitionRequest) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         String columnName = modifyCohortAnnotationDefinitionRequest.getColumnName();
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace

--- a/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
@@ -70,14 +70,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                                        String workspaceId,
                                                                                        Long cohortId,
                                                                                        CohortAnnotationDefinition request) {
-        // TODO: enforce access level.
         // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -106,14 +101,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                           String workspaceId,
                                                                           Long cohortId,
                                                                           Long annotationDefinitionId) {
-        // TODO: enforce access level.
         // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -131,14 +121,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                                                                     String workspaceId,
                                                                                     Long cohortId,
                                                                                     Long annotationDefinitionId) {
-        // TODO: enforce access level.
         // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -153,14 +138,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
     public ResponseEntity<CohortAnnotationDefinitionListResponse> getCohortAnnotationDefinitions(String workspaceNamespace,
                                                                                                  String workspaceId,
                                                                                                  Long cohortId) {
-        // TODO: enforce access level.
         // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace
         validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -181,14 +161,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                                      Long cohortId,
                                      Long annotationDefinitionId,
                                      ModifyCohortAnnotationDefinitionRequest modifyCohortAnnotationDefinitionRequest) {
-        // TODO: enforce access level.
         // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
         String columnName = modifyCohortAnnotationDefinitionRequest.getColumnName();
         Cohort cohort = findCohort(cohortId);
         //this validates that the user is in the proper workspace

--- a/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
@@ -11,6 +11,7 @@ import org.pmiops.workbench.model.CohortAnnotationDefinition;
 import org.pmiops.workbench.model.CohortAnnotationDefinitionListResponse;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ModifyCohortAnnotationDefinitionRequest;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -73,7 +74,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -109,7 +110,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -134,7 +135,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -156,7 +157,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -184,7 +185,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -133,6 +133,15 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                       Long cohortId,
                                                                                       Long cdrVersionId,
                                                                                       CreateReviewRequest request) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
+
         if (request.getSize() <= 0 || request.getSize() > MAX_REVIEW_SIZE) {
             throw new BadRequestException(
                     String.format("Invalid Request: Cohort Review size must be between %s and %s", 0, MAX_REVIEW_SIZE));
@@ -189,6 +198,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                          Long cohortReviewId,
                                                                                          Long participantId,
                                                                                          ParticipantCohortAnnotation request) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotation());
     }
 
@@ -198,6 +215,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                            Long cohortReviewId,
                                                                            Long participantId,
                                                                            Long annotationId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new EmptyResponse());
     }
 
@@ -207,6 +232,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                       Long cohortId,
                                                                       Long cdrVersionId,
                                                                       String domain) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new CohortSummaryListResponse());
     }
 
@@ -215,6 +248,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                    String workspaceId,
                                                                                                    Long cohortReviewId,
                                                                                                    Long participantId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotationListResponse());
     }
 
@@ -224,6 +265,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                          Long cohortId,
                                                                                                          Long cdrVersionId,
                                                                                                          Long participantId) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
         cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -240,7 +289,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                             Long cdrVersionId,
                                                                                                             Long participantId,
                                                                                                             ModifyCohortStatusRequest cohortStatusRequest) {
-
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
         cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
@@ -283,6 +339,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                 String sortColumn,
                                                                                                 List<String> filterColumns,
                                                                                                 List<String> filterValues) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         CohortReview cohortReview = null;
         try {
             cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
@@ -310,6 +374,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                       Long participantId,
                                       Long annotationId,
                                       ModifyParticipantCohortAnnotationRequest request) {
+        // TODO: enforce access level.
+        // This also enforces registered auth domain.
+        WorkspaceAccessLevel accessLevel;
+        try {
+          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+        } catch (Exception e) {
+          throw e;
+        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotation());
     }
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -287,13 +287,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                 List<String> filterColumns,
                                                                                                 List<String> filterValues) {
         CohortReview cohortReview = null;
+        Cohort cohort = cohortReviewService.findCohort(cohortId);
+
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
         try {
             cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
         } catch (NotFoundException nfe) {
             cohortReview = initializeAndSaveCohortReview(workspaceNamespace, workspaceId, cohortId, cdrVersionId);
         }
-
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohortId, WorkspaceAccessLevel.READER);
 
         PageRequest pageRequest = createPageRequest(page, pageSize, sortOrder, sortColumn);
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -137,15 +137,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                       Long cohortId,
                                                                                       Long cdrVersionId,
                                                                                       CreateReviewRequest request) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
-
         if (request.getSize() <= 0 || request.getSize() > MAX_REVIEW_SIZE) {
             throw new BadRequestException(
                     String.format("Invalid Request: Cohort Review size must be between %s and %s", 0, MAX_REVIEW_SIZE));
@@ -164,7 +155,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
 
         SearchRequest searchRequest = new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);
 
@@ -202,14 +193,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                          Long cohortReviewId,
                                                                                          Long participantId,
                                                                                          ParticipantCohortAnnotation request) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotation());
     }
 
@@ -219,14 +202,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                            Long cohortReviewId,
                                                                            Long participantId,
                                                                            Long annotationId) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new EmptyResponse());
     }
 
@@ -236,14 +211,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                       Long cohortId,
                                                                       Long cdrVersionId,
                                                                       String domain) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new CohortSummaryListResponse());
     }
 
@@ -252,14 +219,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                    String workspaceId,
                                                                                                    Long cohortReviewId,
                                                                                                    Long participantId) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotationListResponse());
     }
 
@@ -269,17 +228,9 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                          Long cohortId,
                                                                                                          Long cdrVersionId,
                                                                                                          Long participantId) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
         CohortReview review = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
         ParticipantCohortStatus status =
                 cohortReviewService.findParticipantCohortStatus(review.getCohortReviewId(), participantId);
@@ -293,17 +244,9 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                             Long cdrVersionId,
                                                                                                             Long participantId,
                                                                                                             ModifyCohortStatusRequest cohortStatusRequest) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
 
         CohortReview cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
 
@@ -343,20 +286,14 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                 String sortColumn,
                                                                                                 List<String> filterColumns,
                                                                                                 List<String> filterValues) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         CohortReview cohortReview = null;
         try {
             cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
         } catch (NotFoundException nfe) {
             cohortReview = initializeAndSaveCohortReview(workspaceNamespace, workspaceId, cohortId, cdrVersionId);
         }
+
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohortId, WorkspaceAccessLevel.READER);
 
         PageRequest pageRequest = createPageRequest(page, pageSize, sortOrder, sortColumn);
 
@@ -378,14 +315,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                       Long participantId,
                                       Long annotationId,
                                       ModifyParticipantCohortAnnotationRequest request) {
-        // TODO: enforce access level.
-        // This also enforces registered auth domain.
-        WorkspaceAccessLevel accessLevel;
-        try {
-          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-        } catch (Exception e) {
-          throw e;
-        }
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(new ParticipantCohortAnnotation());
     }
 
@@ -404,7 +333,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                        Long cdrVersionId) {
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId());
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
 
         SearchRequest request = new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -155,7 +155,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.WRITER);
 
         SearchRequest searchRequest = new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);
 
@@ -246,7 +246,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                                                                             ModifyCohortStatusRequest cohortStatusRequest) {
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.WRITER);
 
         CohortReview cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
 
@@ -333,7 +333,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
                                                        Long cdrVersionId) {
         Cohort cohort = cohortReviewService.findCohort(cohortId);
         //this validates that the user is in the proper workspace
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.WRITER);
 
         SearchRequest request = new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -6,6 +6,7 @@ import com.google.cloud.bigquery.QueryResult;
 import com.google.gson.Gson;
 import org.pmiops.workbench.cohortbuilder.ParticipantCounter;
 import org.pmiops.workbench.cohortreview.CohortReviewService;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.Cohort;
 import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
@@ -22,6 +23,7 @@ import org.pmiops.workbench.model.ParticipantCohortAnnotation;
 import org.pmiops.workbench.model.ParticipantCohortAnnotationListResponse;
 import org.pmiops.workbench.model.ReviewStatus;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -56,7 +58,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     private BigQueryService bigQueryService;
     private CodeDomainLookupService codeDomainLookupService;
     private ParticipantCounter participantCounter;
-
+    private WorkspaceService workspaceService;
     private static final Logger log = Logger.getLogger(CohortReviewController.class.getName());
 
     /**
@@ -108,11 +110,13 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     CohortReviewController(CohortReviewService cohortReviewService,
                            BigQueryService bigQueryService,
                            CodeDomainLookupService codeDomainLookupService,
-                           ParticipantCounter participantCounter) {
+                           ParticipantCounter participantCounter,
+                           WorkspaceService workspaceService) {
         this.cohortReviewService = cohortReviewService;
         this.bigQueryService = bigQueryService;
         this.codeDomainLookupService = codeDomainLookupService;
         this.participantCounter = participantCounter;
+        this.workspaceService = workspaceService;
     }
 
     /**
@@ -137,7 +141,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -202,7 +206,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -219,7 +223,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -236,7 +240,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -252,7 +256,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -269,7 +273,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -293,7 +297,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -343,7 +347,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }
@@ -378,7 +382,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         // This also enforces registered auth domain.
         WorkspaceAccessLevel accessLevel;
         try {
-          accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+          accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
         } catch (Exception e) {
           throw e;
         }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.MaterializeCohortRequest;
 import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
@@ -119,7 +120,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -151,7 +152,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -168,7 +169,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -184,7 +185,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -207,7 +208,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }
@@ -252,7 +253,7 @@ public class CohortsController implements CohortsApiDelegate {
     // This also enforces registered auth domain.
     WorkspaceAccessLevel accessLevel;
     try {
-      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     } catch (Exception e) {
       throw e;
     }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -116,14 +116,9 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> createCohort(String workspaceNamespace, String workspaceId,
       Cohort cohort) {
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
     Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     org.pmiops.workbench.db.model.Cohort dbCohort = FROM_CLIENT_COHORT.apply(cohort);
@@ -148,14 +143,9 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<EmptyResponse> deleteCohort(String workspaceNamespace, String workspaceId,
       Long cohortId) {
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     cohortDao.delete(dbCohort);
@@ -165,14 +155,9 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> getCohort(String workspaceNamespace, String workspaceId,
       Long cohortId) {
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     return ResponseEntity.ok(TO_CLIENT_COHORT.apply(dbCohort));
@@ -181,14 +166,9 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<CohortListResponse> getCohortsInWorkspace(String workspaceNamespace,
       String workspaceId) {
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+
     Workspace workspace = workspaceService.getRequiredWithCohorts(workspaceNamespace, workspaceId);
     CohortListResponse response = new CohortListResponse();
     Set<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
@@ -204,14 +184,9 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> updateCohort(String workspaceNamespace, String workspaceId,
       Long cohortId, Cohort cohort) {
-    // TODO: enforce access level.
     // This also enforces registered auth domain.
-    WorkspaceAccessLevel accessLevel;
-    try {
-      accessLevel = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
+
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     if(Strings.isNullOrEmpty(cohort.getEtag())) {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -115,6 +115,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> createCohort(String workspaceNamespace, String workspaceId,
       Cohort cohort) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     org.pmiops.workbench.db.model.Cohort dbCohort = FROM_CLIENT_COHORT.apply(cohort);
@@ -139,6 +147,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<EmptyResponse> deleteCohort(String workspaceNamespace, String workspaceId,
       Long cohortId) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     cohortDao.delete(dbCohort);
@@ -148,6 +164,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> getCohort(String workspaceNamespace, String workspaceId,
       Long cohortId) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     return ResponseEntity.ok(TO_CLIENT_COHORT.apply(dbCohort));
@@ -156,6 +180,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<CohortListResponse> getCohortsInWorkspace(String workspaceNamespace,
       String workspaceId) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     Workspace workspace = workspaceService.getRequiredWithCohorts(workspaceNamespace, workspaceId);
     CohortListResponse response = new CohortListResponse();
     Set<org.pmiops.workbench.db.model.Cohort> cohorts = workspace.getCohorts();
@@ -171,6 +203,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<Cohort> updateCohort(String workspaceNamespace, String workspaceId,
       Long cohortId, Cohort cohort) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     org.pmiops.workbench.db.model.Cohort dbCohort = getDbCohort(workspaceNamespace, workspaceId,
         cohortId);
     if(Strings.isNullOrEmpty(cohort.getEtag())) {
@@ -208,6 +248,14 @@ public class CohortsController implements CohortsApiDelegate {
   @Override
   public ResponseEntity<MaterializeCohortResponse> materializeCohort(String workspaceNamespace,
       String workspaceId, MaterializeCohortRequest request) {
+    // TODO: enforce access level.
+    // This also enforces registered auth domain.
+    WorkspaceAccessLevel accessLevel;
+    try {
+      accessLevel = WorkspacesController.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
     Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
     CdrVersion cdrVersion = workspace.getCdrVersion();
     if (request.getCdrVersionName() != null) {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -330,7 +330,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
   }
 
-  private WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId) {
+  public static WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId) {
     String userAccess;
     try {
       userAccess = fireCloudService.getWorkspace(

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -433,6 +433,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     org.pmiops.workbench.db.model.Workspace dbWorkspace = workspaceService.getRequired(
         workspaceNamespace, workspaceId);
     try {
+      // This automatically handles access control to the workspace.
       fireCloudService.deleteWorkspace(workspaceNamespace, workspaceId);
     } catch (org.pmiops.workbench.firecloud.ApiException e) {
       throw ExceptionUtils.convertFirecloudException(e);
@@ -451,6 +452,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     WorkspaceResponse response = new WorkspaceResponse();
 
     try {
+      // This enforces access controls.
       fcResponse = fireCloudService.getWorkspace(
           workspaceNamespace, workspaceId);
       fcWorkspace = fcResponse.getWorkspace();
@@ -620,6 +622,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       newUserRole.setRole(user.getRole());
       dbUserRoles.add(newUserRole);
     }
+    // This automatically enforces owner role.
     dbWorkspace = workspaceService.updateUserRoles(dbWorkspace, dbUserRoles);
     ShareWorkspaceResponse resp = new ShareWorkspaceResponse();
     resp.setWorkspaceEtag(Etags.fromVersion(dbWorkspace.getVersion()));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -312,7 +312,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   private void checkWorkspaceWriteAccess(String workspaceNamespace, String workspaceId) {
-    WorkspaceAccessLevel userAccess = getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    WorkspaceAccessLevel userAccess = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     if (!(WorkspaceAccessLevel.OWNER.equals(userAccess) ||
           WorkspaceAccessLevel.WRITER.equals(userAccess))) {
       throw new ForbiddenException(String.format("Insufficient permissions to edit workspace %s/%s",
@@ -321,24 +321,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   private void checkWorkspaceReadAccess(String workspaceNamespace, String workspaceId) {
-    WorkspaceAccessLevel userAccess = getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    WorkspaceAccessLevel userAccess = workspaceService.getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
     if (!(WorkspaceAccessLevel.OWNER.equals(userAccess) ||
           WorkspaceAccessLevel.WRITER.equals(userAccess) ||
           WorkspaceAccessLevel.READER.equals(userAccess))) {
       throw new ForbiddenException(String.format("Insufficient permissions to read workspace %s/%s",
           workspaceNamespace, workspaceId));
     }
-  }
-
-  public static WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId) {
-    String userAccess;
-    try {
-      userAccess = fireCloudService.getWorkspace(
-          workspaceNamespace, workspaceId).getAccessLevel();
-    } catch (org.pmiops.workbench.firecloud.ApiException e) {
-      throw ExceptionUtils.convertFirecloudException(e);
-    }
-    return WorkspaceAccessLevel.fromValue(userAccess);
   }
 
   private org.pmiops.workbench.firecloud.model.Workspace

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.cohortreview;
 import org.pmiops.workbench.db.model.Cohort;
 import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
@@ -25,7 +26,7 @@ public interface CohortReviewService {
      * @param workspaceName
      * @param workspaceId
      */
-    void validateMatchingWorkspace(String workspaceNamespace, String workspaceName, long workspaceId);
+    void validateMatchingWorkspace(String workspaceNamespace, String workspaceName, long workspaceId, WorkspaceAccessLevel requiredAccess);
 
     /**
      * Find the {@link CohortReview} for the specified cohortId and cdrVersionId.

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -58,12 +58,9 @@ public class CohortReviewServiceImpl implements CohortReviewService {
         String workspaceNamespace, String workspaceName,
         long workspaceId, WorkspaceAccessLevel accessRequired) {
       // This also enforces registered auth domain.
-      try {
-        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, accessRequired);
-      } catch (Exception e) {
-        throw e;
-      }
+      workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, accessRequired);
 
+      
       Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceName);
       if (workspace.getWorkspaceId() != workspaceId) {
           throw new NotFoundException(

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -53,13 +54,22 @@ public class CohortReviewServiceImpl implements CohortReviewService {
     }
 
     @Override
-    public void validateMatchingWorkspace(String workspaceNamespace, String workspaceName, long workspaceId) {
-        Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceName);
-        if (workspace.getWorkspaceId() != workspaceId) {
-            throw new NotFoundException(
-                    String.format("Not Found: No workspace matching workspaceNamespace: %s, workspaceId: %s",
-                            workspaceNamespace, workspaceName));
-        }
+    public void validateMatchingWorkspace(
+        String workspaceNamespace, String workspaceName,
+        long workspaceId, WorkspaceAccessLevel accessRequired) {
+      // This also enforces registered auth domain.
+      try {
+        workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, accessRequired);
+      } catch (Exception e) {
+        throw e;
+      }
+
+      Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceName);
+      if (workspace.getWorkspaceId() != workspaceId) {
+          throw new NotFoundException(
+                  String.format("Not Found: No workspace matching workspaceNamespace: %s, workspaceId: %s",
+                          workspaceNamespace, workspaceName));
+      }
     }
 
     @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
 public interface WorkspaceService {
   public WorkspaceDao getDao();
@@ -18,4 +19,5 @@ public interface WorkspaceService {
   public void setResearchPurposeApproved(String ns, String firecloudName, boolean approved);
   public Workspace updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
   public Workspace saveAndCloneCohorts(Workspace from, Workspace to);
+  public WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceService.java
@@ -20,4 +20,6 @@ public interface WorkspaceService {
   public Workspace updateUserRoles(Workspace workspace, Set<WorkspaceUserRole> userRoleSet);
   public Workspace saveAndCloneCohorts(Workspace from, Workspace to);
   public WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId);
+  public WorkspaceAccessLevel enforceWorkspaceAccessLevel(String workspaceNamespace,
+      String workspaceId, WorkspaceAccessLevel requiredAccess);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -18,6 +18,7 @@ import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.db.model.WorkspaceUserRole;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
+import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.ServerUnavailableException;
@@ -239,5 +240,44 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       }
     }
     return WorkspaceAccessLevel.fromValue(userAccess);
+  }
+
+  @Override
+  public WorkspaceAccessLevel enforceWorkspaceAccessLevel(String workspaceNamespace,
+      String workspaceId, WorkspaceAccessLevel requiredAccess) {
+    WorkspaceAccessLevel access;
+    try {
+      access = getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
+    } catch (Exception e) {
+      throw e;
+    }
+
+    if (workspaceAccessLevelCompare(requiredAccess, access) == -1) {
+      throw new ForbiddenException(String.format("You do not have sufficient permissions to access workspace %s/%s",
+          workspaceNamespace, workspaceId));
+    } else {
+      return access;
+    }
+  }
+
+
+  private int workspaceAccessLevelCompare(WorkspaceAccessLevel accessLevelOne,
+      WorkspaceAccessLevel accessLevelTwo) {
+    if (accessLevelOne.equals(accessLevelTwo)) {
+      return 0;
+    } else if (accessLevelOne.equals(WorkspaceAccessLevel.OWNER)) {
+      return -1;
+    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.OWNER)) {
+      return 1;
+    } else if (accessLevelOne.equals(WorkspaceAccessLevel.NO_ACCESS)) {
+      return 1;
+    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.NO_ACCESS)){
+      return -1;
+    } else if (accessLevelOne.equals(WorkspaceAccessLevel.WRITER) && accessLevelTwo.equals(WorkspaceAccessLevel.READER)) {
+      return -1;
+    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.WRITER) && accessLevelOne.equals(WorkspaceAccessLevel.READER)) {
+      return 1;
+    }
+    throw new ServerErrorException("Access level not handled by compare.");
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -204,7 +204,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     }
     return this.saveWithLastModified(workspace);
   }
-
   @Override
   @Transactional
   public Workspace saveAndCloneCohorts(Workspace from, Workspace to) {
@@ -224,5 +223,21 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       cohortService.saveAndCloneReviews(fromCohort, c);
     }
     return saved;
+  }
+  @Override
+  public WorkspaceAccessLevel getWorkspaceAccessLevel(String workspaceNamespace, String workspaceId) {
+    String userAccess;
+    try {
+      userAccess = fireCloudService.getWorkspace(
+          workspaceNamespace, workspaceId).getAccessLevel();
+    } catch (org.pmiops.workbench.firecloud.ApiException e) {
+      if (e.getCode() == 404) {
+        throw new NotFoundException(String.format("Workspace %s/%s not found",
+            workspaceNamespace, workspaceId));
+      } else {
+        throw new ServerErrorException(e.getResponseBody());
+      }
+    }
+    return WorkspaceAccessLevel.fromValue(userAccess);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -245,39 +245,14 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public WorkspaceAccessLevel enforceWorkspaceAccessLevel(String workspaceNamespace,
       String workspaceId, WorkspaceAccessLevel requiredAccess) {
-    WorkspaceAccessLevel access;
-    try {
-      access = getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
-    } catch (Exception e) {
-      throw e;
-    }
+    WorkspaceAccessLevel access = getWorkspaceAccessLevel(workspaceNamespace, workspaceId);
 
-    if (workspaceAccessLevelCompare(requiredAccess, access) == -1) {
+
+    if (requiredAccess.compareTo(access) > 0) {
       throw new ForbiddenException(String.format("You do not have sufficient permissions to access workspace %s/%s",
           workspaceNamespace, workspaceId));
     } else {
       return access;
     }
-  }
-
-
-  private int workspaceAccessLevelCompare(WorkspaceAccessLevel accessLevelOne,
-      WorkspaceAccessLevel accessLevelTwo) {
-    if (accessLevelOne.equals(accessLevelTwo)) {
-      return 0;
-    } else if (accessLevelOne.equals(WorkspaceAccessLevel.OWNER)) {
-      return -1;
-    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.OWNER)) {
-      return 1;
-    } else if (accessLevelOne.equals(WorkspaceAccessLevel.NO_ACCESS)) {
-      return 1;
-    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.NO_ACCESS)){
-      return -1;
-    } else if (accessLevelOne.equals(WorkspaceAccessLevel.WRITER) && accessLevelTwo.equals(WorkspaceAccessLevel.READER)) {
-      return -1;
-    } else if (accessLevelTwo.equals(WorkspaceAccessLevel.WRITER) && accessLevelOne.equals(WorkspaceAccessLevel.READER)) {
-      return 1;
-    }
-    throw new ServerErrorException("Access level not handled by compare.");
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
@@ -47,7 +47,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -61,7 +61,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
         verifyNoMoreMockInteractions();
     }
 
@@ -78,7 +78,7 @@ public class CohortAnnotationDefinitionControllerTest {
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -95,7 +95,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -128,7 +128,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findByCohortIdAndColumnName(cohortId, columnName)).thenReturn(existingDefinition);
@@ -153,7 +153,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -186,7 +186,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.save(dbCohortAnnotationDefinition)).thenReturn(dbCohortAnnotationDefinition);
@@ -211,7 +211,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).save(dbCohortAnnotationDefinition);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -226,7 +226,7 @@ public class CohortAnnotationDefinitionControllerTest {
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -242,7 +242,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -264,7 +264,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -283,7 +283,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -303,7 +303,7 @@ public class CohortAnnotationDefinitionControllerTest {
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -324,7 +324,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -353,7 +353,7 @@ public class CohortAnnotationDefinitionControllerTest {
                         "name1");
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(definition);
@@ -376,7 +376,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -412,7 +412,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(definition);
@@ -434,7 +434,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
         verify(cohortAnnotationDefinitionDao, times(1)).save(definition);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -447,7 +447,7 @@ public class CohortAnnotationDefinitionControllerTest {
         long annotationDefinitionId = 1;
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -462,7 +462,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -482,7 +482,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -500,7 +500,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -519,7 +519,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -539,7 +539,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -566,7 +566,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(cohortAnnotationDefinition);
@@ -584,7 +584,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).delete(annotationDefinitionId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER);
 
         verifyNoMoreMockInteractions();
     }
@@ -598,7 +598,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -613,7 +613,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -633,7 +633,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -651,7 +651,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -670,7 +670,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -690,7 +690,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -717,7 +717,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(cohortAnnotationDefinition);
@@ -739,7 +739,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -752,7 +752,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -766,7 +766,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -787,7 +787,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
 
         try {
             cohortAnnotationDefinitionController.getCohortAnnotationDefinitions(
@@ -802,7 +802,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }
@@ -823,7 +823,7 @@ public class CohortAnnotationDefinitionControllerTest {
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findByCohortId(cohortId)).thenReturn(new ArrayList<>());
-        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
 
         cohortAnnotationDefinitionController.getCohortAnnotationDefinitions(
                 namespace,
@@ -833,7 +833,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortId(cohortId);
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
+        verify(workspaceService).enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER);
 
         verifyNoMoreMockInteractions();
     }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
@@ -16,6 +16,7 @@ import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.CohortAnnotationDefinition;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ModifyCohortAnnotationDefinitionRequest;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
 import java.util.ArrayList;
 
@@ -44,6 +45,9 @@ public class CohortAnnotationDefinitionControllerTest {
         String name = "test";
         long cohortId = 1;
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -57,7 +61,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
-
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
         verifyNoMoreMockInteractions();
     }
 
@@ -72,7 +76,9 @@ public class CohortAnnotationDefinitionControllerTest {
         Cohort cohort = createCohort(workspaceId);
 
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -89,6 +95,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -119,6 +126,9 @@ public class CohortAnnotationDefinitionControllerTest {
                         request.getAnnotationType(),
                         request.getColumnName());
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findByCohortIdAndColumnName(cohortId, columnName)).thenReturn(existingDefinition);
@@ -143,6 +153,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -173,6 +184,9 @@ public class CohortAnnotationDefinitionControllerTest {
                         request.getAnnotationType(),
                         request.getColumnName());
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.save(dbCohortAnnotationDefinition)).thenReturn(dbCohortAnnotationDefinition);
@@ -197,6 +211,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).save(dbCohortAnnotationDefinition);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -209,7 +224,9 @@ public class CohortAnnotationDefinitionControllerTest {
         long annotationDefinitionId = 1;
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -225,6 +242,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -244,6 +262,9 @@ public class CohortAnnotationDefinitionControllerTest {
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -262,6 +283,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -279,7 +301,9 @@ public class CohortAnnotationDefinitionControllerTest {
         Workspace workspace = createWorkspace(namespace, name, workspaceId);
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -300,6 +324,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -326,7 +351,9 @@ public class CohortAnnotationDefinitionControllerTest {
                         annotationDefinitionId,
                         AnnotationType.STRING,
                         "name1");
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(definition);
@@ -349,6 +376,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -382,6 +410,9 @@ public class CohortAnnotationDefinitionControllerTest {
                 request.getColumnName(),
                 AnnotationType.STRING);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(definition);
@@ -403,6 +434,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortIdAndColumnName(cohortId, columnName);
         verify(cohortAnnotationDefinitionDao, times(1)).save(definition);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -413,7 +445,9 @@ public class CohortAnnotationDefinitionControllerTest {
         String name = "test";
         long cohortId = 1;
         long annotationDefinitionId = 1;
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -428,6 +462,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -445,6 +480,9 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -462,6 +500,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -478,6 +517,9 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, workspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -497,6 +539,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -521,6 +564,9 @@ public class CohortAnnotationDefinitionControllerTest {
                         AnnotationType.STRING,
                         columnName);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(cohortAnnotationDefinition);
@@ -538,6 +584,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
         verify(cohortAnnotationDefinitionDao, times(1)).delete(annotationDefinitionId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -549,6 +596,9 @@ public class CohortAnnotationDefinitionControllerTest {
         long cohortId = 1;
         long annotationDefinitionId = 1;
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -563,6 +613,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -580,6 +631,9 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
 
@@ -597,6 +651,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -613,6 +668,9 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, workspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(null);
@@ -632,6 +690,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -656,6 +715,9 @@ public class CohortAnnotationDefinitionControllerTest {
                         AnnotationType.STRING,
                         columnName);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findOne(annotationDefinitionId)).thenReturn(cohortAnnotationDefinition);
@@ -677,6 +739,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findOne(annotationDefinitionId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -687,6 +750,9 @@ public class CohortAnnotationDefinitionControllerTest {
         String name = "test";
         long cohortId = 1;
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
         when(cohortDao.findOne(cohortId)).thenReturn(null);
 
         try {
@@ -700,6 +766,7 @@ public class CohortAnnotationDefinitionControllerTest {
         }
 
         verify(cohortDao, times(1)).findOne(cohortId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -716,8 +783,11 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
 
         try {
             cohortAnnotationDefinitionController.getCohortAnnotationDefinitions(
@@ -732,6 +802,7 @@ public class CohortAnnotationDefinitionControllerTest {
 
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }
@@ -747,9 +818,12 @@ public class CohortAnnotationDefinitionControllerTest {
 
         Workspace workspace = createWorkspace(namespace, name, workspaceId);
 
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
         when(cohortDao.findOne(cohortId)).thenReturn(cohort);
         when(workspaceService.getRequired(namespace, name)).thenReturn(workspace);
         when(cohortAnnotationDefinitionDao.findByCohortId(cohortId)).thenReturn(new ArrayList<>());
+        when(workspaceService.getWorkspaceAccessLevel(namespace, name)).thenReturn(owner);
 
         cohortAnnotationDefinitionController.getCohortAnnotationDefinitions(
                 namespace,
@@ -759,6 +833,7 @@ public class CohortAnnotationDefinitionControllerTest {
         verify(cohortDao, times(1)).findOne(cohortId);
         verify(workspaceService, times(1)).getRequired(namespace, name);
         verify(cohortAnnotationDefinitionDao, times(1)).findByCohortId(cohortId);
+        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
 
         verifyNoMoreMockInteractions();
     }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -355,9 +355,14 @@ public class CohortReviewControllerTest {
                 ? new Sort(orderParam, columnParam)
                 : new Sort(orderParam, columnParam, CohortReviewController.PARTICIPANT_ID);
 
+        Cohort cohort = new Cohort();
+        cohort.setWorkspaceId(1);
+
         when(cohortReviewService.findCohortReview(cohortId, cdrVersionId)).thenReturn(cohortReviewAfter);
         when(cohortReviewService.findParticipantCohortStatuses(cohortId,
                 new PageRequest(pageParam, pageSizeParam, sort))).thenReturn(expectedPage);
+        doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.READER);
+        when(cohortReviewService.findCohort(cohortId)).thenReturn(cohort);
 
         ResponseEntity<org.pmiops.workbench.model.CohortReview> response =
                 reviewController.getParticipantCohortStatuses(
@@ -370,6 +375,7 @@ public class CohortReviewControllerTest {
         verify(cohortReviewService, atLeast(1)).findCohortReview(cohortId, cdrVersionId);
         verify(cohortReviewService, times(1))
                 .findParticipantCohortStatuses(cohortId, new PageRequest(pageParam, pageSizeParam, sort));
+        verify(cohortReviewService, atLeast(1)).findCohort(cohortId);
         verifyNoMoreMockInteractions();
     }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -229,6 +229,7 @@ public class CohortReviewControllerTest {
         Page expectedPage = new PageImpl(participants);
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
+        when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(cohortReviewService.findCohortReview(cohortId, cdrVersionId)).thenReturn(cohortReview);
         when(cohortReviewService.findCohort(cohortId)).thenReturn(cohort);
         doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.WRITER);
@@ -266,7 +267,6 @@ public class CohortReviewControllerTest {
         verify(queryResult, times(1)).iterateAll();
         verify(cohortReviewService, times(1)).saveFullCohortReview(isA(CohortReview.class), isA(List.class));
         verify(cohortReviewService).findParticipantCohortStatuses(isA(Long.class), isA(PageRequest.class));
-        verify(workspaceService).getWorkspaceAccessLevel(namespace, name);
         verifyNoMoreMockInteractions();
     }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -129,7 +129,7 @@ public class CohortReviewControllerTest {
 
         when(cohortReviewService.findCohortReview(cohortId, cdrVersionId)).thenReturn(cohortReview);
         when(cohortReviewService.findCohort(cohortId)).thenReturn(cohort);
-        doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.READER);
+        doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.WRITER);
 
         try {
             reviewController.createCohortReview(namespace, name, cohortId, cdrVersionId, new CreateReviewRequest().size(200));
@@ -142,7 +142,7 @@ public class CohortReviewControllerTest {
 
         verify(cohortReviewService, times(1)).findCohortReview(cohortId, cdrVersionId);
         verify(cohortReviewService, times(1)).findCohort(cohortId);
-        verify(cohortReviewService, times(1)).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.READER);
+        verify(cohortReviewService, times(1)).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.WRITER);
         verifyNoMoreMockInteractions();
     }
 
@@ -231,7 +231,7 @@ public class CohortReviewControllerTest {
 
         when(cohortReviewService.findCohortReview(cohortId, cdrVersionId)).thenReturn(cohortReview);
         when(cohortReviewService.findCohort(cohortId)).thenReturn(cohort);
-        doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.READER);
+        doNothing().when(cohortReviewService).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.WRITER);
         doNothing().when(codeDomainLookupService).findCodesForEmptyDomains(searchRequest.getIncludes());
         doNothing().when(codeDomainLookupService).findCodesForEmptyDomains(searchRequest.getExcludes());
         when(participantCounter.buildParticipantIdQuery(request, 200, 0L)).thenReturn(null);
@@ -251,7 +251,7 @@ public class CohortReviewControllerTest {
 
         verify(cohortReviewService, times(1)).findCohortReview(cohortId, cdrVersionId);
         verify(cohortReviewService, times(1)).findCohort(cohortId);
-        verify(cohortReviewService, times(1)).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.READER);
+        verify(cohortReviewService, times(1)).validateMatchingWorkspace(namespace, name, workspaceId, WorkspaceAccessLevel.WRITER);
         verify(codeDomainLookupService, times(1)).findCodesForEmptyDomains(searchRequest.getIncludes());
         verify(codeDomainLookupService, times(1)).findCodesForEmptyDomains(searchRequest.getExcludes());
         verify(participantCounter, times(1)).buildParticipantIdQuery(request, 200, 0L);

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -238,10 +238,18 @@ public class CohortsControllerTest {
   public void testMaterializeCohortWorkspaceNotFound() throws Exception {
     Cohort cohort = createDefaultCohort();
     cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
-
+    WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+    String workspaceName = "badWorkspace";
+    org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =
+        new org.pmiops.workbench.firecloud.model.WorkspaceResponse();
+    fcResponse.setAccessLevel(owner.toString());
+    when(fireCloudService.getWorkspace(WORKSPACE_NAMESPACE, workspaceName)).thenReturn(
+        fcResponse
+    );
+    when(workspaceService.getWorkspaceAccessLevel(WORKSPACE_NAMESPACE, workspaceName)).thenThrow(new NotFoundException());
     MaterializeCohortRequest request = new MaterializeCohortRequest();
     request.setCohortName(cohort.getName());
-    cohortsController.materializeCohort(WORKSPACE_NAMESPACE, "badWorkspace", request);
+    cohortsController.materializeCohort(WORKSPACE_NAMESPACE, workspaceName, request);
   }
 
   @Test(expected = NotFoundException.class)

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -5,6 +5,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import static junit.framework.TestCase.fail;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -46,6 +47,7 @@ import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.dao.WorkspaceServiceImpl;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
@@ -151,6 +153,8 @@ public class WorkspacesControllerTest {
   BigQueryService bigQueryService;
   @Autowired
   WorkspaceDao workspaceDao;
+  @Mock
+  WorkspaceService workspaceService;
   @Autowired
   UserDao userDao;
   @Autowired
@@ -571,6 +575,9 @@ public class WorkspacesControllerTest {
     Workspace workspace = createDefaultWorkspace();
     workspace = workspacesController.createWorkspace(workspace).getBody();
 
+    when(workspaceService.enforceWorkspaceAccessLevel(workspace.getNamespace(), workspace.getId(), WorkspaceAccessLevel.READER)).thenReturn(WorkspaceAccessLevel.OWNER);
+    when(workspaceService.enforceWorkspaceAccessLevel(workspace.getNamespace(), workspace.getId(), WorkspaceAccessLevel.WRITER)).thenReturn(WorkspaceAccessLevel.OWNER);
+
     Cohort c1 = createDefaultCohort("c1");
     c1 = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), c1).getBody();
     Cohort c2 = createDefaultCohort("c2");
@@ -586,19 +593,22 @@ public class WorkspacesControllerTest {
     CohortReview cr2 = cohortReviewController.createCohortReview(
         workspace.getNamespace(), workspace.getId(), c2.getId(),
         cdrVersion.getCdrVersionId(), reviewReq).getBody();
-    
+
     stubGetWorkspace(workspace.getNamespace(), workspace.getName(),
         LOGGED_IN_USER_EMAIL, WorkspaceAccessLevel.OWNER);
     CloneWorkspaceRequest req = new CloneWorkspaceRequest();
     Workspace modWorkspace = new Workspace();
     modWorkspace.setName("cloned");
     modWorkspace.setNamespace("cloned-ns");
+
     ResearchPurpose modPurpose = new ResearchPurpose();
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
     Workspace cloned = workspacesController.cloneWorkspace(
         workspace.getNamespace(), workspace.getId(), req).getBody().getWorkspace();
+    when(workspaceService.enforceWorkspaceAccessLevel(cloned.getNamespace(), cloned.getId(), WorkspaceAccessLevel.READER)).thenReturn(WorkspaceAccessLevel.OWNER);
+    when(workspaceService.enforceWorkspaceAccessLevel(cloned.getNamespace(), cloned.getId(), WorkspaceAccessLevel.WRITER)).thenReturn(WorkspaceAccessLevel.OWNER);
 
     List<Cohort> cohorts = cohortsController
         .getCohortsInWorkspace(cloned.getNamespace(), cloned.getId()).getBody().getItems();

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -575,9 +575,6 @@ public class WorkspacesControllerTest {
     Workspace workspace = createDefaultWorkspace();
     workspace = workspacesController.createWorkspace(workspace).getBody();
 
-    when(workspaceService.enforceWorkspaceAccessLevel(workspace.getNamespace(), workspace.getId(), WorkspaceAccessLevel.READER)).thenReturn(WorkspaceAccessLevel.OWNER);
-    when(workspaceService.enforceWorkspaceAccessLevel(workspace.getNamespace(), workspace.getId(), WorkspaceAccessLevel.WRITER)).thenReturn(WorkspaceAccessLevel.OWNER);
-
     Cohort c1 = createDefaultCohort("c1");
     c1 = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), c1).getBody();
     Cohort c2 = createDefaultCohort("c2");
@@ -607,9 +604,9 @@ public class WorkspacesControllerTest {
     req.setWorkspace(modWorkspace);
     Workspace cloned = workspacesController.cloneWorkspace(
         workspace.getNamespace(), workspace.getId(), req).getBody().getWorkspace();
-    when(workspaceService.enforceWorkspaceAccessLevel(cloned.getNamespace(), cloned.getId(), WorkspaceAccessLevel.READER)).thenReturn(WorkspaceAccessLevel.OWNER);
-    when(workspaceService.enforceWorkspaceAccessLevel(cloned.getNamespace(), cloned.getId(), WorkspaceAccessLevel.WRITER)).thenReturn(WorkspaceAccessLevel.OWNER);
 
+    stubGetWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(),
+        LOGGED_IN_USER_EMAIL, WorkspaceAccessLevel.OWNER);
     List<Cohort> cohorts = cohortsController
         .getCohortsInWorkspace(cloned.getNamespace(), cloned.getId()).getBody().getItems();
     Map<String, Cohort> cohortsByName = Maps.uniqueIndex(cohorts, c -> c.getName());

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImplTest.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -81,16 +82,19 @@ public class CohortReviewServiceImplTest {
 
         Workspace workspace = new Workspace();
         workspace.setWorkspaceId(badWorkspaceId);
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(workspaceService.getRequired(workspaceNamespace, workspaceName)).thenReturn(workspace);
 
         try {
-            cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceName, workspaceId);
+            cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceName, workspaceId, WorkspaceAccessLevel.READER);
             fail("Should have thrown NotFoundException!");
         } catch (NotFoundException e) {
             assertEquals("Not Found: No workspace matching workspaceNamespace: "
                     + workspaceNamespace + ", workspaceId: " + workspaceName, e.getMessage());
         }
-
+        verify(workspaceService).enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, WorkspaceAccessLevel.READER);
         verify(workspaceService).getRequired(workspaceNamespace, workspaceName);
         verifyNoMoreMockInteractions();
     }
@@ -103,10 +107,14 @@ public class CohortReviewServiceImplTest {
 
         Workspace workspace = new Workspace();
         workspace.setWorkspaceId(workspaceId);
+        WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
+
+        when(workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, WorkspaceAccessLevel.READER)).thenReturn(owner);
         when(workspaceService.getRequired(workspaceNamespace, workspaceName)).thenReturn(workspace);
 
-        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceName, workspaceId);
+        cohortReviewService.validateMatchingWorkspace(workspaceNamespace, workspaceName, workspaceId, WorkspaceAccessLevel.READER);
 
+        verify(workspaceService).enforceWorkspaceAccessLevel(workspaceNamespace, workspaceName, WorkspaceAccessLevel.READER);
         verify(workspaceService).getRequired(workspaceNamespace, workspaceName);
         verifyNoMoreMockInteractions();
     }


### PR DESCRIPTION
This should by nature of FireCloud's access controls, enforce registered access for all calls that involve a workspace. @freemabd1, please let me know if I missed any cohort builder calls that should be behind registered access? 