### PR TITLE
[RW-429] Fix SignInService in the signed out case

### DIFF
--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -84,7 +84,6 @@ export class SignInService {
       gapi.auth2.getAuthInstance().currentUser.listen((e: any) => {
         const currentUser = gapi.auth2.getAuthInstance().currentUser.get();
         const details = this.extractSignInDetails(currentUser);
-        this.currentAccessToken = details.authResponse['access_token'];
         // Without this, Angular views won't "notice" the externally-triggered
         // event, though the Angular models will update... so the change
         // won't propagate to UI automatically. Calling `zone.run`


### PR DESCRIPTION
I noticed this error in the console, and also noticed signout being broken.

`this.currentAccessToken` gets set on `subscribeToUser()`, so the deleted line appears redundant to me. If it was actually necessary for some weird reason, should rework to guard against the signed out case.

Please merge this for me or hijack my branch if needed, I will likely not be online when this is reviewed.