### PR TITLE
Removing distinct from BigQuery SQL

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
@@ -28,12 +28,12 @@ public class ParticipantCounter {
     private DomainLookupService domainLookupService;
 
     private static final String COUNT_SQL_TEMPLATE =
-            "select count(distinct person_id) as count\n" +
+            "select count(*) as count\n" +
                     "from `${projectId}.${dataSetId}.person` person\n" +
                     "where\n";
 
     private static final String ID_SQL_TEMPLATE =
-            "select distinct person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime\n" +
+            "select person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime\n" +
                     "from `${projectId}.${dataSetId}.person` person\n" +
                     "where\n";
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
@@ -57,7 +57,7 @@ public class ParticipantCounter {
 
     private static final String OFFSET_SUFFIX = " offset ";
 
-    private static final String UNION_TEMPLATE = "union distinct\n";
+    private static final String UNION_TEMPLATE = "union all\n";
 
     private static final String INCLUDE_SQL_TEMPLATE = "person.person_id in (${includeSql})\n";
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilder.java
@@ -38,7 +38,7 @@ public class CodesQueryBuilder extends AbstractQueryBuilder {
     }
 
     private static final String INNER_SQL_TEMPLATE =
-            "select distinct person_id\n" +
+            "select person_id\n" +
                     "from `${projectId}.${dataSetId}.${tableName}` a, `${projectId}.${dataSetId}.concept` b\n"+
                     "where a.${tableId} = b.concept_id\n";
 
@@ -50,7 +50,7 @@ public class CodesQueryBuilder extends AbstractQueryBuilder {
 
     private static final String GROUP_CODE_LIKE_TEMPLATE = "and b.concept_code like ${conceptCodes}\n";
 
-    private static final String UNION_TEMPLATE = " union distinct\n";
+    private static final String UNION_TEMPLATE = " union all\n";
 
     private static final String OUTER_SQL_TEMPLATE =
             "select person_id\n"+

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/DemoQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/DemoQueryBuilder.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 @Service
 public class DemoQueryBuilder extends AbstractQueryBuilder {
 
-    private static final String SELECT = "select distinct person_id\n" +
+    private static final String SELECT = "select person_id\n" +
             "from `${projectId}.${dataSetId}.person` p\n" +
             "where\n";
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilder.java
@@ -23,15 +23,15 @@ public class PhecodesQueryBuilder extends AbstractQueryBuilder {
             "select person_id\n" +
                     "from `${projectId}.${dataSetId}.condition_occurrence` co\n" +
                     "where co.condition_source_concept_id in (${innerSql})\n" +
-                    "union distinct\n" +
+                    "union all\n" +
             "select person_id\n" +
                     "from `${projectId}.${dataSetId}.procedure_occurrence` po\n" +
                     "where po.procedure_source_concept_id in (${innerSql})\n" +
-                    "union distinct\n" +
+                    "union all\n" +
             "select person_id\n" +
                     "from `${projectId}.${dataSetId}.measurement` m\n" +
                     "where m.measurement_source_concept_id in (${innerSql})\n" +
-                    "union distinct\n" +
+                    "union all\n" +
             "select person_id\n" +
                     "from `${projectId}.${dataSetId}.observation` o\n" +
                     "where o.observation_source_concept_id in (${innerSql})\n";

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/ParticipantCounterTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/ParticipantCounterTest.java
@@ -69,10 +69,10 @@ public class ParticipantCounterTest {
             }
         }
 
-        final String expectedSql = "select count(distinct person_id) as count\n" +
+        final String expectedSql = "select count(*) as count\n" +
                 "from `${projectId}.${dataSetId}.person` person\n" +
                 "where\n" +
-                "person.person_id in (select distinct person_id\n" +
+                "person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
                 "where\n" +
                 "p.gender_concept_id in unnest(@" + genderNamedParameter + ")\n" +
@@ -150,19 +150,19 @@ public class ParticipantCounterTest {
             }
         }
 
-        final String expectedSql = "select count(distinct person_id) as count\n" +
+        final String expectedSql = "select count(*) as count\n" +
                 "from `${projectId}.${dataSetId}.person` person\n" +
                 "where\n" +
                 "person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.condition_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.condition_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmConditionParameter + ",@" + procConditionParameter + ")\n" +
                 "and b.concept_code in unnest(@" + conditionNamedParameter + ")\n" +
                 ")\n" +
                 ")\n" +
-                "and person.person_id in (select distinct person_id\n" +
+                "and person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
                 "where\n" +
                 "p.gender_concept_id in unnest(@" + genderNamedParameter + ")\n" +
@@ -171,7 +171,7 @@ public class ParticipantCounterTest {
                 "(select 'x' from\n" +
                 "(select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.procedure_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.procedure_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmProcedureParameter + ",@" + procProcedureParameter + ")\n" +
@@ -259,19 +259,19 @@ public class ParticipantCounterTest {
             }
         }
 
-        final String expectedSql = "select distinct person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime\n" +
+        final String expectedSql = "select person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime\n" +
                 "from `${projectId}.${dataSetId}.person` person\n" +
                 "where\n" +
                 "person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.condition_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.condition_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmConditionParameter + ",@" + procConditionParameter + ")\n" +
                 "and b.concept_code in unnest(@" + conditionNamedParameter + ")\n" +
                 ")\n" +
                 ")\n" +
-                "and person.person_id in (select distinct person_id\n" +
+                "and person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
                 "where\n" +
                 "p.gender_concept_id in unnest(@" + genderNamedParameter + ")\n" +
@@ -280,7 +280,7 @@ public class ParticipantCounterTest {
                 "(select 'x' from\n" +
                 "(select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.procedure_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.procedure_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmProcedureParameter + ",@" + procProcedureParameter + ")\n" +
@@ -383,14 +383,14 @@ public class ParticipantCounterTest {
                 "where\n" +
                 "person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.condition_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.condition_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmConditionParameter + ",@" + procConditionParameter + ")\n" +
                 "and b.concept_code in unnest(@" + conditionNamedParameter + ")\n" +
                 ")\n" +
                 ")\n" +
-                "and person.person_id in (select distinct person_id\n" +
+                "and person.person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
                 "where\n" +
                 "p.gender_concept_id in unnest(@" + genderNamedParameter + ")\n" +
@@ -399,7 +399,7 @@ public class ParticipantCounterTest {
                 "(select 'x' from\n" +
                 "(select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
-                "where person_id in (select distinct person_id\n" +
+                "where person_id in (select person_id\n" +
                 "from `${projectId}.${dataSetId}.procedure_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                 "where a.procedure_source_concept_id = b.concept_id\n" +
                 "and b.vocabulary_id in (@" + cmProcedureParameter + ",@" + procProcedureParameter + ")\n" +

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilderTest.java
@@ -60,13 +60,13 @@ public class CodesQueryBuilderTest {
         String expected =
                 "select person_id\n" +
                         "from `${projectId}.${dataSetId}.person` p\n" +
-                        "where person_id in (select distinct person_id\n" +
+                        "where person_id in (select person_id\n" +
                         "from `${projectId}.${dataSetId}.condition_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                         "where a.condition_source_concept_id = b.concept_id\n" +
                         "and b.vocabulary_id in (@" + cmConditionParameter + ",@" + procConditionParameter + ")\n" +
                         "and b.concept_code in unnest(@" + conditionNamedParameter + ")\n" +
-                        " union distinct\n" +
-                        "select distinct person_id\n" +
+                        " union all\n" +
+                        "select person_id\n" +
                         "from `${projectId}.${dataSetId}.measurement` a, `${projectId}.${dataSetId}.concept` b\n" +
                         "where a.measurement_source_concept_id = b.concept_id\n" +
                         "and b.vocabulary_id in (@" + cmMeasurementParameter + ",@" + procMeasurementParameter + ")\n" +
@@ -145,19 +145,19 @@ public class CodesQueryBuilderTest {
         String expected =
                 "select person_id\n" +
                         "from `${projectId}.${dataSetId}.person` p\n" +
-                        "where person_id in (select distinct person_id\n" +
+                        "where person_id in (select person_id\n" +
                         "from `${projectId}.${dataSetId}.measurement` a, `${projectId}.${dataSetId}.concept` b\n" +
                         "where a.measurement_source_concept_id = b.concept_id\n" +
                         "and b.vocabulary_id in (@" + cmMeasurementParameter + ",@" + procMeasurementParameter + ")\n" +
                         "and b.concept_code like @" + measurementNamedParameter + "\n" +
-                        " union distinct\n" +
-                        "select distinct person_id\n" +
+                        " union all\n" +
+                        "select person_id\n" +
                         "from `${projectId}.${dataSetId}.procedure_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                         "where a.procedure_source_concept_id = b.concept_id\n" +
                         "and b.vocabulary_id in (@" + cmProcedureParameter + ",@" + procProcedureParameter + ")\n" +
                         "and b.concept_code like @" + procedureNamedParameter + "\n" +
-                        " union distinct\n" +
-                        "select distinct person_id\n" +
+                        " union all\n" +
+                        "select person_id\n" +
                         "from `${projectId}.${dataSetId}.condition_occurrence` a, `${projectId}.${dataSetId}.concept` b\n" +
                         "where a.condition_source_concept_id = b.concept_id\n" +
                         "and b.vocabulary_id in (@" + cmConditionParameter + ",@" + procConditionParameter + ")\n" +

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/DemoQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/DemoQueryBuilderTest.java
@@ -46,7 +46,7 @@ public class DemoQueryBuilderTest {
             }
         }
 
-        String expected = "select distinct person_id\n" +
+        String expected = "select person_id\n" +
                 "from `${projectId}.${dataSetId}.person` p\n" +
                 "where\n" +
                 "p.gender_concept_id in unnest(@" + genderNamedParameter + ")\n" +

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilderTest.java
@@ -51,7 +51,7 @@ public class PhecodesQueryBuilderTest {
                         "where phecode in unnest(@" + pheCodesNamedParameter + "))\n" +
                         "and vocabulary_id in ('ICD9Proc', 'ICD9CM')\n" +
                         ")\n" +
-                        "union distinct\n" +
+                        "union all\n" +
                         "select person_id\n" +
                         "from `${projectId}.${dataSetId}.procedure_occurrence` po\n" +
                         "where po.procedure_source_concept_id in (select concept_id\n" +
@@ -61,7 +61,7 @@ public class PhecodesQueryBuilderTest {
                         "where phecode in unnest(@" + pheCodesNamedParameter + "))\n" +
                         "and vocabulary_id in ('ICD9Proc', 'ICD9CM')\n" +
                         ")\n" +
-                        "union distinct\n" +
+                        "union all\n" +
                         "select person_id\n" +
                         "from `${projectId}.${dataSetId}.measurement` m\n" +
                         "where m.measurement_source_concept_id in (select concept_id\n" +
@@ -71,7 +71,7 @@ public class PhecodesQueryBuilderTest {
                         "where phecode in unnest(@" + pheCodesNamedParameter + "))\n" +
                         "and vocabulary_id in ('ICD9Proc', 'ICD9CM')\n" +
                         ")\n" +
-                        "union distinct\n" +
+                        "union all\n" +
                         "select person_id\n" +
                         "from `${projectId}.${dataSetId}.observation` o\n" +
                         "where o.observation_source_concept_id in (select concept_id\n" +


### PR DESCRIPTION
It turns out we didn't really need it anywhere... and queries should run faster without it I believe. 

All BigQuery tests pass, a bit faster than before.