### PR TITLE
Switch cluster creation to lazy, reduce API/UI surface

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
@@ -73,6 +73,7 @@ public class AuthDomainController implements AuthDomainApiDelegate {
         throw new ServerErrorException(e.getResponseBody());
       }
     }
+    // TODO(calbach): Teardown any active clusters here.
     user.setDataAccessLevel(DataAccessLevel.REVOKED);
     user.setDisabled(true);
     user.setDisabledTime(timestamp);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -76,7 +76,7 @@ public class ClusterController implements ClusterApiDelegate {
 
     org.pmiops.workbench.notebooks.model.Cluster fcCluster;
     try {
-      fcCluster = this.notebooksService.getCluster(project, clusterName);
+      fcCluster = this.notebooksService.getCluster(project, DEFAULT_CLUSTER_NAME);
     } catch (NotFoundException e) {
       fcCluster = this.notebooksService.createCluster(
           project, DEFAULT_CLUSTER_NAME, createFirecloudClusterRequest());

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -1,19 +1,23 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.firecloud.ApiException;
+import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterListResponse;
-import org.pmiops.workbench.model.EmptyResponse;
-import org.pmiops.workbench.model.FileDetail;
-import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.model.ClusterLocalizeRequest;
+import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,10 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class ClusterController implements ClusterApiDelegate {
-  private final NotebooksService notebooksService;
-  private final Provider<User> userProvider;
-  private final WorkspaceService workspaceService;
-  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private static final Map<org.pmiops.workbench.notebooks.model.ClusterStatus, ClusterStatus> fcToWorkbenchStatusMap =
+      new ImmutableMap.Builder<org.pmiops.workbench.notebooks.model.ClusterStatus, ClusterStatus>()
+      .put(org.pmiops.workbench.notebooks.model.ClusterStatus.CREATING, ClusterStatus.CREATING)
+      .put(org.pmiops.workbench.notebooks.model.ClusterStatus.RUNNING, ClusterStatus.RUNNING)
+      .put(org.pmiops.workbench.notebooks.model.ClusterStatus.ERROR, ClusterStatus.ERROR)
+      .build();
+
+  private static final Logger log = Logger.getLogger(ClusterController.class.getName());
 
   private static final Function<org.pmiops.workbench.notebooks.model.Cluster, Cluster> TO_ALL_OF_US_CLUSTER =
     new Function<org.pmiops.workbench.notebooks.model.Cluster, Cluster>() {
@@ -34,117 +42,109 @@ public class ClusterController implements ClusterApiDelegate {
         Cluster allOfUsCluster = new Cluster();
         allOfUsCluster.setClusterName(firecloudCluster.getClusterName());
         allOfUsCluster.setClusterNamespace(firecloudCluster.getGoogleProject());
-        // TODO(calbach): Use an enum in the Workbench notebooks API.
-        allOfUsCluster.setStatus(firecloudCluster.getStatus().toString());
+        if (fcToWorkbenchStatusMap.containsKey(firecloudCluster.getStatus())) {
+          allOfUsCluster.setStatus(fcToWorkbenchStatusMap.get(firecloudCluster.getStatus()));
+        }
         allOfUsCluster.setCreatedDate(firecloudCluster.getCreatedDate());
-        allOfUsCluster.setDestroyedDate(firecloudCluster.getDestroyedDate());
-        allOfUsCluster.setLabels(firecloudCluster.getLabels());
         return allOfUsCluster;
       }
     };
 
-  private org.pmiops.workbench.notebooks.model.ClusterRequest createFirecloudClusterRequest() {
-    org.pmiops.workbench.notebooks.model.ClusterRequest firecloudClusterRequest = new org.pmiops.workbench.notebooks.model.ClusterRequest();
-    Map<String, String> labels = new HashMap<String, String>();
-    labels.put("all-of-us", "true");
-    labels.put("created-by", userProvider.get().getEmail());
-    firecloudClusterRequest.setLabels(labels);
-    // TODO: Host our extension somewhere.
-    // firecloudClusterRequest.setJupyterExtensionUri("");
-    firecloudClusterRequest.setJupyterUserScriptUri(
-        workbenchConfigProvider.get().firecloud.jupyterUserScriptUri);
-
-    return firecloudClusterRequest;
-  }
-
-  private String convertClusterName(String workspaceId) {
-      String clusterName = workspaceId + this.userProvider.get().getUserId();
-      clusterName = clusterName.toLowerCase();
-      return clusterName;
-  }
+  private final NotebooksService notebooksService;
+  private final Provider<User> userProvider;
+  private final FireCloudService fireCloudService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired
   ClusterController(NotebooksService notebooksService,
       Provider<User> userProvider,
-      WorkspaceService workspaceService,
+      FireCloudService fireCloudService,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.notebooksService = notebooksService;
     this.userProvider = userProvider;
-    this.workspaceService = workspaceService;
+    this.fireCloudService = fireCloudService;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
-  @Override
-  public ResponseEntity<Cluster> createCluster(String workspaceNamespace,
-      String workspaceId) {
-
-    // This also enforces registered auth domain.
-    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-        workspaceId, WorkspaceAccessLevel.WRITER);
-
-    String clusterName = this.convertClusterName(workspaceId);
-    Cluster createdCluster = TO_ALL_OF_US_CLUSTER.apply(
-        this.notebooksService.createCluster(
-            workspaceNamespace, clusterName, createFirecloudClusterRequest()));
-    return ResponseEntity.ok(createdCluster);
-  }
-
-
-  @Override
-  public ResponseEntity<EmptyResponse> deleteCluster(String workspaceNamespace,
-      String workspaceId) {
-
-    // This also enforces registered auth domain.
-    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-        workspaceId, WorkspaceAccessLevel.WRITER);
-
-    String clusterName = this.convertClusterName(workspaceId);
-    this.notebooksService.deleteCluster(workspaceNamespace, clusterName);
-    return ResponseEntity.ok(new EmptyResponse());
-  }
-
-
-  @Override
-  public ResponseEntity<Cluster> getCluster(String workspaceNamespace,
-      String workspaceId) {
-
-    // This also enforces registered auth domain.
-    workspaceService.enforceWorkspaceAccessLevel(workspaceNamespace,
-        workspaceId, WorkspaceAccessLevel.WRITER);
-
-    String clusterName = this.convertClusterName(workspaceId);
-    Cluster cluster = TO_ALL_OF_US_CLUSTER.apply(
-        this.notebooksService.getCluster(workspaceNamespace, clusterName));
-    return ResponseEntity.ok(cluster);
-  }
-
-
-  @Override
-  public ResponseEntity<ClusterListResponse> listClusters(String labels) {
-    List<org.pmiops.workbench.notebooks.model.Cluster> oldClusters;
-    oldClusters = this.notebooksService.listClusters(labels, /* includeDeleted */ false);
-    ClusterListResponse response = new ClusterListResponse();
-    response.setItems(oldClusters.stream().map(TO_ALL_OF_US_CLUSTER).collect(Collectors.toList()));
-    return ResponseEntity.ok(response);
-  }
-
-  @Override
-  public ResponseEntity<Void> localizeNotebook(String workspaceNamespace, String workspaceId,
-      List<FileDetail> fileList) {
-    String clusterName = convertClusterName(workspaceId);
-    this.notebooksService.localize(workspaceNamespace, clusterName,
-        convertfileDetailsToMap(fileList));
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-  }
-
   /**
-   * Create a map with key as ~/fileName and value as file path which should be in format the gs://firecloudBucket name/filename
-   * @param fileList
-   * @return FileDetail Map
+   * Deterministically produces a cluster name for a given user/environment.
+   * Clusters are namespaced under a free tier project, which is unique to each
+   * user, therefore the only true requirements here are to:
+   * 1. have a reproducible mapping of user -> cluster name (as we currently
+   *    don't store this)
+   * 2. generate a unique name across AoU environments (decision still pending)
    */
-  private Map<String, String> convertfileDetailsToMap(List<FileDetail> fileList) {
-    return fileList.stream()
-        .collect(Collectors.toMap(fileDetail -> "~/" + fileDetail.getName(),
-            fileDetail -> fileDetail.getPath()));
+  private String clusterNameForUser() {
+      String id =
+          workbenchConfigProvider.get().server.projectId + this.userProvider.get().getEmail();
+      // Take the last 4 digits of the hash of the above.
+      return "aou-" + String.format("%04x", id.hashCode()).substring(0, 4);
+  }
+
+  @Override
+  public ResponseEntity<ClusterListResponse> listClusters() {
+    String project = userProvider.get().getFreeTierBillingProjectName();
+    String clusterName = this.clusterNameForUser();
+
+    org.pmiops.workbench.notebooks.model.Cluster fcCluster;
+    try {
+      fcCluster = this.notebooksService.getCluster(project, clusterName);
+    } catch (NotFoundException e) {
+      fcCluster = this.notebooksService.createCluster(project, clusterName, createFirecloudClusterRequest());
+    }
+    ClusterListResponse resp = new ClusterListResponse();
+    resp.setDefaultCluster(TO_ALL_OF_US_CLUSTER.apply(fcCluster));
+    return ResponseEntity.ok(resp);
+  }
+
+  private org.pmiops.workbench.notebooks.model.ClusterRequest createFirecloudClusterRequest() {
+    org.pmiops.workbench.notebooks.model.ClusterRequest firecloudClusterRequest = new org.pmiops.workbench.notebooks.model.ClusterRequest();
+    // TODO(calbach): Configure Jupyter server extensions here.
+    Map<String, String> labels = new HashMap<String, String>();
+    labels.put("all-of-us", "true");
+    labels.put("created-by", userProvider.get().getEmail());
+    firecloudClusterRequest.setLabels(labels);
+    return firecloudClusterRequest;
+  }
+
+  @Override
+  public ResponseEntity<Void> localize(
+      String projectName, String clusterName, ClusterLocalizeRequest body) {
+    String workspaceBucket;
+    try {
+      workspaceBucket = "gs://" + fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
+          .getWorkspace()
+          .getBucketName();
+    } catch (ApiException e) {
+      if (e.getCode() == 404) {
+        log.log(Level.INFO, "Firecloud workspace not found", e);
+        throw new NotFoundException(String.format(
+            "workspace %s/%s not found or not accessible",
+            body.getWorkspaceNamespace(), body.getWorkspaceId()));
+      }
+      throw ExceptionUtils.convertFirecloudException(e);
+    }
+
+    // For the common case where the notebook cluster matches the workspace
+    // namespace, simply name the directory as the workspace ID; else we
+    // include the namespace in the directory name to avoid possible conflicts
+    // in workspace IDs.
+    String workspacePath = body.getWorkspaceId();
+    if (!projectName.equals(body.getWorkspaceNamespace())) {
+      workspacePath = body.getWorkspaceNamespace() + ":" + body.getWorkspaceId();
+    }
+    String localDir = String.join("/", "~", "workspaces", workspacePath);
+    Map<String, String> toLocalize = body.getNotebookNames()
+        .stream()
+        .collect(Collectors.<String, String, String>toMap(
+            name -> localDir + "/" + name,
+            name -> String.join("/", workspaceBucket, "notebooks", name)));
+    // TODO(calbach): Localize a delocalize config JSON file as well, once Leo supports this.
+    toLocalize.put(
+        localDir + "/.all_of_us_config.json",
+        workspaceBucket + "/" + WorkspacesController.CONFIG_FILENAME);
+
+    notebooksService.localize(projectName, clusterName, toLocalize);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -388,158 +388,51 @@ paths:
 
   /v1/clusters:
     get:
-      summary: List all clusters
-      description: List all clusters, optionally filtering on a set of labels
+      summary: List available notebook clusters
+      description: >
+        Returns the clusters available to the current user. Currently there is a
+        single default cluster supported per researcher and this cluster should
+        always either exist or be in the process of being initialized. In a
+        future where researchers have more control over cluster creation, this
+        endpoint would be extended to return all clusters.
       operationId: listClusters
       tags:
         - cluster
-      parameters:
-        - in: query
-          name: _labels
-          description: |
-            Optional label key-value pairs to filter results by. Example: key1=val1,key2=val2.
-
-            Note: this string format is a workaround because Swagger doesn't support free-form
-            query string parameters. The recommended way to use this endpoint is to specify the
-            labels as top-level query string parameters. For instance: GET /api/clusters?key1=val1&key2=val2.
-          required: false
-          type: string
       responses:
         200:
-          description: A list of cluster definitions.
+          description: Available clusters
           schema:
-            $ref: "#/definitions/ClusterListResponse"
-        400:
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/ErrorResponse'
+            $ref: '#/definitions/ClusterListResponse'
         500:
           description: Internal Error
           schema:
             $ref: '#/definitions/ErrorResponse'
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cluster:
-    parameters:
-      - $ref: '#/parameters/workspaceNamespace'
-      - $ref: '#/parameters/workspaceId'
-    get:
-      summary: Get details of a dataproc cluster
-      description: Returns information about an existing dataproc cluster managed by Leo. Poll this to find out when your cluster has finished starting up.
-      operationId: getCluster
-      tags:
-        - cluster
-      responses:
-        200:
-          description: Cluster found, here are the details
-          schema:
-            $ref: '#/definitions/Cluster'
-        404:
-          description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-    put:
-      summary: Creates a new dataproc cluster in the given project with the given name
-      description: creates dataproc cluster with jupyters
-      operationId: createCluster
-      tags:
-        - cluster
-      responses:
-        200:
-          description: Cluster creation successful
-          schema:
-            $ref: '#/definitions/Cluster'
-        400:
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-    delete:
-      summary: Deletes an existing dataproc cluster in the given project
-      description: deletes a dataproc cluster
-      operationId: deleteCluster
-      tags:
-        - cluster
-      responses:
-        202:
-          description: Cluster deletion request accepted
-          schema:
-            $ref: '#/definitions/EmptyResponse'
-        404:
-          description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebook-list:
-    get:
-      summary: Get details of Python files from google Bucket directory notebook
-      description: Returns list of name and path of python files from google bucket, directory notebook.
-      operationId: getNoteBookList
-      tags:
-        - workspaces
-      parameters:
-        - in: path
-          name: workspaceNamespace
-          description: workspaceNamespace
-          required: true
-          type: string
-        - in: path
-          name: workspaceId
-          description: workspaceId
-          required: true
-          type: string
-      responses:
-        200:
-          description: List of files
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/FileDetail'
-        404:
-          description: Workspace not found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/localize-notebooks:
+  /v1/clusters/{clusterNamespace}/{clusterName}/localize:
     post:
-      summary: Localize files from workspace to notebook cluster
-      description: localize files
-      operationId: localizeNotebook
+      summary: >
+        Localize files from a workspace to notebook cluster. As a side-effect, a
+        JSON workspace environment file will also be localized to the cluster.
+      description: Localize notebook files to the corresponding notebook cluster.
+      operationId: localize
       tags:
         - cluster
       parameters:
       - in: path
-        name: workspaceNamespace
-        description: workspaceNamespace
+        name: clusterNamespace
+        description: clusterNamespace
         required: true
         type: string
       - in: path
-        name: workspaceId
-        description: workspaceId
+        name: clusterName
+        description: clusterName
         required: true
         type: string
       - in: body
-        name: fileList
-        description: List of file to be transfered
-        required: true
+        name: body
+        description: Localization request.
         schema:
-          type: array
-          items:
-            $ref: '#/definitions/FileDetail'
+          $ref: '#/definitions/ClusterLocalizeRequest'
       responses:
         200:
          description: List of files
@@ -551,36 +444,6 @@ paths:
          description: Internal Error
          schema:
           $ref: '#/definitions/ErrorResponse'
-
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/localize-all-files:
-    get:
-      summary: Get file details from google bucket and then localize to notebook server
-      description: Get files details from bucket folders config and notebooks and then localize to notebook server
-      operationId: localizeAllFiles
-      tags:
-        - workspaces
-      parameters:
-        - in: path
-          name: workspaceNamespace
-          description: workspaceNamespace
-          required: true
-          type: string
-        - in: path
-          name: workspaceId
-          description: workspaceId
-          required: true
-          type: string
-      responses:
-        200:
-          description: Files have been localized
-        404:
-          description: Workspace or Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
 
   # Billing projects #####################################################################
 
@@ -689,6 +552,42 @@ paths:
           description: A list of workspaces
           schema:
             $ref: "#/definitions/WorkspaceListResponse"
+
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebook-list:
+    get:
+      summary: Get details of Python files from google Bucket directory notebook
+      description: >
+        Returns list of name and path of python files from google bucket,
+        directory notebook.
+      operationId: getNoteBookList
+      tags:
+        - workspaces
+      parameters:
+        - in: path
+          name: workspaceNamespace
+          description: workspaceNamespace
+          required: true
+          type: string
+        - in: path
+          name: workspaceId
+          description: workspaceId
+          required: true
+          type: string
+      responses:
+        200:
+          description: List of files
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/FileDetail'
+        404:
+          description: Workspace not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
 
   /v1/admin/users/id-verification/list:
     get:
@@ -2496,15 +2395,17 @@ definitions:
         type: integer
         description: line number
 
-  # TODO: Clean up the client representation of the cluster
+  ClusterStatus:
+    type: string
+    description: The status for a Firecloud notebook cluster.
+    enum: [CREATING, RUNNING, ERROR]
+
   Cluster:
-    description: ''
+    description: A Firecloud notebook cluster.
     required:
       - clusterName
       - clusterNamespace
       - status
-      - createdDate
-      - labels
     properties:
       clusterName:
         type: string
@@ -2513,17 +2414,10 @@ definitions:
         type: string
         description: The Google Project used to create the cluster
       status:
-        type: string
-        description: The current state of the cluster
+        $ref: "#/definitions/ClusterStatus"
       createdDate:
         type: string
         description: The date and time the cluster was created, in ISO-8601 format
-      destroyedDate:
-        type: string
-        description: The date and time the cluster was destroyed, in ISO-8601 format
-      labels:
-        type: object
-        description: The labels to be placed on the cluster. Of type Map[String,String]
 
   FileDetail:
     type: object
@@ -2541,12 +2435,32 @@ definitions:
   ClusterListResponse:
     type: object
     required:
-      - items
+      - defaultCluster
     properties:
-      items:
-        type: "array"
+      defaultCluster:
+        $ref: "#/definitions/Cluster"
+
+  ClusterLocalizeRequest:
+    type: object
+    required:
+      - workspaceNamespace
+      - workspaceId
+      - notebookNames
+    properties:
+      workspaceNamespace:
+        type: string
+        description: Workspace namespace from which to source notebooks
+      workspaceId:
+        type: string
+        description: Workspace from which to source notebooks
+      notebookNames:
+        type: array
+        description: >
+          Names of notebooks to localize. This is just the basename (no gs://
+          needed). This is interpreted as relative to the /notebooks directory
+          within the provided workspace's Google Cloud Storage bucket.
         items:
-          $ref: "#/definitions/Cluster"
+          type: string
 
   UsernameTakenResponse:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1036,17 +1036,6 @@ public class WorkspacesControllerTest {
     }
   }
 
-  @Test
-  public void testLocalizeAllFiles() throws Exception {
-    mockObjectsForBuckFileList();
-    try {
-      workspacesController.localizeAllFiles("mockProjectName", "mockWorkspaceName");
-    }
-    catch(Exception ex){
-      fail();
-    }
-  }
-
   private void mockObjectsForBuckFileList() throws ApiException {
     org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =
         new org.pmiops.workbench.firecloud.model.WorkspaceResponse();

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -28,3 +28,11 @@ h3 {
 .permissions-group {
   margin: 1rem 0rem 0rem 1rem;
 }
+
+.cluster-spinner {
+  display: inline-block;
+}
+
+.notebook-table-row {
+  cursor: pointer;
+}

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -97,10 +97,10 @@
   </clr-modal>
 
   <clr-modal [(clrModalOpen)]="clusterPulled">
-    <h3 class="modal-title">Cluster Created:</h3>
-    <div class="modal-body">Your notebook cluster is ready. Would you like to enter the cluster?</div>
+    <h3 class="modal-title">Notebook Server Ready:</h3>
+    <div class="modal-body">Your notebook server is ready, please confirm to open in a new tab</div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="openCluster()">Ok</button>
+      <button type="button" class="btn btn-primary" (click)="openCluster(launchedNotebookName)">Ok</button>
       <button type="button" class="btn btn-primary" (click)="cancelCluster()">Cancel</button>
     </div>
   </clr-modal>
@@ -117,31 +117,25 @@
           </div>
         </div>
       </div>
-      <button class="btn" (click)="launchNotebook()">Launch Notebook Server</button>
-      <button class="btn" id="createAndLaunch" (click)="createAndLaunchNotebook()">
-        <div *ngIf="!clusterLoading; else clusterCreateLoading">Create Notebook Server</div>
-        <ng-template #clusterCreateLoading>
-          <div>
-            <span class="spinner spinner-sm"></span>
-            <span class="loading-text">Creating Notebook Server...</span>
-          </div>
-        </ng-template>
+      <button class="btn" (click)="launchCluster()">New Notebook
       </button>
-      <button class="btn" (click)="killNotebook()">Delete Notebook Server</button>
+      <div *ngIf="clusterLoading" class="cluster-spinner">
+        <span class="spinner spinner-sm" alt=Creating Notebook Server...></span>
+      </div>
     </div>
     <div class="indented">
-      <button class="btn" (click)="localizeNotebooks(notebookList)"
-              [ngClass]="{disabled: !enablePushNotebookBtn}">Push To Notebook Server</button>
       <clr-datagrid [clrDgLoading]="notebooksLoading">
-        <clr-dg-column><input type="checkbox" (change)="selectAllNoteBooks()" [(ngModel)]="checkColumnNotebook"/></clr-dg-column>
         <clr-dg-column [clrDgField]="'notebook.name'" [clrDgSortBy]="notebookNameComparator">
           Name
           <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>
         </clr-dg-column>
         <clr-dg-column>Path</clr-dg-column>
         <clr-dg-placeholder>No notebooks found in this workspace.</clr-dg-placeholder>
-        <clr-dg-row *clrDgItems="let notebook of notebookList" [clrDgItem]="notebook" class="table-row notebook-table-row">
-          <clr-dg-cell><input type="checkbox" (change)="selectANotebook(notebook)" [(ngModel)]="notebook.selected"/></clr-dg-cell>
+        <clr-dg-row
+          class="table-row notebook-table-row"
+          *clrDgItems="let notebook of notebookList"
+          [clrDgItem]="notebook"
+          (click)="launchNotebook(notebook)">
           <clr-dg-cell>{{notebook.name}}</clr-dg-cell>
           <clr-dg-cell>{{notebook.path}}</clr-dg-cell>
         </clr-dg-row>

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -145,14 +145,4 @@ describe('WorkspaceComponent', () => {
     expect(app.notebookList[0].name).toEqual('FileDetails');
     expect(app.notebookList[0].path).toEqual('gs://bucket/notebooks/mockFile');
   }));
-
-  it('Calls localize All files after creating cluster', fakeAsync(() => {
-    const fixture = workspacePage.fixture;
-    const app = fixture.debugElement.componentInstance;
-    fixture.componentRef.instance.createAndLaunchNotebook();
-    tick(5000);
-    expect(app.clusterPulled).toEqual(true);
-  }));
-
-
 });

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -10,6 +10,7 @@ import {SignInService} from 'app/services/sign-in.service';
 import {
   Cluster,
   ClusterService,
+  ClusterStatus,
   Cohort,
   CohortsService,
   FileDetail,
@@ -20,7 +21,7 @@ import {
 
 
 class Notebook {
-  constructor(public name: string, public path: string, public selected: boolean) {}
+  constructor(public name: string, public path: string) {}
 }
 /*
 * Search filters used by the cohort and notebook data tables to
@@ -86,16 +87,15 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   cohortsError = false;
   notebookError = false;
   notebooksLoading = false;
-  checkColumnNotebook = false;
   cohortList: Cohort[] = [];
   cluster: Cluster;
+  clusterLoading = true;
   clusterPulled = false;
-  clusterLoading = false;
+  launchedNotebookName: string;
   notFound = false;
   private accessLevel: WorkspaceAccessLevel;
   deleting = false;
   showAlerts = false;
-  enablePushNotebookBtn = false;
   // TODO: Replace with real data/notebooks read in from GCS
   notebookList: Notebook[] = [];
   editHover = false;
@@ -146,14 +146,15 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
                   fileList => {
                     for (const filedetail of fileList) {
                       this.notebookList
-                          .push(new Notebook(filedetail.name, filedetail.path, false));
+                          .push(new Notebook(filedetail.name, filedetail.path));
                     }
                   },
                   error => {
                     this.notebooksLoading = false;
                     this.notebookError = false;
                   });
-            },
+            this.initCluster();
+          },
           error => {
             if (error.status === 404) {
               this.notFound = true;
@@ -167,21 +168,46 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     window.removeEventListener('message', this.notebookAuthListener);
   }
 
-  launchNotebook(): void {
-    this.pollCluster().subscribe(cluster => {
-      this.cluster = cluster;
-      this.initializeNotebookCookies().subscribe(() => {
-        this.localizeAllFiles();
+  launchNotebook(notebook): void {
+    if (this.clusterLoading) {
+      return;
+    }
+    this.localizeNotebooks([notebook]).subscribe(() => {
+      this.launchedNotebookName = notebook.name;
+      this.clusterPulled = true;
+    });
+  }
+
+  launchCluster(): void {
+    if (this.clusterLoading) {
+      return;
+    }
+    this.localizeNotebooks(this.notebookList).subscribe(() => {
+      // TODO(calbach): Going through this modal is a temporary hack to avoid
+      // triggering pop-up blockers. Likely we'll want to switch notebook
+      // cluster opening to go through a redirect URL to make the localize and
+      // redirect look more atomic to the browser. Once this is in place, rm the
+      // modal and this hacky passing of the launched notebook name.
+      this.launchedNotebookName = '';
+      this.clusterPulled = true;
+    });
+  }
+
+  private initCluster(): void {
+    this.pollCluster().subscribe((c) => {
+      this.initializeNotebookCookies(c).subscribe(() => {
+        this.clusterLoading = false;
+        this.cluster = c;
       });
     });
   }
 
-  initializeNotebookCookies(): Observable<Response> {
+  private initializeNotebookCookies(cluster: Cluster): Observable<Response> {
     // TODO (blrubenstein): Make this configurable by environment
     const leoBaseUrl = 'https://notebooks.firecloud.org';
     const leoNotebookUrl = leoBaseUrl + '/notebooks/'
-        + this.cluster.clusterNamespace + '/'
-        + this.cluster.clusterName;
+        + cluster.clusterNamespace + '/'
+        + cluster.clusterName;
     const leoSetCookieUrl = leoNotebookUrl + '/setCookie';
 
     const headers = new Headers();
@@ -192,41 +218,52 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
-  pollCluster(): Observable<Cluster> {
-    // Polls for cluster startup every minute.
+  private pollCluster(): Observable<Cluster> {
+    // Polls for cluster startup every 10s.
     return new Observable<Cluster>(observer => {
-      this.clusterService.getCluster(this.workspace.namespace, this.workspace.id)
-          .subscribe((cluster) => {
-        if (cluster.status !== 'Running' && cluster.status !== 'Deleting') {
-          setTimeout(() => {
+      this.clusterService.listClusters()
+        .subscribe((resp) => {
+          const cluster = resp.defaultCluster;
+          if (cluster.status !== ClusterStatus.RUNNING) {
+            setTimeout(() => {
               this.pollCluster().subscribe(newCluster => {
                 this.cluster = newCluster;
                 observer.next(newCluster);
                 observer.complete();
               });
-            }, 60000
-          );
-        } else {
-          this.cluster = cluster;
-          observer.next(cluster);
-          observer.complete();
-        }
+            }, 10000);
+          } else {
+            observer.next(cluster);
+            observer.complete();
+          }
       });
     });
   }
 
   cancelCluster(): void {
+    this.launchedNotebookName = '';
     this.clusterPulled = false;
   }
 
-  openCluster(): void {
+  openCluster(notebookName?: string): void {
     // TODO (blrubenstein): Make this configurable by environment
     const leoBaseUrl = 'https://notebooks.firecloud.org';
-    const leoNotebookUrl = leoBaseUrl + '/notebooks/'
-        + this.cluster.clusterNamespace + '/'
-        + this.cluster.clusterName;
+    let leoNotebookUrl = leoBaseUrl + '/notebooks/'
+      + this.cluster.clusterNamespace + '/'
+      + this.cluster.clusterName;
+    if (notebookName) {
+      leoNotebookUrl = [
+        leoNotebookUrl, 'edit', 'workspaces', this.workspace.id, notebookName
+      ].join('/');
+    } else {
+      // TODO(calbach): If lacking a notebook name, should create a new notebook instead.
+      leoNotebookUrl = [
+        leoNotebookUrl, 'tree', 'workspaces', this.workspace.id
+      ].join('/');
+    }
 
     const notebook = window.open(leoNotebookUrl, '_blank');
+    this.launchedNotebookName = '';
     this.clusterPulled = false;
     // TODO (blrubenstein): Make the notebook page a list of pages, and
     //    move this to component scope.
@@ -253,25 +290,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     }
   }
 
-  createAndLaunchNotebook(): void {
-    this.clusterLoading = true;
-    this.clusterService.createCluster(this.workspace.namespace, this.workspace.id)
-        .subscribe(() => {
-      this.pollCluster().subscribe(polledCluster => {
-        this.clusterLoading = false;
-        this.cluster = polledCluster;
-        this.initializeNotebookCookies().subscribe(() => {
-          this.localizeAllFiles();
-        });
-      });
-    });
-  }
-
-  killNotebook(): void {
-    this.clusterService.deleteCluster(
-        this.workspace.namespace, this.workspace.id).subscribe(() => {});
-  }
-
   edit(): void {
     this.router.navigate(['edit'], {relativeTo : this.route});
   }
@@ -283,19 +301,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   share(): void {
     this.router.navigate(['share'], {relativeTo : this.route});
   }
-
-  selectANotebook(): void {
-    this.checkColumnNotebook = this.notebookList.every(notebook => notebook.selected);
-    this.enablePushNotebookBtn = this.notebookList.some(notebook => notebook.selected);
-  }
-
-  selectAllNoteBooks(): void {
-    for (const file of this.notebookList) {
-      file.selected = this.checkColumnNotebook;
-    }
-    this.enablePushNotebookBtn = this.checkColumnNotebook;
-  }
-
 
   delete(): void {
     this.deleting = true;
@@ -314,46 +319,26 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     return this.accessLevel === WorkspaceAccessLevel.OWNER;
   }
 
-  localizeNotebooks(notebooks): void {
-    const fileList: Array<FileDetail> = notebooks.filter((item) => item.selected);
-    this.clusterService
-        .localizeNotebook(this.workspace.namespace, this.workspace.id, fileList)
+  private localizeNotebooks(notebooks): Observable<void> {
+    const names: Array<string> = notebooks.map(n => n.name);
+    return new Observable<void>(obs => {
+      this.clusterService
+        .localize(this.cluster.clusterNamespace, this.cluster.clusterName, {
+          workspaceNamespace: this.workspace.namespace,
+          workspaceId: this.workspace.id,
+          notebookNames: names
+        })
         .subscribe(() => {
-          this.handleLocalizeSuccess();
-          setTimeout(() => {
-            this.resetAlerts();
-          }, 5000);
-        }, () => {
+          obs.next();
+          obs.complete();
+        }, (err) => {
           this.handleLocalizeError();
           setTimeout(() => {
             this.resetAlerts();
           }, 5000);
+          obs.error(err);
         });
-  }
-
-  localizeAllFiles(): void {
-    this.workspacesService.localizeAllFiles(this.wsNamespace, this.wsId)
-        .subscribe(() => {
-              this.handleLocalizeSuccess();
-              this.clusterPulled = true;
-              setTimeout(() => {
-                this.resetAlerts();
-              }, 3000);
-            },
-            error => {
-              this.handleLocalizeError();
-              this.clusterPulled = true;
-              setTimeout(() => {
-                this.resetAlerts();
-              }, 3000);
-            });
-
-  }
-
-  handleLocalizeSuccess(): void {
-    this.alertCategory = 'alert-success';
-    this.alertMsg = 'File(s) have been saved';
-    this.showAlerts = true;
+    });
   }
 
   handleLocalizeError(): void {

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -71,6 +71,8 @@ class NotebookNameComparator implements Comparator<Notebook> {
   templateUrl: './component.html',
 })
 export class WorkspaceComponent implements OnInit, OnDestroy {
+  // Keep in sync with api/src/main/resources/notebooks.yaml.
+  private readonly leoBaseUrl = 'https://notebooks.firecloud.org';
 
   private cohortNameFilter = new CohortNameFilter();
   private cohortDescriptionFilter = new CohortDescriptionFilter();
@@ -203,11 +205,10 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   private initializeNotebookCookies(cluster: Cluster): Observable<Response> {
-    // TODO (blrubenstein): Make this configurable by environment
-    const leoBaseUrl = 'https://notebooks.firecloud.org';
+    // TODO(calbach): Generate the FC notebook Typescript client and call here.
     const leoNotebookUrl = leoBaseUrl + '/notebooks/'
         + cluster.clusterNamespace + '/'
-        + cluster.clusterName;
+      + cluster.clusterName;
     const leoSetCookieUrl = leoNotebookUrl + '/setCookie';
 
     const headers = new Headers();
@@ -246,8 +247,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   openCluster(notebookName?: string): void {
-    // TODO (blrubenstein): Make this configurable by environment
-    const leoBaseUrl = 'https://notebooks.firecloud.org';
     let leoNotebookUrl = leoBaseUrl + '/notebooks/'
       + this.cluster.clusterNamespace + '/'
       + this.cluster.clusterName;

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -72,7 +72,7 @@ class NotebookNameComparator implements Comparator<Notebook> {
 })
 export class WorkspaceComponent implements OnInit, OnDestroy {
   // Keep in sync with api/src/main/resources/notebooks.yaml.
-  private readonly leoBaseUrl = 'https://notebooks.firecloud.org';
+  private static readonly leoBaseUrl = 'https://notebooks.firecloud.org';
 
   private cohortNameFilter = new CohortNameFilter();
   private cohortDescriptionFilter = new CohortDescriptionFilter();
@@ -206,7 +206,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
 
   private initializeNotebookCookies(cluster: Cluster): Observable<Response> {
     // TODO(calbach): Generate the FC notebook Typescript client and call here.
-    const leoNotebookUrl = leoBaseUrl + '/notebooks/'
+    const leoNotebookUrl = WorkspaceComponent.leoBaseUrl + '/notebooks/'
         + cluster.clusterNamespace + '/'
       + cluster.clusterName;
     const leoSetCookieUrl = leoNotebookUrl + '/setCookie';
@@ -247,7 +247,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   openCluster(notebookName?: string): void {
-    let leoNotebookUrl = leoBaseUrl + '/notebooks/'
+    let leoNotebookUrl = WorkspaceComponent.leoBaseUrl + '/notebooks/'
       + this.cluster.clusterNamespace + '/'
       + this.cluster.clusterName;
     if (notebookName) {
@@ -271,7 +271,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         if (e.source !== notebook) {
           return;
         }
-        if (e.origin !== leoBaseUrl) {
+        if (e.origin !== WorkspaceComponent.leoBaseUrl) {
           return;
         }
         if (e.data.type !== 'bootstrap-auth.request') {
@@ -282,7 +282,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
           'body': {
               'googleClientId': this.signInService.clientId
           }
-        }, leoBaseUrl);
+        }, WorkspaceComponent.leoBaseUrl);
       };
       window.addEventListener('message', this.notebookAuthListener);
       this.listenerAdded = true;

--- a/ui/src/testing/stubs/cluster-service-stub.ts
+++ b/ui/src/testing/stubs/cluster-service-stub.ts
@@ -1,6 +1,6 @@
 import {Observable} from 'rxjs/Observable';
 
-import {Cluster, FileDetail} from 'generated';
+import {Cluster, ClusterStatus, FileDetail} from 'generated';
 
 export class ClusterServiceStub {
 
@@ -10,7 +10,7 @@ export class ClusterServiceStub {
     const stubCluster: Cluster = <Cluster>{
       clusterName: 'Cluster Name',
       clusterNamespace: 'Namespace',
-      status: 'Running',
+      status: ClusterStatus.RUNNING,
       createdDate: '08/08/2018',
       labels: null
     };

--- a/ui/src/testing/stubs/cluster-service-stub.ts
+++ b/ui/src/testing/stubs/cluster-service-stub.ts
@@ -1,47 +1,33 @@
 import {Observable} from 'rxjs/Observable';
 
-import {Cluster, ClusterStatus, FileDetail} from 'generated';
+import {Cluster, ClusterListResponse, ClusterLocalizeRequest, ClusterStatus} from 'generated';
 
 export class ClusterServiceStub {
 
   cluster: Cluster;
 
   constructor() {
-    const stubCluster: Cluster = <Cluster>{
+    this.cluster = {
       clusterName: 'Cluster Name',
       clusterNamespace: 'Namespace',
       status: ClusterStatus.RUNNING,
-      createdDate: '08/08/2018',
-      labels: null
+      createdDate: '08/08/2018'
     };
-    this.cluster = stubCluster;
   }
 
-  createCluster(workspaceNamespace: string, workspaceId: string, extraHttpRequestParams?: any)
-  : Observable<Cluster> {
-    return new Observable<Cluster>(observer => {
+  listClusters(extraHttpRequestParams?: any): Observable<ClusterListResponse> {
+    return new Observable<ClusterListResponse>(observer => {
       setTimeout(() => {
-        observer.next(this.cluster);
+        observer.next({defaultCluster: this.cluster});
         observer.complete();
       }, 0);
     });
   }
 
-  getCluster(workspaceNamespace: string, workspaceId: string, extraHttpRequestParams?: any)
-  : Observable<Cluster> {
-    return new Observable<Cluster>(observer => {
-      setTimeout(() => {
-        observer.next(this.cluster);
-        observer.complete();
-      }, 0);
-    });
-  }
-
-  localizeNotebook(workspaceNamespace: string, workspaceId: string, fileList: Array<FileDetail>,
+  localize(projectName: string, clusterName: string, req: ClusterLocalizeRequest,
       extraHttpRequestParams?: any): Observable<{}> {
     return new Observable<{}>(observer => {
       setTimeout(() => {
-        observer.next(fileList);
         observer.complete();
       }, 0);
     });


### PR DESCRIPTION
This moves things closer to my [design doc proposal](https://docs.google.com/document/d/1GbaL1otgswBEOqfte8JO8uQDG_vSEG4a-qcKMEdufLI/edit), while leaving things in a mostly-working intermediate state.

Key changes:
- Switch from 1 cluster : researcher+workspace to 1 cluster : 1 researcher
- Change the assumed directory structure on the notebook cluster.
- Switch cluster creation to be lazy on GET (using a generic List endpoint to support future extension)
- Remove several as-of-yet unneeded Cluster APIs from Workbench
- Update the notebooks UI to directionally match what we want (not really matching any particular mocks yet, though).
  - Drop the concept of cluster management.
  - Drop explicit localization and notebook select/multiselect. Just click a notebook to open.

Changes to follow:
- Move cluster initialization further back, into user initialization.
- Get rid of the notebook launcher modal (currently a pop-up blocker workaround)
- Update Python libs to match updated config file location
- Figure out how to launch straight into a new notebook flow

Open questions:
- This PR proposes that clusters would not be shared across environments; does this seem reasonable?