### PR TITLE
Switching filters specification in API to allow for arbitrary

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -178,6 +178,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     return request;
   }
 
+  /*
   @Test
   public void testMaterializeCohortOneMale() {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -443,6 +444,28 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
+  */
+
+
+  @Test
+  public void testMaterializeCohortPersonFieldSetPersonIdWithNumberNotEqualFilter() {
+    TableQuery tableQuery = new TableQuery();
+    tableQuery.setTableName("person");
+    tableQuery.setColumns(ImmutableList.of("person_id"));
+    ColumnFilter filter = new ColumnFilter();
+    filter.setColumnName("person_id");
+    filter.setOperator(Operator.NOT_EQUAL);
+    filter.setValueNumber(new BigDecimal(2L));
+    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setTableQuery(tableQuery);
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+    assertPersonIds(response, 1L, 102246L);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  /*
 
   @Test
   public void testMaterializeCohortPersonFieldSetPersonIdWithNumbersFilter() {
@@ -550,6 +573,45 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertThat(response.getNextPageToken()).isNull();
   }
 
+  */
+
+  @Test
+  public void testMaterializeCohortPersonFieldSetPersonIdWithStringNotEqualNullNonMatch() {
+    TableQuery tableQuery = new TableQuery();
+    tableQuery.setTableName("person");
+    tableQuery.setColumns(ImmutableList.of("person_id"));
+    ColumnFilter filter = new ColumnFilter();
+    filter.setColumnName("ethnicity_source_value");
+    filter.setOperator(Operator.NOT_EQUAL);
+    filter.setValue("esv");
+    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setTableQuery(tableQuery);
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+    assertPersonIds(response);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  @Test
+  public void testMaterializeCohortPersonFieldSetPersonIdWithStringIsNotNull() {
+    TableQuery tableQuery = new TableQuery();
+    tableQuery.setTableName("person");
+    tableQuery.setColumns(ImmutableList.of("person_id"));
+    ColumnFilter filter = new ColumnFilter();
+    filter.setColumnName("ethnicity_source_value");
+    filter.setOperator(Operator.NOT_EQUAL);
+    filter.setValueNull(true);
+    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setTableQuery(tableQuery);
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+    assertPersonIds(response, 1L, 2L);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  /*
   @Test
   public void testMaterializeCohortPersonFieldSetOrderByGenderConceptId() {
     TableQuery tableQuery = new TableQuery();
@@ -987,6 +1049,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
+*/
 
   private void assertResults(MaterializeCohortResponse response, ImmutableMap<String, Object>... results) {
     if (response.getResults().size() != results.length) {

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +48,7 @@ import org.pmiops.workbench.model.FieldSet;
 import org.pmiops.workbench.model.MaterializeCohortRequest;
 import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.pmiops.workbench.model.Operator;
+import org.pmiops.workbench.model.ResultFilters;
 import org.pmiops.workbench.model.TableQuery;
 import org.pmiops.workbench.test.SearchRequests;
 import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
@@ -178,7 +180,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     return request;
   }
 
-  /*
   @Test
   public void testMaterializeCohortOneMale() {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -364,12 +365,31 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter = new ColumnFilter();
     filter.setColumnName("person_id");
     filter.setValueNumber(new BigDecimal(1L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
         SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  @Test
+  public void testMaterializeCohortPersonFieldSetPersonIdWithNotFilter() {
+    TableQuery tableQuery = new TableQuery();
+    tableQuery.setTableName("person");
+    tableQuery.setColumns(ImmutableList.of("person_id"));
+    ColumnFilter filter = new ColumnFilter();
+    filter.setColumnName("person_id");
+    filter.setValueNumber(new BigDecimal(1L));
+    ResultFilters resultFilters = makeResultFilters(filter);
+    resultFilters.setNot(true);
+    tableQuery.setFilters(resultFilters);
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setTableQuery(tableQuery);
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+    assertPersonIds(response, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
 
@@ -382,7 +402,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.GREATER_THAN);
     filter.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -400,7 +420,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.GREATER_THAN_OR_EQUAL_TO);
     filter.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -418,7 +438,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.LESS_THAN);
     filter.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -436,7 +456,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.LESS_THAN_OR_EQUAL_TO);
     filter.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -444,8 +464,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
-  */
-
 
   @Test
   public void testMaterializeCohortPersonFieldSetPersonIdWithNumberNotEqualFilter() {
@@ -456,7 +474,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.NOT_EQUAL);
     filter.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -464,8 +482,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertPersonIds(response, 1L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
-
-  /*
 
   @Test
   public void testMaterializeCohortPersonFieldSetPersonIdWithNumbersFilter() {
@@ -476,7 +492,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setOperator(Operator.IN);
     filter.setValueNumbers(ImmutableList.of(new BigDecimal(1L), new BigDecimal(2L)));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -493,7 +509,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter = new ColumnFilter();
     filter.setColumnName("person_source_value");
     filter.setValue("psv");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -510,7 +526,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter = new ColumnFilter();
     filter.setColumnName("ethnicity_source_value");
     filter.setValue("esv");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -528,7 +544,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("ethnicity_source_value");
     filter.setOperator(Operator.GREATER_THAN);
     filter.setValue("esf");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -546,7 +562,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("ethnicity_source_value");
     filter.setOperator(Operator.LESS_THAN);
     filter.setValue("esv");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -564,7 +580,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("ethnicity_source_value");
     filter.setOperator(Operator.EQUAL);
     filter.setValueNull(true);
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -572,8 +588,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
-
-  */
 
   @Test
   public void testMaterializeCohortPersonFieldSetPersonIdWithStringNotEqualNullNonMatch() {
@@ -584,7 +598,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("ethnicity_source_value");
     filter.setOperator(Operator.NOT_EQUAL);
     filter.setValue("esv");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -602,7 +616,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("ethnicity_source_value");
     filter.setOperator(Operator.NOT_EQUAL);
     filter.setValueNull(true);
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -611,7 +625,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertThat(response.getNextPageToken()).isNull();
   }
 
-  /*
   @Test
   public void testMaterializeCohortPersonFieldSetOrderByGenderConceptId() {
     TableQuery tableQuery = new TableQuery();
@@ -661,7 +674,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_source_value");
     filter.setOperator(Operator.LIKE);
     filter.setValue("p%");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -679,7 +692,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_source_value");
     filter.setOperator(Operator.LIKE);
     filter.setValue("p");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -697,7 +710,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_source_value");
     filter.setOperator(Operator.IN);
     filter.setValues(ImmutableList.of("foobar", "psv"));
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -714,7 +727,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter = new ColumnFilter();
     filter.setColumnName("person_source_value");
     filter.setValue("foobar");
-    tableQuery.addFiltersItem(ImmutableList.of(filter));
+    tableQuery.setFilters(makeResultFilters(filter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -724,7 +737,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void testMaterializeCohortPersonFieldSetPersonIdWithStringAndPersonIdFilter() {
+  public void testMaterializeCohortPersonFieldSetPersonIdWithAllOfFilter() {
     TableQuery tableQuery = new TableQuery();
     tableQuery.setTableName("person");
     tableQuery.setColumns(ImmutableList.of("person_id"));
@@ -734,7 +747,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter2 = new ColumnFilter();
     filter2.setColumnName("person_id");
     filter2.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter1, filter2));
+    tableQuery.setFilters(makeAllOf(filter1, filter2));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -744,7 +757,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void testMaterializeCohortPersonFieldSetYearOfBirthOrPersonIdFilters() {
+  public void testMaterializeCohortPersonFieldSetAnyOfFilters() {
     TableQuery tableQuery = new TableQuery();
     tableQuery.setTableName("person");
     tableQuery.setColumns(ImmutableList.of("person_id"));
@@ -754,8 +767,35 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter filter2 = new ColumnFilter();
     filter2.setColumnName("person_id");
     filter2.setValueNumber(new BigDecimal(2L));
-    tableQuery.addFiltersItem(ImmutableList.of(filter1));
-    tableQuery.addFiltersItem(ImmutableList.of(filter2));
+    tableQuery.setFilters(makeAnyOf(filter1, filter2));
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setTableQuery(tableQuery);
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+    assertPersonIds(response, 1L, 2L, 102246L);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  @Test
+  public void testMaterializeCohortPersonFieldSetPersonIdWithMultiLevelFilter() {
+    TableQuery tableQuery = new TableQuery();
+    tableQuery.setTableName("person");
+    tableQuery.setColumns(ImmutableList.of("person_id"));
+    ColumnFilter filter1 = new ColumnFilter();
+    filter1.setColumnName("year_of_birth");
+    filter1.setValueNumber(new BigDecimal(1987));
+    ColumnFilter filter2 = new ColumnFilter();
+    filter2.setColumnName("person_id");
+    filter2.setValueNumber(new BigDecimal(4L));
+    ColumnFilter filter3 = new ColumnFilter();
+    filter3.setColumnName("person_id");
+    filter3.setOperator(Operator.LESS_THAN_OR_EQUAL_TO);
+    filter3.setValueNumber(new BigDecimal(3L));
+    ResultFilters resultFilters = new ResultFilters();
+    ResultFilters anyOf = makeAnyOf(filter1, filter2);
+    anyOf.setNot(true);
+    resultFilters.setAllOf(ImmutableList.of(makeResultFilters(filter3), anyOf));
+    tableQuery.setFilters(resultFilters);
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -846,7 +886,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter columnFilter = new ColumnFilter();
     columnFilter.setColumnName("observation_date");
     columnFilter.setValueDate("2009-12-03");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -863,7 +903,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter columnFilter = new ColumnFilter();
     columnFilter.setColumnName("observation_date");
     columnFilter.setValueDate("2009-12-04");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -881,7 +921,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_date");
     columnFilter.setOperator(Operator.GREATER_THAN);
     columnFilter.setValueDate("2009-12-02");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -899,7 +939,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_date");
     columnFilter.setOperator(Operator.GREATER_THAN_OR_EQUAL_TO);
     columnFilter.setValueDate("2009-12-03");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -917,7 +957,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_date");
     columnFilter.setOperator(Operator.LESS_THAN);
     columnFilter.setValueDate("2009-12-04");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -935,7 +975,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_date");
     columnFilter.setOperator(Operator.LESS_THAN_OR_EQUAL_TO);
     columnFilter.setValueDate("2009-12-03");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -952,7 +992,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter columnFilter = new ColumnFilter();
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setValueDate("2009-12-03 05:00:00 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -969,7 +1009,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     ColumnFilter columnFilter = new ColumnFilter();
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setValueDate("2009-12-03 05:00:01 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -987,7 +1027,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setOperator(Operator.GREATER_THAN);
     columnFilter.setValueDate("2009-12-03 04:59:59 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -1005,7 +1045,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setOperator(Operator.GREATER_THAN_OR_EQUAL_TO);
     columnFilter.setValueDate("2009-12-03 05:00:00 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -1023,7 +1063,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setOperator(Operator.LESS_THAN);
     columnFilter.setValueDate("2009-12-03 05:00:01 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -1041,7 +1081,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     columnFilter.setColumnName("observation_datetime");
     columnFilter.setOperator(Operator.LESS_THAN_OR_EQUAL_TO);
     columnFilter.setValueDate("2009-12-03 05:00:00 UTC");
-    tableQuery.addFiltersItem(ImmutableList.of(columnFilter));
+    tableQuery.setFilters(makeResultFilters(columnFilter));
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
@@ -1049,7 +1089,29 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
-*/
+
+  private ResultFilters makeResultFilters(ColumnFilter columnFilter) {
+    ResultFilters result = new ResultFilters();
+    result.setColumnFilter(columnFilter);
+    return result;
+  }
+
+  private ResultFilters makeAnyOf(ColumnFilter... columnFilters) {
+    ResultFilters result = new ResultFilters();
+    result.setAnyOf(
+        Arrays.asList(columnFilters).stream().map(columnFilter -> makeResultFilters(columnFilter))
+            .collect(Collectors.toList()));
+    return result;
+  }
+
+  private ResultFilters makeAllOf(ColumnFilter... columnFilters) {
+    ResultFilters result = new ResultFilters();
+    result.setAllOf(
+        Arrays.asList(columnFilters).stream().map(columnFilter -> makeResultFilters(columnFilter))
+            .collect(Collectors.toList()));
+    return result;
+  }
+
 
   private void assertResults(MaterializeCohortResponse response, ImmutableMap<String, Object>... results) {
     if (response.getResults().size() != results.length) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -100,11 +100,15 @@ public class FieldSetQueryBuilder {
             + " of type " + columnConfig.type);
       }
     } else if (columnFilter.getValueNull() != null && columnFilter.getValueNull()) {
-      if (operator != Operator.EQUAL) {
+      if (operator != Operator.EQUAL && operator != Operator.NOT_EQUAL) {
         throw new BadRequestException("Unsupported operator for valueNull: " + operator);
       }
       sqlBuilder.append(columnFilter.getColumnName());
-      sqlBuilder.append(" is null\n");
+      if (operator.equals(Operator.EQUAL)) {
+        sqlBuilder.append(" is null\n");
+      } else {
+        sqlBuilder.append(" is not null\n");
+      }
       return;
     }
     sqlBuilder.append(columnFilter.getColumnName());

--- a/api/src/main/java/org/pmiops/workbench/utils/OperatorUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/OperatorUtils.java
@@ -8,6 +8,7 @@ public class OperatorUtils {
   private static final ImmutableMap<Operator, String> operatorToSqlOperator =
       ImmutableMap.<Operator, String>builder()
           .put(Operator.EQUAL, "=")
+          .put(Operator.NOT_EQUAL, "!=")
           .put(Operator.GREATER_THAN, ">")
           .put(Operator.GREATER_THAN_OR_EQUAL_TO, ">=")
           .put(Operator.IN, "IN")

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -188,7 +188,7 @@ definitions:
     type: object
     description: >
       A list of filters applied to the results of a query. Only results matching the filter criteria
-      should be returned.
+      should be returned. Exactly one of "allOf", "anyOf", and "columnFilter" should be set.
     properties:
       not:
         description: >

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -194,6 +194,7 @@ definitions:
         description: >
          Set to true if a result matching allOf or anyOf below should result in a result *not*
          being returned.
+        type: boolean
       allOf:
         description: >
           A list of result filters. All filters matching means a result should be returned (or not returned

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -173,15 +173,9 @@ definitions:
           type: string
       filters:
         description: >
-          An array of arrays of ColumnFilter objects to apply to results.
-          Each child array represents a series of criteria to logically AND together; these
-          expressions are then logically OR'd together at the top level.
-        type: array
-        items:
-          type: array
-          items:
-            $ref: "#/definitions/ColumnFilter"
-
+          Filters on the results. Only results matching the criteria specified in the filters
+          will be returned
+        $ref: "#/definitions/ResultFilters"
       orderBy:
         description: >
           An array of columns to sort the resulting data by, taken from the table specified above,
@@ -189,6 +183,36 @@ definitions:
         type: array
         items:
           type: string
+
+  ResultFilters:
+    type: object
+    description: >
+      A list of filters applied to the results of a query. Only results matching the filter criteria
+      should be returned.
+    properties:
+      not:
+        description: >
+         Set to true if a result matching allOf or anyOf below should result in a result *not*
+         being returned.
+      allOf:
+        description: >
+          A list of result filters. All filters matching means a result should be returned (or not returned
+          if "not" is true.)
+        type: array
+        items:
+          $ref: "#/definitions/ResultFilters"
+      anyOf:
+        description: >
+          A list of column filters. Any filters matching means a result should be returned
+          (or not returned if "not" is true.)
+        type: array
+        items:
+          $ref: "#/definitions/ResultFilters"
+      columnFilter:
+        description: >
+          A filter on a column in the table. Only a result matching this filter should be returned
+          (or not returned if "not" is true.)
+        $ref: "#/definitions/ColumnFilter"
 
   ColumnFilter:
     type: object
@@ -247,4 +271,4 @@ definitions:
 
   Operator:
     type: string
-    enum: [EQUAL, LESS_THAN, GREATER_THAN, LESS_THAN_OR_EQUAL_TO, GREATER_THAN_OR_EQUAL_TO, LIKE, IN]
+    enum: [EQUAL, NOT_EQUAL, LESS_THAN, GREATER_THAN, LESS_THAN_OR_EQUAL_TO, GREATER_THAN_OR_EQUAL_TO, LIKE, IN]


### PR DESCRIPTION
 and, ors, not recursively.

Adding NOT_EQUAL operator.
