### PR TITLE
Add yarn coverage command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /api/tools/.gradle/*
 /build/*
 /ui/package-lock.json
+/ui/coverage
 /ui/ui.iml
 /ui/.idea/*
 /ui/**/*.js

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,8 +14,8 @@
     "codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-angular --input-spec ../api/src/main/resources/workbench.yaml --output src/generated --additional-properties ngVersion=2",
     "post-codegen": "sed -i.bak -e 's/OpaqueToken/InjectionToken/' src/generated/variables.ts",
     "public-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-angular --input-spec ../public-api/src/main/resources/public-api.yaml --output src/publicGenerated --additional-properties ngVersion=2",
-    "public-post-codegen": "sed -i.bak -e 's/OpaqueToken/InjectionToken/' src/publicGenerated/variables.ts"
-
+    "public-post-codegen": "sed -i.bak -e 's/OpaqueToken/InjectionToken/' src/publicGenerated/variables.ts",
+    "coverage": "ng test --sourcemaps=false --watch=false --code-coverage"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Adds a simple command `yarn run coverage` that will run the test suite and generate a code coverage report.