### PR TITLE
Make CdrDataSource return default CDR version during initialization.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -1,13 +1,8 @@
 package org.pmiops.workbench.cdr;
 
-import com.mysql.fabric.Server;
-import java.rmi.ServerError;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.PostConstruct;
-import javax.inject.Provider;
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
+import com.google.common.cache.LoadingCache;
+import org.pmiops.workbench.config.CacheSpringConfiguration;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -17,12 +12,21 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 @Configuration
 @EnableTransactionManagement
@@ -43,16 +47,17 @@ public class CdrDbConfig {
   private static final String DB_PASSWORD_KEY = "spring.datasource.password";
   private static final String WORKBENCH_DB_USER = "workbench";
 
+  @Service
   public static class CdrDataSource extends AbstractRoutingDataSource {
 
     private boolean finishedInitialization = false;
 
-    private final Provider<CdrVersion> defaultCdrVersionProvider;
+    private final Long defaultCdrVersionId;
 
     @Autowired
     public CdrDataSource(CdrVersionDao cdrVersionDao,
-                         @Qualifier("defaultCdr") Provider<CdrVersion> defaultCdrVersionProvider) {
-      this.defaultCdrVersionProvider = defaultCdrVersionProvider;
+                         @Qualifier("configCache") LoadingCache<String, Object> configCache) throws ExecutionException {
+      WorkbenchConfig workbenchConfig = CacheSpringConfiguration.lookupWorkbenchConfig(configCache);
       Map<String, String> envVariables = System.getenv();
       String dbDriverClassName = envVariables.get(DB_DRIVER_CLASS_NAME_KEY);
       String dbUser = envVariables.get(DB_USER_KEY);
@@ -66,7 +71,11 @@ public class CdrDbConfig {
       // TODO: find a way to make sure CDR versions aren't shown in the UI until they are in use by
       // all servers.
       Map<Object, Object> cdrVersionDataSourceMap = new HashMap<>();
+      Long cdrVersionId = null;
       for (CdrVersion cdrVersion : cdrVersionDao.findAll()) {
+        if (cdrVersion.getName().equals(workbenchConfig.cdr.defaultCdrVersion)) {
+          cdrVersionId = cdrVersion.getCdrVersionId();
+        }
         // The database name used for a given CDR version is depends on whether this is the
         // workbench database user or data browser user.
         String dbName = isWorkbenchDbUser ? cdrVersion.getCdrDbName() : cdrVersion.getPublicDbName();
@@ -81,12 +90,16 @@ public class CdrDbConfig {
             .build();
         cdrVersionDataSourceMap.put(cdrVersion.getCdrVersionId(), dataSource);
       }
+      this.defaultCdrVersionId = cdrVersionId;
+      if (this.defaultCdrVersionId == null) {
+        throw new ServerErrorException("Default CDR version not found!");
+      }
       setTargetDataSources(cdrVersionDataSourceMap);
       afterPropertiesSet();
     }
 
-    @PostConstruct
-    public void init() {
+    @EventListener
+    public void handleContextRefresh(ContextRefreshedEvent event) {
       finishedInitialization = true;
     }
 
@@ -102,7 +115,7 @@ public class CdrDbConfig {
         // Return the the default CDR version for configuring metadata.
         // After Spring beans are finished being initialized, init() will
         // be called and we will start requiring clients to specify a CDR version.
-        cdrVersion = defaultCdrVersionProvider.get();
+        return defaultCdrVersionId;
       }
       return cdrVersion.getCdrVersionId();
     }
@@ -121,9 +134,8 @@ public class CdrDbConfig {
   }
 
   @Bean("cdrDataSource")
-  public DataSource getCdrDataSource(CdrVersionDao cdrVersionDao,
-                                     @Qualifier("defaultCdr") Provider<CdrVersion> defaultCdrVersionProvider) {
-    return new CdrDataSource(cdrVersionDao, defaultCdrVersionProvider);
+  public DataSource getCdrDataSource(CdrDataSource cdrDataSource) {
+    return cdrDataSource;
   }
 
   @Bean(name = "cdrEntityManagerFactory")

--- a/api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
@@ -49,9 +49,14 @@ public class CacheSpringConfiguration {
         });
   }
 
+  public static WorkbenchConfig lookupWorkbenchConfig(
+          LoadingCache<String, Object> configCache) throws ExecutionException {
+    return (WorkbenchConfig) configCache.get(Config.MAIN_CONFIG_ID);
+  }
+
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   WorkbenchConfig getWorkbenchConfig(@Qualifier("configCache") LoadingCache<String, Object> configCache) throws ExecutionException {
-    return (WorkbenchConfig) configCache.get(Config.MAIN_CONFIG_ID);
+    return lookupWorkbenchConfig(configCache);
   }
 }


### PR DESCRIPTION
This should allow Spring to figure out metadata about the database while it's starting, and still require clients to specify CDR version afterwards.