### PR TITLE
[RW-383] Fix StatusApi binding

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -93,12 +93,11 @@ public class FireCloudConfig {
     return api;
   }
 
-  @Bean
-  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public StatusApi statusApi(@Qualifier(ALL_OF_US_API_CLIENT) ApiClient apiClient) {
-    // Group/Auth Domain creation and addition are made by the AllOfUs service account
-    StatusApi api = new StatusApi();
-    api.setApiClient(apiClient);
-    return api;
+  // For some reason, Spring boot binding doesn't work on the StatusApi class
+  // key, but do work when string-qualified.
+  @Bean("statusApi")
+  public StatusApi statusApi() {
+    // Auth not required.
+    return new StatusApi();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.firecloud.model.WorkspaceIngest;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -39,8 +40,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<ProfileApi> profileApiProvider;
   private final Provider<BillingApi> billingApiProvider;
   private final Provider<GroupsApi> groupsApiProvider;
-  private final Provider<StatusApi> statusApiProvider;
   private final Provider<WorkspacesApi> workspacesApiProvider;
+  private final StatusApi statusApi;
 
   private static final String STATUS_SUBSYSTEMS_KEY = "systems";
 
@@ -55,19 +56,18 @@ public class FireCloudServiceImpl implements FireCloudService {
       Provider<ProfileApi> profileApiProvider,
       Provider<BillingApi> billingApiProvider,
       Provider<GroupsApi> groupsApiProvider,
-      Provider<StatusApi> statusApiProvider,
-      Provider<WorkspacesApi> workspacesApiProvider) {
+      Provider<WorkspacesApi> workspacesApiProvider,
+      @Qualifier("statusApi") StatusApi statusApi) {
     this.configProvider = configProvider;
     this.profileApiProvider = profileApiProvider;
     this.billingApiProvider = billingApiProvider;
     this.groupsApiProvider = groupsApiProvider;
-    this.statusApiProvider = statusApiProvider;
     this.workspacesApiProvider = workspacesApiProvider;
+    this.statusApi = statusApi;
   }
 
   @Override
   public boolean getFirecloudStatus() {
-    StatusApi statusApi = statusApiProvider.get();
     try {
       statusApi.status();
     } catch (ApiException e) {
@@ -220,6 +220,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     return workspacesApi.getWorkspace(projectName, workspaceName);
   }
 
+  @Override
   public void deleteWorkspace(String projectName, String workspaceName) throws ApiException {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     workspacesApi.deleteWorkspace(projectName, workspaceName);

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -44,7 +44,7 @@ public class FireCloudServiceImplTest {
   public void setup() {
     service = new FireCloudServiceImpl(Providers.of(workbenchConfig),
         Providers.of(profileApi), Providers.of(billingApi), Providers.of(groupsApi),
-        Providers.of(statusApi), Providers.of(workspacesApi));
+        Providers.of(workspacesApi), statusApi);
   }
 
   @Test(expected = ApiException.class)


### PR DESCRIPTION
I wound up debugging this anyways; the Jira issue wasn't really necessary. On an unrelated point, while I was here I dropped the auth modifier. It doesn't seem to be necessary (my requests go through without).

For some reason Spring didn't like `StatusApi` as a binding key; I tried a qualifier on a whim and it worked:

```
api_1                          | Caused by: 
api_1                          | org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.pmiops.workbench.firecloud.api.StatusApi' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
api_1                          | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1486)
api_1                          | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1104)
api_1                          | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1066)
api_1                          | 	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:835)
api_1                          | 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:741)
api_1                          | 	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:189)
api_1                          | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1193)
api_1                          | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1095)
api_1                          | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:513)
api_1                          | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
```