### PR TITLE
Split out test vs compile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,15 @@ jobs:
             - ~/workbench/ui/node_modules
           key: ui-cache-{{ checksum "~/workbench/ui/package.json" }}
       - run:
+          name: Run Angular tests
           working_directory: ~/workbench/ui
           command: |
-            npm run codegen && npm run build && npm test -- --no-watch
+            npm run codegen && npm test -- --no-watch
+      - run:
+          name: Test compilation of the Angular app
+          working_directory: ~/workbench/ui
+          command: |
+            npm run build
       - deploy:
           name: Deploy to gcloud test project
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,7 @@ jobs:
           - ui-cache-
       - run:
           working_directory: ~/workbench/ui
-          command: |
-            npm install
+          command: npm install
       - save_cache:
           paths:
             - ~/workbench/ui/node_modules
@@ -79,8 +78,7 @@ jobs:
       - run:
           name: Test compilation of the Angular app
           working_directory: ~/workbench/ui
-          command: |
-            npm run build
+          command: npm run build
       - deploy:
           name: Deploy to gcloud test project
           command: |


### PR DESCRIPTION
Split UI test and compile into separate stages. `ng build` is super spammy and pushes down the test output failures.