### PR TITLE
Moving gsuite admin SA fetch before appengine stage.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,6 @@ jobs:
           working_directory: ~/workbench
           command: cp api/circle-sa-key.json public-api
       - run:
-          working_directory: ~/workbench
-          command: |
-            gsutil cp \
-              gs://all-of-us-workbench-test-credentials/all-of-us-workbench-test-9b5c623a838e.json \
-              api/src/main/webapp/WEB-INF/sa-key.json
-      - run:
           working_directory: ~/workbench/api
           command: ./project.rb test
       - save_cache:
@@ -78,12 +72,6 @@ jobs:
           #Used to call gsutil from the circle environment.
           command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
-          working_directory: ~/workbench
-          command: |
-            gsutil cp \
-              gs://all-of-us-workbench-test-credentials/all-of-us-workbench-test-9b5c623a838e.json \
-              api/src/main/webapp/WEB-INF/sa-key.json
-      - run:
           working_directory: ~/workbench/api
           command: ./project.rb integration
       - save_cache:
@@ -111,12 +99,6 @@ jobs:
           working_directory: ~/workbench
           #Used to call gsutil from the circle environment.
           command: ci/activate_creds.sh api/circle-sa-key.json
-      - run:
-          working_directory: ~/workbench
-          command: |
-            gsutil cp \
-              gs://all-of-us-workbench-test-credentials/all-of-us-workbench-test-9b5c623a838e.json \
-              api/src/main/webapp/WEB-INF/sa-key.json
       - run:
           working_directory: ~/workbench/api
           command: ./project.rb bigquerytest --project all-of-us-workbench-test

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -826,16 +826,18 @@ def deploy(cmd_name, args, with_cron, with_gsuite_admin)
   gcc.validate
   env = read_db_vars_v2(gcc)
   ENV.update(env)
-  common.run_inline %W{gradle :appengineStage}
-  promote = op.opts.promote.nil? ? (op.opts.version ? "--no-promote" : "--promote") \
-    : (op.opts.promote ? "--promote" : "--no-promote")
-  quiet = op.opts.quiet ? " --quiet" : ""
 
   if with_gsuite_admin
     common.run_inline %W{rm -f #{GSUITE_ADMIN_KEY_PATH}}
     # TODO: generate new key here
     get_gsuite_admin_key(gcc.project)
   end
+
+  common.run_inline %W{gradle :appengineStage}
+  promote = op.opts.promote.nil? ? (op.opts.version ? "--no-promote" : "--promote") \
+    : (op.opts.promote ? "--promote" : "--no-promote")
+  quiet = op.opts.quiet ? " --quiet" : ""
+
   common.run_inline %W{
     gcloud app deploy
       build/staged-app/app.yaml


### PR DESCRIPTION
(This will hopefully get the SA key file in the deployment and make account creation work properly.)

Removing unnecessary gsutil commands from circle config