### PR TITLE
Warn when UID is set to ANY existing user

### DIFF
--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -54,10 +54,6 @@ ENV GRADLE_USER_HOME /.gradle
 # It never makes sense for Gradle to run a daemon within a docker container.
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
-ADD with-uid.sh /usr/local/bin
-
-ENTRYPOINT ["with-uid.sh"]
-
 RUN apk --no-cache add ruby ruby-json ruby-io-console
 
 RUN curl https://services.gradle.org/distributions/gradle-4.3.1-bin.zip -L > /tmp/gradle.zip \
@@ -66,3 +62,7 @@ RUN curl https://services.gradle.org/distributions/gradle-4.3.1-bin.zip -L > /tm
 ENV PATH="$PATH:/gradle/bin"
 
 RUN gem install --no-document googleauth
+
+ADD with-uid.sh /usr/local/bin
+
+ENTRYPOINT ["with-uid.sh"]

--- a/api/src/dev/server/with-uid.sh
+++ b/api/src/dev/server/with-uid.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-if [[ "$(whoami 2>/dev/null)" == 'root' ]]; then
-  >&2 echo 'This container should not be run as the root user. Exiting.';
+USERNAME=$(whoami 2>/dev/null)
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  >&2 echo 'This container has poor behavior if run as an existing user.' \
+    'The given UID matches the user '"'$USERNAME'"'. Exiting.';
   exit 1;
 fi
 

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:alpine
 
+# We set the UID to the host's UID to ensure written files get proper permissions. The default UID
+# for node is 1000, which conflicts with some of our host machines.
+RUN apk --no-cache add shadow
+RUN groupmod -g 9999 node \
+  && usermod -u 9999 -g 9999 node
+
 #
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
 #

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -35,9 +35,8 @@ RUN mkdir -p /.cache/yarn /.yarn \
     && touch /.yarnrc \
     && chmod a+rwx /.cache/yarn /.yarn /.yarnrc
 
+RUN apk --no-cache add ruby ruby-json ruby-io-console
+
 ADD with-uid.sh /usr/local/bin
 
 ENTRYPOINT ["with-uid.sh"]
-
-RUN apk --no-cache add ruby ruby-json ruby-io-console
-

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -3,8 +3,8 @@ FROM node:alpine
 # We set the UID to the host's UID to ensure written files get proper permissions. The default UID
 # for node is 1000, which conflicts with some of our host machines.
 RUN apk --no-cache add shadow
-RUN groupmod -g 9999 node \
-  && usermod -u 9999 -g 9999 node
+RUN groupmod -g 666 node \
+  && usermod -u 666 -g 666 node
 
 #
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile

--- a/ui/src/dev/server/with-uid.sh
+++ b/ui/src/dev/server/with-uid.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-if [[ "$(whoami 2>/dev/null)" == 'root' ]]; then
-  >&2 echo 'This container should not be run as the root user. Exiting.';
+USERNAME=$(whoami 2>/dev/null)
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  >&2 echo 'This container has poor behavior if run as an existing user.' \
+    'The given UID matches the user '"'$USERNAME'"'. Exiting.';
   exit 1;
 fi
 


### PR DESCRIPTION
Previously we only checked for the root user which caused problems when a dev was unlucky-enough to have a UID matching one of the users in the image.