### PR TITLE
Synchronize clone() behavior with create()

### DIFF
--- a/api/db/changelog/db.changelog-26-billing-status.xml
+++ b/api/db/changelog/db.changelog-26-billing-status.xml
@@ -6,7 +6,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="calbach" id="changelog-26-billing-status">
     <addColumn tableName="user">
-      <!-- Enum: NONE, PENDING, READY, defaults to NONE -->
+      <!-- Enum: NONE, PENDING, READY, ERROR, defaults to NONE -->
       <column name="free_tier_billing_project_status" type="tinyint" value="0">
         <constraints nullable="false"/>
       </column>

--- a/api/db/changelog/db.changelog-26-billing-status.xml
+++ b/api/db/changelog/db.changelog-26-billing-status.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="calbach" id="changelog-26-billing-status">
+    <addColumn tableName="user">
+      <!-- Enum: NONE, PENDING, READY, defaults to NONE -->
+      <column name="free_tier_billing_project_status" type="tinyint" value="0">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -31,5 +31,7 @@
   <include file="changelog/db.changelog-21.xml"/>
   <include file="changelog/db.changelog-22-email-verification-status.xml"/>
   <include file="changelog/db.changelog-23.xml"/>
+  <include file="changelog/db.changelog-24-email-verification-status-default.xml"/>
   <include file="changelog/db.changelog-25.xml"/>
+  <include file="changelog/db.changelog-26-billing-status.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -210,6 +210,15 @@ public class ProfileController implements ProfileApiDelegate {
         user.setFreeTierBillingProjectName(billingProjectName);
       }
 
+      // If the user has not been granted the BQ job user Google role on the billing project yet,
+      // give it to them (so they can run BQ queries from notebooks.)
+      try {
+        fireCloudService.grantGoogleRoleToUser(user.getFreeTierBillingProjectName(),
+            FireCloudService.BIGQUERY_JOB_USER_GOOGLE_ROLE, user.getEmail());
+      } catch (org.pmiops.workbench.firecloud.ApiException e) {
+        throw ExceptionUtils.convertFirecloudException(e);
+      }
+
       user.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
       try {
         return userDao.save(user);

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -232,7 +232,7 @@ public class ProfileController implements ProfileApiDelegate {
       try {
         fireCloudService.grantGoogleRoleToUser(user.getFreeTierBillingProjectName(),
             FireCloudService.BIGQUERY_JOB_USER_GOOGLE_ROLE, user.getEmail());
-      } catch (org.pmiops.workbench.firecloud.ApiException e) {
+      } catch (ApiException e) {
         log.log(Level.INFO, String.format(
             "granting BigQuery role on free tier billing project failed, this is expected " +
             "shortly after creation of the project; will retry on next initialization attempt", e));

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -264,6 +264,10 @@ public class ProfileController implements ProfileApiDelegate {
 
       case READY:
         break;
+
+      default:
+        log.log(Level.SEVERE, String.format("unrecognized status '%s'", status));
+        return user;
     }
 
     // Grant the user BQ job access on the billing project so that they can run BQ queries from
@@ -272,9 +276,8 @@ public class ProfileController implements ProfileApiDelegate {
       fireCloudService.grantGoogleRoleToUser(user.getFreeTierBillingProjectName(),
           FireCloudService.BIGQUERY_JOB_USER_GOOGLE_ROLE, user.getEmail());
     } catch (ApiException e) {
-      log.log(Level.INFO,
-          "granting BigQuery role on free tier billing project failed, this is expected " +
-              "shortly after creation of the project; will retry on next initialization attempt", e);
+      log.log(Level.WARNING,
+          "granting BigQuery role on created free tier billing project failed", e);
       // Allow the user to continue, as most workbench functionality will still be usable.
       return user;
     }

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.auth;
 import java.util.ArrayList;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.mailchimp.MailChimpService;
@@ -45,6 +44,7 @@ public class ProfileService {
     profile.setContactEmail(user.getContactEmail());
     profile.setPhoneNumber(user.getPhoneNumber());
     profile.setFreeTierBillingProjectName(user.getFreeTierBillingProjectName());
+    profile.setFreeTierBillingProjectStatus(user.getFreeTierBillingProjectStatus());
     profile.setEnabledInFireCloud(enabledInFireCloud);
 
     if (user.getBlockscoreVerificationIsValid() == null) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -13,6 +13,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,6 +112,7 @@ public class UserService {
     user.setGivenName(givenName);
     user.setDisabled(false);
     user.setEmailVerificationStatus(EmailVerificationStatus.UNVERIFIED);
+    user.setFreeTierBillingProjectStatus(BillingProjectStatus.NONE);
     try {
       userDao.save(user);
     } catch (DataIntegrityViolationException e) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -1,9 +1,8 @@
 package org.pmiops.workbench.db.model;
 
-import org.pmiops.workbench.model.Authority;
-import org.pmiops.workbench.model.DataAccessLevel;
-import org.pmiops.workbench.model.EmailVerificationStatus;
-
+import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -16,9 +15,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Version;
-import java.sql.Timestamp;
-import java.util.HashSet;
-import java.util.Set;
+import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.BillingProjectStatus;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.EmailVerificationStatus;
 
 @Entity
 @Table(name = "user")
@@ -35,6 +35,7 @@ public class User {
   private String familyName;
   private String phoneNumber;
   private String freeTierBillingProjectName;
+  private BillingProjectStatus freeTierBillingProjectStatus;
   private Timestamp firstSignInTime;
   private Set<Authority> authorities = new HashSet<Authority>();
   private Set<WorkspaceUserRole> workspaceUserRoles = new HashSet<WorkspaceUserRole>();
@@ -46,7 +47,6 @@ public class User {
   private boolean disabled;
   private Timestamp disabledTime;
   private Long disablingAdminId;
-  private String mailchimpHash;
   private EmailVerificationStatus emailVerificationStatus;
 
   @Id
@@ -128,6 +128,15 @@ public class User {
 
   public void setFreeTierBillingProjectName(String freeTierBillingProjectName) {
     this.freeTierBillingProjectName = freeTierBillingProjectName;
+  }
+
+  @Column(name = "free_tier_billing_project_status")
+  public BillingProjectStatus getFreeTierBillingProjectStatus() {
+    return freeTierBillingProjectStatus;
+  }
+
+  public void setFreeTierBillingProjectStatus(BillingProjectStatus freeTierBillingProjectStatus) {
+    this.freeTierBillingProjectStatus = freeTierBillingProjectStatus;
   }
 
   @Column(name = "first_sign_in_time")

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -545,12 +545,9 @@ definitions:
       role:
         type: string
         description: the role of the current user in the project
-      status:
+      creationStatus:
         type: string
         enum: ["Creating", "Ready", "Error"]
-      message:
-        type: string
-        description: informational message about the project
 
   CreateRawlsBillingProjectFullRequest:
     description: ''

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1349,6 +1349,12 @@ definitions:
         type: string
         description: informational message about the project
 
+  BillingProjectStatus:
+    type: string
+    description: >
+      Initialization status of a Firecloud billing project for use with Workbench.
+    enum: &BILLING_PROJECT_STATUS [none, pending, ready]
+
   DataAccessLevel:
     type: string
     description: levels of access to data in the curated data repository
@@ -1754,6 +1760,12 @@ definitions:
       freeTierBillingProjectName:
         description: name of the AllOfUs free tier billing project created for this user
         type: string
+      freeTierBillingProjectStatus:
+        description: >
+          the initialization status of the free tier billing project, some
+          workbench functionality may not work fully with this project until it
+          is fully initialized
+        $ref: "#/definitions/BillingProjectStatus"
       dataAccessLevel:
         description: what level of data access the user has
         $ref: "#/definitions/DataAccessLevel"

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1343,17 +1343,13 @@ definitions:
         type: string
         description: the role of the current user in the project
       status:
-        type: string
-        enum: ["Creating", "Ready", "Error"]
-      message:
-        type: string
-        description: informational message about the project
+        $ref: "#/definitions/BillingProjectStatus"
 
   BillingProjectStatus:
     type: string
     description: >
       Initialization status of a Firecloud billing project for use with Workbench.
-    enum: &BILLING_PROJECT_STATUS [none, pending, ready]
+    enum: &BILLING_PROJECT_STATUS [none, pending, ready, error]
 
   DataAccessLevel:
     type: string

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -6,6 +6,7 @@ import static junit.framework.TestCase.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +73,8 @@ public class ProfileControllerTest {
   private static final String PASSWORD = "12345";
   private static final String PRIMARY_EMAIL = "bob@researchallofus.org";
   private static final String BILLING_PROJECT_PREFIX = "all-of-us-free-";
+  private static final String BILLING_PROJECT_NAME =
+      BILLING_PROJECT_PREFIX + PRIMARY_EMAIL.hashCode();
 
   @Mock
   private Provider<User> userProvider;
@@ -249,14 +252,92 @@ public class ProfileControllerTest {
     when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
 
     Profile profile = profileController.getMe().getBody();
-
-    String projectName = BILLING_PROJECT_PREFIX + PRIMARY_EMAIL.hashCode();
     assertProfile(profile, PRIMARY_EMAIL, CONTACT_EMAIL, FAMILY_NAME, GIVEN_NAME,
-        DataAccessLevel.UNREGISTERED, TIMESTAMP, projectName, true);
+        DataAccessLevel.UNREGISTERED, TIMESTAMP, BILLING_PROJECT_NAME, true);
     verify(fireCloudService).registerUser(CONTACT_EMAIL, GIVEN_NAME, FAMILY_NAME);
 
-    verify(fireCloudService).createAllOfUsBillingProject(projectName);
-    verify(fireCloudService).addUserToBillingProject(PRIMARY_EMAIL, projectName);
+    verify(fireCloudService).createAllOfUsBillingProject(BILLING_PROJECT_NAME);
+    verify(fireCloudService).addUserToBillingProject(PRIMARY_EMAIL, BILLING_PROJECT_NAME);
+  }
+
+  @Test
+  public void testMe_secondCallInitializesProject() throws Exception {
+    createUser();
+    when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    // Simulate FC "Ready".
+    org.pmiops.workbench.firecloud.model.BillingProjectMembership membership =
+        new org.pmiops.workbench.firecloud.model.BillingProjectMembership();
+    membership.setCreationStatus(CreationStatusEnum.READY);
+    membership.setProjectName(BILLING_PROJECT_NAME);
+    when(fireCloudService.getBillingProjectMemberships()).thenReturn(ImmutableList.of(membership));
+    profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.READY);
+
+    verify(fireCloudService).grantGoogleRoleToUser(
+        BILLING_PROJECT_NAME, FireCloudService.BIGQUERY_JOB_USER_GOOGLE_ROLE, PRIMARY_EMAIL);
+  }
+
+  @Test
+  public void testMe_secondCallErrorsProject() throws Exception {
+    createUser();
+    when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    // Simulate FC "Error".
+    org.pmiops.workbench.firecloud.model.BillingProjectMembership membership =
+        new org.pmiops.workbench.firecloud.model.BillingProjectMembership();
+    membership.setCreationStatus(CreationStatusEnum.ERROR);
+    membership.setProjectName(BILLING_PROJECT_NAME);
+    when(fireCloudService.getBillingProjectMemberships()).thenReturn(ImmutableList.of(membership));
+    profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.ERROR);
+
+    verify(fireCloudService, never()).grantGoogleRoleToUser(any(), any(), any());
+  }
+
+  @Test
+  public void testMe_secondCallStillPendingProject() throws Exception {
+    createUser();
+    when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    // Simulate FC "Creating".
+    org.pmiops.workbench.firecloud.model.BillingProjectMembership membership =
+        new org.pmiops.workbench.firecloud.model.BillingProjectMembership();
+    membership.setCreationStatus(CreationStatusEnum.CREATING);
+    membership.setProjectName(BILLING_PROJECT_NAME);
+    when(fireCloudService.getBillingProjectMemberships()).thenReturn(ImmutableList.of(membership));
+    profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    verify(fireCloudService, never()).grantGoogleRoleToUser(any(), any(), any());
+  }
+
+  @Test
+  public void testMe_secondCallProjectNotReturned() throws Exception {
+    createUser();
+    when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    org.pmiops.workbench.firecloud.model.BillingProjectMembership membership =
+        new org.pmiops.workbench.firecloud.model.BillingProjectMembership();
+    membership.setCreationStatus(CreationStatusEnum.READY);
+    membership.setProjectName("unrelated-project");
+    when(fireCloudService.getBillingProjectMemberships()).thenReturn(ImmutableList.of(membership));
+    profile = profileController.getMe().getBody();
+    assertThat(profile.getFreeTierBillingProjectStatus()).isEqualTo(BillingProjectStatus.PENDING);
+
+    verify(fireCloudService, never()).grantGoogleRoleToUser(any(), any(), any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -33,11 +33,12 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.BillingProjectMembership.StatusEnum;
+import org.pmiops.workbench.firecloud.model.BillingProjectMembership.CreationStatusEnum;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.mailchimp.MailChimpService;
 import org.pmiops.workbench.model.BillingProjectMembership;
+import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.BlockscoreIdVerificationStatus;
 import org.pmiops.workbench.model.CreateAccountRequest;
 import org.pmiops.workbench.model.DataAccessLevel;
@@ -369,9 +370,8 @@ public class ProfileControllerTest {
     org.pmiops.workbench.firecloud.model.BillingProjectMembership membership =
         new org.pmiops.workbench.firecloud.model.BillingProjectMembership();
     membership.setProjectName("a");
-    membership.setMessage("b");
     membership.setRole("c");
-    membership.setStatus(StatusEnum.CREATING);
+    membership.setCreationStatus(CreationStatusEnum.CREATING);
     when(fireCloudService.getBillingProjectMemberships()).thenReturn(
         ImmutableList.of(membership));
     List<BillingProjectMembership> memberships =
@@ -379,9 +379,8 @@ public class ProfileControllerTest {
     assertThat(memberships.size()).isEqualTo(1);
     BillingProjectMembership result = memberships.get(0);
     assertThat(result.getProjectName()).isEqualTo("a");
-    assertThat(result.getMessage()).isEqualTo("b");
     assertThat(result.getRole()).isEqualTo("c");
-    assertThat(result.getStatus()).isEqualTo(BillingProjectMembership.StatusEnum.CREATING);
+    assertThat(result.getStatus()).isEqualTo(BillingProjectStatus.PENDING);
   }
 
   private Profile createUser() throws Exception {

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -63,6 +63,7 @@ sourceSets {
                    'org/pmiops/workbench/config/WorkbenchConfig.java',
                    'org/pmiops/workbench/model/Authority.java',
                    'org/pmiops/workbench/model/BlockscoreVerificationStatus.java',
+                   'org/pmiops/workbench/model/BillingProjectStatus.java',
                    'org/pmiops/workbench/model/DataAccessLevel.java',
                    'org/pmiops/workbench/model/EmailVerificationStatus.java',
                    'org/pmiops/workbench/model/ErrorCode.java',


### PR DESCRIPTION
- Add explicit free tier billing project status tracking and plumb through to the client
- Fix our representation of the Firecloud billing projects API to match reality
- Move BigQuery role granting from `CreateWorkspace()` -> `initializeUser()`; this seemed a more appropriate place, and I don't think we should be seeing any projects in AoU that we haven't initialized ourselves.
- Write the config file when cloning, as is done during workspace creation