### PR TITLE
Hotfix name errors in CohortEditComponent

### DIFF
--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
@@ -1,6 +1,6 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS, Map} from 'immutable';
 
@@ -16,7 +16,7 @@ describe('AttributesComponent', () => {
   let component: AttributesComponent;
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
@@ -1,6 +1,6 @@
 import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS} from 'immutable';
@@ -48,7 +48,7 @@ describe('SelectionComponent', () => {
   let typeStub;
   let listStub;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
@@ -1,6 +1,6 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS, Map} from 'immutable';
 
@@ -20,7 +20,7 @@ describe('TreeComponent', () => {
   let dispatchSpy;
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
@@ -1,6 +1,6 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from 'clarity-angular';
@@ -34,7 +34,7 @@ describe('WizardComponent', () => {
 
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/overview/overview.component.spec.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.spec.ts
@@ -1,6 +1,6 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS} from 'immutable';
 import {Observable} from 'rxjs/Observable';
@@ -19,7 +19,7 @@ describe('OverviewComponent', () => {
 
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
@@ -1,6 +1,6 @@
 import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS, List} from 'immutable';
@@ -48,7 +48,7 @@ describe('SearchGroupItemComponent', () => {
   let itemStub;
   let codeStub;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
@@ -1,6 +1,6 @@
 import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS, List} from 'immutable';
 import {NgxPopperModule} from 'ngx-popper';
@@ -31,7 +31,7 @@ describe('SearchGroupListComponent', () => {
 
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
@@ -1,6 +1,6 @@
 import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
-import {async as _async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ClarityModule} from 'clarity-angular';
 import {fromJS} from 'immutable';
@@ -62,7 +62,7 @@ describe('SearchGroupComponent', () => {
 
   let mockReduxInst;
 
-  beforeEach(_async(() => {
+  beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());

--- a/ui/src/app/views/cohort-edit/component.spec.ts
+++ b/ui/src/app/views/cohort-edit/component.spec.ts
@@ -1,8 +1,4 @@
-import {
-  async as _async,
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ClarityModule} from 'clarity-angular';
@@ -34,7 +30,7 @@ describe('CohortEditComponent', () => {
   let component: CohortEditComponent;
   let fixture: ComponentFixture<CohortEditComponent>;
 
-  beforeEach(_async(() =>
+  beforeEach(async(() =>
     TestBed.configureTestingModule({
       imports: [
         ClarityModule.forRoot(),

--- a/ui/src/app/views/cohort-edit/component.spec.ts
+++ b/ui/src/app/views/cohort-edit/component.spec.ts
@@ -1,0 +1,63 @@
+import {
+  async as _async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {ActivatedRoute, Router} from '@angular/router';
+import {ClarityModule} from 'clarity-angular';
+import {Observable} from 'rxjs/Observable';
+
+import {ErrorHandlingService} from '../../services/error-handling.service';
+import {CohortEditComponent} from './component';
+
+import {CohortsServiceStub} from 'testing/stubs/cohort-service-stub';
+import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stub';
+
+import {CohortsService} from 'generated';
+
+class RouterStub {
+  navigate(...args) {
+    return args;
+  }
+}
+
+class ActivatedRouteStub {
+  params = Observable.of({
+    ns: 'test-namespace',
+    wsid: 'test-workspace-id',
+    cid: 1
+  });
+}
+
+describe('CohortEditComponent', () => {
+  let component: CohortEditComponent;
+  let fixture: ComponentFixture<CohortEditComponent>;
+
+  beforeEach(_async(() =>
+    TestBed.configureTestingModule({
+      imports: [
+        ClarityModule.forRoot(),
+        FormsModule,
+      ],
+      declarations: [CohortEditComponent],
+      providers: [
+        { provide: Router, useClass: RouterStub },
+        { provide: ActivatedRoute, useClass: ActivatedRouteStub },
+        { provide: CohortsService, useClass: CohortsServiceStub },
+        { provide: ErrorHandlingService, useClass: ErrorHandlingServiceStub },
+      ]
+    }).compileComponents()
+  ));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CohortEditComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('Should render without errors', () => {
+    // fully initializes the component for rendering
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/views/cohort-edit/component.ts
+++ b/ui/src/app/views/cohort-edit/component.ts
@@ -11,7 +11,12 @@ import {Cohort, CohortsService} from 'generated';
   templateUrl: './component.html',
 })
 export class CohortEditComponent implements OnInit, OnDestroy {
-  cohort: Cohort;
+  cohort: Cohort = {
+    name: '',
+    description: '',
+    criteria: '',
+    type: '',
+  };
   workspaceNamespace: string;
   workspaceId: string;
   private sub: Subscription;


### PR DESCRIPTION
This should be considered temporary until the UI is designed to include spinners, etc - really, rather than providing dummy data for the frames when the component is rendering before the API call comes back, either (A) the data should be loaded via a resolver or (B) we should separate the form from the data (via the reactive forms framework) and have them disabled - perhaps with a spinner - until the data is loaded.