### PR TITLE
[RW-425] Disable Stackdriver for http:// hosts, to catch local dev; always log

### DIFF
--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -52,7 +52,7 @@ class DevUpOptions
   attr_accessor :env
 
   def initialize
-    self.env = "test"
+    self.env = nil
   end
 
   def parse args
@@ -63,7 +63,7 @@ class DevUpOptions
         # The default environment file (called "dev" in Angular language)
         # compiles a local server to run against the deployed remote test API.
         # Leave this unset to get that default.
-        self.env = v == "local-test" ? "" : v
+        self.env = v == "local-test" ? nil : v
       end
     end
     parser.parse args

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -48,7 +48,7 @@ Common.register_command({
 })
 
 class DevUpOptions
-  ENV_CHOICES = %W{local test prod}
+  ENV_CHOICES = %W{local-test local test prod}
   attr_accessor :env
 
   def initialize
@@ -59,8 +59,11 @@ class DevUpOptions
     parser = OptionParser.new do |parser|
       parser.banner = "Usage: ./project.rb dev-up [options]"
       parser.on(
-          "--environment ENV", ENV_CHOICES, "Environment [local (default), test, prod]") do |v|
-        self.env = v
+          "--environment ENV", ENV_CHOICES, "Environment [local-test (default), local, test, prod]") do |v|
+        # The default environment file (called "dev" in Angular language)
+        # compiles a local server to run against the deployed remote test API.
+        # Leave this unset to get that default.
+        self.env = v == "local-test" ? "" : v
       end
     end
     parser.parse args
@@ -141,7 +144,7 @@ def dev_up(*args)
 
   install_dependencies
 
-  ENV["ENV_FLAG"] = options.env == "local" ? "" : "--environment=#{options.env}"
+  ENV["ENV_FLAG"] = options.env ? "--environment=#{options.env}" : ""
   at_exit { common.run_inline %W{docker-compose down} }
   swagger_regen()
   common.run_inline %W{docker-compose run -d --service-ports tests}

--- a/ui/src/app/services/error-reporter.service.ts
+++ b/ui/src/app/services/error-reporter.service.ts
@@ -30,8 +30,9 @@ export class ErrorReporterService extends ErrorHandler {
   }
 
   handleError(error: any) {
+    // Always log to console regardless of whether Stackdriver is enabled.
+    super.handleError(error);
     if (!this.stackdriverReporter) {
-      super.handleError(error);
       return;
     }
     this.stackdriverReporter.report(error, (e) => {

--- a/ui/src/app/services/error-reporter.service.ts
+++ b/ui/src/app/services/error-reporter.service.ts
@@ -2,6 +2,7 @@ import {ErrorHandler, Injectable} from '@angular/core';
 import {StackdriverErrorReporter} from 'stackdriver-errors-js';
 
 import {ServerConfigService} from 'app/services/server-config.service';
+import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
 
 @Injectable()
@@ -10,9 +11,8 @@ export class ErrorReporterService extends ErrorHandler {
 
   constructor(serverConfigService: ServerConfigService) {
     super();
-    if (window.location.protocol !== 'https:') {
-      // The scheme is an indirect proxy for whether this is a local dev
-      // deployment. If it is local, we want to disable Stackdriver reporting as
+    if (environment.debug) {
+      // This is a local dev server, we want to disable Stackdriver reporting as
       // it's not useful and likely won't work due to the origin.
       return;
     }

--- a/ui/src/app/services/error-reporter.service.ts
+++ b/ui/src/app/services/error-reporter.service.ts
@@ -10,6 +10,12 @@ export class ErrorReporterService extends ErrorHandler {
 
   constructor(serverConfigService: ServerConfigService) {
     super();
+    if (window.location.protocol !== 'https:') {
+      // The scheme is an indirect proxy for whether this is a local dev
+      // deployment. If it is local, we want to disable Stackdriver reporting as
+      // it's not useful and likely won't work due to the origin.
+      return;
+    }
     serverConfigService.getConfig().subscribe((config: ConfigResponse) => {
       if (!config.stackdriverApiKey) {
         return;
@@ -29,6 +35,8 @@ export class ErrorReporterService extends ErrorHandler {
       return;
     }
     this.stackdriverReporter.report(error, (e) => {
+      // Note: this does not detect non-200 responses from Stackdriver:
+      // https://github.com/GoogleCloudPlatform/stackdriver-errors-js/issues/32
       if (e) {
         console.log('failed to send error report: ' + e);
       }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -1,0 +1,10 @@
+import {testEnvironmentBase} from 'environments/test-env-base';
+
+export const environment = {
+  displayTag: 'Local->Local',
+  allOfUsApiUrl: 'http://localhost:8081',
+  clientId: testEnvironmentBase.clientId,
+  publicApiUrl: 'http://localhost:8083',
+  debug: true,
+  testing: false
+};

--- a/ui/src/environments/environment.test.ts
+++ b/ui/src/environments/environment.test.ts
@@ -1,8 +1,8 @@
+import {testEnvironmentBase} from 'environments/test-env-base';
+
 export const environment = {
+  ...testEnvironmentBase,
   displayTag: 'Test',
-  allOfUsApiUrl: 'https://api-dot-all-of-us-workbench-test.appspot.com',
-  clientId: '602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com',
-  publicApiUrl: 'https://public-api-dot-all-of-us-workbench-test.appspot.com',
   debug: false,
   testing: true
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,8 +1,8 @@
+import {testEnvironmentBase} from 'environments/test-env-base';
+
 export const environment = {
-  displayTag: 'Local',
-  allOfUsApiUrl: 'http://localhost:8081',
-  clientId: '602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com',
-  publicApiUrl: 'http://localhost:8083',
+  ...testEnvironmentBase,
+  displayTag: 'Local->Test',
   debug: true,
   testing: false
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -1,0 +1,7 @@
+// The values are shared across the deployed test env as well as the local dev
+// environments.
+export const testEnvironmentBase = {
+  allOfUsApiUrl: 'https://api-dot-all-of-us-workbench-test.appspot.com',
+  clientId: '602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com',
+  publicApiUrl: 'https://public-api-dot-all-of-us-workbench-test.appspot.com'
+};


### PR DESCRIPTION
Unfortunately I couldn't come up with a better way to detect whether we were running a local development deployment or not. Using the protocol as a proxy is the best I got. Let me know if you have any ideas on this (deployed should always be https, else it's probably local).

My requirements are that SD reporting is disabled for a local workstation deployment, continue to be enabled the test GAE UI, and that I don't depend too much on what host devs access their local deployment on, e.g. localhost vs 0.0.0.0 vs myhostname etc.

Here's what I tried:
- `isDevMode()` - this is `true` in test
- `process.env.ENV === 'production'`; this is a signal that the Angular app has been compiled for production. I believe it will be set when we `ng build --prod` (I've not verified though). Unfortunately it's not set in `test` currently, though I don't know if this is intentional and I could imagine making an argument to change it.
- `environment.ts`; when running locally against test, we actually use `environment.test.ts`

I've also changed this to always log to console on errors (possibly in addition to StackDriver), so that should handle the original concern regardless.