### PR TITLE
Fixing Ruby for integration, bigquery test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
               api/src/main/webapp/WEB-INF/sa-key.json
       - run:
           working_directory: ~/workbench/api
-          command: ./project.rb integration --project all-of-us-workbench-test
+          command: ./project.rb integration
       - save_cache:
           paths:
             - ~/.gradle


### PR DESCRIPTION
Note that integration tests still fail locally with errors like:

rg.pmiops.workbench.google.DirectoryServiceImplIntegrationTest > testDirectoryServiceUsernameIsTaken FAILED
    com.google.apphosting.api.ApiProxy$CallNotFoundException: Can't make API call urlfetch.Fetch in a thread that is neither the original request thread nor a thread created by ThreadManager
        at com.google.apphosting.api.ApiProxy$CallNotFoundException.foreignThread(ApiProxy.java:800)
        at com.google.apphosting.api.ApiProxy.makeSyncCall(ApiProxy.java:112)
        at com.google.appengine.api.urlfetch.URLFetchServiceImpl.fetch(URLFetchServiceImpl.java:40)
        at com.google.api.client.extensions.appengine.http.UrlFetchRequest.execute(UrlFetchRequest.java:74)
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:981)
        at com.google.api.client.auth.oauth2.TokenRequest.executeUnparsed(TokenRequest.java:283)
        at com.google.api.client.auth.oauth2.TokenRequest.execute(TokenRequest.java:307)
        at com.google.api.client.googleapis.auth.oauth2.GoogleCredential.executeRefreshToken(GoogleCredential.java:394)
        at com.google.api.client.auth.oauth2.Credential.refreshToken(Credential.java:489)
        at com.google.api.client.auth.oauth2.Credential.intercept(Credential.java:217)
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:868)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
        at org.pmiops.workbench.exceptions.ExceptionUtils.executeWithRetries(ExceptionUtils.java:87)
        at org.pmiops.workbench.google.DirectoryServiceImpl.getUser(DirectoryServiceImpl.java:77)
        at org.pmiops.workbench.google.DirectoryServiceImpl.isUsernameTaken(DirectoryServiceImpl.java:89)
        at org.pmiops.workbench.google.DirectoryServiceImplIntegrationTest.testDirectoryServiceUsernameIsTaken(DirectoryServiceImplIntegrationTest.java:32)


But at least the Ruby is fixed. :)