### PR TITLE
Build with --aot for deploys; fix compilation errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,10 +218,6 @@ jobs:
           working_directory: ~/workbench/ui
           command: |
             yarn run codegen && yarn test --no-watch --no-progress --browsers=ChromeHeadless
-      - run:
-          name: Test compilation of the Angular app
-          working_directory: ~/workbench/ui
-          command: yarn run build --no-watch --no-progress
       - deploy:
           name: Maybe deploy to test/staging
           working_directory: ~/workbench/ui
@@ -241,7 +237,8 @@ jobs:
                 --version "${CIRCLE_TAG}" \
                 --promote
             else
-              echo "Not master branch or tagged release, skipping deploy"
+              echo "Not master branch or tagged release, skipping deploy; building only"
+              yarn run build --aot --no-watch --no-progress
             fi
 
 workflows:

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -127,7 +127,9 @@ class DeployUI
     }
     environment_name = environment_names[@opts.project]
     common.run_inline %W{yarn install}
-    common.run_inline %W{yarn run build --environment=#{environment_name} --no-watch --no-progress}
+    # TODO(calbach): Upgrade this to --prod for the full production build
+    # treatment. Need to fix a bunch of errors to move ahead with that.
+    common.run_inline %W{yarn run build --aot --environment=#{environment_name} --no-watch --no-progress}
     ServiceAccountContext.new(@opts.project, service_account=@opts.account).run do
       common.run_inline %W{gcloud app deploy
         --project #{@opts.project}

--- a/ui/src/app/cohort-review/cohort-review.module.ts
+++ b/ui/src/app/cohort-review/cohort-review.module.ts
@@ -39,7 +39,7 @@ import {CohortReviewRoutingModule} from './routing/routing.module';
 import {WorkspacesService} from 'generated';
 
 // This is a temporary measure until we have specs and APIs for overview specific charts
-import {ComboChartComponent} from '../cohort-search/combo-chart/combo-chart.component';
+import {CohortSearchModule} from '../cohort-search/cohort-search.module';
 /* tslint:enable:max-line-length */
 
 
@@ -54,6 +54,9 @@ import {ComboChartComponent} from '../cohort-search/combo-chart/combo-chart.comp
     ClarityModule,
     NgxChartsModule,
     NgxPopperModule,
+    // Ours
+    // TODO: Remove this once the dependency on ComboChartComponent is broken.
+    CohortSearchModule
   ],
   declarations: [
     /* Scaffolding and Pages */
@@ -63,7 +66,6 @@ import {ComboChartComponent} from '../cohort-search/combo-chart/combo-chart.comp
     PageLayout,
     TablePage,
 
-    ComboChartComponent,
     ReviewNavComponent,
 
     /* Annotations */

--- a/ui/src/app/cohort-search/cohort-search.module.ts
+++ b/ui/src/app/cohort-search/cohort-search.module.ts
@@ -54,6 +54,10 @@ const routes: Routes = [{
     OverviewComponent,
     SearchGroupSelectComponent,
   ],
+  exports: [
+    // TODO: Remove this once no longer needed by CohortReviewModule.
+    ComboChartComponent
+  ],
   providers: [
     CohortSearchActions,
     CohortSearchEpics,

--- a/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/explorer/explorer.component.ts
@@ -28,12 +28,12 @@ export class ExplorerComponent implements OnInit {
   private readonly parentId = 0;  /* Root parent ID is always zero */
 
   private searchValue = '';
-  private searchResults;
+  searchResults;
   private settingAttributes = false;
 
-  private loading$: Observable<boolean>;
-  private errors$: Observable<any>;
-  private nodeInFocus$: Observable<Map<any, any>>;
+  loading$: Observable<boolean>;
+  errors$: Observable<any>;
+  nodeInFocus$: Observable<Map<any, any>>;
 
   constructor(
     private ngRedux: NgRedux<CohortSearchState>,

--- a/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/quicksearch/quicksearch.component.ts
@@ -7,8 +7,8 @@ import {FormControl} from '@angular/forms';
   styleUrls: ['./quicksearch.component.css'],
 })
 export class QuickSearchComponent {
-  private fuzzyFinder = new FormControl();
-  private isFocused = false;
+  fuzzyFinder = new FormControl();
+  isFocused = false;
   @Output() value = new EventEmitter<string>();
 
   @Input()

--- a/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
+++ b/ui/src/app/cohort-search/criteria-wizard/tree/tree.component.ts
@@ -19,9 +19,9 @@ export class TreeComponent implements OnInit {
   @Input() node;
 
   /* Selections derived from `node` */
-  private loading$: Observable<boolean>;
-  private hasError$: Observable<boolean>;
-  private children$: Observable<List<any>>;
+  loading$: Observable<boolean>;
+  hasError$: Observable<boolean>;
+  children$: Observable<List<any>>;
 
   constructor(
     private ngRedux: NgRedux<CohortSearchState>,

--- a/ui/src/app/cohort-search/overview/overview.component.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.ts
@@ -24,7 +24,7 @@ export class OverviewComponent {
   @Input() total$: Observable<number>;
   @Input() isRequesting$: Observable<boolean>;
 
-  private cohortForm = new FormGroup({
+  cohortForm = new FormGroup({
     name: new FormControl('', [Validators.required]),
     description: new FormControl()
   });

--- a/ui/src/app/data-browser/data-browser.module.ts
+++ b/ui/src/app/data-browser/data-browser.module.ts
@@ -49,13 +49,10 @@ const DataBrowserServiceFactory = (http: Http) => {
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    ChartModule.forRoot(highcharts),
+    ChartModule,
     HttpModule,
     ClarityModule,
-    LocalStorageModule.withConfig({
-      prefix: 'my-app',
-      storageType: 'localStorage'
-    })
+    LocalStorageModule
   ],
   declarations: [
     ChartComponent,
@@ -84,6 +81,12 @@ const DataBrowserServiceFactory = (http: Http) => {
       {
         provide: HighchartsStatic,
         useValue: highcharts,
+      },
+      {
+        provide: 'LOCAL_STORAGE_SERVICE_CONFIG', useValue: {
+          prefix: 'my-app',
+          storageType: 'localStorage'
+        }
       }
   ]
 })

--- a/ui/src/app/data-browser/one-concept/one-concept.component.html
+++ b/ui/src/app/data-browser/one-concept/one-concept.component.html
@@ -1,6 +1,7 @@
 <div class="card">
   <div class=" text-center card-header">
-    <div class="text-right"><button class="btn btn-sm btn-icon btn-danger-outline" style="margin-right:6px!important" (click)="sendRemove()"><clr-icon shape="times"></clr-icon></button></div>
+    <!-- TODO: Send a valid parameter here. -->
+    <div class="text-right"><button class="btn btn-sm btn-icon btn-danger-outline" style="margin-right:6px!important" (click)="sendRemove(null)"><clr-icon shape="times"></clr-icon></button></div>
     <h3 style="margin-top: .5rem; line-height:1.3; transform: translateY(-10%);" class="card-header-text">{{concept.concept_name}}</h3>
   </div>
   <div style="padding:0!important; padding-top:.5rem !important;" class="card-block">

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -27,8 +27,8 @@ export const overriddenPublicUrlKey = 'publicApiUrlOverride';
 })
 export class AppComponent implements OnInit {
   isSignedIn = false;
+  overriddenUrl: string = null;
   private baseTitle: string;
-  private overriddenUrl: string = null;
   private showCreateAccount = false;
   private overriddenPublicUrl: string = null;
 

--- a/ui/src/app/views/error-handler/component.ts
+++ b/ui/src/app/views/error-handler/component.ts
@@ -11,8 +11,8 @@ import {StatusCheckService} from 'app/services/status-check.service';
 export class ErrorHandlerComponent implements OnInit {
 
   constructor(
-    private errorHandlingService: ErrorHandlingService,
-    private statusCheckService: StatusCheckService
+    public errorHandlingService: ErrorHandlingService,
+    public statusCheckService: StatusCheckService
   ) {}
 
   ngOnInit(): void {}

--- a/ui/src/app/views/profile-page/component.ts
+++ b/ui/src/app/views/profile-page/component.ts
@@ -21,6 +21,7 @@ import {
   templateUrl: './component.html',
 })
 export class ProfilePageComponent implements OnInit {
+  editHover = false;
   profile: Profile;
   workingProfile: Profile;
   profileImage: string;

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -12,8 +12,7 @@
       <app-share-icon [shareHover]="shareHover"></app-share-icon>
       <span class="tooltip-content">Share Workspace</span>
     </button>
-    <button (mouseover)="cloneHover=true" (mouseleave)="cloneHover=false"
-            (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
+    <button (click)="clone()" class="btn btn-icon btn-primary-outline tooltip tooltip-sm">
       <!-- TODO(calbach): Check whether we have the real asset available. -->
       <clr-icon shape="copy"></clr-icon>
       <span class="tooltip-content">Clone Workspace</span>

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -72,12 +72,12 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   // Keep in sync with api/src/main/resources/notebooks.yaml.
   private static readonly leoBaseUrl = 'https://notebooks.firecloud.org';
 
-  private cohortNameFilter = new CohortNameFilter();
-  private cohortDescriptionFilter = new CohortDescriptionFilter();
-  private notebookNameFilter = new NotebookNameFilter();
-  private cohortNameComparator = new CohortNameComparator();
-  private cohortDescriptionComparator = new CohortDescriptionComparator();
-  private notebookNameComparator = new NotebookNameComparator();
+  cohortNameFilter = new CohortNameFilter();
+  cohortDescriptionFilter = new CohortDescriptionFilter();
+  notebookNameFilter = new NotebookNameFilter();
+  cohortNameComparator = new CohortNameComparator();
+  cohortDescriptionComparator = new CohortDescriptionComparator();
+  notebookNameComparator = new NotebookNameComparator();
 
   workspace: Workspace;
   wsId: string;
@@ -91,8 +91,8 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   cluster: Cluster;
   clusterLoading = true;
   clusterPulled = false;
+  launchedNotebookName: string;
   private clusterLocalDirectory: string;
-  private launchedNotebookName: string;
   private accessLevel: WorkspaceAccessLevel;
   deleting = false;
   showAlerts = false;


### PR DESCRIPTION
The 2-3s stall-time on initial page load dissipates with `--aot` enabled, which leads me to believe that during this time the browser is mostly doing JIT compilation. It may be that we recently brought in more Typescript deps somehow, which is why this seemingly got worse recently, but `--aot` has never been enabled for our GAE deployments.

We don't want to enable this locally as it takes way longer to recompile after a change. Later I would like to do further compilation optimizations, but there's a bunch of NgModule problems blocking that.