### PR TITLE
[RW-286] Implement Clone UI

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ import {IdVerificationPageComponent} from './views/id-verification-page/componen
 import {ProfileEditComponent} from './views/profile-edit/component';
 import {ProfilePageComponent} from './views/profile-page/component';
 import {ReviewComponent} from './views/review/component';
-import {WorkspaceEditComponent} from './views/workspace-edit/component';
+import {WorkspaceEditComponent, WorkspaceEditMode} from './views/workspace-edit/component';
 import {WorkspaceShareComponent} from './views/workspace-share/component';
 import {WorkspaceComponent} from './views/workspace/component';
 
@@ -53,11 +53,15 @@ const routes: Routes = [
   }, {
     path: 'workspace/build',
     component: WorkspaceEditComponent,
-    data: {title: 'Create Workspace', adding: true}
+    data: {title: 'Create Workspace', mode: WorkspaceEditMode.Create}
   }, {
     path: 'workspace/:ns/:wsid/edit',
     component: WorkspaceEditComponent,
-    data: {title: 'Edit Workspace', adding: false}
+    data: {title: 'Edit Workspace', mode: WorkspaceEditMode.Edit}
+  }, {
+    path: 'workspace/:ns/:wsid/clone',
+    component: WorkspaceEditComponent,
+    data: {title: 'Clone Workspace', mode: WorkspaceEditMode.Clone}
   }, {
     path: 'review',
     component: ReviewComponent,

--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -1,6 +1,9 @@
 <div *ngIf="!notFound else notFoundMessage">
-  <h2 *ngIf="adding">Create a new Workspace</h2>
-  <h2 *ngIf="!adding">Edit workspace "{{workspace.name}}"</h2>
+  <ng-container [ngSwitch]="mode">
+    <h2 *ngSwitchCase="Mode.Create">Create a new Workspace</h2>
+    <h2 *ngSwitchCase="Mode.Edit">Edit workspace "{{workspace.name}}"</h2>
+    <h2 *ngSwitchCase="Mode.Clone">Clone workspace "{{oldWorkspaceName}}"</h2>
+  </ng-container>
   <div>* is a required field</div>
   <div class="form-area">
     <div class="name-area" [class.validation-error]="nameNotEntered">
@@ -27,7 +30,7 @@
                 name="disease-focused-research"
                 id="disease-focused-research"
                 [(ngModel)]="workspace.researchPurpose.diseaseFocusedResearch"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Disease focused research
             </clr-checkbox>
             <input type="text" class="input" name="disease-specification"
@@ -38,7 +41,7 @@
                 name="methods-development"
                 id="methods-development"
                 [(ngModel)]="workspace.researchPurpose.methodsDevelopment"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Methods development/validation study
             </clr-checkbox>
           </div>
@@ -47,7 +50,7 @@
                 name="control-set"
                 id="control-set"
                 [(ngModel)]="workspace.researchPurpose.controlSet"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Control set
             </clr-checkbox>
           </div>
@@ -56,7 +59,7 @@
                 name="aggregate-analysis"
                 id="aggregate-analysis"
                 [(ngModel)]="workspace.researchPurpose.aggregateAnalysis"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Aggregate analysis to understand variation in general population
             </clr-checkbox>
           </div>
@@ -65,7 +68,7 @@
                 name="ancestry"
                 id="ancestry"
                 [(ngModel)]="workspace.researchPurpose.ancestry"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Population origins or ancestry
             </clr-checkbox>
           </div>
@@ -74,7 +77,7 @@
                 name="commercial-purpose"
                 id="commercial-purpose"
                 [(ngModel)]="workspace.researchPurpose.commercialPurpose"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Commercial purpose/entity
             </clr-checkbox>
           </div>
@@ -83,7 +86,7 @@
                 name="population"
                 id="population"
                 [(ngModel)]="workspace.researchPurpose.population"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Restricted to a specific population
             </clr-checkbox>
             <!-- TODO: Dropdown for population-->
@@ -97,7 +100,7 @@
                 name="requestApproval"
                 id="requestApproval"
                 [(ngModel)]="workspace.researchPurpose.reviewRequested"
-                [clrDisabled]="!adding">
+                [clrDisabled]="mode == Mode.Edit">
               Review my workspace
             </clr-checkbox>
           </div>
@@ -106,10 +109,21 @@
     </div>
     <div style="display: flex; flex: 0 0 0; padding: 0">
       <div class="button">
-        <button *ngIf="adding else editing" class="btn add-button btn-primary" [clrLoading]="savingWorkspace" (click)="addWorkspace()">Create Workspace</button>
-        <ng-template #editing>
-          <button class="btn add-button btn-primary" [clrLoading]="savingWorkspace" (click)="updateWorkspace()" [disabled]="!hasPermission">Update Workspace</button>
-        </ng-template>
+        <ng-container [ngSwitch]="mode">
+          <button *ngSwitchCase="Mode.Create" class="btn add-button btn-primary"
+                  [clrLoading]="savingWorkspace" (click)="addWorkspace()">
+            Create Workspace
+          </button>
+          <button *ngSwitchCase="Mode.Edit" class="btn add-button btn-primary"
+                  [clrLoading]="savingWorkspace" (click)="updateWorkspace()"
+                  [disabled]="!hasPermission">
+            Update Workspace
+          </button>
+          <button *ngSwitchCase="Mode.Clone" class="btn add-button btn-primary"
+                  [clrLoading]="savingWorkspace" (click)="cloneWorkspace()">
+            Clone Workspace
+          </button>
+        </ng-container>
         <button class="btn" (click)="navigateBack()">Cancel</button>
       </div>
       <p *ngIf="valueNotEntered;">* is a required field</p>

--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -111,16 +111,16 @@
       <div class="button">
         <ng-container [ngSwitch]="mode">
           <button *ngSwitchCase="Mode.Create" class="btn add-button btn-primary"
-                  [clrLoading]="savingWorkspace" (click)="addWorkspace()">
+              [clrLoading]="savingWorkspace" (click)="addWorkspace()">
             Create Workspace
           </button>
           <button *ngSwitchCase="Mode.Edit" class="btn add-button btn-primary"
-                  [clrLoading]="savingWorkspace" (click)="updateWorkspace()"
-                  [disabled]="!hasPermission">
+              [clrLoading]="savingWorkspace" (click)="updateWorkspace()"
+              [disabled]="!hasPermission">
             Update Workspace
           </button>
           <button *ngSwitchCase="Mode.Clone" class="btn add-button btn-primary"
-                  [clrLoading]="savingWorkspace" (click)="cloneWorkspace()">
+              [clrLoading]="savingWorkspace" (click)="cloneWorkspace()">
             Clone Workspace
           </button>
         </ng-container>

--- a/ui/src/app/views/workspace-edit/component.spec.ts
+++ b/ui/src/app/views/workspace-edit/component.spec.ts
@@ -1,0 +1,121 @@
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
+import {ActivatedRoute, Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ClarityModule} from 'clarity-angular';
+
+import {ErrorHandlingService} from 'app/services/error-handling.service';
+import {WorkspaceEditComponent, WorkspaceEditMode} from 'app/views/workspace-edit/component';
+
+import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
+import {ProfileServiceStub, ProfileStubVariables} from 'testing/stubs/profile-service-stub';
+import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
+
+import {ProfileService} from 'generated';
+import {WorkspacesService} from 'generated';
+
+
+describe('WorkspaceEditComponent', () => {
+  let activatedRouteStub;
+  let testComponent: WorkspaceEditComponent;
+  let fixture: ComponentFixture<WorkspaceEditComponent>;
+  let workspacesService: WorkspacesServiceStub;
+
+  function setupComponent(mode: WorkspaceEditMode) {
+    activatedRouteStub.routeConfig.data.mode = mode;
+    fixture = TestBed.createComponent(WorkspaceEditComponent);
+    testComponent = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }
+
+  beforeEach(fakeAsync(() => {
+    activatedRouteStub = {
+      snapshot: {
+        url: [
+          {path: 'workspace'},
+          {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
+          {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID},
+          {path: 'clone'}
+        ],
+        params: {
+          'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+          'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+        }
+      },
+      routeConfig: {data: {}}
+    };
+    workspacesService = new WorkspacesServiceStub();
+    TestBed.configureTestingModule({
+      declarations: [
+        WorkspaceEditComponent
+      ],
+      imports: [
+        RouterTestingModule,
+        FormsModule,
+        ClarityModule.forRoot()
+      ],
+      providers: [
+        { provide: ErrorHandlingService, useValue: new ErrorHandlingServiceStub() },
+        { provide: WorkspacesService, useValue: workspacesService },
+        // Wrap in a factory function so we can later mutate the value if needed
+        // for testing.
+        { provide: ActivatedRoute, useFactory: () => activatedRouteStub },
+        { provide: ProfileService, useValue: new ProfileServiceStub() }
+      ]
+    }).compileComponents();
+  }));
+
+
+  it('should support updating a workspace', fakeAsync(() => {
+    setupComponent(WorkspaceEditMode.Edit);
+    testComponent.workspace.name = 'edited';
+    fixture.detectChanges();
+    expect(workspacesService.workspaces[0].name).not.toBe('edited');
+
+    fixture.debugElement.query(By.css('.add-button'))
+      .triggerEventHandler('click', null);
+    fixture.detectChanges();
+    tick();
+    expect(workspacesService.workspaces.length).toBe(1);
+    expect(workspacesService.workspaces[0].name).toBe('edited');
+  }));
+
+  it('should support creating a workspace', fakeAsync(() => {
+    workspacesService.workspaces = [];
+    setupComponent(WorkspaceEditMode.Create);
+
+    testComponent.workspace.namespace = 'foo';
+    testComponent.workspace.name = 'created';
+    fixture.detectChanges();
+
+    fixture.debugElement.query(By.css('.add-button'))
+      .triggerEventHandler('click', null);
+    fixture.detectChanges();
+    tick();
+    expect(workspacesService.workspaces.length).toBe(1);
+    expect(workspacesService.workspaces[0].name).toBe('created');
+  }));
+
+  it('should support cloning a workspace', inject(
+    [Router], fakeAsync((router: Router) => {
+      setupComponent(WorkspaceEditMode.Clone);
+      expect(testComponent.workspace.name).toBe(
+        `Clone of ${WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME}`);
+
+      const spy = spyOn(router, 'navigate');
+      fixture.debugElement.query(By.css('.add-button'))
+        .triggerEventHandler('click', null);
+      fixture.detectChanges();
+      tick();
+
+      expect(workspacesService.workspaces.length).toBe(2);
+      const got = workspacesService.workspaces.find(w => w.name === testComponent.workspace.name);
+      expect(got).not.toBeNull();
+      expect(got.namespace).toBe(
+        ProfileStubVariables.PROFILE_STUB.freeTierBillingProjectName);
+      expect(spy).toHaveBeenCalled();
+    })));
+});

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -113,7 +113,9 @@ export class WorkspaceEditComponent implements OnInit {
   }
 
   reloadConflictingWorkspace(): void {
-    this.loadWorkspace().subscribe(() => this.resetWorkspaceEditor());
+    this.loadWorkspace().subscribe(() => {
+      this.resetWorkspaceEditor();
+    });
   }
 
   resetWorkspaceEditor(): void {
@@ -142,8 +144,12 @@ export class WorkspaceEditComponent implements OnInit {
     this.errorHandlingService.retryApi(
       this.workspacesService.createWorkspace(this.workspace))
       .subscribe(
-        () => this.navigateBack(),
-        (error) => this.workspaceCreationError = true);
+        () => {
+          this.navigateBack();
+        },
+        (error) => {
+          this.workspaceCreationError = true;
+        });
   }
 
   updateWorkspace(): void {
@@ -156,7 +162,9 @@ export class WorkspaceEditComponent implements OnInit {
       this.oldWorkspaceName,
       this.workspace))
       .subscribe(
-        () => this.navigateBack(),
+        () => {
+          this.navigateBack();
+        },
         (error) => {
           if (error.status === 409) {
             this.workspaceUpdateConflictError = true;

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -185,8 +185,8 @@ export class WorkspaceEditComponent implements OnInit {
         workspace: this.workspace,
       }))
       .subscribe(
-        (resp: CloneWorkspaceResponse) => {
-          this.router.navigate(['/workspace', resp.workspace.namespace, resp.workspace.id]);
+        (r: CloneWorkspaceResponse) => {
+          this.router.navigate(['/workspace', r.workspace.namespace, r.workspace.id]);
         });
   }
 

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -1,12 +1,13 @@
 import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {isBlank} from 'app/utils';
 
 import {
+  CloneWorkspaceResponse,
   DataAccessLevel,
   ProfileService,
   Workspace,
@@ -15,22 +16,29 @@ import {
   WorkspacesService
 } from 'generated';
 
+export enum WorkspaceEditMode { Create = 1, Edit = 2, Clone = 3 }
+
 @Component({
   styleUrls: ['./component.css'],
   templateUrl: './component.html',
 })
 export class WorkspaceEditComponent implements OnInit {
+  // Defines the supported modes for the workspace edit component.
+  // Unfortunately, it is not currently possible to define an enum directly
+  // within a class in Typescript, so make do with this type alias.
+  Mode = WorkspaceEditMode;
+
+  mode: WorkspaceEditMode;
   workspace: Workspace;
   workspaceId: string;
   oldWorkspaceName: string;
   oldWorkspaceNamespace: string;
-  adding = false;
   savingWorkspace = false;
   nameNotEntered = false;
+  notFound = false;
   workspaceCreationError = false;
   workspaceUpdateError = false;
   workspaceUpdateConflictError = false;
-  notFound = false;
   private accessLevel: WorkspaceAccessLevel;
   constructor(
       private errorHandlingService: ErrorHandlingService,
@@ -38,6 +46,7 @@ export class WorkspaceEditComponent implements OnInit {
       private route: ActivatedRoute,
       private workspacesService: WorkspacesService,
       private profileService: ProfileService,
+      private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -57,36 +66,23 @@ export class WorkspaceEditComponent implements OnInit {
         population: false,
         reviewRequested: false
       }};
-    if (this.route.routeConfig.data.adding) {
-      this.adding = true;
+    this.mode = WorkspaceEditMode.Edit;
+    if (this.route.routeConfig.data.mode) {
+      this.mode = this.route.routeConfig.data.mode;
+    }
+
+    if (this.mode === WorkspaceEditMode.Create || this.mode === WorkspaceEditMode.Clone) {
+      // There is a new workspace to be created via this flow.
+      this.accessLevel = WorkspaceAccessLevel.OWNER;
       this.errorHandlingService.retryApi(this.profileService.getMe()).subscribe(profile => {
         this.workspace.namespace = profile.freeTierBillingProjectName;
       });
-      this.accessLevel = WorkspaceAccessLevel.OWNER;
-    } else {
+    }
+    if (this.mode === WorkspaceEditMode.Edit || this.mode === WorkspaceEditMode.Clone) {
+      // There is an existing workspace referenced in this flow.
       this.oldWorkspaceNamespace = this.route.snapshot.params['ns'];
       this.oldWorkspaceName = this.route.snapshot.params['wsid'];
       this.loadWorkspace();
-    }
-  }
-
-  addWorkspace(): void {
-    if (!this.savingWorkspace) {
-      if (isBlank(this.workspace.name)) {
-        this.nameNotEntered = true;
-      } else {
-        this.savingWorkspace = true;
-        this.nameNotEntered = false;
-        this.errorHandlingService.retryApi(
-          this.workspacesService.createWorkspace(this.workspace))
-            .subscribe(
-              () => {
-                this.navigateBack();
-              },
-              (error) => {
-                this.workspaceCreationError = true;
-              });
-      }
     }
   }
 
@@ -94,9 +90,14 @@ export class WorkspaceEditComponent implements OnInit {
     const obs: Observable<WorkspaceResponse> = this.workspacesService.getWorkspace(
       this.oldWorkspaceNamespace, this.oldWorkspaceName);
     obs.subscribe(
-      (workspaceResponse) => {
-        this.accessLevel = workspaceResponse.accessLevel;
-        this.workspace = workspaceResponse.workspace;
+      (resp) => {
+        this.accessLevel = resp.accessLevel;
+        if (this.mode === WorkspaceEditMode.Edit) {
+          this.workspace = resp.workspace;
+        } else if (this.mode === WorkspaceEditMode.Clone) {
+          this.workspace.name = 'Clone of ' + resp.workspace.name;
+          this.workspace.description = resp.workspace.description;
+        }
       },
       (error) => {
         if (error.status === 404) {
@@ -122,31 +123,65 @@ export class WorkspaceEditComponent implements OnInit {
     this.savingWorkspace = false;
   }
 
-  updateWorkspace(): void {
-    if (!this.savingWorkspace) {
-      if (isBlank(this.workspace.name)) {
-        this.nameNotEntered = true;
-      } else {
-        this.savingWorkspace = true;
-        this.nameNotEntered = false;
-        this.errorHandlingService.retryApi(this.workspacesService.updateWorkspace(
-            this.oldWorkspaceNamespace,
-            this.oldWorkspaceName,
-            this.workspace))
-          .subscribe(
-            () => {
-              this.navigateBack();
-            },
-            (error) => {
-              if (error.status === 409) {
-                this.workspaceUpdateConflictError = true;
-              } else {
-                this.workspaceUpdateError = true;
-              }
-            });
-      }
+  validateForm(): boolean {
+    if (this.savingWorkspace) {
+      return false;
     }
+    this.nameNotEntered = isBlank(this.workspace.name);
+    if (this.nameNotEntered) {
+      return false;
+    }
+    return true;
   }
+
+  addWorkspace(): void {
+    if (!this.validateForm()) {
+      return;
+    }
+    this.savingWorkspace = true;
+    this.errorHandlingService.retryApi(
+      this.workspacesService.createWorkspace(this.workspace))
+      .subscribe(
+        () => this.navigateBack(),
+        (error) => this.workspaceCreationError = true);
+  }
+
+  updateWorkspace(): void {
+    if (!this.validateForm()) {
+      return;
+    }
+    this.savingWorkspace = true;
+    this.errorHandlingService.retryApi(this.workspacesService.updateWorkspace(
+      this.oldWorkspaceNamespace,
+      this.oldWorkspaceName,
+      this.workspace))
+      .subscribe(
+        () => this.navigateBack(),
+        (error) => {
+          if (error.status === 409) {
+            this.workspaceUpdateConflictError = true;
+          } else {
+            this.workspaceUpdateError = true;
+          }
+        });
+  }
+
+  cloneWorkspace(): void {
+    if (!this.validateForm()) {
+      return;
+    }
+    this.savingWorkspace = true;
+    this.errorHandlingService.retryApi(this.workspacesService.cloneWorkspace(
+      this.oldWorkspaceNamespace,
+      this.oldWorkspaceName, {
+        workspace: this.workspace,
+      }))
+      .subscribe(
+        (resp: CloneWorkspaceResponse) => {
+          this.router.navigate(['/workspace', resp.workspace.namespace, resp.workspace.id]);
+        });
+  }
+
   get hasPermission(): boolean {
     return this.accessLevel === WorkspaceAccessLevel.OWNER
         || this.accessLevel === WorkspaceAccessLevel.WRITER;

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -13,6 +13,12 @@
         <app-share-icon [shareHover]="shareHover"></app-share-icon>
         <span class="tooltip-content">Share Workspace</span>
       </button>
+      <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
+              (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+        <!-- TODO(calbach): Check whether we have the real asset available. -->
+        <clr-icon shape="copy"></clr-icon>
+        <span class="tooltip-content">Clone Workspace</span>
+      </button>
       <button (mouseover)="trashHover=true" (mouseleave)="trashHover=false"
           [disabled]="!ownerPermission"
           class="btn btn-icon btn-danger-outline btn-deleting tooltip tooltip-sm"

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -275,6 +275,10 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.router.navigate(['edit'], {relativeTo : this.route});
   }
 
+  clone(): void {
+    this.router.navigate(['clone'], {relativeTo : this.route});
+  }
+
   share(): void {
     this.router.navigate(['share'], {relativeTo : this.route});
   }


### PR DESCRIPTION
- Multiplex workspace edit page into a total of 3 modes: edit, create, clone
- Clone has an existing workspace, and redirects to the new workspace upon creation
- Using a standin icon from clr for copy (the same used for the cohort clone option); let me know if there's a better asset I should be pulling in