### PR TITLE
Fix a few clone UI bugs

### DIFF
--- a/ui/src/app/views/workspace-edit/component.spec.ts
+++ b/ui/src/app/views/workspace-edit/component.spec.ts
@@ -105,7 +105,8 @@ describe('WorkspaceEditComponent', () => {
       setupComponent(WorkspaceEditMode.Clone);
       expect(testComponent.workspace.name).toBe(
         `Clone of ${WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME}`);
-      expect(testComponent.hasPermission).toBeTruthy('cloner should be able to edit cloned workspace');
+      expect(testComponent.hasPermission).toBeTruthy(
+        'cloner should be able to edit cloned workspace');
 
       const spy = spyOn(router, 'navigate');
       fixture.debugElement.query(By.css('.add-button'))

--- a/ui/src/app/views/workspace-edit/component.spec.ts
+++ b/ui/src/app/views/workspace-edit/component.spec.ts
@@ -12,8 +12,7 @@ import {ErrorHandlingServiceStub} from 'testing/stubs/error-handling-service-stu
 import {ProfileServiceStub, ProfileStubVariables} from 'testing/stubs/profile-service-stub';
 import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
 
-import {ProfileService} from 'generated';
-import {WorkspacesService} from 'generated';
+import {ProfileService, WorkspaceAccessLevel, WorkspacesService} from 'generated';
 
 
 describe('WorkspaceEditComponent', () => {
@@ -101,9 +100,12 @@ describe('WorkspaceEditComponent', () => {
 
   it('should support cloning a workspace', inject(
     [Router], fakeAsync((router: Router) => {
+      workspacesService.workspaceAccess.set(
+        WorkspaceStubVariables.DEFAULT_WORKSPACE_ID, WorkspaceAccessLevel.READER);
       setupComponent(WorkspaceEditMode.Clone);
       expect(testComponent.workspace.name).toBe(
         `Clone of ${WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME}`);
+      expect(testComponent.hasPermission).toBeTruthy('cloner should be able to edit cloned workspace');
 
       const spy = spyOn(router, 'navigate');
       fixture.debugElement.query(By.css('.add-button'))

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -91,9 +91,9 @@ export class WorkspaceEditComponent implements OnInit {
       this.oldWorkspaceNamespace, this.oldWorkspaceName);
     obs.subscribe(
       (resp) => {
-        this.accessLevel = resp.accessLevel;
         if (this.mode === WorkspaceEditMode.Edit) {
           this.workspace = resp.workspace;
+          this.accessLevel = resp.accessLevel;
         } else if (this.mode === WorkspaceEditMode.Clone) {
           this.workspace.name = 'Clone of ' + resp.workspace.name;
           this.workspace.description = resp.workspace.description;

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -187,6 +187,10 @@ export class WorkspaceEditComponent implements OnInit {
       .subscribe(
         (r: CloneWorkspaceResponse) => {
           this.router.navigate(['/workspace', r.workspace.namespace, r.workspace.id]);
+        },
+        () => {
+          // Only expected errors are transient, so allow the user to try again.
+          this.resetWorkspaceEditor();
         });
   }
 

--- a/ui/src/testing/stubs/workspace-service-stub.ts
+++ b/ui/src/testing/stubs/workspace-service-stub.ts
@@ -23,7 +23,8 @@ export class WorkspaceStubVariables {
 
 export class WorkspacesServiceStub {
   workspaces: Workspace[];
-  workspaceResponses: WorkspaceResponse[];
+  // By default, access is OWNER.
+  workspaceAccess: Map<string, WorkspaceAccessLevel>;
 
   constructor() {
     const stubWorkspace: Workspace = {
@@ -61,6 +62,7 @@ export class WorkspacesServiceStub {
     };
 
     this.workspaces = [stubWorkspace];
+    this.workspaceAccess = new Map<string, WorkspaceAccessLevel>();
   }
 
   private clone(w: Workspace): Workspace {
@@ -112,9 +114,13 @@ export class WorkspacesServiceStub {
             return true;
           }
         });
+        let accessLevel = WorkspaceAccessLevel.OWNER;
+        if (this.workspaceAccess.has(workspaceId)) {
+          accessLevel = this.workspaceAccess.get(workspaceId);
+        }
         const response: WorkspaceResponse = {
           workspace: this.clone(workspaceReceived),
-          accessLevel: WorkspaceAccessLevel.OWNER
+          accessLevel: accessLevel
         };
         observer.next(response);
         observer.complete();
@@ -127,9 +133,13 @@ export class WorkspacesServiceStub {
       setTimeout(() => {
         observer.next({
           items: this.workspaces.map(workspace => {
+            let accessLevel = WorkspaceAccessLevel.OWNER;
+            if (this.workspaceAccess.has(workspace.id)) {
+              accessLevel = this.workspaceAccess.get(workspace.id);
+            }
             return {
               workspace: this.clone(workspace),
-              accessLevel: WorkspaceAccessLevel.OWNER
+              accessLevel: accessLevel
             };
           })
         });


### PR DESCRIPTION
- User could not edit when cloning readonly workspaces
- Reset the editor saving/error states upon transient clone failure