### PR TITLE
[RW-410] Await MySQL startup in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,10 @@ jobs:
           working_directory: ~/workbench
           command: cp api/circle-sa-key.json public-api
       - run:
+          # MySQL sometimes refuses connections by the time we attempt to apply
+          # data migrations. Watch the port for 2m for startup.
           name: Await MySQL startup
-          command: nc -z 127.0.0.1 3306
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m
       - run:
           working_directory: ~/workbench/api
           command: ./project.rb run-local-migrations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,9 @@ jobs:
           working_directory: ~/workbench
           command: cp api/circle-sa-key.json public-api
       - run:
+          name: Await MySQL startup
+          command: nc -z 127.0.0.1 3306
+      - run:
           working_directory: ~/workbench/api
           command: ./project.rb run-local-migrations
       - run:

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -9,6 +9,7 @@
 # For permission to push, request to be added to the DockerHub repository.
 # Include your changes to circle.yml in the PR that uses the build image.
 
+# Note: we depend on dockerize being installed on this image.
 FROM circleci/openjdk:8-jdk-browsers
 
 USER circleci
@@ -25,11 +26,6 @@ RUN cd && \
   tar -xJf node.tar.xz && \
   mv node-v6.11.1-linux-x64 node && \
   rm -rf node.tar.xz
-
-ENV DOCKERIZE_VERSION v0.6.0
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN sudo apt-get update
 RUN sudo apt-get install gettext ruby mysql-client python-pip

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -26,6 +26,10 @@ RUN cd && \
   mv node-v6.11.1-linux-x64 node && \
   rm -rf node.tar.xz
 
+ENV DOCKERIZE_VERSION v0.6.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN sudo apt-get update
 RUN sudo apt-get install gettext ruby mysql-client python-pip


### PR DESCRIPTION
Sending for review, but I haven't yet been able to test this. Need access to dockerhub to test images. Alternative to using `dockerize` would be to loop with `nc -z 127.0.0.1 3306`; this might be relatively hairy bash to put in the config file though. I *believe* a single `nc` invocation would not necessarily cover the issues we're seeing (though it's proven difficult to repro).

Local `circleci build` also fails for me:

```
$ circleci build --job api-local-tests -v $(pwd):/home/circle/workbench

====>> Spin up Environment
Build-agent version 0.0.4710-44beb0a (2018-02-27T20:05:34+0000)
Starting container allofustest/workbench:buildimage-0.0.10
  using image allofustest/workbench@sha256:bb261fd62fa3124c44e80cbdeca9eb5bff06cf697c7083f4efdfb26a53c0b492
Starting container mysql:5.7
  using image mysql@sha256:227d5c3f54ee3a70c075b1c3013e72781564000d34fc8c7ec5ec353c5b7ef7fa
====>> Container mysql:5.7
Service containers logs streaming is disabled for local builds
You can manually monitor container 713df503c2ccd41338a857ee341a163307b9a98b900e32ed2a630d2f1137a6f1
====>> Checkout code
  #!/bin/sh
mkdir -p /home/circleci/workbench && cp -r /tmp/_circleci_local_build_repo/. /home/circleci/workbench
cp: cannot stat '/tmp/_circleci_local_build_repo/.': No such file or directory
Error: Exited with code 1
Step failed
Task failed
```