### PR TITLE
Fixes to Cloud SQL import script

### DIFF
--- a/api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -12,7 +12,6 @@ USAGE="./generate-clousql-cdr/make-cloudsql-db.sh --instance <INSTANCE> --sql-du
 while [ $# -gt 0 ]; do
   echo "1 is $1"
   case "$1" in
-    --account) ACCOUNT=$2; shift 2;;
     --project) PROJECT=$2; shift 2;;
     --instance) INSTANCE=$2; shift 2;;
     --sql-dump-file) SQL_DUMP_FILE=$2; shift 2;;
@@ -21,12 +20,6 @@ while [ $# -gt 0 ]; do
     * ) break ;;
   esac
 done
-
-if [ -z "${ACCOUNT}" ]
-then
-  echo "Usage: $USAGE"
-  exit 1
-fi
 
 if [ -z "${PROJECT}" ]
 then
@@ -53,8 +46,7 @@ then
 fi
 
 echo "Creating cloudsql DB from dump file $SQL_DUMP_FILE \n"
-# SERVICE_ACCOUNT=all-of-us-workbench-test@appspot.gserviceaccount.com
-SERVICE_ACCOUNT=$ACCOUNT
+SERVICE_ACCOUNT="${PROJECT}@appspot.gserviceaccount.com"
 
 gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 

--- a/api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -71,7 +71,7 @@ minutes_waited=0
 while true; do
   sleep 1m
   minutes_waited=$((minutes_waited + 1))
-  import_status=`gcloud sql operations list --instance workbenchmaindb --project $PROJECT | grep "IMPORT"`
+  import_status=`gcloud sql operations list --instance $INSTANCE --project $PROJECT | grep "IMPORT"`
   if [[ $import_status =~ .*RUNNING* ]]
   then
      echo "Import is still running after ${minutes_waited} minutes."

--- a/api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -65,7 +65,8 @@ gsutil acl ch -u ${SQL_SERVICE_ACCOUNT}:R gs://$BUCKET/$SQL_DUMP_FILE
 # Import asynch
 gcloud sql instances import --project $PROJECT --account $SERVICE_ACCOUNT $INSTANCE gs://$BUCKET/$SQL_DUMP_FILE --async
 
-echo "Import started, waiting for it to complete..."
+echo "Import started, waiting for it to complete."
+echo "You can also kill this script and check status at at https://console.cloud.google.com/sql/instances/${INSTANCE}/operations?project=${PROJECT}."
 minutes_waited=0
 while true; do
   sleep 1m

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -19,7 +19,7 @@ TEST_PROJECT = "all-of-us-workbench-test"
 GSUITE_ADMIN_KEY_PATH = "src/main/webapp/WEB-INF/gsuite-admin-sa.json"
 INSTANCE_NAME = "workbenchmaindb"
 FAILOVER_INSTANCE_NAME = "workbenchbackupdb"
-SERVICES = %W{servicemanagement.googleapis.com storage-component.googleapis.com
+SERVICES = %W{servicemanagement.googleapis.com storage-component.googleapis.com iam.googleapis.com
               compute.googleapis.com admin.googleapis.com
               cloudbilling.googleapis.com sqladmin.googleapis.com sql-component.googleapis.com
               clouderrorreporting.googleapis.com bigquery-json.googleapis.com}
@@ -553,14 +553,32 @@ Dumps the local mysql db and uploads the .sql file to bucket",
 })
 
 def cloudsql_import(cmd_name, *args)
-  ensure_docker cmd_name, args
   op = WbOptionsParser.new(cmd_name, args)
-  gcc = GcloudContextV2.new(op)
+  op.add_option(
+      "--project [project]",
+      lambda {|opts, v| opts.project = v},
+      "Project to import the database into (e.g. all-of-us-rw-stable)"
+  )
+  op.add_option(
+    "--instance [instance]",
+    lambda {|opts, v| opts.instance = v},
+    "Database instance to import into (e.g. workbenchmaindb)"
+  )
+  op.add_option(
+    "--sql-dump-file [filename]",
+    lambda {|opts, v| opts.file = v},
+    "File name of the SQL dump to import"
+  )
+  op.add_option(
+    "--bucket [bucket]",
+    lambda {|opts, v| opts.bucket = v},
+    "Name of the GCS bucket containing the SQL dump"
+  )
   op.parse.validate
-  gcc.validate
-  ServiceAccountContext.new(gcc.project).run do
+  ServiceAccountContext.new(op.opts.project).run do
     common = Common.new
-    common.run_inline %W{docker-compose run db-cloudsql-import} + args
+    common.run_inline %W{docker-compose run db-cloudsql-import --instance #{op.opts.instance}
+        --sql-dump-file #{op.opts.file} --bucket #{op.opts.bucket} --project #{op.opts.project}}
   end
 end
 Common.register_command({


### PR DESCRIPTION
- Set up service account key before running
- Don't require account passed in; just use appengine service account
- Make SA owner on the file (it won't be if it's not all-of-us-workbench-test)
- Wait for the import to finish after it's kicked off.