### PR TITLE
Populate all research purpose details by default in the clone UI

### DIFF
--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -34,7 +34,7 @@
               Disease focused research
             </clr-checkbox>
             <input type="text" class="input" name="disease-specification"
-                [(ngModel)]="workspace.researchPurpose.diseaseOfFocus" [disabled]="!adding">
+                [(ngModel)]="workspace.researchPurpose.diseaseOfFocus" [disabled]="mode == Mode.Edit">
           </div>
           <div class="checkbox-group">
             <clr-checkbox

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -96,6 +96,18 @@ export class WorkspaceEditComponent implements OnInit {
         } else if (this.mode === WorkspaceEditMode.Clone) {
           this.workspace.name = 'Clone of ' + resp.workspace.name;
           this.workspace.description = resp.workspace.description;
+          const fromPurpose = resp.workspace.researchPurpose;
+          this.workspace.researchPurpose = {
+            ...fromPurpose,
+            // Heuristic for whether the user will want to request a review,
+            // assuming minimal changes to the existing research purpose.
+            reviewRequested: (
+              fromPurpose.reviewRequested && !fromPurpose.approved),
+            timeRequested: null,
+            approved: null,
+            timeReviewed: null,
+            additionalNotes: null
+          };
         }
       },
       (error) => {


### PR DESCRIPTION
- Note: the cloner can modify any of these fields before cloning.
- Try to guess whether the cloner would want to tick the "review requested" box
- Also fix a bug in editability of the diseaseOfFocus.