### PR TITLE
[RW-440] Support loading the CDR DBs from a different SQL instance

### DIFF
--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -1,5 +1,6 @@
 # "db" hostname is established for the local docker network via docker-compose.yaml
 DB_CONNECTION_STRING=jdbc:mysql://db/workbench?useSSL=false
+CDR_DB_CONNECTION_STRING=jdbc:mysql://db/workbench?useSSL=false
 # TODO: change to public DB once it exists
 PUBLIC_DB_CONNECTION_STRING=jdbc:mysql://db/public?useSSL=false
 DB_DRIVER=com.mysql.jdbc.Driver
@@ -11,5 +12,7 @@ LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench
 WORKBENCH_DB_PASSWORD=wb-notasecret
+CDR_DB_USER=workbench
+CDR_DB_PASSWORD=wb-notasecret
 PUBLIC_DB_USER=public
 PUBLIC_DB_PASSWORD=public-notasecret

--- a/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
@@ -35,14 +35,14 @@ public class WorkbenchDbConfig {
 
   @Primary
   @Bean(name = "dataSourceProperties")
-  @ConfigurationProperties(prefix = "workbench.datasource")
+  @ConfigurationProperties(prefix = "spring.datasource")
   public DataSourceProperties dataSourceProperties() {
     return new DataSourceProperties();
   }
 
   @Primary
   @Bean(name = "dataSource")
-  @ConfigurationProperties(prefix = "workbench.datasource")
+  @ConfigurationProperties(prefix = "spring.datasource")
   public DataSource dataSource() {
     return dataSourceProperties().initializeDataSourceBuilder().build();
   }
@@ -73,7 +73,7 @@ public class WorkbenchDbConfig {
    */
   @Bean("poolConfiguration")
   @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  @ConfigurationProperties(prefix = "workbench.datasource")
+  @ConfigurationProperties(prefix = "spring.datasource")
   public PoolConfiguration poolConfig() {
     return new PoolProperties();
   }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,12 +12,12 @@
 # Note: we use a custom property name rather than spring.datasource as we're not
 # using standard data source autoconfiguration (in order to support multiple
 # data sources). See WorkbenchDbConfig and CdrDbConfig.
-workbench.datasource.test-on-borrow=true
-workbench.datasource.test-while-idle=true
-workbench.datasource.time-between-eviction-runs-millis=3600000
-workbench.datasource.validation-query=SELECT 1
-workbench.datasource.initial-size=5
-workbench.datasource.max-idle=5
-workbench.datasource.min-idle=1
+spring.datasource.test-on-borrow=true
+spring.datasource.test-while-idle=true
+spring.datasource.time-between-eviction-runs-millis=3600000
+spring.datasource.validation-query=SELECT 1
+spring.datasource.initial-size=5
+spring.datasource.max-idle=5
+spring.datasource.min-idle=1
 
 spring.jpa.hibernate.ddl-auto=none

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -9,9 +9,11 @@
 #logging.level.org.springframework=DEBUG
 
 # Keep the db connection alive. (https://precisionmedicineinitiative.atlassian.net/browse/RW-235)
-# Note: we use a custom property name rather than spring.datasource as we're not
-# using standard data source autoconfiguration (in order to support multiple
-# data sources). See WorkbenchDbConfig and CdrDbConfig.
+# Note: We're using a flat namespace for spring datasource because we have a
+# custom data source configuration (needed in order to support multiple data
+# sources). Putting properties onto "spring.datasource.tomcat" (as you might
+# see in Spring documentation) will do nothing. See WorkbenchDbConfig and
+# CdrDbConfig.
 spring.datasource.test-on-borrow=true
 spring.datasource.test-while-idle=true
 spring.datasource.time-between-eviction-runs-millis=3600000

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -10,10 +10,14 @@
   </system-properties>
 
   <env-variables>
-    <env-var name="workbench.datasource.driver-class-name" value="${DB_DRIVER}"/>
-    <env-var name="workbench.datasource.url" value="${DB_CONNECTION_STRING}"/>
-    <env-var name="workbench.datasource.username" value="${WORKBENCH_DB_USER}"/>
-    <env-var name="workbench.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
+    <env-var name="spring.datasource.driver-class-name" value="${DB_DRIVER}"/>
+    <env-var name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>
+    <env-var name="spring.datasource.username" value="${WORKBENCH_DB_USER}"/>
+    <env-var name="spring.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
+
+    <env-var name="cdr.datasource.url" value="${CDR_DB_CONNECTION_STRING}"/>
+    <env-var name="cdr.datasource.username" value="${CDR_DB_USER}"/>
+    <env-var name="cdr.datasource.password" value="${CDR_DB_PASSWORD}"/>
   </env-variables>
 
   <resource-files>

--- a/public-api/src/main/resources/application.properties
+++ b/public-api/src/main/resources/application.properties
@@ -6,6 +6,10 @@
 #spring.jpa.properties.hibernate.type=trace
 
 # Keep the db connection alive. (https://precisionmedicineinitiative.atlassian.net/browse/RW-235)
+# Note: We're using a flat namespace for spring datasource because we have a
+# custom data source configuration (needed in order to support multiple data
+# sources). Putting properties onto "spring.datasource.tomcat" (as you might
+# see in Spring documentation) will do nothing. See PublicDbConfig.
 spring.datasource.test-on-borrow=true
 spring.datasource.test-while-idle=true
 spring.datasource.time-between-eviction-runs-millis=3600000


### PR DESCRIPTION
This enables sharing the CDR DBs across multiple nonprod environments.

Also:
- Fix a several setup_project bugs in `devstart.rb`
- Remove dead functions from `devstart.rb`

Notes:
- This is desirable as the CDR itself is shared across nonprod environments and it is slow to produce the CDR SQL databases.
- The plan is to use the `all-of-us-workbench-test` DB instance as the shared nonprod CDR db.
- There is no requirement that the SQL instance be in `all-of-us-workbench-test` or any other environment. This is just an existing environment which already has a Google MySQL instance.