### PR TITLE
Biopete/create db creds test

### DIFF
--- a/api/db-cdr/create_db.sql
+++ b/api/db-cdr/create_db.sql
@@ -1,3 +1,7 @@
+/* Note -- this is general script and these vars get envsubst in scripts.
+ * CDR_DB_NAME , WORKBENCH_DB_USER AND PASSWORD,  may be substituted in scripts for PUBLIC versions,  .. etc
+ * if creating a a differnt db with this script
+ */
 CREATE DATABASE IF NOT EXISTS ${CDR_DB_NAME} CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 CREATE USER IF NOT EXISTS '${WORKBENCH_DB_USER}'@'%' IDENTIFIED BY '${WORKBENCH_DB_PASSWORD}';

--- a/api/db-cdr/generate-cdr/generate-local-cdr-db.sh
+++ b/api/db-cdr/generate-cdr/generate-local-cdr-db.sh
@@ -4,13 +4,13 @@
 # It is called twice from generate-local-count-dbs.sh to make the cdr and public mysql dbs the workbench uses
 
 # Example
-# ../project.rb generate-cloudsql-cdr --cdr-version 20180130 --cdr-db-prefix cdr --bucket all-of-us-workbench-cloudsql-create
+# ../project.rb generate-local-cdr --cdr-version 20180130 --cdr-db-prefix cdr --bucket all-of-us-workbench-cloudsql-create
 
 set -xeuo pipefail
 IFS=$'\n\t'
 
-USAGE="./generate-cdr/generate-cloudsql-cdr --cdr-version YYYYMMDD --cdr-db-prefix <cdr|public> --bucket <BUCKET>"
-USAGE="$USAGE \n Local mysql or remote cloudsql database named cdr<cdr-version> and public<cdr-version> are created and populated."
+USAGE="./generate-cdr/generate-local-cdr --cdr-version YYYYMMDD --cdr-db-prefix <cdr|public> --bucket <BUCKET>"
+USAGE="$USAGE \n Local mysql cdr database created and  populated."
 
 while [ $# -gt 0 ]; do
   echo "1 is $1"

--- a/api/db-cdr/generate-cdr/init-new-cdr-db.sh
+++ b/api/db-cdr/generate-cdr/init-new-cdr-db.sh
@@ -26,6 +26,15 @@ fi
 # export for liquibase to use this
 export CDR_DB_NAME
 
+# If CDR_DB_NAME matches ^public, we want to the public_db_user env var substituted in the create_db.sql
+if [[ CDR_DB_NAME =~ ^public ]]
+then
+    echo "Working the public db init cdr"
+    export WORKBENCH_DB_USER=$PUBLIC_DB_USER
+    export WORKBENCH_DB_PASSWORD=$PUBLIC_DB_PASSWORD
+fi
+
+
 CREATE_DB_FILE=/tmp/create_db.sql
 
 function finish {

--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -12,5 +12,5 @@ MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench
 WORKBENCH_DB_PASSWORD=wb-notasecret
 # TODO: change to public DB user once it exists
-PUBLIC_DB_USER=workbench
-PUBLIC_DB_PASSWORD=wb-notasecret
+PUBLIC_DB_USER=public
+PUBLIC_DB_PASSWORD=public-notasecret

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -592,7 +592,7 @@ Common.register_command({
 })
 
 
-def do_create_db_creds(project, account, creds_file)
+def do_create_db_creds(project, account, creds_file, cdr_db_name, public_db_name)
   puts "Enter the root DB user password:"
   root_password = STDIN.noecho(&:gets)
   puts "Enter the root DB user password again:"
@@ -629,7 +629,7 @@ def do_create_db_creds(project, account, creds_file)
       db_creds_file.close
 
       activate_service_account(creds_file)
-      copy_file_to_gcs(db_creds_file.path, "#{project}-credentials", "vars.env")
+      copy_file_to_gcs(db_creds_file.path, "#{project}-credentials", "peter_vars.env")
     ensure
       db_creds_file.unlink
     end
@@ -640,7 +640,7 @@ end
 
 def create_db_creds(*args)
   GcloudContext.new("create-db-creds", args, true).run do |ctx|
-    do_create_db_creds(ctx.opts.project, ctx.opts.account, ctx.opts.creds_file)
+    do_create_db_creds(ctx.opts.project, ctx.opts.account, ctx.opts.creds_file, ctx.opts.cdr_db_name, ctx.opts.public_db_name)
   end
 end
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -623,7 +623,9 @@ def do_create_db_creds(project, account, creds_file, cdr_db_name, public_db_name
       db_creds_file.puts "WORKBENCH_DB_USER=workbench"
       db_creds_file.puts "WORKBENCH_DB_PASSWORD=#{workbench_password}"
       # TODO: replace with public DB, user, password
-      db_creds_file.puts "PUBLIC_DB_CONNECTION_STRING=jdbc:google:mysql://#{instance_name}/cdr?rewriteBatchedStatements=true"
+      # Todo -- where is cdr db connection string ?
+      db_creds_file.puts "CDR_DB_CONNECTION_STRING=jdbc:google:mysql://#{instance_name}/#{cdr_db_name}?rewriteBatchedStatements=true"
+      db_creds_file.puts "PUBLIC_DB_CONNECTION_STRING=jdbc:google:mysql://#{instance_name}/#{public_db_name}?rewriteBatchedStatements=true"
       db_creds_file.puts "PUBLIC_DB_USER=workbench"
       db_creds_file.puts "PUBLIC_DB_PASSWORD=#{workbench_password}"
       db_creds_file.close


### PR DESCRIPTION
Have some public db things ...

Where is the CDR DB STRING , ? Currently only workbench is specified  in any vars.env 

How can I add db name args to the create-db-creds goal
