### PR TITLE
cleanup unwanted underscore prefixes

### DIFF
--- a/ui/src/app/charts/chart-container/component.ts
+++ b/ui/src/app/charts/chart-container/component.ts
@@ -50,13 +50,13 @@ export default class ChartContainerComponent {
    * Provides a handle on the SVGGElement selection that renders the chart inside the margins
    */
   @ViewChild('chart') gElement: ElementRef;
-  private _selection;
+  private selection;
 
   get chart() {
-    if (!this._selection) {
-      this._selection = d3.select(this.gElement.nativeElement);
+    if (!this.selection) {
+      this.selection = d3.select(this.gElement.nativeElement);
     }
-    return this._selection;
+    return this.selection;
   }
 
   /*
@@ -68,16 +68,17 @@ export default class ChartContainerComponent {
   /*
    * Option processing
    */
+  private readonly defaultOptions: Options = DEFAULT_OPTIONS;
+
   private _options: Options;
-  private readonly _defaultOptions: Options = DEFAULT_OPTIONS;
 
   get options(): Options {
-    return this._options || this._defaultOptions;
+    return this._options || this.defaultOptions;
   }
 
   @Input() set options(opts) {
     this._options = {
-      ...this._defaultOptions,
+      ...this.defaultOptions,
       ...opts,
     };
   }

--- a/ui/src/app/cohort-review/cohort-review/cohort-review.component.ts
+++ b/ui/src/app/cohort-review/cohort-review/cohort-review.component.ts
@@ -24,16 +24,16 @@ export class CohortReviewComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this._broadcast();
-    this.subscription = this._newReviewSub();
-    this.subscription.add(this._sidebarSub());
+    this.broadcast();
+    this.subscription = this.newReviewSub();
+    this.subscription.add(this.sidebarSub());
   }
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
   }
 
-  private _broadcast() {
+  private broadcast() {
     const {annotationDefinitions, cohort, review} = this.route.snapshot.data;
     const {workspace} = this.route.parent.snapshot.data;
 
@@ -42,14 +42,14 @@ export class CohortReviewComponent implements OnInit, OnDestroy {
     this.state.review.next(review);
   }
 
-  private _newReviewSub = () => this.route.data
+  private newReviewSub = () => this.route.data
     .map(({review}) => review.reviewStatus)
     .map(status => status === ReviewStatus.NONE)
     .subscribe(val => val
       ? this.createReviewModal.modal.open()
       : this.createReviewModal.modal.close())
 
-  private _sidebarSub = () =>
+  private sidebarSub = () =>
     this.state.sidebarOpen$.subscribe(val => val
       ? this.sidebar.open()
       : this.sidebar.close())

--- a/ui/src/app/cohort-review/directives/fullPage.directive.ts
+++ b/ui/src/app/cohort-review/directives/fullPage.directive.ts
@@ -17,15 +17,15 @@ export class FullPageDirective implements OnInit {
     this.renderer.setStyle(el, 'padding', '1rem');
     this.renderer.setStyle(el, 'margin-bottom', '1rem');
     this.renderer.setStyle(el, 'position', 'relative');
-    this._updateWrapperDimensions();
+    this.updateWrapperDimensions();
   }
 
   @HostListener('window:resize')
   onResize() {
-    this._updateWrapperDimensions();
+    this.updateWrapperDimensions();
   }
 
-  _updateWrapperDimensions() {
+  updateWrapperDimensions() {
     const nativeEl = this.element.nativeElement;
     const {top} = nativeEl.getBoundingClientRect();
     const minHeight = pixel(window.innerHeight - top - ONE_REM);

--- a/ui/src/app/cohort-review/participant-detail/participant-detail.component.ts
+++ b/ui/src/app/cohort-review/participant-detail/participant-detail.component.ts
@@ -90,19 +90,19 @@ export class ParticipantDetailComponent implements OnInit, OnDestroy {
   }
 
   previous() {
-    this._navigate(true);
+    this.navigate(true);
   }
 
   next() {
-    this._navigate(false);
+    this.navigate(false);
   }
 
-  private _navigate(left: boolean) {
+  private navigate(left: boolean) {
     const id = left ? this.priorId : this.afterId;
     const hasNext = !(left ? this.isFirstParticipant : this.isLastParticipant);
 
     if (id !== undefined) {
-      this._navigateById(id);
+      this.navigateById(id);
     } else if (hasNext) {
       const statusGetter = (statuses: ParticipantCohortStatus[]) => left
         ? statuses[statuses.length - 1]
@@ -115,21 +115,21 @@ export class ParticipantDetailComponent implements OnInit, OnDestroy {
       this.state.review$
         .take(1)
         .map(({page, pageSize}) => ({page: adjustPage(page), size: pageSize}))
-        .mergeMap(({page, size}) => this._callAPI(page, size))
+        .mergeMap(({page, size}) => this.callAPI(page, size))
         .subscribe(review => {
           this.state.review.next(review);
           const stat = statusGetter(review.participantCohortStatuses);
-          this._navigateById(stat.participantId);
+          this.navigateById(stat.participantId);
         });
     }
   }
 
-  private _callAPI = (page: number, size: number): Observable<CohortReview> => {
+  private callAPI = (page: number, size: number): Observable<CohortReview> => {
     const {ns, wsid, cid} = this.route.parent.snapshot.params;
     return this.reviewAPI.getParticipantCohortStatuses(ns, wsid, cid, CDR_VERSION, page, size);
   }
 
-  private _navigateById = (id: number): void => {
+  private navigateById = (id: number): void => {
     this.router.navigate(['..', id], {relativeTo: this.route});
   }
 }

--- a/ui/src/app/cohort-review/participant-status/participant-status.component.ts
+++ b/ui/src/app/cohort-review/participant-status/participant-status.component.ts
@@ -61,8 +61,8 @@ export class ParticipantStatusComponent implements OnInit, OnDestroy {
 
     const statusChanger = this.statusControl.valueChanges
       .withLatestFrom(participantId)
-      .switchMap(this._callApi)
-      .subscribe(this._emit);
+      .switchMap(this.callApi)
+      .subscribe(this.emit);
 
     this.subscription.add(statusChanger);
   }
@@ -71,7 +71,7 @@ export class ParticipantStatusComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  private _callApi = ([status, participantId]): Observable<ParticipantCohortStatus> => {
+  private callApi = ([status, participantId]): Observable<ParticipantCohortStatus> => {
     this.changingStatus = true;
     const request = <ModifyCohortStatusRequest>{status};
     const {ns, wsid, cid} = this.route.snapshot.params;
@@ -81,7 +81,7 @@ export class ParticipantStatusComponent implements OnInit, OnDestroy {
     );
   }
 
-  private _emit = (newStatus: ParticipantCohortStatus) => {
+  private emit = (newStatus: ParticipantCohortStatus) => {
     this.changingStatus = false;
     const participant = Participant.makeRandomFromExisting(newStatus);
     this.state.participant.next(participant);

--- a/ui/src/app/cohort-review/set-annotation-detail/set-annotation-detail.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-detail/set-annotation-detail.component.ts
@@ -53,7 +53,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
         this.defn = defn;
 
         if (this.editing) {
-          this._setFromDefn();
+          this.setFromDefn();
           this.kind.disable();
         }
       });
@@ -63,7 +63,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  private _setFromDefn(): void {
+  private setFromDefn(): void {
     this.name.setValue(this.defn.columnName);
     this.kind.setValue(this.defn.annotationType);
     const vals = this.defn.enumValues || [];
@@ -87,7 +87,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
 
   clear(): void {
     this.editing
-      ? this._setFromDefn()
+      ? this.setFromDefn()
       : this.form.reset();
   }
 
@@ -97,13 +97,13 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
 
   save(): void {
     const call = this.editing
-      ? this._update()
-      : this._create();
+      ? this.update()
+      : this.create();
 
     this.posting = true;
 
-    call.switchMap(_ => this._fetchAll())
-      .do(defns => this._broadcast(defns))
+    call.switchMap(_ => this.fetchAll())
+      .do(defns => this.broadcast(defns))
       .do(_ => this.posting = false)
       .subscribe(_ => this.toOverview());
   }
@@ -113,10 +113,10 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
   }
 
   get canSave(): boolean {
-    return this.editing ? this._editsAreValid : this.form.valid;
+    return this.editing ? this.editsAreValid : this.form.valid;
   }
 
-  get _editsAreValid(): boolean {
+  get editsAreValid(): boolean {
     if (!this.form.valid) { return false; }
     let somethingChanged = false;
 
@@ -148,7 +148,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
     });
   }
 
-  private _create(): Observable<CohortAnnotationDefinition> {
+  private create(): Observable<CohortAnnotationDefinition> {
     const {ns, wsid, cid} = this.route.snapshot.params;
     const request = <CohortAnnotationDefinition>{
       cohortId: cid,
@@ -159,7 +159,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
       .createCohortAnnotationDefinition(ns, wsid, cid, request);
   }
 
-  private _update(): Observable<CohortAnnotationDefinition> {
+  private update(): Observable<CohortAnnotationDefinition> {
     const {ns, wsid, cid} = this.route.snapshot.params;
     const id = this.defn.cohortAnnotationDefinitionId;
     const request = <ModifyCohortAnnotationDefinitionRequest>{
@@ -169,7 +169,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
       .updateCohortAnnotationDefinition(ns, wsid, cid, id, request);
   }
 
-  private _fetchAll(): Observable<CohortAnnotationDefinition[]> {
+  private fetchAll(): Observable<CohortAnnotationDefinition[]> {
     const {ns, wsid, cid} = this.route.snapshot.params;
     const call = this.annotationAPI
       .getCohortAnnotationDefinitions(ns, wsid, cid)
@@ -177,7 +177,7 @@ export class SetAnnotationDetailComponent implements OnInit, OnDestroy {
     return <Observable<CohortAnnotationDefinition[]>>call;
   }
 
-  private _broadcast(defns: CohortAnnotationDefinition[]): void {
+  private broadcast(defns: CohortAnnotationDefinition[]): void {
     this.state.annotationDefinitions.next(defns);
   }
 }

--- a/ui/src/app/cohort-review/set-annotation-master/set-annotation-master.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-master/set-annotation-master.component.ts
@@ -45,7 +45,7 @@ export class SetAnnotationMasterComponent {
   delete(): void {
     const {ns, wsid, cid} = this.route.snapshot.params;
 
-    const _deleteCalls = this.selected.map(({cohortAnnotationDefinitionId: id}) =>
+    const deleteCalls = this.selected.map(({cohortAnnotationDefinitionId: id}) =>
       this.annotationAPI.deleteCohortAnnotationDefinition(ns, wsid, cid, id)
     );
 
@@ -58,7 +58,7 @@ export class SetAnnotationMasterComponent {
 
     this.posting = true;
     Observable
-      .forkJoin(..._deleteCalls)
+      .forkJoin(...deleteCalls)
       .switchMap(_ => allDefns$)
       .do(broadcast)
       .subscribe(_ => this.posting = false);

--- a/ui/src/app/cohort-search/charts/google-chart.directive.ts
+++ b/ui/src/app/cohort-search/charts/google-chart.directive.ts
@@ -12,21 +12,18 @@ declare var google: any;
   selector: '[appGoogleChart]'
 })
 export class GoogleChartDirective implements OnChanges {
-  public _element: any;
   @Input() public chartType: string;
   @Input() public options: object;
   @Input() public dataTable: object;
 
-  constructor(public element: ElementRef) {
-    this._element = this.element.nativeElement;
-  }
+  constructor(public element: ElementRef) {}
 
   ngOnChanges(changes: SimpleChanges) {
     const chart = {
       chartType: this.chartType,
       dataTable: this.dataTable,
       options: this.options,
-      containerId: this._element.id
+      containerId: this.element.nativeElement.id
     };
 
     for (const prop of Object.keys(changes)) {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
@@ -39,7 +39,7 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
   @select(isRequstingTotal) isRequesting$: Observable<boolean>;
   @select(activeCriteriaType) criteriaType$: Observable<string>;
 
-  @ViewChild('wrapper') _wrapper;
+  @ViewChild('wrapper') wrapper;
 
   private subscription;
 
@@ -66,7 +66,7 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
         this.actions.runAllRequests();
       }
     });
-    this._updateWrapperDimensions();
+    this.updateWrapperDimensions();
   }
 
   ngOnDestroy() {
@@ -75,11 +75,11 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
 
   @HostListener('window:resize')
   onResize() {
-    this._updateWrapperDimensions();
+    this.updateWrapperDimensions();
   }
 
-  _updateWrapperDimensions() {
-    const wrapper = this._wrapper.nativeElement;
+  updateWrapperDimensions() {
+    const wrapper = this.wrapper.nativeElement;
 
     const {top} = wrapper.getBoundingClientRect();
     wrapper.style.minHeight = pixel(window.innerHeight - top - ONE_REM);

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/age-form.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/age-form.component.ts
@@ -22,18 +22,18 @@ const OPERATORS = {
 
 const MAX_AGE = 120;
 const MIN_AGE = 0;
-const _operatorIsRange = (op: string): boolean => (op === 'between');
-const _operatorIsValid = (op: string): boolean => (Object.keys(OPERATORS).includes(op));
+const operatorIsRange = (op: string): boolean => (op === 'between');
+const operatorIsValid = (op: string): boolean => (Object.keys(OPERATORS).includes(op));
 
-const _asAttribute = (ageForm: FormGroup): Attribute => {
+const asAttribute = (ageForm: FormGroup): Attribute => {
   const operator = ageForm.get('operator').value;
-  const operands = _operatorIsRange(operator)
+  const operands = operatorIsRange(operator)
     ? [ageForm.get('rangeOpen').value, ageForm.get('rangeClose').value]
     : [ageForm.get('age').value];
   return <Attribute>{operator, operands};
 };
 
-const _validate = {
+const validate = {
   interval: (group: FormGroup): null|object => {
     const start = group.get('rangeOpen').value;
     const close = group.get('rangeClose').value;
@@ -43,7 +43,7 @@ const _validate = {
   },
   uniqueness: (existent: List<string>) =>
     (ageForm: FormGroup): null|object => {
-      const wrapped = fromJS(_asAttribute(ageForm));
+      const wrapped = fromJS(asAttribute(ageForm));
       const hash = wrapped.hashCode();
       const paramId = `param${hash}`;
       return existent.includes(paramId)
@@ -87,22 +87,22 @@ export class AgeFormComponent implements AttributeFormComponent, OnInit, OnDestr
       .subscribe(ids => this.selected = ids);
 
     const [isRange, isNotRange] = this.operator.valueChanges
-      .filter(_operatorIsValid)
-      .partition(_operatorIsRange);
+      .filter(operatorIsValid)
+      .partition(operatorIsRange);
 
     this.subscription.add(isRange.subscribe(op => {
       this.age.clearValidators();
       this.age.updateValueAndValidity();
 
-      this.rangeOpen.setValidators(_validate.age);
+      this.rangeOpen.setValidators(validate.age);
       this.rangeOpen.updateValueAndValidity();
 
-      this.rangeClose.setValidators(_validate.age);
+      this.rangeClose.setValidators(validate.age);
       this.rangeClose.updateValueAndValidity();
 
       this.ageForm.setValidators([
-        _validate.interval,
-        _validate.uniqueness(this.selected),
+        validate.interval,
+        validate.uniqueness(this.selected),
       ]);
       this.ageForm.updateValueAndValidity();
     }));
@@ -114,11 +114,11 @@ export class AgeFormComponent implements AttributeFormComponent, OnInit, OnDestr
       this.rangeClose.clearValidators();
       this.rangeClose.updateValueAndValidity();
 
-      this.age.setValidators(_validate.age);
+      this.age.setValidators(validate.age);
       this.age.updateValueAndValidity();
 
       this.ageForm.setValidators([
-        _validate.uniqueness(this.selected),
+        validate.uniqueness(this.selected),
       ]);
       this.ageForm.updateValueAndValidity();
     }));
@@ -133,18 +133,18 @@ export class AgeFormComponent implements AttributeFormComponent, OnInit, OnDestr
   get rangeOpen() { return this.ageForm.get('rangeOpen'); }
   get rangeClose() { return this.ageForm.get('rangeClose'); }
 
-  get operatorIsRange() { return _operatorIsRange(this.operator.value); }
-  get operatorIsValid() { return _operatorIsValid(this.operator.value); }
+  get operatorIsRange() { return operatorIsRange(this.operator.value); }
+  get operatorIsValid() { return operatorIsValid(this.operator.value); }
 
   get errorList() {
-    const _errors = this.ageForm.errors;
-    if (_errors) {
-      return Object.keys(_errors).map(key => _errors[key]);
+    const errors = this.ageForm.errors;
+    if (errors) {
+      return Object.keys(errors).map(key => errors[key]);
     }
   }
 
   submit(): void {
-    this.attribute.emit(_asAttribute(this.ageForm));
+    this.attribute.emit(asAttribute(this.ageForm));
   }
 
   cancel(): void {

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.spec.ts
@@ -18,9 +18,9 @@ describe('AttributesComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/attributes/attributes.component.ts
@@ -58,8 +58,8 @@ export class AttributesComponent implements AfterViewInit, OnDestroy {
       this.createForm();
     });
 
-    this.subscription.add(submit$.subscribe(_attr => {
-      const attr = fromJS(_attr);
+    this.subscription.add(submit$.subscribe(arg => {
+      const attr = fromJS(arg);
       const parameterId = `param${attr.hashCode()}`;
       const param = this.node
         .set('attribute', attr)

--- a/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
@@ -43,11 +43,11 @@ export class ExplorerComponent implements OnInit {
 
   ngOnInit() {
     const _type = <string>this.rootNode.get('type');
-    const _id = <number>this.rootNode.get('id');
+    const id = <number>this.rootNode.get('id');
 
     // TODO(jms) - loading now needs to listen for either the roots loading or
     // the quicksearch results loading as appropriate
-    this.loading$ = this.ngRedux.select(isCriteriaLoading(_type, _id));
+    this.loading$ = this.ngRedux.select(isCriteriaLoading(_type, id));
     this.errors$ = this.ngRedux.select(criteriaLoadErrors).map(errSet =>
       errSet
         .filter((_, key) => key.first() === this.criteriaType)

--- a/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/selection/selection.component.spec.ts
@@ -49,9 +49,9 @@ describe('SelectionComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.spec.ts
@@ -22,9 +22,9 @@ describe('TreeComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
@@ -30,15 +30,15 @@ export class TreeComponent implements OnInit {
 
   ngOnInit() {
     const _type = this.node.get('type').toLowerCase();
-    const _parentId = this.node.get('id');
+    const parentId = this.node.get('id');
 
     this.hasError$ = this.ngRedux
-      .select(criteriaError(_type, _parentId))
+      .select(criteriaError(_type, parentId))
       .map(err => !(err === null || err === undefined));
 
-    this.loading$ = this.ngRedux.select(isCriteriaLoading(_type, _parentId));
-    this.children$ = this.ngRedux.select(criteriaChildren(_type, _parentId));
+    this.loading$ = this.ngRedux.select(isCriteriaLoading(_type, parentId));
+    this.children$ = this.ngRedux.select(criteriaChildren(_type, parentId));
 
-    this.actions.fetchCriteria(_type, _parentId);
+    this.actions.fetchCriteria(_type, parentId);
   }
 }

--- a/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/wizard/wizard.component.spec.ts
@@ -36,9 +36,9 @@ describe('WizardComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/overview/overview.component.spec.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.spec.ts
@@ -21,9 +21,9 @@ describe('OverviewComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/redux/actions/service.spec.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.spec.ts
@@ -131,7 +131,7 @@ describe('CohortSearchActions', () => {
   /* If the group being updated is the only group, then whether it has a
     * count or not, we should request totals from the API
     */
-  const _requestTotalCountWithOneGroup = (mockStore) => {
+  const requestTotalCountWithOneGroup = (mockStore) => {
     const requestSpy = spyOn(actions, 'requestCharts');
     const setDataSpy = spyOn(actions, 'setChartData');
     mockReduxInst.getState = () => mockStore;
@@ -143,17 +143,17 @@ describe('CohortSearchActions', () => {
   it('requestTotalCount(id): ignore group is only group, count is null', () => {
     // dummyState already has null for group count and just a single group
     const mockStore = dummyState;
-    _requestTotalCountWithOneGroup(mockStore);
+    requestTotalCountWithOneGroup(mockStore);
   });
 
   it('requestTotalCount(id): ignore group is only group, count is zero', () => {
     const mockStore = dummyState.setIn(['entities', 'groups', 'include0', 'count'], 0);
-    _requestTotalCountWithOneGroup(mockStore);
+    requestTotalCountWithOneGroup(mockStore);
   });
 
   it('requestTotalCount(id): ignore group is only group, count is real', () => {
     const mockStore = dummyState.setIn(['entities', 'groups', 'include0', 'count'], 123);
-    _requestTotalCountWithOneGroup(mockStore);
+    requestTotalCountWithOneGroup(mockStore);
   });
 
   it('requestTotalCount(id): group given is not only group', () => {

--- a/ui/src/app/cohort-search/redux/actions/service.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.ts
@@ -75,28 +75,28 @@ export class CohortSearchActions {
   @dispatch() _resetStore = ActionFuncs.resetStore;
 
   /** Internal tooling */
-  _idsInUse = Set<string>();
+  idsInUse = Set<string>();
 
   generateId(prefix?: string): string {
     prefix = prefix || 'id';
-    let newId = `${prefix}_${this._genSuffix()}`;
-    while (this._idsInUse.has(newId)) {
-      newId = `${prefix}_${this._genSuffix()}`;
+    let newId = `${prefix}_${this.genSuffix()}`;
+    while (this.idsInUse.has(newId)) {
+      newId = `${prefix}_${this.genSuffix()}`;
     }
     this.addId(newId);
     return newId;
   }
 
-  _genSuffix(): string {
+  genSuffix(): string {
     return Math.random().toString(36).substr(2, 9);
   }
 
   removeId(id: string): void {
-    this._idsInUse = this._idsInUse.delete(id);
+    this.idsInUse = this.idsInUse.delete(id);
   }
 
   addId(newId: string): void {
-    this._idsInUse = this._idsInUse.add(newId);
+    this.idsInUse = this.idsInUse.add(newId);
   }
 
   get state() {
@@ -270,7 +270,7 @@ export class CohortSearchActions {
    * requests
    */
   runAllRequests() {
-    const _doRequests = (kind) => {
+    const doRequests = (kind) => {
       const groups = groupList(kind)(this.state);
       groups.forEach(group => {
         group.get('items', List()).forEach(itemId => {
@@ -279,8 +279,8 @@ export class CohortSearchActions {
         this.requestGroupCount(kind, group.get('id'));
       });
     };
-    _doRequests('includes');
-    _doRequests('excludes');
+    doRequests('includes');
+    doRequests('excludes');
 
     /* Since everything is being run again, the optimizations in
      * `this.requestTotalCount` are sure to be off.  Basically ALL the groups
@@ -332,21 +332,21 @@ export class CohortSearchActions {
     };
   }
 
-  mapParameter = (_param): SearchParameter => {
+  mapParameter = (immParam): SearchParameter => {
     const param = <SearchParameter>{
-      parameterId: _param.get('parameterId'),
-      name: _param.get('name', ''),
-      value: _param.get('code'),
-      type: _param.get('type', ''),
-      subtype: _param.get('subtype', ''),
-      group: _param.get('group'),
+      parameterId: immParam.get('parameterId'),
+      name: immParam.get('name', ''),
+      value: immParam.get('code'),
+      type: immParam.get('type', ''),
+      subtype: immParam.get('subtype', ''),
+      group: immParam.get('group'),
     };
 
     if (param.type.match(/^DEMO.*/i)) {
-      param.conceptId = _param.get('conceptId');
-      param.attribute = _param.get('attribute');
+      param.conceptId = immParam.get('conceptId');
+      param.attribute = immParam.get('attribute');
     } else if (param.type.match(/^ICD|CPT|PHECODE.*/i)) {
-      param.domain = _param.get('domainId');
+      param.domain = immParam.get('domainId');
     }
 
     return param;
@@ -400,7 +400,7 @@ export class CohortSearchActions {
    * Loads a JSONified SearchRequest into the store
    */
   loadFromJSON(json: string): void {
-    this._idsInUse = Set<string>();
+    this.idsInUse = Set<string>();
     const entities = this.deserializeEntities(json);
     this.loadEntities(entities);
   }
@@ -409,7 +409,7 @@ export class CohortSearchActions {
    * Reset Store: reset the store to the initial state and wipe all cached ID's
    */
   resetStore(): void {
-    this._idsInUse = Set<string>();
+    this.idsInUse = Set<string>();
     this._resetStore();
   }
 }

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.ts
@@ -49,9 +49,9 @@ describe('SearchGroupItemComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.ts
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.ts
@@ -32,7 +32,7 @@ export class SearchGroupItemComponent implements OnInit, OnDestroy {
 
   private item: Map<any, any> = Map();
   private rawCodes: List<any> = List();
-  private _subscriptions: Subscription[];
+  private subscriptions: Subscription[];
 
   constructor(
     private ngRedux: NgRedux<CohortSearchState>,
@@ -41,14 +41,14 @@ export class SearchGroupItemComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const select = this.ngRedux.select;
-    this._subscriptions = [
+    this.subscriptions = [
       select(getItem(this.itemId)).subscribe(item => this.item = item),
       select(parameterList(this.itemId)).subscribe(rawCodes => this.rawCodes = rawCodes),
     ];
   }
 
   ngOnDestroy() {
-    this._subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 
   get codeType() {
@@ -69,14 +69,14 @@ export class SearchGroupItemComponent implements OnInit, OnDestroy {
 
   get codes() {
     const _type = this.codeType;
-    const _formatter = (param) => {
+    const formatter = (param) => {
       const funcs = _type === 'Demographics'
         ? [typeDisplay, nameDisplay, attributeDisplay]
         : [typeDisplay, attributeDisplay];
       return funcs.map(f => f(param)).join(' ').trim();
     };
     const sep = _type === 'Demographics' ? '; ' : ', ';
-    return this.rawCodes.map(_formatter).join(sep);
+    return this.rawCodes.map(formatter).join(sep);
   }
 
   remove() {

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.spec.ts
@@ -33,9 +33,9 @@ describe('SearchGroupListComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
@@ -61,9 +61,9 @@ describe('SearchGroupComponent', () => {
 
   beforeEach(async(() => {
     mockReduxInst = MockNgRedux.getInstance();
-    const _old = mockReduxInst.getState;
-    const _wrapped = () => fromJS(_old());
-    mockReduxInst.getState = _wrapped;
+    const old = mockReduxInst.getState;
+    const wrapped = () => fromJS(old());
+    mockReduxInst.getState = wrapped;
 
     TestBed
       .configureTestingModule({

--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -32,15 +32,15 @@
       <div style="height: 2rem; margin: 0.5rem 2rem;">
         <ng-template *ngIf="true; then logoImages"></ng-template>
       </div>
-      <div *ngIf="!_showCreateAccount;" style="margin-top: 1.5rem;">
+      <div *ngIf="!showCreateAccount;" style="margin-top: 1.5rem;">
         <div style="display: flex; justify-content: space-around;">
-          <button (click)="showCreateAccount()" class="btn btn-primary">Create Account</button>
+          <button (click)="showCreateAccount = true" class="btn btn-primary">Create Account</button>
         </div>
         <div style="display: flex; justify-content: space-around;">
           <button (click)="signIn()" class="btn btn-primary">Sign In</button>
         </div>
       </div>
-      <div *ngIf="_showCreateAccount;">
+      <div *ngIf="showCreateAccount;">
         <app-invitation-key></app-invitation-key>
       </div>
     </div>

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -33,7 +33,7 @@ export class AppComponent implements OnInit {
 
   private baseTitle: string;
   private overriddenUrl: string = null;
-  private _showCreateAccount = false;
+  private showCreateAccount = false;
 
   constructor(
     /* Ours */
@@ -117,12 +117,8 @@ export class AppComponent implements OnInit {
     this.signInService.signOut();
   }
 
-  showCreateAccount(): void {
-    this._showCreateAccount = true;
-  }
-
   getTopMargin(): string {
-    return this._showCreateAccount ? '10vh' : '30vh';
+    return this.showCreateAccount ? '10vh' : '30vh';
   }
 
   get reviewActive(): boolean {


### PR DESCRIPTION
Removes a leading underscore used to indicate privacy of a property unless the underscore is preventing the variable from shadowing a keyword or other variable (such as `_type`) or the underscore is part of a managed property, i.e.

```
class SomeClass {
  private _theProperty;
  get theProperty() {/* ... */}
  set theProperty(value) {/* ... */}
}
```