### PR TITLE
Pin the Spring boot package to the previous version

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,8 @@
 import io.swagger.codegen.config.CodegenConfigurator
 import io.swagger.codegen.DefaultGenerator
 
+def SPRING_VERSION = '1.5.10.RELEASE'
+
 def swaggerTemplateDir = 'src/main/resources'
 def mergedApiSourceFile = 'src/main/resources/merged.yaml'
 def clientApiSourceFile = 'src/main/resources/client_api.yaml'
@@ -189,7 +191,7 @@ dependencies {
   compile 'com.google.cloud.sql:mysql-socket-factory:+'
   compile 'com.google.appengine:appengine:+'
   compile 'com.google.appengine:appengine-api-1.0-sdk:+'
-  compile('org.springframework.boot:spring-boot-starter-web:1.5.10.RELEASE') {
+  compile("org.springframework.boot:spring-boot-starter-web:${SPRING_VERSION}") {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
@@ -197,7 +199,7 @@ dependencies {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
-  compile('org.springframework.boot:spring-boot-starter-actuator:+') {
+  compile("org.springframework.boot:spring-boot-starter-actuator:${SPRING_VERSION}") {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
@@ -230,7 +232,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.+'
   testCompile 'com.google.truth:truth:+'
-  testCompile 'org.springframework.boot:spring-boot-starter-test:+'
+  testCompile "org.springframework.boot:spring-boot-starter-test:${SPRING_VERSION}"
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -189,7 +189,7 @@ dependencies {
   compile 'com.google.cloud.sql:mysql-socket-factory:+'
   compile 'com.google.appengine:appengine:+'
   compile 'com.google.appengine:appengine-api-1.0-sdk:+'
-  compile('org.springframework.boot:spring-boot-starter-web:+') {
+  compile('org.springframework.boot:spring-boot-starter-web:1.5.10.RELEASE') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }


### PR DESCRIPTION
Dependency checks are currently failing, but it's also likely that there would be other issues introduced with an upgrade to a different major version.

```
Execution failed for task ':dependencyCheckAnalyze'.
> Could not resolve all dependencies for configuration ':compile'.
   > Could not resolve org.springframework.boot:spring-boot-starter-web:+.
     Required by:
         project :
         project : > project :common-api
      > Could not resolve org.springframework.boot:spring-boot-starter-web:2.0.0.RELEASE.
         > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-starter-web/2.0.0.RELEASE/spring-boot-starter-web-2.0.0.RELEASE.pom
            > Could not resolve org.springframework.boot:spring-boot-starters:2.0.0.RELEASE.
               > Could not resolve org.springframework.boot:spring-boot-starters:2.0.0.RELEASE.
                  > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-starters/2.0.0.RELEASE/spring-boot-starters-2.0.0.RELEASE.pom
                     > Could not resolve org.springframework.boot:spring-boot-parent:2.0.0.RELEASE.
                        > Could not resolve org.springframework.boot:spring-boot-parent:2.0.0.RELEASE.
                           > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-parent/2.0.0.RELEASE/spring-boot-parent-2.0.0.RELEASE.pom
                              > Could not resolve org.springframework.boot:spring-boot-dependencies:2.0.0.RELEASE.
                                 > Could not resolve org.springframework.boot:spring-boot-dependencies:2.0.0.RELEASE.
                                    > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-dependencies/2.0.0.RELEASE/spring-boot-dependencies-2.0.0.RELEASE.pom
                                       > Could not find org.springframework.data:spring-data-releasetrain:Kay-SR5.
   > Could not resolve org.springframework.boot:spring-boot-starter-actuator:+.
     Required by:
         project :
      > Could not resolve org.springframework.boot:spring-boot-starter-actuator:2.0.0.RELEASE.
         > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-starter-actuator/2.0.0.RELEASE/spring-boot-starter-actuator-2.0.0.RELEASE.pom
            > Could not resolve org.springframework.boot:spring-boot-starters:2.0.0.RELEASE.
               > Could not resolve org.springframework.boot:spring-boot-starters:2.0.0.RELEASE.
                  > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-starters/2.0.0.RELEASE/spring-boot-starters-2.0.0.RELEASE.pom
                     > Could not resolve org.springframework.boot:spring-boot-parent:2.0.0.RELEASE.
                        > Could not resolve org.springframework.boot:spring-boot-parent:2.0.0.RELEASE.
                           > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-parent/2.0.0.RELEASE/spring-boot-parent-2.0.0.RELEASE.pom
                              > Could not resolve org.springframework.boot:spring-boot-dependencies:2.0.0.RELEASE.
                                 > Could not resolve org.springframework.boot:spring-boot-dependencies:2.0.0.RELEASE.
                                    > Could not parse POM https://jcenter.bintray.com/org/springframework/boot/spring-boot-dependencies/2.0.0.RELEASE/spring-boot-dependencies-2.0.0.RELEASE.pom
                                       > Could not find org.springframework.data:spring-data-releasetrain:Kay-SR5.
```