### PR TITLE
Simplify workspace loading flow

### DIFF
--- a/ui/src/app/resolvers/workspace.ts
+++ b/ui/src/app/resolvers/workspace.ts
@@ -7,7 +7,7 @@ import {Workspace, WorkspaceAccessLevel, WorkspacesService} from 'generated';
 /**
  * Flatten a layer of nesting
  */
-interface WorkspaceData extends Workspace {
+export interface WorkspaceData extends Workspace {
   accessLevel: WorkspaceAccessLevel;
 }
 

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -1,3 +1,7 @@
+.workspace-header {
+  display: flex;
+}
+
 .area-block {
   margin-top: 0.2rem;
   margin-left: 4%;

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -1,158 +1,140 @@
-<div *ngIf="!notFound else notFoundMessage">
-  <div *ngIf="!workspaceLoading; else workspacePageLoading" style="display: flex;">
-    <h2>{{workspace.name}}</h2>
-    <div class="btn-group btn-primary-outline permissions-group">
-      <button (mouseover)="editHover=true" (mouseleave)="editHover=false"
-          [disabled]="!writePermission" (click)="edit()"
-          class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-        <app-edit-icon [editHover]="editHover"></app-edit-icon>
-        <span class="tooltip-content">Edit Workspace</span>
-      </button>
-      <button (mouseover)="shareHover=true" (mouseleave)="shareHover=false"
-          (click)="share()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-        <app-share-icon [shareHover]="shareHover"></app-share-icon>
-        <span class="tooltip-content">Share Workspace</span>
-      </button>
-      <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
-              (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-        <!-- TODO(calbach): Check whether we have the real asset available. -->
-        <clr-icon shape="copy"></clr-icon>
-        <span class="tooltip-content">Clone Workspace</span>
-      </button>
-      <button (mouseover)="trashHover=true" (mouseleave)="trashHover=false"
-          [disabled]="!ownerPermission"
-          class="btn btn-icon btn-danger-outline btn-deleting tooltip tooltip-sm"
-          (click)="delete()" [clrLoading]="deleting">
-        <app-trash-icon [trashHover]="trashHover"></app-trash-icon>
-        <span class="tooltip-content">Delete Workspace</span>
-      </button>
-    </div>
+<h2>{{workspace.name}}</h2>
+<div class="btn-group btn-primary-outline permissions-group">
+  <button (mouseover)="editHover=true" (mouseleave)="editHover=false"
+      [disabled]="!writePermission" (click)="edit()"
+      class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+    <app-edit-icon [editHover]="editHover"></app-edit-icon>
+    <span class="tooltip-content">Edit Workspace</span>
+  </button>
+  <button (mouseover)="shareHover=true" (mouseleave)="shareHover=false"
+      (click)="share()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+    <app-share-icon [shareHover]="shareHover"></app-share-icon>
+    <span class="tooltip-content">Share Workspace</span>
+  </button>
+  <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
+          (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+    <!-- TODO(calbach): Check whether we have the real asset available. -->
+    <clr-icon shape="copy"></clr-icon>
+    <span class="tooltip-content">Clone Workspace</span>
+  </button>
+  <button (mouseover)="trashHover=true" (mouseleave)="trashHover=false"
+      [disabled]="!ownerPermission"
+      class="btn btn-icon btn-danger-outline btn-deleting tooltip tooltip-sm"
+      (click)="delete()" [clrLoading]="deleting">
+    <app-trash-icon [trashHover]="trashHover"></app-trash-icon>
+    <span class="tooltip-content">Delete Workspace</span>
+  </button>
+</div>
+<div class="description-text">
+  {{workspace.description}}
+</div>
+<div class="area-block">
+  <h3>CDR Version</h3>
+  <div class="indented">
+    <p class="cdr-text">
+      {{workspace.cdrVersionId}}
+    </p>
   </div>
-  <ng-template #workspacePageLoading>
-    <div class="loading-area">
-      <span class="spinner spinner-md" style="padding-top: 1rem"></span>
-      <span class="loading-text">Loading...</span>
-    </div>
-  </ng-template>
-  <div *ngIf="!workspaceLoading;" class="description-text">
-    {{workspace.description}}
+</div>
+<div class="area-block">
+  <div class="table-header">
+    <h3 class="table-header-descriptor">Cohorts</h3>
+    <a class="btn btn-link" [routerLink]="['cohorts', 'build']">Add a Cohort</a>
   </div>
-  <div class="area-block">
-    <h3>CDR Version</h3>
-    <div class="indented">
-      <p *ngIf="!workspaceLoading;" class="cdr-text">
-        {{workspace.cdrVersionId}}
-      </p>
-    </div>
+  <div class="indented">
+    <clr-datagrid [clrDgLoading]="cohortsLoading">
+      <clr-dg-column [clrDgField]="'cohort.name'" [clrDgSortBy]="cohortNameComparator" [style.width.%]="25">
+        Name
+        <clr-dg-string-filter [clrDgStringFilter]="cohortNameFilter"></clr-dg-string-filter>
+      </clr-dg-column>
+      <clr-dg-column [clrDgField]="'cohort.description'" [clrDgSortBy]="cohortDescriptionComparator" [style.width.%]="50">
+        Description
+        <clr-dg-string-filter [clrDgStringFilter]="cohortDescriptionFilter"></clr-dg-string-filter>
+      </clr-dg-column>
+      <clr-dg-column [style.width.%]="25">Created Date</clr-dg-column>
+      <clr-dg-placeholder>No cohorts found in this workspace.</clr-dg-placeholder>
+      <clr-dg-row *clrDgItems="let cohort of cohortList" [clrDgItem]="cohort" class="table-row cohort-table-row">
+        <clr-dg-action-overflow>
+          <button class="action-item"
+            [routerLink]="['cohorts', 'build']"
+            [queryParams]="{criteria: cohort.criteria}">
+            <clr-icon shape="copy"></clr-icon>
+            Clone
+          </button>
+          <button class="action-item"
+            routerLink="{{document.location.pathname}}/cohorts/{{cohort.id}}/edit">
+            <clr-icon shape="pencil"></clr-icon>
+            Edit
+          </button>
+          <button class="action-item"
+            routerLink="{{document.location.pathname}}/cohorts/{{cohort.id}}/review">
+            <clr-icon shape="grid-view"></clr-icon>
+            Review
+          </button>
+        </clr-dg-action-overflow>
+        <clr-dg-cell>{{cohort.name}}</clr-dg-cell>
+        <clr-dg-cell>{{cohort.description}}</clr-dg-cell>
+        <clr-dg-cell>{{cohort.creationTime | date:'medium'}}</clr-dg-cell>
+      </clr-dg-row>
+    </clr-datagrid>
   </div>
-  <div class="area-block">
-    <div class="table-header">
-      <h3 class="table-header-descriptor">Cohorts</h3>
-      <a class="btn btn-link" [routerLink]="['cohorts', 'build']">Add a Cohort</a>
-    </div>
-    <div class="indented">
-      <clr-datagrid [clrDgLoading]="cohortsLoading">
-        <clr-dg-column [clrDgField]="'cohort.name'" [clrDgSortBy]="cohortNameComparator" [style.width.%]="25">
-          Name
-          <clr-dg-string-filter [clrDgStringFilter]="cohortNameFilter"></clr-dg-string-filter>
-        </clr-dg-column>
-        <clr-dg-column [clrDgField]="'cohort.description'" [clrDgSortBy]="cohortDescriptionComparator" [style.width.%]="50">
-          Description
-          <clr-dg-string-filter [clrDgStringFilter]="cohortDescriptionFilter"></clr-dg-string-filter>
-        </clr-dg-column>
-        <clr-dg-column [style.width.%]="25">Created Date</clr-dg-column>
-        <clr-dg-placeholder>No cohorts found in this workspace.</clr-dg-placeholder>
-        <clr-dg-row *clrDgItems="let cohort of cohortList" [clrDgItem]="cohort" class="table-row cohort-table-row">
-          <clr-dg-action-overflow>
-            <button class="action-item"
-              [routerLink]="['cohorts', 'build']"
-              [queryParams]="{criteria: cohort.criteria}">
-              <clr-icon shape="copy"></clr-icon>
-              Clone
-            </button>
-            <button class="action-item"
-              routerLink="{{document.location.pathname}}/cohorts/{{cohort.id}}/edit">
-              <clr-icon shape="pencil"></clr-icon>
-              Edit
-            </button>
-            <button class="action-item"
-              routerLink="{{document.location.pathname}}/cohorts/{{cohort.id}}/review">
-              <clr-icon shape="grid-view"></clr-icon>
-              Review
-            </button>
-          </clr-dg-action-overflow>
-          <clr-dg-cell>{{cohort.name}}</clr-dg-cell>
-          <clr-dg-cell>{{cohort.description}}</clr-dg-cell>
-          <clr-dg-cell>{{cohort.creationTime | date:'medium'}}</clr-dg-cell>
-        </clr-dg-row>
-      </clr-datagrid>
-    </div>
+</div>
+<clr-modal [(clrModalOpen)]="cohortsError">
+  <h3 class="modal-title">Error:</h3>
+  <div class="modal-body">Could not fetch cohorts from workspace.</div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="cohortsError = false">Ok</button>
   </div>
-  <clr-modal [(clrModalOpen)]="cohortsError">
-    <h3 class="modal-title">Error:</h3>
-    <div class="modal-body">Could not fetch cohorts from workspace.</div>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="cohortsError = false">Ok</button>
-    </div>
-  </clr-modal>
+</clr-modal>
 
-  <clr-modal [(clrModalOpen)]="clusterPulled">
-    <h3 class="modal-title">Notebook Server Ready:</h3>
-    <div class="modal-body">Your notebook server is ready, please confirm to open in a new tab</div>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="openCluster(launchedNotebookName)">Ok</button>
-      <button type="button" class="btn btn-primary" (click)="cancelCluster()">Cancel</button>
-    </div>
-  </clr-modal>
-  <div class="area-block">
-    <div class="table-header">
-      <h3 class="table-header-descriptor">Notebooks</h3>
-      <div class="alert {{alertCategory}}" *ngIf="showAlerts">
-        <div class="alert-items">
-          <div class="alert-item static">
-            <div class="alert-icon-wrapper">
-              <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
-            </div>
-            <span class="alert-text">{{alertMsg}}</span>
+<clr-modal [(clrModalOpen)]="clusterPulled">
+  <h3 class="modal-title">Notebook Server Ready:</h3>
+  <div class="modal-body">Your notebook server is ready, please confirm to open in a new tab</div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="openCluster(launchedNotebookName)">Ok</button>
+    <button type="button" class="btn btn-primary" (click)="cancelCluster()">Cancel</button>
+  </div>
+</clr-modal>
+<div class="area-block">
+  <div class="table-header">
+    <h3 class="table-header-descriptor">Notebooks</h3>
+    <div class="alert {{alertCategory}}" *ngIf="showAlerts">
+      <div class="alert-items">
+        <div class="alert-item static">
+          <div class="alert-icon-wrapper">
+            <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
           </div>
+          <span class="alert-text">{{alertMsg}}</span>
         </div>
       </div>
-      <button class="btn" (click)="launchCluster()">New Notebook
-      </button>
-      <div *ngIf="clusterLoading" class="cluster-spinner">
-        <span class="spinner spinner-sm" alt=Creating Notebook Server...></span>
-      </div>
     </div>
-    <div class="indented">
-      <clr-datagrid [clrDgLoading]="notebooksLoading">
-        <clr-dg-column [clrDgField]="'notebook.name'" [clrDgSortBy]="notebookNameComparator">
-          Name
-          <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>
-        </clr-dg-column>
-        <clr-dg-column>Path</clr-dg-column>
-        <clr-dg-placeholder>No notebooks found in this workspace.</clr-dg-placeholder>
-        <clr-dg-row
-          class="table-row notebook-table-row"
-          *clrDgItems="let notebook of notebookList"
-          [clrDgItem]="notebook"
-          (click)="launchNotebook(notebook)">
-          <clr-dg-cell>{{notebook.name}}</clr-dg-cell>
-          <clr-dg-cell>{{notebook.path}}</clr-dg-cell>
-        </clr-dg-row>
-      </clr-datagrid>
-    </div>
+    <button class="btn" [disabled]="clusterLoading" (click)="launchCluster()">
+      New Notebook
+    </button>
   </div>
-  <clr-modal [(clrModalOpen)]="notebookError">
-    <h3 class="modal-title">Error:</h3>
-    <div class="modal-body">Could not fetch notebooks from workspace.</div>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="notebookError = false">Ok</button>
-    </div>
-  </clr-modal>
+  <div class="indented">
+    <clr-datagrid [clrDgLoading]="notebooksLoading || clusterLoading">
+      <clr-dg-column [clrDgField]="'notebook.name'" [clrDgSortBy]="notebookNameComparator">
+        Name
+        <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>
+      </clr-dg-column>
+      <clr-dg-column>Path</clr-dg-column>
+      <clr-dg-placeholder>No notebooks found in this workspace.</clr-dg-placeholder>
+      <clr-dg-row
+        class="table-row notebook-table-row"
+        *clrDgItems="let notebook of notebookList"
+        [clrDgItem]="notebook"
+        (click)="launchNotebook(notebook)">
+        <clr-dg-cell>{{notebook.name}}</clr-dg-cell>
+        <clr-dg-cell>{{notebook.path}}</clr-dg-cell>
+      </clr-dg-row>
+    </clr-datagrid>
+  </div>
 </div>
-<!-- TODO: Factor out to component -->
-<ng-template #notFoundMessage>
-  <h3>
-    Workspace {{route.snapshot.params['ns']}}/{{route.snapshot.params['wsid']}} could not be found.
-  </h3>
-</ng-template>
+<clr-modal [(clrModalOpen)]="notebookError">
+  <h3 class="modal-title">Error:</h3>
+  <div class="modal-body">Could not fetch notebooks from workspace.</div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="notebookError = false">Ok</button>
+  </div>
+</clr-modal>

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -1,29 +1,31 @@
-<h2>{{workspace.name}}</h2>
-<div class="btn-group btn-primary-outline permissions-group">
-  <button (mouseover)="editHover=true" (mouseleave)="editHover=false"
-      [disabled]="!writePermission" (click)="edit()"
-      class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-    <app-edit-icon [editHover]="editHover"></app-edit-icon>
-    <span class="tooltip-content">Edit Workspace</span>
-  </button>
-  <button (mouseover)="shareHover=true" (mouseleave)="shareHover=false"
-      (click)="share()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-    <app-share-icon [shareHover]="shareHover"></app-share-icon>
-    <span class="tooltip-content">Share Workspace</span>
-  </button>
-  <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
-          (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
-    <!-- TODO(calbach): Check whether we have the real asset available. -->
-    <clr-icon shape="copy"></clr-icon>
-    <span class="tooltip-content">Clone Workspace</span>
-  </button>
-  <button (mouseover)="trashHover=true" (mouseleave)="trashHover=false"
-      [disabled]="!ownerPermission"
-      class="btn btn-icon btn-danger-outline btn-deleting tooltip tooltip-sm"
-      (click)="delete()" [clrLoading]="deleting">
-    <app-trash-icon [trashHover]="trashHover"></app-trash-icon>
-    <span class="tooltip-content">Delete Workspace</span>
-  </button>
+<div class="workspace-header">
+  <h2>{{workspace.name}}</h2>
+  <div class="btn-group btn-primary-outline permissions-group">
+    <button (mouseover)="editHover=true" (mouseleave)="editHover=false"
+        [disabled]="!writePermission" (click)="edit()"
+        class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+      <app-edit-icon [editHover]="editHover"></app-edit-icon>
+      <span class="tooltip-content">Edit Workspace</span>
+    </button>
+    <button (mouseover)="shareHover=true" (mouseleave)="shareHover=false"
+        (click)="share()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+      <app-share-icon [shareHover]="shareHover"></app-share-icon>
+      <span class="tooltip-content">Share Workspace</span>
+    </button>
+    <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
+            (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+      <!-- TODO(calbach): Check whether we have the real asset available. -->
+      <clr-icon shape="copy"></clr-icon>
+      <span class="tooltip-content">Clone Workspace</span>
+    </button>
+    <button (mouseover)="trashHover=true" (mouseleave)="trashHover=false"
+        [disabled]="!ownerPermission"
+        class="btn btn-icon btn-danger-outline btn-deleting tooltip tooltip-sm"
+        (click)="delete()" [clrLoading]="deleting">
+      <app-trash-icon [trashHover]="trashHover"></app-trash-icon>
+      <span class="tooltip-content">Delete Workspace</span>
+    </button>
+  </div>
 </div>
 <div class="description-text">
   {{workspace.description}}

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -9,7 +9,7 @@ import {ClarityModule} from '@clr/angular';
 import {IconsModule} from 'app/icons/icons.module';
 import {SignInService} from 'app/services/sign-in.service';
 import {WorkspaceComponent} from 'app/views/workspace/component';
-import {ClusterService, CohortsService, WorkspacesService} from 'generated';
+import {ClusterService, CohortsService, WorkspaceAccessLevel, WorkspacesService} from 'generated';
 import {ClusterServiceStub} from 'testing/stubs/cluster-service-stub';
 import {CohortsServiceStub} from 'testing/stubs/cohort-service-stub';
 import {HttpStub} from 'testing/stubs/http-stub';
@@ -68,6 +68,12 @@ const activatedRouteStub  = {
     params: {
       'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
       'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+    },
+    data: {
+      workspace: {
+        ...WorkspacesServiceStub.stubWorkspace(),
+        accessLevel: WorkspaceAccessLevel.OWNER,
+      }
     }
   }
 };

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -81,7 +81,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   workspace: Workspace;
   wsId: string;
   wsNamespace: string;
-  workspaceLoading = true;
   cohortsLoading = true;
   cohortsError = false;
   notebookError = false;
@@ -92,7 +91,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   clusterPulled = false;
   private clusterLocalDirectory: string;
   private launchedNotebookName: string;
-  notFound = false;
   private accessLevel: WorkspaceAccessLevel;
   deleting = false;
   showAlerts = false;
@@ -114,50 +112,36 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
       private signInService: SignInService,
       private workspacesService: WorkspacesService,
       @Inject(DOCUMENT) private document: any
-  ) {}
+  ) {
+    this.workspace = this.route.snapshot.data['workspace'];
+    this.accessLevel = this.route.snapshot.data['workspace'].accessLevel;
+  }
 
   ngOnInit(): void {
-    this.workspaceLoading = true;
     this.wsNamespace = this.route.snapshot.params['ns'];
     this.wsId = this.route.snapshot.params['wsid'];
-
-    this.workspacesService.getWorkspace(this.wsNamespace, this.wsId)
-        .subscribe(
-          workspaceResponse => {
-            this.workspace = workspaceResponse.workspace;
-            this.accessLevel = workspaceResponse.accessLevel;
-            this.workspaceLoading = false;
-            this.cohortsService.getCohortsInWorkspace(this.wsNamespace, this.wsId)
-                .subscribe(
-                    cohortsReceived => {
-                      for (const coho of cohortsReceived.items) {
-                        this.cohortList.push(coho);
-                      }
-                      this.cohortsLoading = false;
-                    },
-                    error => {
-                      this.cohortsLoading = false;
-                      this.cohortsError = true;
-                    });
-
-            this.workspacesService.getNoteBookList(this.wsNamespace, this.wsId)
-                .subscribe(
-                  fileList => {
-                    this.notebookList = fileList;
-                  },
-                  error => {
-                    this.notebooksLoading = false;
-                    this.notebookError = false;
-                  });
-            this.initCluster();
-          },
-          error => {
-            if (error.status === 404) {
-              this.notFound = true;
-            } else {
-              this.workspaceLoading = false;
-            }
-          });
+    this.cohortsService.getCohortsInWorkspace(this.wsNamespace, this.wsId)
+      .subscribe(
+        cohortsReceived => {
+          for (const coho of cohortsReceived.items) {
+            this.cohortList.push(coho);
+          }
+          this.cohortsLoading = false;
+        },
+        error => {
+          this.cohortsLoading = false;
+          this.cohortsError = true;
+        });
+    this.workspacesService.getNoteBookList(this.wsNamespace, this.wsId)
+      .subscribe(
+        fileList => {
+          this.notebookList = fileList;
+        },
+        error => {
+          this.notebooksLoading = false;
+          this.notebookError = false;
+        });
+    this.initCluster();
   }
 
   ngOnDestroy(): void {

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -5,6 +5,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {Comparator, StringFilter} from '@clr/angular';
 import {Observable} from 'rxjs/Observable';
 
+import {WorkspaceData} from 'app/resolvers/workspace';
 import {SignInService} from 'app/services/sign-in.service';
 
 import {
@@ -113,8 +114,9 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
       private workspacesService: WorkspacesService,
       @Inject(DOCUMENT) private document: any
   ) {
-    this.workspace = this.route.snapshot.data['workspace'];
-    this.accessLevel = this.route.snapshot.data['workspace'].accessLevel;
+    const wsData: WorkspaceData = this.route.snapshot.data.workspace;
+    this.workspace = wsData;
+    this.accessLevel = wsData.accessLevel;
   }
 
   ngOnInit(): void {

--- a/ui/src/testing/stubs/workspace-service-stub.ts
+++ b/ui/src/testing/stubs/workspace-service-stub.ts
@@ -28,7 +28,13 @@ export class WorkspacesServiceStub {
   workspaceAccess: Map<string, WorkspaceAccessLevel>;
 
   constructor() {
-    const stubWorkspace: Workspace = {
+
+    this.workspaces = [WorkspacesServiceStub.stubWorkspace()];
+    this.workspaceAccess = new Map<string, WorkspaceAccessLevel>();
+  }
+
+  static stubWorkspace(): Workspace {
+    return {
       name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
       id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
       namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
@@ -62,9 +68,6 @@ export class WorkspacesServiceStub {
         },
       ]
     };
-
-    this.workspaces = [stubWorkspace];
-    this.workspaceAccess = new Map<string, WorkspaceAccessLevel>();
   }
 
   private clone(w: Workspace): Workspace {


### PR DESCRIPTION
- Reduce spinner count on the workspace page from 4 -> 2, now it's just the two tables
- Use the resolver-provided `Workspace`, instead of double-requesting
- Disable "new notebook" and keep spinning the notebooks table until your cluster is online
