### PR TITLE
Enable delocalization on AoU Leo clusters

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +74,7 @@ public class ClusterController implements ClusterApiDelegate {
     };
 
   private final NotebooksService notebooksService;
-  private final Provider<User> userProvider;
+  private Provider<User> userProvider;
   private final WorkspaceService workspaceService;
   private final FireCloudService fireCloudService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
@@ -92,6 +93,11 @@ public class ClusterController implements ClusterApiDelegate {
     this.fireCloudService = fireCloudService;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.apiHostName = apiHostName;
+  }
+
+  @VisibleForTesting
+  public void setUserProvider(Provider<User> userProvider) {
+    this.userProvider = userProvider;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -8,7 +8,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+import org.json.JSONObject;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.WorkspaceService;
+import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -21,6 +24,7 @@ import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,6 +33,20 @@ public class ClusterController implements ClusterApiDelegate {
   private static final String DEFAULT_CLUSTER_NAME = "all-of-us";
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
+
+  // Writing this file to a directory on a Leonardo cluster will result in
+  // delocalization of saved files back to a given GCS location. See
+  // https://github.com/DataBiosphere/leonardo/blob/develop/jupyter-docker/jupyter_delocalize.py#L12
+  private static final String DELOCALIZE_CONFIG_FILENAME = ".delocalize.json";
+
+  // This file is used by the All of Us libraries to access workspace/CDR metadata.
+  private static final String AOU_CONFIG_FILENAME = ".all_of_us_config.json";
+  private static final String WORKSPACE_NAMESPACE_KEY = "WORKSPACE_NAMESPACE";
+  private static final String WORKSPACE_ID_KEY = "WORKSPACE_ID";
+  private static final String API_HOST_KEY = "API_HOST";
+  private static final String BUCKET_NAME_KEY = "BUCKET_NAME";
+  private static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
+  private static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
 
   private static final Logger log = Logger.getLogger(ClusterController.class.getName());
 
@@ -56,18 +74,24 @@ public class ClusterController implements ClusterApiDelegate {
 
   private final NotebooksService notebooksService;
   private final Provider<User> userProvider;
+  private final WorkspaceService workspaceService;
   private final FireCloudService fireCloudService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final String apiHostName;
 
   @Autowired
   ClusterController(NotebooksService notebooksService,
       Provider<User> userProvider,
+      WorkspaceService workspaceService,
       FireCloudService fireCloudService,
-      Provider<WorkbenchConfig> workbenchConfigProvider) {
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      @Qualifier("apiHostName") String apiHostName) {
     this.notebooksService = notebooksService;
     this.userProvider = userProvider;
+    this.workspaceService = workspaceService;
     this.fireCloudService = fireCloudService;
     this.workbenchConfigProvider = workbenchConfigProvider;
+    this.apiHostName = apiHostName;
   }
 
   @Override
@@ -100,11 +124,10 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterLocalizeResponse> localize(
       String projectName, String clusterName, ClusterLocalizeRequest body) {
-    String workspaceBucket;
+    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
     try {
-      workspaceBucket = "gs://" + fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
-          .getWorkspace()
-          .getBucketName();
+      fcWorkspace = fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
+          .getWorkspace();
     } catch (ApiException e) {
       if (e.getCode() == 404) {
         log.log(Level.INFO, "Firecloud workspace not found", e);
@@ -114,29 +137,61 @@ public class ClusterController implements ClusterApiDelegate {
       }
       throw ExceptionUtils.convertFirecloudException(e);
     }
+    CdrVersion cdrVersion =
+        workspaceService.getRequired(body.getWorkspaceNamespace(), body.getWorkspaceId()).getCdrVersion();
 
     // For the common case where the notebook cluster matches the workspace
     // namespace, simply name the directory as the workspace ID; else we
     // include the namespace in the directory name to avoid possible conflicts
     // in workspace IDs.
+    String gcsNotebooksDir = "gs://" + fcWorkspace.getBucketName() + "/notebooks";
     String workspacePath = body.getWorkspaceId();
     if (!projectName.equals(body.getWorkspaceNamespace())) {
       workspacePath = body.getWorkspaceNamespace() + ":" + body.getWorkspaceId();
     }
-    String apiDir = String.join("/", "workspaces", workspacePath);
-    String localDir = String.join("/", "~", apiDir);
-    Map<String, String> toLocalize = body.getNotebookNames()
-        .stream()
-        .collect(Collectors.<String, String, String>toMap(
-            name -> localDir + "/" + name,
-            name -> String.join("/", workspaceBucket, "notebooks", name)));
-    // TODO(calbach): Localize a delocalize config JSON file as well, once Leo supports this.
-    toLocalize.put(
-        localDir + "/.all_of_us_config.json",
-        workspaceBucket + "/" + WorkspacesController.CONFIG_FILENAME);
-    notebooksService.localize(projectName, clusterName, toLocalize);
+
+    // Materialize the JSON config files directly via the Jupyter server API.
+    // TODO: It is very inefficient to do 5 serial requests here. Rework this
+    // to utilize "mkdir -p"-like functionality, e.g. via starting with calling
+    // the /localize endpoint.
+    notebooksService.putRootWorkspacesDir(projectName, clusterName);
+    notebooksService.putWorkspaceDir(projectName, clusterName, workspacePath);
+    notebooksService.putFile(
+        projectName, clusterName, workspacePath, DELOCALIZE_CONFIG_FILENAME,
+        new JSONObject()
+            .put("destination", gcsNotebooksDir)
+            .put("pattern", "\\.ipynb$")
+            .toString());
+    notebooksService.putFile(
+        projectName, clusterName, workspacePath, AOU_CONFIG_FILENAME,
+        aouConfigJson(fcWorkspace, cdrVersion).toString());
+
+    // Localize the requested notebooks, if any.
+    String apiDir = "workspaces/" + workspacePath;
+    if (body.getNotebookNames() != null && !body.getNotebookNames().isEmpty()) {
+      String localDir = "~/" + apiDir;
+      notebooksService.localize(projectName, clusterName, body.getNotebookNames()
+          .stream()
+          .collect(Collectors.<String, String, String>toMap(
+              name -> localDir + "/" + name,
+              name -> gcsNotebooksDir + "/" + name)));
+    }
+
     ClusterLocalizeResponse resp = new ClusterLocalizeResponse();
     resp.setClusterLocalDirectory(apiDir);
     return ResponseEntity.ok(resp);
+  }
+
+  private JSONObject aouConfigJson(org.pmiops.workbench.firecloud.model.Workspace fcWorkspace,
+      CdrVersion cdrVersion) {
+    JSONObject config = new JSONObject();
+
+    config.put(WORKSPACE_NAMESPACE_KEY, fcWorkspace.getNamespace());
+    config.put(WORKSPACE_ID_KEY, fcWorkspace.getName());
+    config.put(BUCKET_NAME_KEY, fcWorkspace.getBucketName());
+    config.put(API_HOST_KEY, this.apiHostName);
+    config.put(CDR_VERSION_CLOUD_PROJECT, cdrVersion.getBigqueryProject());
+    config.put(CDR_VERSION_BIGQUERY_DATASET, cdrVersion.getBigqueryDataset());
+    return config;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -157,6 +157,11 @@ public class ClusterController implements ClusterApiDelegate {
     }
 
     // Materialize the JSON config files directly via the Jupyter server API.
+    // We perform this on every localize call because the Jupyter local
+    // directory can be deleted by the user, and config files may become
+    // outdated, e.g. as we add new properties to the .all_of_us_config.json.
+    // In most cases, aside from the first localize() call this initialization
+    // work will be a no-op.
     // TODO: It is very inefficient to do 5 serial requests here. Rework this
     // to utilize "mkdir -p"-like functionality, e.g. via starting with calling
     // the /localize endpoint.

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.notebooks;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
+import org.pmiops.workbench.notebooks.api.JupyterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -35,6 +36,14 @@ public class NotebooksConfig {
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public NotebooksApi notebooksApi(@Qualifier(NOTEBOOKS_CLIENT) ApiClient apiClient) {
     NotebooksApi api = new NotebooksApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  @Bean
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public JupyterApi jupyterApi(@Qualifier(NOTEBOOKS_CLIENT) ApiClient apiClient) {
+    JupyterApi api = new JupyterApi();
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -43,6 +43,16 @@ public interface NotebooksService {
       throws WorkbenchException;
 
   /**
+   * Write the given file contents on a notebook Cluster. The given jupyterPath
+   * is a Jupyter "API path", meaning it is relative to the root of the Jupyter
+   * user directory. For example, specifying "foo.txt" would write a file which
+   * would appear at the root directory in the Jupyter UI.
+   */
+  void putFile(String googleProject, String clusterName, String workspaceDir, String fileName, String fileContents);
+  void putRootWorkspacesDir(String googleProject, String clusterName);
+  void putWorkspaceDir(String googleProject, String clusterName, String workspaceDir);
+
+  /**
    * @return true if notebooks is okay, false if notebooks are down.
    */
   boolean getNotebooksStatus();

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -376,6 +376,172 @@ paths:
             $ref: '#/definitions/ErrorReport'
 
 ##########################################################################################
+## Subset of the Jupyter API
+## https://github.com/jupyter/notebook/blob/master/notebook/services/api/api.yaml
+##########################################################################################
+
+  # In Swagger 2, path params are escaped so we need to hardcode any known "/"
+  # delimiters. With Swagger 3, allowReserved would allow us to collapse the
+  # "workspaces/..." fragment into a single "path" var, as is used in Jupyter's
+  # own Swagger definition. The next 3 methods are actually one in the same in
+  # Jupyter's API.
+  /notebooks/{googleProject}/{clusterName}/api/contents/workspaces:
+    parameters:
+      - in: path
+        name: googleProject
+        description: googleProject
+        required: true
+        type: string
+      - in: path
+        name: clusterName
+        description: clusterName
+        required: true
+        type: string
+    put:
+      summary: Save or upload file.
+      description: "Saves the file in the location specified by name and path.  PUT is very similar to POST, but the requester specifies the name, whereas with POST, the server picks the name."
+      tags:
+        - jupyter
+      operationId: putWorkspacesRootDir
+      parameters:
+        - name: model
+          in: body
+          description: New path for file or directory
+          schema:
+            $ref: '#/definitions/JupyterModel'
+      responses:
+        200:
+          description: File saved
+          headers:
+            Location:
+              description: Updated URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+        201:
+          description: Path created
+          headers:
+            Location:
+              description: URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+  /notebooks/{googleProject}/{clusterName}/api/contents/workspaces/{workspaceDir}:
+    parameters:
+      - in: path
+        name: googleProject
+        description: googleProject
+        required: true
+        type: string
+      - in: path
+        name: clusterName
+        description: clusterName
+        required: true
+        type: string
+      - in: path
+        name: workspaceDir
+        description: workspaceDir
+        required: true
+        type: string
+    put:
+      summary: Save or upload file.
+      description: "Saves the file in the location specified by name and path.  PUT is very similar to POST, but the requester specifies the name, whereas with POST, the server picks the name."
+      tags:
+        - jupyter
+      operationId: putWorkspaceDir
+      parameters:
+        - name: model
+          in: body
+          description: New path for file or directory
+          schema:
+            $ref: '#/definitions/JupyterModel'
+      responses:
+        200:
+          description: File saved
+          headers:
+            Location:
+              description: Updated URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+        201:
+          description: Path created
+          headers:
+            Location:
+              description: URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+  /notebooks/{googleProject}/{clusterName}/api/contents/workspaces/{workspaceDir}/{fileName}:
+    parameters:
+      - in: path
+        name: googleProject
+        description: googleProject
+        required: true
+        type: string
+      - in: path
+        name: clusterName
+        description: clusterName
+        required: true
+        type: string
+      - in: path
+        name: workspaceDir
+        description: workspaceDir
+        required: true
+        type: string
+      - in: path
+        name: fileName
+        description: fileName
+        required: true
+        type: string
+    put:
+      summary: Save or upload file.
+      description: "Saves the file in the location specified by name and path.  PUT is very similar to POST, but the requester specifies the name, whereas with POST, the server picks the name."
+      tags:
+        - jupyter
+      operationId: putContents
+      parameters:
+        - name: model
+          in: body
+          description: New path for file or directory
+          schema:
+            $ref: '#/definitions/JupyterModel'
+      responses:
+        200:
+          description: File saved
+          headers:
+            Location:
+              description: Updated URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+        201:
+          description: Path created
+          headers:
+            Location:
+              description: URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/JupyterContents'
+        400:
+          description: No data provided
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+
+##########################################################################################
 ## DEFINITIONS
 ##########################################################################################
 definitions:
@@ -575,3 +741,71 @@ definitions:
       systems:
         type: object
         description: Map[String, SubsystemStatus]
+
+  # Jupyter API definitions
+  JupyterModel:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The new filename if changed
+      path:
+        type: string
+        description: New path for file or directory
+      type:
+        type: string
+        description: Path dtype ('notebook', 'file', 'directory')
+      format:
+        type: string
+        description: File format ('json', 'text', 'base64')
+      content:
+        type: string
+        description: The actual body of the document excluding directory type
+
+  JupyterContents:
+    description: "A contents object.  The content and format keys may be null if content is not contained.  If type is 'file', then the mimetype will be null."
+    type: object
+    required:
+      - type
+      - name
+      - path
+      - writable
+      - created
+      - last_modified
+      - mimetype
+      - format
+      - content
+    properties:
+      name:
+        type: string
+        description: "Name of file or directory, equivalent to the last part of the path"
+      path:
+        type: string
+        description: Full path for file or directory
+      type:
+        type: string
+        description: Type of content
+        enum:
+          - directory
+          - file
+          - notebook
+      writable:
+        type: boolean
+        description: indicates whether the requester has permission to edit the file
+      created:
+        type: string
+        description: Creation timestamp
+        format: dateTime
+      last_modified:
+        type: string
+        description: Last modified timestamp
+        format: dateTime
+      mimetype:
+        type: string
+        description: "The mimetype of a file.  If content is not null, and type is 'file', this will contain the mimetype of the file, otherwise this will be null."
+      content:
+        type: string
+        description: "The content, if requested (otherwise null).  Will be an array if type is 'directory'"
+      format:
+        type: string
+        description: Format of content (one of null, 'text', 'base64', 'json')

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -1,0 +1,182 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import javax.inject.Provider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.dao.WorkspaceService;
+import org.pmiops.workbench.db.model.CdrVersion;
+import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.ClusterLocalizeRequest;
+import org.pmiops.workbench.model.ClusterLocalizeResponse;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.notebooks.NotebooksService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class ClusterControllerTest {
+  private static final String WORKSPACE_NS = "proj";
+  private static final String WORKSPACE_ID = "wsid";
+  private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
+  private static final String BUCKET_NAME = "workspace-bucket";
+
+  @TestConfiguration
+  @Import({
+    ClusterController.class
+  })
+  @MockBean({
+    FireCloudService.class,
+    NotebooksService.class,
+    UserService.class,
+    WorkspaceService.class
+  })
+  static class Configuration {
+    @Bean
+    @Qualifier("apiHostName")
+    String apiHostName() {
+      return "https://api.blah.com";
+    }
+
+    @Bean
+    User user() {
+      // Allows for wiring of the initial Provider<User>; actual mocking of the
+      // user is achieved via setUserProvider().
+      return null;
+    }
+  }
+
+  @Autowired
+  NotebooksService notebookService;
+  @Autowired
+  FireCloudService fireCloudService;
+  @Autowired
+  UserDao userDao;
+  @Autowired
+  CdrVersionDao cdrVersionDao;
+  @Autowired
+  WorkspaceService workspaceService;
+  @Mock
+  Provider<User> userProvider;
+  @Autowired
+  ClusterController clusterController;
+
+  private CdrVersion cdrVersion;
+
+  @Before
+  public void setUp() {
+    User user = new User();
+    user.setEmail(LOGGED_IN_USER_EMAIL);
+    user.setUserId(123L);
+    user.setFreeTierBillingProjectName(WORKSPACE_NS);
+    when(userProvider.get()).thenReturn(user);
+    clusterController.setUserProvider(userProvider);
+
+    cdrVersion = new CdrVersion();
+    cdrVersion.setName("1");
+    //set the db name to be empty since test cases currently
+    //run in the workbench schema only.
+    cdrVersion.setCdrDbName("");
+  }
+
+  private org.pmiops.workbench.firecloud.model.Workspace createFcWorkspace(
+      String ns, String name, String creator) {
+    return new org.pmiops.workbench.firecloud.model.Workspace()
+        .namespace(ns)
+        .name(name)
+        .createdBy(creator)
+        .bucketName(BUCKET_NAME);
+  }
+
+  private void stubGetWorkspace(String ns, String name, String creator) throws Exception {
+    Workspace w = new Workspace();
+    w.setWorkspaceNamespace(ns);
+    w.setFirecloudName(name);
+    w.setCdrVersion(cdrVersion);
+    when(workspaceService.getRequired(ns, name)).thenReturn(w);
+    stubGetFcWorkspace(createFcWorkspace(ns, name, creator));
+  }
+
+  private void stubGetFcWorkspace(org.pmiops.workbench.firecloud.model.Workspace fcWorkspace)
+      throws Exception {
+    org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =
+        new org.pmiops.workbench.firecloud.model.WorkspaceResponse();
+    fcResponse.setWorkspace(fcWorkspace);
+    fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
+    when(fireCloudService.getWorkspace(fcWorkspace.getNamespace(), fcWorkspace.getName()))
+        .thenReturn(fcResponse);
+  }
+
+  @Test
+  public void testLocalize() throws Exception {
+    ClusterLocalizeRequest req = new ClusterLocalizeRequest();
+    req.setWorkspaceNamespace(WORKSPACE_NS);
+    req.setWorkspaceId(WORKSPACE_ID);
+    req.setNotebookNames(ImmutableList.of("foo.ipynb"));
+    stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, LOGGED_IN_USER_EMAIL);
+    ClusterLocalizeResponse resp =
+        clusterController.localize(WORKSPACE_NS, "cluster", req).getBody();
+    verify(notebookService).localize(
+        WORKSPACE_NS, "cluster",
+        ImmutableMap.of("~/workspaces/wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb"));
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/wsid");
+  }
+
+  @Test
+  public void testLocalize_differentNamespace() throws Exception {
+    ClusterLocalizeRequest req = new ClusterLocalizeRequest();
+    req.setWorkspaceNamespace(WORKSPACE_NS);
+    req.setWorkspaceId(WORKSPACE_ID);
+    req.setNotebookNames(ImmutableList.of("foo.ipynb"));
+    stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, LOGGED_IN_USER_EMAIL);
+    ClusterLocalizeResponse resp =
+        clusterController.localize("other-proj", "cluster", req).getBody();
+    verify(notebookService).localize(
+        "other-proj", "cluster",
+        ImmutableMap.of("~/workspaces/proj:wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb"));
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/proj:wsid");
+  }
+
+  @Test
+  public void testLocalize_noNotebooks() throws Exception {
+    ClusterLocalizeRequest req = new ClusterLocalizeRequest();
+    req.setWorkspaceNamespace(WORKSPACE_NS);
+    req.setWorkspaceId(WORKSPACE_ID);
+    stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, LOGGED_IN_USER_EMAIL);
+    ClusterLocalizeResponse resp =
+        clusterController.localize(WORKSPACE_NS, "cluster", req).getBody();
+    verify(notebookService, never()).localize(anyString(), anyString(), any());
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/wsid");
+  }}

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -138,7 +138,7 @@ public class CohortsControllerTest {
     CLOCK.setInstant(NOW);
     WorkspacesController workspacesController = new WorkspacesController(workspaceService,
         cdrVersionDao, userDao, userProvider, fireCloudService, cloudStorageService, CLOCK,
-        "https://api.blah.com", userService);
+        userService);
     stubGetWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME, "bob@gmail.com",
         WorkspaceAccessLevel.OWNER);
     workspace = workspacesController.createWorkspace(workspace).getBody();


### PR DESCRIPTION
- Dynamically materialize config files rather than writing from GCS -> localizing, using the [Jupyter server contents API](https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API). Dynamically materializing is vastly preferred to writing a file to GCS, as we no longer need to worry about outdated config files.
- Pull in parts of the Jupyter Server API swagger into `notebooks.yaml` to formalize the above calls
- Write a second config file, `.delocalize.json`, when localizing notebooks. This enables delocalization on Leonardo (only for clusters created as of 1 week ago).

Two major things to cleanup here:
- There are a lot of serial calls to Jupyter server happening here to initialize the directory structure we want. This could be fixed in several ways, possibly with FRs to Leo.
- The Jupyter Server API swagger is very verbose. We need to upgrade to Swagger 3 to fix that.

I'm adding tests now for `ClusterController`; sending for review in the meantime. 