### PR TITLE
More robust cloud_sql_proxy usage

### DIFF
--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -5,23 +5,25 @@ require_relative "../../aou-utils/workbench"
 class CloudSqlProxyContext < ServiceAccountContext
 
   def run()
-    # TODO(dmohs): An error here does not cause the main thread to die.
-    super do
-      common = Common.new
-      @ps = fork do
-        exec *%W{
-          cloud_sql_proxy
-            -instances #{@project}:us-central1:workbenchmaindb=tcp:0.0.0.0:3307
-            -credential_file=#{@path}
-        }
-      end
-      begin
-        sleep 1 # TODO(dmohs): Detect running better.
-        yield
-      ensure
-        Process.kill "HUP", @ps
-        Process.wait
-      end
+    @ps = fork do
+      exec *%W{
+        cloud_sql_proxy
+          -instances #{@project}:us-central1:workbenchmaindb=tcp:0.0.0.0:3307
+          -credential_file=#{ServiceAccountContext::SERVICE_ACCOUNT_KEY_PATH}
+      }
+    end
+    sleep 0.2 # Allow cloud_sql_proxy to start and fail early if that is going to happen.
+    exit_code = Process.wait(@ps, Process::WNOHANG)
+    if exit_code
+      Common.new.error "cloud_sql_proxy failed to start"
+      exit exit_code
+    end
+    begin
+      Common.new.run_inline %W{wait-for localhost:3307 --timeout=5}
+      yield
+    ensure
+      Process.kill "HUP", @ps
+      Process.wait
     end
   end
 end


### PR DESCRIPTION
Causes proxy failures to happen early to avoid "why the hell isn't my database working" moments.

Tested by calling the `/v1/me` endpoint which didn't return a 500.