### PR TITLE
Check API dependencies for vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,12 @@ jobs:
       - image: allofustest/workbench:buildimage-0.0.10
     working_directory: ~/workbench
     environment:
-      JVM_OPTS: -Xmx3200m
+      # As best I can tell (dmohs, 7 Feb '17), this is the only way to set a memory limit that Java
+      # processes executed within CircleCI's docker containers will respect. Very helpful resource:
+      # https://circleci.com/blog/how-to-handle-java-oom-errors/
+      # Gradle itself doesn't usually reach 1G, so as long as we can keep tasks under 3G, we should
+      # have room in Circle's 4G to get our work done.
+      JAVA_TOOL_OPTIONS: -Xmx3g
       TERM: dumb
     steps:
       - checkout
@@ -48,7 +53,10 @@ jobs:
           command: |
             ./project.rb circle-deploy \
               --project all-of-us-workbench-test --creds-file circle-sa-key.json
-
+      - run:
+          name: Scan dependencies for vulnerabilities
+          working_directory: ~/workbench/api
+          command: ./project.rb gradle dependencyCheckAnalyze --info
   ui-build-test-deploy:
     docker:
       - image: allofustest/workbench:buildimage-0.0.10

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -96,6 +96,7 @@ buildscript {    // Configuration for building
     classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
     classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.9.0'
     classpath 'io.swagger:swagger-codegen:2.2.3'
+    classpath 'org.owasp:dependency-check-gradle:3.1.0'
   }
 }
 
@@ -106,6 +107,7 @@ apply plugin: 'war'
 apply plugin: 'com.google.cloud.tools.appengine-standard'  // App Engine tasks
 apply plugin: 'org.springframework.boot'
 apply plugin: 'org.hidetake.swagger.generator'
+apply plugin: 'org.owasp.dependencycheck'
 
 configurations {
   integrationCompile.extendsFrom testCompile
@@ -281,16 +283,6 @@ tasks.withType(Test) {
       events "passed", "skipped", "failed"
     }
   }
-}
-
-test {
-  // Starting with a smaller minimum seems to help this task use memory more slowly.
-  // Increase max heap size from default of 1024M in order to avoid OOM errors.
-  // When Gradle runs out of memory, it fails with this message:
-  //   Process 'Gradle Test Executor 1' finished with non-zero exit value 137
-  // and literally nothing else in terms of helpful debugging information.
-  minHeapSize = '128m'
-  maxHeapSize = '2048m'
 }
 
 integration {

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -139,9 +139,16 @@ def run_bigquery_tests(*args)
   end
 end
 
-def run_gradle(*args)
-  common = Common.new
-  common.run_inline %W{docker-compose run --rm api ./gradlew} + args
+def run_gradle(cmd_name, args)
+  ensure_docker cmd_name, args
+  begin
+    Common.new.run_inline %W{gradle} + args
+  ensure
+    if $! && $!.status != 0
+      Common.new.error "Command exited with non-zero status"
+      exit 1
+    end
+  end
 end
 
 def connect_to_db(*args)
@@ -679,7 +686,7 @@ Common.register_command({
 Common.register_command({
   :invocation => "gradle",
   :description => "Runs gradle inside the API docker container with the given arguments.",
-  :fn => lambda { |*args| run_gradle(*args) }
+  :fn => lambda { |*args| run_gradle("gradle", args) }
 })
 
 Common.register_command({


### PR DESCRIPTION
This adds about two minutes to our CircleCI runs, which isn't great, but gives us a jumping off point for iterating.