### PR TITLE
Switching to api prefix to avoid weirdness

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -66,10 +66,7 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   public String getHostName() {
     ApiProxy.Environment env = ApiProxy.getCurrentEnvironment();
     // TODO: see if there's a better way of doing this?
-    String version = System.getProperty("com.google.appengine.application.version");
-    // Strip off the timestamp suffix.
-    version = version.substring(0, version.lastIndexOf('.'));
-    return version + "-dot-" + (String) env.getAttributes().get("com.google.appengine.runtime.default_version_hostname");
+    return "api-dot-" + (String) env.getAttributes().get("com.google.appengine.runtime.default_version_hostname");
   }
 
   @Bean


### PR DESCRIPTION
(In Cloud, what I had before would fetch back api:circle-ci-test, which isn't really helpful... for now we'll just hardcode "api-" on front.)