### PR TITLE
[RW-146] Implement BigQuery audit logs endpoint + cron

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -18,6 +18,6 @@
   },
   "server": {
     "stackdriverApiKey": "",
-    "projectId": ""
+    "projectId": "all-of-us-workbench-test"
   }
 }

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -807,7 +807,7 @@ def deploy(cmd_name, args)
   gcc.validate
   env = read_db_vars_v2(gcc)
   ENV.update(env)
-  common.run_inline %W{gradle :appengineStage --info}
+  common.run_inline %W{gradle :appengineStage}
   promote = op.opts.promote.nil? ? (op.opts.version ? "--no-promote" : "--promote") \
     : (op.opts.promote ? "--promote" : "--no-promote")
   quiet = op.opts.quiet ? "--quiet" : ""

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -807,12 +807,14 @@ def deploy(cmd_name, args)
   gcc.validate
   env = read_db_vars_v2(gcc)
   ENV.update(env)
-  common.run_inline %W{gradle :appengineStage}
+  common.run_inline %W{gradle :appengineStage --info}
   promote = op.opts.promote.nil? ? (op.opts.version ? "--no-promote" : "--promote") \
     : (op.opts.promote ? "--promote" : "--no-promote")
   quiet = op.opts.quiet ? "--quiet" : ""
   common.run_inline %W{
-    gcloud app deploy build/staged-app/app.yaml
+    gcloud app deploy
+      build/staged-app/app.yaml
+      build/staged-app/WEB-INF/appengine-generated/cron.yaml
       --project #{gcc.project} #{promote} #{quiet}
   } + (op.opts.version ? %W{--version #{op.opts.version}} : [])
 end

--- a/api/src/main/java/org/pmiops/workbench/api/AuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuditController.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.model.AuditBigQueryResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -98,11 +97,7 @@ public class AuditController implements AuditApiDelegate {
   }
 
   @Override
-  public ResponseEntity<AuditBigQueryResponse> auditBigQuery(Boolean isAppengineCron) {
-    if (!isAppengineCron) {
-      throw new ForbiddenException("this endpoint is only callable via app engine cron");
-    }
-
+  public ResponseEntity<AuditBigQueryResponse> auditBigQuery() {
     // We expect to only see queries run within Firecloud AoU projects, or for administrative
     // purposes within the CDR project itself.
     String cdrProjectId = workbenchConfigProvider.get().server.projectId;

--- a/api/src/main/java/org/pmiops/workbench/api/AuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuditController.java
@@ -86,10 +86,9 @@ public class AuditController implements AuditApiDelegate {
         "  SUM(1) total\n" +
         "FROM `%s`\n" +
         "WHERE protopayload_auditlog.methodName = 'jobservice.insert'\n" +
-        // Filter out queries where access was denied.
-        "  AND NOT EXISTS (\n" +
-        "    SELECT 1 FROM UNNEST(protopayload_auditlog.authorizationInfo)\n" +
-        "    WHERE granted IS NULL OR NOT granted)\n" +
+        // Filter out failed queries (0/unset means OK).
+        "  AND (protopayload_auditlog.status.code IS NULL\n" +
+        "       OR protopayload_auditlog.status.code = 0)\n" +
         "  AND _TABLE_SUFFIX IN (%s)\n" +
         "GROUP BY 1, 2",
         tableWildcard,

--- a/api/src/main/java/org/pmiops/workbench/api/AuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuditController.java
@@ -1,0 +1,138 @@
+package org.pmiops.workbench.api;
+
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryResult;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.inject.Provider;
+import org.pmiops.workbench.annotations.AuthorityRequired;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.model.AuditBigQueryResponse;
+import org.pmiops.workbench.model.Authority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * The audit controller is meant for performing offline audit checks. Currently, audit violations
+ * result in SEVERE log statements being written, which may then be alerted on in cloud console.
+ * The audit policy implemented by this API reflects the design outlined here:
+ *   https://docs.google.com/document/d/14HT1GWXHPMaCc9rhCM0y5CglAIY-GgRBwebdZpqwEDs
+ */
+@RestController
+public class AuditController implements AuditApiDelegate {
+
+  private static final Logger log = Logger.getLogger(AuditController.class.getName());
+  private static final String AUDIT_SINK_NAME = "cdr_audit_logs";
+  // How many days into the past (including today) logs should be checked. This could become a
+  // request parameter if the need arises.
+  private static final int AUDIT_DAY_RANGE = 7;
+  // BigQuery log sink table names are have a suffix like "20170103", per
+  // https://cloud.google.com/logging/docs/export/using_exported_logs#table_organization
+  private static final DateTimeFormatter auditTableNameDateFormatter =
+      new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4)
+        .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+        .appendValue(ChronoField.DAY_OF_MONTH, 2)
+        .toFormatter();
+
+  private final Clock clock;
+  private final BigQueryService bigQueryService;
+  private final UserDao userDao;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  @Autowired
+  AuditController(
+      Clock clock,
+      BigQueryService bigQueryService,
+      UserDao userDao,
+      Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.clock = clock;
+    this.bigQueryService = bigQueryService;
+    this.userDao = userDao;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  @VisibleForTesting
+  static String auditTableSuffix(Instant now, int daysAgo) {
+    Instant target = now.minus(daysAgo, ChronoUnit.DAYS);
+    return auditTableNameDateFormatter.withZone(ZoneId.of("UTC")).format(target);
+  }
+
+  private static String auditSql(String cdrProjectId, List<String> tableSuffixes) {
+    // "jobInsertResponse" appears to always be included, despite whether or not job request
+    // metadata was included (i.e. for jobs running in other projects).
+    String tableWildcard = String.format(
+        "%s.%s.cloudaudit_googleapis_com_data_access_*", cdrProjectId, AUDIT_SINK_NAME);
+    return String.format(
+        "SELECT\n" +
+        "  protopayload_auditlog.servicedata_v1_bigquery.jobInsertResponse.resource.jobName.projectId client_project_id,\n" +
+        "  protopayload_auditlog.authenticationInfo.principalEmail user_email,\n" +
+        "  SUM(1) total\n" +
+        "FROM `%s`\n" +
+        "WHERE protopayload_auditlog.methodName = 'jobservice.insert'\n" +
+        "  AND _TABLE_SUFFIX IN (%s)\n" +
+        "GROUP BY 1, 2",
+        tableWildcard,
+        tableSuffixes.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")));
+  }
+
+  @AuthorityRequired({Authority.AUDIT})
+  @Override
+  public ResponseEntity<AuditBigQueryResponse> auditBigQuery() {
+    // We expect to only see queries run within Firecloud AoU projects, or for administrative
+    // purposes within the CDR project itself.
+    String cdrProjectId = workbenchConfigProvider.get().server.projectId;
+    Set<String> whitelist = Sets.union(userDao.getAllUserProjects(), ImmutableSet.of(cdrProjectId));
+
+    Instant now = clock.instant();
+    List<String> suffixes = IntStream.range(0, AUDIT_DAY_RANGE)
+        .mapToObj(i -> auditTableSuffix(now, i))
+        .collect(Collectors.toList());
+
+    QueryResult result = bigQueryService.executeQuery(
+        QueryJobConfiguration.of(auditSql(cdrProjectId, suffixes)));
+    Map<String, Integer> rm = bigQueryService.getResultMapper(result);
+
+    int numBad = 0;
+    int numQueries = 0;
+    for (List<FieldValue> row : result.iterateAll()) {
+      String project_id = bigQueryService.getString(row, rm.get("client_project_id"));
+      String email = bigQueryService.getString(row, rm.get("user_email"));
+      long total = bigQueryService.getLong(row, rm.get("total"));
+      if (bigQueryService.isNull(row, rm.get("client_project_id"))) {
+        log.severe(String.format(
+            "AUDIT: %d queries with missing project ID from user '%s'; indicates an ACL " +
+                "misconfiguration, this user can access the CDR but is not a project jobUser",
+            total, email));
+        numBad += total;
+      } else if (!whitelist.contains(project_id)) {
+        log.severe(String.format(
+            "AUDIT: %d queries in unrecognized project '%s' from user '%s'",
+            total, project_id, email));
+        numBad += total;
+      }
+      numQueries += total;
+    }
+    log.info(String.format(
+        "AUDIT: found audit issues with %d/%d BigQuery queries", numBad, numQueries));
+    return ResponseEntity.ok(new AuditBigQueryResponse().numQueryIssues(numBad));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/AuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuditController.java
@@ -87,6 +87,10 @@ public class AuditController implements AuditApiDelegate {
         "  SUM(1) total\n" +
         "FROM `%s`\n" +
         "WHERE protopayload_auditlog.methodName = 'jobservice.insert'\n" +
+        // Filter out queries where access was denied.
+        "  AND NOT EXISTS (\n" +
+        "    SELECT 1 FROM UNNEST(protopayload_auditlog.authorizationInfo)\n" +
+        "    WHERE granted IS NULL OR NOT granted)\n" +
         "  AND _TABLE_SUFFIX IN (%s)\n" +
         "GROUP BY 1, 2",
         tableWildcard,

--- a/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
@@ -7,18 +7,15 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryResponse;
 import com.google.cloud.bigquery.QueryResult;
-import org.pmiops.workbench.cdr.CdrVersionContext;
-import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.model.CdrVersion;
-import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import javax.inject.Provider;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.pmiops.workbench.cdr.CdrVersionContext;
+import org.pmiops.workbench.db.model.CdrVersion;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class BigQueryService {
@@ -70,6 +67,10 @@ public class BigQueryService {
             throw new BigQueryException(500, "FieldValue is null at position: " + index);
         }
         return row.get(index).getLongValue();
+    }
+
+    public boolean isNull(List<FieldValue> row, int index) {
+      return row.get(index).isNull();
     }
 
     public String getString(List<FieldValue> row, int index) {

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -1,6 +1,12 @@
 package org.pmiops.workbench.cdr;
 
 import com.google.common.cache.LoadingCache;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import org.apache.log4j.Logger;
 import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -22,12 +28,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
  * on the context of the current request. Applies to the model and DAO objects within this package.
  */
 public class CdrDbConfig {
+  private static Logger log = Logger.getLogger(CdrDbConfig.class);
 
   private static final String DB_DRIVER_CLASS_NAME_KEY = "spring.datasource.driver-class-name";
   private static final String DB_URL_KEY = "spring.datasource.url";
@@ -49,7 +50,6 @@ public class CdrDbConfig {
 
   @Service
   public static class CdrDataSource extends AbstractRoutingDataSource {
-
     private boolean finishedInitialization = false;
 
     private final Long defaultCdrVersionId;
@@ -81,6 +81,8 @@ public class CdrDbConfig {
         String dbName = isWorkbenchDbUser ? cdrVersion.getCdrDbName() : cdrVersion.getPublicDbName();
         int slashIndex = originalDbUrl.lastIndexOf('/');
         String dbUrl = originalDbUrl.substring(0, slashIndex + 1) + dbName;
+
+        log.info("initializing db connection to " + dbUrl);
         DataSource dataSource = DataSourceBuilder
             .create()
             .driverClassName(dbDriverClassName)

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -1,12 +1,6 @@
 package org.pmiops.workbench.cdr;
 
 import com.google.common.cache.LoadingCache;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
-import org.apache.log4j.Logger;
 import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -28,6 +22,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(
@@ -40,7 +40,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * on the context of the current request. Applies to the model and DAO objects within this package.
  */
 public class CdrDbConfig {
-  private static Logger log = Logger.getLogger(CdrDbConfig.class);
 
   private static final String DB_DRIVER_CLASS_NAME_KEY = "spring.datasource.driver-class-name";
   private static final String DB_URL_KEY = "spring.datasource.url";
@@ -50,6 +49,7 @@ public class CdrDbConfig {
 
   @Service
   public static class CdrDataSource extends AbstractRoutingDataSource {
+
     private boolean finishedInitialization = false;
 
     private final Long defaultCdrVersionId;
@@ -81,8 +81,6 @@ public class CdrDbConfig {
         String dbName = isWorkbenchDbUser ? cdrVersion.getCdrDbName() : cdrVersion.getPublicDbName();
         int slashIndex = originalDbUrl.lastIndexOf('/');
         String dbUrl = originalDbUrl.substring(0, slashIndex + 1) + dbName;
-
-        log.info("initializing db connection to " + dbUrl);
         DataSource dataSource = DataSourceBuilder
             .create()
             .driverClassName(dbDriverClassName)

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -11,6 +11,7 @@ import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.interceptors.AuthInterceptor;
 import org.pmiops.workbench.interceptors.CorsInterceptor;
 import org.pmiops.workbench.interceptors.ClearCdrVersionContextInterceptor;
+import org.pmiops.workbench.interceptors.CronInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,6 +39,9 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
   @Autowired
   private ClearCdrVersionContextInterceptor clearCdrVersionInterceptor;
+
+  @Autowired
+  private CronInterceptor cronInterceptor;
 
 
   @Bean
@@ -94,6 +98,7 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(corsInterceptor);
     registry.addInterceptor(authInterceptor);
+    registry.addInterceptor(cronInterceptor);
     registry.addInterceptor(clearCdrVersionInterceptor);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -1,6 +1,8 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.List;
+import java.util.Set;
+
 import org.pmiops.workbench.db.model.User;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -22,4 +24,8 @@ public interface UserDao extends CrudRepository<User, Long> {
    */
   @Query("SELECT user FROM User user LEFT JOIN FETCH user.authorities WHERE user.userId = :id")
   User findUserWithAuthorities(@Param("id") long id);
+
+  @Query("SELECT DISTINCT user.freeTierBillingProjectName FROM User user\n" +
+      "WHERE user.freeTierBillingProjectName IS NOT NULL")
+  Set<String> getAllUserProjects();
 }

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.interceptors;
 
+import com.google.api.client.http.HttpMethods;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -16,6 +17,10 @@ public class CronInterceptor extends HandlerInterceptorAdapter {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    if (request.getMethod().equals(HttpMethods.OPTIONS)) {
+      return true;
+    }
+
     HandlerMethod method = (HandlerMethod) handler;
     ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);
     if (apiOp == null) {

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
@@ -1,0 +1,41 @@
+package org.pmiops.workbench.interceptors;
+
+import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+@Service
+public class CronInterceptor extends HandlerInterceptorAdapter {
+  public static final String GAE_CRON_HEADER = "X-Appengine-Cron";
+  private static final String CRON_TAG = "cron";
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    HandlerMethod method = (HandlerMethod) handler;
+    ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);
+    if (apiOp == null) {
+      return true;
+    }
+
+    boolean requireCronHeader = false;
+    for (String tag : apiOp.tags()) {
+      if (CRON_TAG.equals(tag)) {
+        requireCronHeader = true;
+        break;
+      }
+    }
+    boolean hasCronHeader = "true".equals(request.getHeader(GAE_CRON_HEADER));
+    if (requireCronHeader && !hasCronHeader) {
+      response.sendError(HttpServletResponse.SC_FORBIDDEN,
+          String.format("cronjob endpoints are only invocable via app engine cronjob, and " +
+              "require the '%s' header", GAE_CRON_HEADER));
+      return false;
+    }
+    return true;
+  }
+}

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -694,20 +694,20 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
+  # Note: all requests tagged as "cron" must have the header X-Appengine-Cron:
+  # true, which app engine itself only sets when invoking as a cronjob.
+  # See https://cloud.google.com/appengine/docs/standard/java/config/cron#securing_urls_for_cron
+
   /v1/cron/auditBigQuery:
     get:
       security: []
       tags:
         - audit
+        - cron
       description: >
         Endpoint meant to be called offline to trigger BigQuery auditing; may be
         slow to execute. Only executable via App Engine cronjob.
       operationId: auditBigQuery
-      parameters:
-        - in: header
-          name: X-Appengine-Cron
-          type: boolean
-          required: true
       responses:
         200:
           description: Audit was successful.

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -620,21 +620,6 @@ paths:
 
             $ref: '#/definitions/EmptyResponse'
 
-  /v1/admin/auditBigQuery:
-    get:
-      security: []
-      tags:
-        - audit
-      description: >
-        Endpoint meant to be called offline to trigger BigQuery auditing; may be
-        slow to execute.
-      operationId: auditBigQuery
-      responses:
-        200:
-          description: Audit was successful.
-          schema:
-            $ref: "#/definitions/AuditBigQueryResponse"
-
   /v1/admin/workspaces/review:
     get:
       tags:
@@ -708,6 +693,26 @@ paths:
           description: success
           schema:
             $ref: "#/definitions/EmptyResponse"
+
+  /v1/cron/auditBigQuery:
+    get:
+      security: []
+      tags:
+        - audit
+      description: >
+        Endpoint meant to be called offline to trigger BigQuery auditing; may be
+        slow to execute. Only executable via App Engine cronjob.
+      operationId: auditBigQuery
+      parameters:
+        - in: header
+          name: X-Appengine-Cron
+          type: boolean
+          required: true
+      responses:
+        200:
+          description: Audit was successful.
+          schema:
+            $ref: "#/definitions/AuditBigQueryResponse"
 
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
     parameters:
@@ -1323,7 +1328,6 @@ definitions:
         # Note: Swagger trims any common prefix from enum values' corresponding
         # Java fields by default; this has no side-effect currently as there is
         # no common prefix. https://github.com/swagger-api/swagger-codegen/issues/4261
-        AUDIT,
         REVIEW_RESEARCH_PURPOSE,
         MANAGE_GROUP,
         REVIEW_ID_VERIFICATION

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -620,6 +620,21 @@ paths:
 
             $ref: '#/definitions/EmptyResponse'
 
+  /v1/admin/auditBigQuery:
+    get:
+      security: []
+      tags:
+        - audit
+      description: >
+        Endpoint meant to be called offline to trigger BigQuery auditing; may be
+        slow to execute.
+      operationId: auditBigQuery
+      responses:
+        200:
+          description: Audit was successful.
+          schema:
+            $ref: "#/definitions/AuditBigQueryResponse"
+
   /v1/admin/workspaces/review:
     get:
       tags:
@@ -1305,14 +1320,12 @@ definitions:
     type: string
     description: actions a user can have authority/permission to perform
     enum: [
+        # Note: Swagger trims any common prefix from enum values' corresponding
+        # Java fields by default; this has no side-effect currently as there is
+        # no common prefix. https://github.com/swagger-api/swagger-codegen/issues/4261
+        AUDIT,
         REVIEW_RESEARCH_PURPOSE,
         MANAGE_GROUP,
-        # Swagger trims any common prefix from enum values' corresponding Java
-        # fields by default; include a bogus sentinel value to prevent that.
-        # https://github.com/swagger-api/swagger-codegen/issues/4261
-        # TODO: Remove this sentinel when adding a new enum value with a
-        # unique prefix (but leave the above cautionary comment).
-        _PREVENT_COMMON_PREFIX_TRIMMING,
         REVIEW_ID_VERIFICATION
     ]
 
@@ -2477,3 +2490,13 @@ definitions:
     properties:
       email:
         type: string
+
+  AuditBigQueryResponse:
+    type: object
+    properties:
+      numQueryIssues:
+        type: integer
+        format: int32
+        description: >
+          Number of queries issues against the Curated data repository which are
+          flagged as possible audit issues. See logs/alerts for details.

--- a/api/src/main/webapp/WEB-INF/cron.xml
+++ b/api/src/main/webapp/WEB-INF/cron.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cronentries>
+  <cron>
+    <url>/v1/cron/auditBigQuery</url>
+    <target>api</target>
+    <description>daily BigQuery audit job</description>
+    <schedule>every 24 hours</schedule>
+  </cron>
+</cronentries>

--- a/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
@@ -122,18 +122,18 @@ public class AuditControllerTest {
   @Test
   public void testAuditBigQueryCdrQueries() {
     stubBigQueryCalls(CDR_PROJECT_ID, USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(0);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
   }
 
   @Test
   public void testAuditBigQueryFirecloudQueries() {
     stubBigQueryCalls(FC_PROJECT_ID, USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(0);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
   }
 
   @Test
   public void testAuditBigQueryUnrecognizedProjectQueries() {
     stubBigQueryCalls("my-personal-gcp-project", USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(5);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(5);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
@@ -122,18 +122,18 @@ public class AuditControllerTest {
   @Test
   public void testAuditBigQueryCdrQueries() {
     stubBigQueryCalls(CDR_PROJECT_ID, USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
+    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(0);
   }
 
   @Test
   public void testAuditBigQueryFirecloudQueries() {
     stubBigQueryCalls(FC_PROJECT_ID, USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
+    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(0);
   }
 
   @Test
   public void testAuditBigQueryUnrecognizedProjectQueries() {
     stubBigQueryCalls("my-personal-gcp-project", USER_EMAIL, 5);
-    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(5);
+    assertThat(auditController.auditBigQuery(true).getBody().getNumQueryIssues()).isEqualTo(5);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuditControllerTest.java
@@ -1,0 +1,139 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.QueryResult;
+import com.google.common.collect.ImmutableMap;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.test.FakeClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class AuditControllerTest {
+  private static final Instant NOW = Instant.now();
+  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
+  private static final String CDR_PROJECT_ID = "cdr-project";
+  private static final String FC_PROJECT_ID = "fc-project";
+  private static final String USER_EMAIL = "falco@lombardi.com";
+
+  @TestConfiguration
+  @Import({AuditController.class})
+  @MockBean({BigQueryService.class})
+  static class Configuration {
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+
+    @Bean
+    WorkbenchConfig workbenchConfig() {
+      WorkbenchConfig config = new WorkbenchConfig();
+      config.server = new WorkbenchConfig.ServerConfig();
+      config.server.projectId = CDR_PROJECT_ID;
+      return config;
+    }
+  }
+
+  @Autowired
+  BigQueryService bigQueryService;
+  @Autowired
+  UserDao userDao;
+  @Autowired
+  AuditController auditController;
+
+  @Before
+  public void setUp() {
+    User user = new User();
+    user.setEmail(USER_EMAIL);
+    user.setUserId(123L);
+    user.setFreeTierBillingProjectName(FC_PROJECT_ID);
+    user.setDisabled(false);
+    user = userDao.save(user);
+
+    CLOCK.setInstant(NOW);
+  }
+
+  // TODO(RW-350): This stubbing is awful, improve this.
+  private void stubBigQueryCalls(String projectId, String email, long total) {
+    QueryResult queryResult = mock(QueryResult.class);
+    Iterable testIterable = new Iterable() {
+        @Override
+        public Iterator iterator() {
+          List<FieldValue> list = new ArrayList<>();
+          list.add(null);
+          return list.iterator();
+        }
+      };
+    Map<String, Integer> rm = ImmutableMap.<String, Integer>builder()
+        .put("client_project_id", 0)
+        .put("user_email", 1)
+        .put("total", 2)
+        .build();
+
+    when(bigQueryService.executeQuery(any())).thenReturn(queryResult);
+    when(bigQueryService.getResultMapper(queryResult)).thenReturn(rm);
+    when(queryResult.iterateAll()).thenReturn(testIterable);
+    when(bigQueryService.getString(null, 0)).thenReturn(projectId);
+    when(bigQueryService.getString(null, 1)).thenReturn(email);
+    when(bigQueryService.getLong(null, 2)).thenReturn(total);
+  }
+
+  @Test
+  public void testAuditTableSuffix() {
+    assertThat(AuditController.auditTableSuffix(Instant.parse("2007-01-03T00:00:00.00Z"), 0))
+        .isEqualTo("20070103");
+    assertThat(AuditController.auditTableSuffix(Instant.parse("2018-01-01T23:59:59.00Z"), 3))
+        .isEqualTo("20171229");
+  }
+
+  @Test
+  public void testAuditBigQueryCdrQueries() {
+    stubBigQueryCalls(CDR_PROJECT_ID, USER_EMAIL, 5);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
+  }
+
+  @Test
+  public void testAuditBigQueryFirecloudQueries() {
+    stubBigQueryCalls(FC_PROJECT_ID, USER_EMAIL, 5);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(0);
+  }
+
+  @Test
+  public void testAuditBigQueryUnrecognizedProjectQueries() {
+    stubBigQueryCalls("my-personal-gcp-project", USER_EMAIL, 5);
+    assertThat(auditController.auditBigQuery().getBody().getNumQueryIssues()).isEqualTo(5);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
@@ -1,0 +1,64 @@
+package org.pmiops.workbench.interceptors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.pmiops.workbench.api.AuditApi;
+import org.pmiops.workbench.api.WorkspacesApi;
+import org.springframework.web.method.HandlerMethod;
+
+
+public class CronInterceptorTest {
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private HandlerMethod handler;
+  @Mock
+  private HttpServletRequest request;
+  @Mock
+  private HttpServletResponse response;
+
+  private CronInterceptor interceptor;
+
+  @Before
+  public void setup() {
+    interceptor = new CronInterceptor();
+  }
+
+  @Test
+  public void prehandleForCronNoHeader() throws Exception {
+    when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
+    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+  }
+
+  @Test
+  public void prehandleForCronWithBadHeader() throws Exception {
+    when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
+    when(request.getHeader(CronInterceptor.GAE_CRON_HEADER)).thenReturn("asdf");
+    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+  }
+
+  @Test
+  public void prehandleForCronWithHeader() throws Exception {
+    when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
+    when(request.getHeader(CronInterceptor.GAE_CRON_HEADER)).thenReturn("true");
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+
+  @Test
+  public void prehandleForNonCron() throws Exception {
+    when(handler.getMethod()).thenReturn(WorkspacesApi.class.getMethod("getWorkspaces"));
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+}
+
+

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.interceptors;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.google.api.client.http.HttpMethods;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
@@ -35,13 +36,21 @@ public class CronInterceptorTest {
   }
 
   @Test
+  public void preHandleOptions_OPTIONS() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+
+  @Test
   public void prehandleForCronNoHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
     when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
   }
 
   @Test
   public void prehandleForCronWithBadHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
     when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
     when(request.getHeader(CronInterceptor.GAE_CRON_HEADER)).thenReturn("asdf");
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
@@ -49,6 +58,7 @@ public class CronInterceptorTest {
 
   @Test
   public void prehandleForCronWithHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
     when(handler.getMethod()).thenReturn(AuditApi.class.getMethod("auditBigQuery"));
     when(request.getHeader(CronInterceptor.GAE_CRON_HEADER)).thenReturn("true");
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
@@ -56,6 +66,7 @@ public class CronInterceptorTest {
 
   @Test
   public void prehandleForNonCron() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
     when(handler.getMethod()).thenReturn(WorkspacesApi.class.getMethod("getWorkspaces"));
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CronInterceptorTest.java
@@ -60,5 +60,3 @@ public class CronInterceptorTest {
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 }
-
-


### PR DESCRIPTION
Implements the policy described https://docs.google.com/document/d/14HT1GWXHPMaCc9rhCM0y5CglAIY-GgRBwebdZpqwEDs

Endpoint is to be called as an app engine cronjob (which just takes a GET URL). Adds a daily cron config and updates deployment to support it.

Assumptions:
- This endpoint is light-weight enough to allow it to run on the API servers
- We're fine for now just using log metric based alerting, when we want to enable those
- It's fine to load all FC project IDs into memory