### PR TITLE
Add Procedures tab table

### DIFF
--- a/ui/src/app/cohort-review/cohort-review.module.ts
+++ b/ui/src/app/cohort-review/cohort-review.module.ts
@@ -19,6 +19,7 @@ import {ReviewNavComponent} from './review-nav/review-nav.component';
 
 import {DetailConditionsComponent} from './detail-conditions/detail-conditions.component';
 import {DetailHeaderComponent} from './detail-header/detail-header.component';
+import {DetailProceduresComponent} from './detail-procedures/detail-procedures.component';
 import {DetailTabsComponent} from './detail-tabs/detail-tabs.component';
 
 import {AnnotationItemComponent} from './annotation-item/annotation-item.component';
@@ -84,6 +85,7 @@ import {WorkspacesService} from 'generated';
     DetailHeaderComponent,
     DetailTabsComponent,
     DetailConditionsComponent,
+    DetailProceduresComponent,
   ],
   providers: [ReviewStateService]
 })

--- a/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.css
+++ b/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.css
@@ -1,0 +1,7 @@
+.date-col {
+  width: 6.5rem;
+}
+
+.vocab-col {
+  width: 7rem;
+}

--- a/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.html
+++ b/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.html
@@ -1,0 +1,64 @@
+<clr-datagrid
+  [clrDgLoading]="loading"
+  (clrDgRefresh)="update($event)"
+  class="datagrid-compact"
+>
+  <clr-dg-placeholder>No Conditions Data</clr-dg-placeholder>
+  <clr-dg-column [clrDgField]="'itemDate'" class="date-col">
+    Date
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'standardVocabulary'" class="vocab-col">
+    Standard Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'standardName'">
+    Standard Name
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'sourceVocabulary'" class="vocab-col">
+    Source Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'sourceValue'">
+    Source Value
+  </clr-dg-column>
+
+  <clr-dg-column>
+    Age At Event
+  </clr-dg-column>
+
+  <clr-dg-row *ngFor="let procedure of procedures">
+    <clr-dg-cell>
+      {{ procedure.itemDate | date:'yyyy-MM-dd HH:mm:ss' }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ procedure.standardVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ procedure.standardName }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ procedure.sourceVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell
+        [popper]="procedure.sourceName"
+        [popperTrigger]="'hover'"
+        [popperPlacement]="'left'"
+        [popperTarget]="sourceValue">
+      <span #sourceValue>{{ procedure.sourceValue }}</span>
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ procedure.age }}
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    {{ pagination.firstItem + 1 }} - {{ pagination.lastItem + 1 }} of
+    {{ totalCount }} Records
+    <clr-dg-pagination #pagination
+      [clrDgTotalItems]="totalCount"
+      [clrDgPageSize]="request.pageSize"
+      [clrDgPage]="request.page + 1">
+    </clr-dg-pagination>
+  </clr-dg-footer>
+
+</clr-datagrid>

--- a/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.spec.ts
@@ -4,7 +4,7 @@ import {ClarityModule} from '@clr/angular';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 
-import {DetailConditionsComponent} from './detail-conditions.component';
+import {DetailProceduresComponent} from './detail-procedures.component';
 
 import {CohortReviewService} from 'generated';
 
@@ -28,7 +28,7 @@ class StubRoute {
 }
 
 class ApiSpy {
-  getParticipantConditions = jasmine
+  getParticipantProcedures = jasmine
     .createSpy('getParticipantConditions')
     .and
     .callFake((ns, wsid, cid, cdrid, pid, pageRequest) =>
@@ -36,14 +36,14 @@ class ApiSpy {
 }
 
 
-describe('DetailConditionsComponent', () => {
-  let component: DetailConditionsComponent;
-  let fixture: ComponentFixture<DetailConditionsComponent>;
+describe('DetailProceduresComponent', () => {
+  let component: DetailProceduresComponent;
+  let fixture: ComponentFixture<DetailProceduresComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ ClarityModule, NgxPopperModule ],
-      declarations: [ DetailConditionsComponent ],
+      declarations: [ DetailProceduresComponent ],
       providers: [
         {provide: CohortReviewService, useValue: new ApiSpy()},
         {provide: ActivatedRoute, useClass: StubRoute}
@@ -53,7 +53,7 @@ describe('DetailConditionsComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DetailConditionsComponent);
+    fixture = TestBed.createComponent(DetailProceduresComponent);
     component = fixture.componentInstance;
     component.ngOnInit();
     fixture.detectChanges();

--- a/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.ts
+++ b/ui/src/app/cohort-review/detail-procedures/detail-procedures.component.ts
@@ -1,0 +1,108 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {ClrDatagridStateInterface} from '@clr/angular';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+
+import {
+  CohortReviewService,
+  PageFilterRequest,
+  PageFilterType,
+  ParticipantProcedure,
+  ParticipantProceduresColumns as Columns,
+  SortOrder,
+} from 'generated';
+
+@Component({
+  selector: 'app-detail-procedures',
+  templateUrl: './detail-procedures.component.html',
+  styleUrls: ['./detail-procedures.component.css']
+})
+export class DetailProceduresComponent implements OnInit, OnDestroy {
+  /* Maps string values to Enum values */
+  readonly reverseColumnEnum = {
+    itemDate: Columns.ItemDate,
+    standardVocabulary: Columns.StandardVocabulary,
+    standardName: Columns.StandardName,
+    sourceValue: Columns.SourceValue,
+    sourceVocabulary: Columns.SourceVocabulary,
+    sourceName: Columns.SourceName,
+    age: Columns.Age,
+  };
+
+  loading = false;
+
+  procedures: ParticipantProcedure[];
+  request;
+  totalCount: number;
+  apiCaller: (any) => Observable<any>;
+  subscription: Subscription;
+
+  constructor(
+    private route: ActivatedRoute,
+    private reviewApi: CohortReviewService,
+  ) {}
+
+  ngOnInit() {
+    console.dir(this.route);
+    this.subscription = this.route.data
+      .map(({participant}) => participant)
+      .withLatestFrom(
+        this.route.parent.data.map(({cohort}) => cohort),
+        this.route.parent.data.map(({workspace}) => workspace),
+      )
+      .subscribe(([participant, cohort, workspace]) => {
+        this.loading = true;
+
+        this.apiCaller = (request) => this.reviewApi.getParticipantProcedures(
+          workspace.namespace,
+          workspace.id,
+          cohort.id,
+          workspace.cdrVersionId,
+          participant.participantId,
+          request
+        );
+
+        this.request = <PageFilterRequest>{
+          page: 0,
+          pageSize: 50,
+          includeTotal: true,
+          sortOrder: SortOrder.Asc,
+          sortColumn: Columns.ItemDate,
+          pageFilterType: PageFilterType.ParticipantProcedures,
+        };
+
+        this.callApi();
+      });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  callApi() {
+    this.loading = true;
+    this.apiCaller(this.request).subscribe(resp => {
+      this.procedures = resp.items;
+      this.totalCount = resp.count;
+      this.request = resp.pageRequest;
+      this.request.pageFilterType = PageFilterType.ParticipantProcedures;
+      this.loading = false;
+    });
+  }
+
+  update(state: ClrDatagridStateInterface) {
+    console.log('Datagrid state: ');
+    console.dir(state);
+    const page = Math.floor(state.page.from / state.page.size);
+    const pageSize = state.page.size;
+    this.request = {...this.request, page, pageSize};
+
+    if (state.sort) {
+      const sortby = <string>(state.sort.by);
+      this.request.sortColumn = this.reverseColumnEnum[sortby];
+      this.request.sortOrder = state.sort.reverse ? SortOrder.Desc : SortOrder.Asc;
+    }
+    this.callApi();
+  }
+}

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
@@ -16,7 +16,7 @@
   <clr-tab>
     <button clrTabLink id="detail-procedures-tab">Procedures</button>
     <clr-tab-content id="detail-procedures-content" *clrIfActive>
-      <em>Charts go here</em>
+      <app-detail-procedures></app-detail-procedures>
     </clr-tab-content>
   </clr-tab>
 


### PR DESCRIPTION
Note to the sharp-eyed: this PR adds a component `detail-procedures` which is almost identical to `detail-conditions`.  I believe that eventually each of the review tabs may be similar enough to warrant having them derive from a common component superclass (or using a common template or what have you), but at the moment we're not _exactly_ sure how different they will eventually be.  So the plan basically is to perform the refactor (if there will be one) after each concrete tab has been built so that we know exactly what a superclass needs to provide and don't burn time / energy implementing stuff that never gets used.