### PR TITLE
Stopgap: comment out search bar

### DIFF
--- a/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.html
+++ b/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.html
@@ -1,10 +1,17 @@
 <crit-root-spinner [loading$]="loading$"></crit-root-spinner>
 <crit-alerts [errors$]="errors$"></crit-alerts>
 
+<h3>Codes</h3>
+<hr />
+
+<!--
+  TODO (RW-417) - commenting this out is a stopgap in lieu of the impending
+  soft launch.  This will need final design and fixing.
 <crit-quicksearch
   (value)="search($event)"
   [disabled]="mode === 'SetAttr'">
 </crit-quicksearch>
+-->
 
 <div class="explorer-panels">
   <div class="explorer-content crit-tree" [class.active]="mode === 'Tree'">

--- a/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.html
+++ b/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.html
@@ -2,7 +2,6 @@
   class="form-group"
   [ngClass]="isFocused ? 'focused' : 'blurred'">
 
-  <h3>Codes</h3>
   <clr-icon shape="search" [ngClass]="isFocused ? 'is-info' : ''"></clr-icon>
   <input
     (input)="onInput($event)"


### PR DESCRIPTION
This is a temporary measure to prevent users from hitting RW-417 while we wait on finalized specs for the behavior, look, and feel of the search bar.