### PR TITLE
Update pyclient, install for both py2.7 and py3.4, document/deploy scripts

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1256,8 +1256,6 @@ def create_project_resources(gcc)
   common.run_inline %W{gsutil mb -p #{gcc.project} -c regional -l us-central1 gs://#{gcc.project}-credentials/}
   common.status "Creating GCS bucket to store scripts..."
   common.run_inline %W{gsutil mb -p #{gcc.project} -c regional -l us-central1 gs://#{gcc.project}-scripts/}
-  common.run_inline %W{gsutil cp scripts/setup_notebook_cluster.sh gs://#{gcc.project}-scripts/setup_notebook_cluster.sh}
-  common.run_inline %W{gsutil acl ch -u AllUsers:R gs://#{gcc.project}-scripts/setup_notebook_cluster.sh}
   common.status "Creating Cloud SQL instances..."
   common.run_inline %W{gcloud sql instances create #{INSTANCE_NAME} --tier=db-n1-standard-2
                        --activation-policy=ALWAYS --backup-start-time 00:00
@@ -1338,6 +1336,7 @@ def setup_cloud_project(cmd_name, *args)
   create_project_resources(gcc)
   setup_project_data(gcc, op.opts.cdr_db_name, op.opts.public_db_name,
                      random_password(), random_password(), random_password(), args)
+  deploy_gcs_artifacts(cmd_name, args)
 end
 
 Common.register_command({

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -1,0 +1,43 @@
+# setup_notebook_cluster.sh
+
+This is the script run on the Leonardo Jupyter server at cluster initialization
+time, i.e. the [jupyterUserScriptUri](
+https://github.com/DataBiosphere/leonardo/blob/cfdbff2448b9cff73ad658ba028d1feafab01b81/src/main/resources/swagger/api-docs.yaml#L509).
+
+## Local testing
+
+To manually test updates to this script locally:
+
+- Push the script to GCS (username-suffixed) and make it publicly readable:
+
+  ```
+  api$ gsutil cp scripts/setup_notebook_cluster.sh "gs://all-of-us-workbench-test-scripts/setup_notebook_cluster-${USER}.sh" &&
+    gsutil acl ch -u AllUsers:R "gs://all-of-us-workbench-test-scripts/setup_notebook_cluster-${USER}.sh"
+  ```
+
+- (**Disclaimer**: local code change, do not submit) Temporarily update your
+  local server config to use your custom script:
+
+  ```
+  api$ sed -i "s,setup_notebook_cluster\.sh,setup_notebook_cluster-${USER}.sh," config/config_local.json
+  ```
+
+- Restart your dev API server and point a local UI to it
+- Find your existing notebook cluster if any, by authorizing as your
+  fake-research-aou.org user [here](
+  https://notebooks.firecloud.org/#!/cluster/listClusters).
+- Delete your existing clusters, if any [here](
+  https://notebooks.firecloud.org/#!/cluster/deleteCluster).
+- Open your local Workbench UI and wait for the notebook cluster to be created.
+  - Cluster creation will fail with 500s if your old server of the same
+    name is still deleting (https://github.com/DataBiosphere/leonardo/issues/220);
+    this may take a minute.
+  - Cluster creation will fail with 500s if the user script is not accessible,
+    ensure your script is publicly readable via [cloud console UI](
+    https://console.cloud.google.com/storage/browser/all-of-us-workbench-test-scripts?project=all-of-us-workbench-test)
+- Revert changes to `config/config_local.json`
+
+## Releasing
+
+This script will be pushed to the appropriate GCS environment along with our
+normal release process.

--- a/api/scripts/setup_notebook_cluster.sh
+++ b/api/scripts/setup_notebook_cluster.sh
@@ -2,4 +2,7 @@
 # Initializes a Jupyter notebook cluster. This file is copied to the GCS bucket <PROJECT>-scripts
 # and its GCS path is passed in as jupyterUserScriptUri during notebook cluster creation.
 
-pip install --upgrade 'https://github.com/all-of-us/pyclient/archive/pyclient-v1-1-rc4.zip#egg=aou_workbench_client&subdirectory=py'
+
+for v in "2.7" "3.4"; do
+  "pip${v}" install --upgrade 'https://github.com/all-of-us/pyclient/archive/pyclient-v1-2.zip#egg=aou_workbench_client&subdirectory=py'
+done


### PR DESCRIPTION
- Push new pyclient release
- The default `pip` version as of the latest Leo image is 3.4, this explains why I wasn't able to see AoU installed on py2.7 kernels; install on both
- Autopush scripts on circle-deploy
- Add docs for testing local changes to user scripts

Confirmed locally that this user script fixes the py2/3 issue.