### PR TITLE
Fix: Removing the last item should remove the group

### DIFF
--- a/ui/src/app/cohort-search/redux/actions/service.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.ts
@@ -179,7 +179,7 @@ export class CohortSearchActions {
       /* If this was the only item in the group, the group no longer has a
        * count, not really. */
       if (isOnlyChild) {
-        this.setCount('groups', groupId, null);
+        this.removeGroup(role, groupId);
       } else {
         this.requestGroupCount(role, groupId);
       }


### PR DESCRIPTION
If the last item is removed from a search group, we should remove the search group.