### PR TITLE
Suppress build output when merging to master

### DIFF
--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -116,7 +116,7 @@ class DeployUI
       "all-of-us-rw-stable" => "stable",
     }
     environment_name = environment_names[@opts.project]
-    common.run_inline %W{yarn run build --environment=#{environment_name}}
+    common.run_inline %W{yarn run build --environment=#{environment_name} --no-watch --no-progress}
     ServiceAccountContext.new(@opts.project).run do
       common.run_inline %W{gcloud app deploy --project #{@opts.project} --version #{@opts.version} --#{@opts.promote}}
     end


### PR DESCRIPTION
The CircleCI logs are getting clogged up with spammy build percentage stuff, this should suppress that. 

Example: https://circleci.com/gh/all-of-us/workbench/8150