### PR TITLE
[RW-341] Always ng build in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           working_directory: ~/workbench/ui
           command: |
-            npm run codegen && npm test  -- --no-watch
+            npm run codegen && npm run build && npm test -- --no-watch
       - deploy:
           name: Deploy to gcloud test project
           command: |


### PR DESCRIPTION
Previously, we would only explicitly call `ng build` when attempting to deploy, which only happens on master merges.

Without this change, I believe we do have partial compilation checks in place, but only for files which were transitively included for `ng test`.