### PR TITLE
Add logging on status check failure

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -69,6 +69,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     try {
       new StatusApi().status();
     } catch (ApiException e) {
+      log.log(Level.WARNING, "Firecloud status check request failed", e);
       String response = e.getResponseBody();
       JSONObject errorBody = new JSONObject(response);
       JSONObject subSystemStatus = errorBody.getJSONObject(STATUS_SUBSYSTEMS_KEY);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.notebooks;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.inject.Provider;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class NotebooksServiceImpl implements NotebooksService {
+  private static final Logger log = Logger.getLogger(NotebooksServiceImpl.class.getName());
 
   private final Provider<ClusterApi> clusterApiProvider;
   private final Provider<NotebooksApi> notebooksApiProvider;
@@ -81,6 +84,7 @@ public class NotebooksServiceImpl implements NotebooksService {
       new StatusApi().getSystemStatus();
     } catch (ApiException e) {
       // If any of the systems for notebooks are down, it won't work for us.
+      log.log(Level.WARNING, "notebooks status check request failed", e);
       return false;
     }
     return true;


### PR DESCRIPTION
THis logging would have been useful last week when we started reported notebook service down due to a cert issue (vs notebook service returning a negative response).