### PR TITLE
Wait on initial nav for gapi to load

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -112,7 +112,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, {onSameUrlNavigation: 'reload'})],
+  imports: [RouterModule.forRoot(routes, {onSameUrlNavigation: 'reload',
+      initialNavigation: false})],
   exports: [RouterModule],
   providers: [
     CohortResolver,

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -112,8 +112,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, {onSameUrlNavigation: 'reload',
-      initialNavigation: false})],
+  imports: [RouterModule.forRoot(routes, {onSameUrlNavigation: 'reload'})],
   exports: [RouterModule],
   providers: [
     CohortResolver,

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -8,8 +8,9 @@ import {ActivatedRouteSnapshot, NavigationEnd, Router} from '@angular/router';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
-import {AsyncSubject} from 'rxjs/AsyncSubject';
 import {Observable} from 'rxjs/Observable';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
+
 
 declare const gapi: any;
 
@@ -19,7 +20,7 @@ const SIGNED_IN_USER = 'signedInUser';
 @Injectable()
 export class SignInService {
   // Expose "current user details" as an Observable
-  private isSignedIn = new AsyncSubject<boolean>();
+  private isSignedIn = new ReplaySubject<boolean>(1);
   public isSignedIn$ = this.isSignedIn.asObservable();
   // Expose "current user details" as an Observable
   public clientId = environment.clientId;
@@ -59,15 +60,9 @@ export class SignInService {
   private subscribeToAuth2User(): void {
     // The listen below only fires on changes, so we need an initial
     // check to handle the case where the user is already signed in.
-    if (gapi.auth2.getAuthInstance().isSignedIn.get()) {
-      this.zone.run(() => {
-        this.isSignedIn.next(true);
-      });
-    } else if (gapi.auth2.getAuthInstance().isSignedIn.get() === false) {
-      this.zone.run(() => {
-        this.isSignedIn.next(false);
-      });
-    }
+    this.zone.run(() => {
+      this.isSignedIn.next(gapi.auth2.getAuthInstance().isSignedIn.get());
+    });
     gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn: boolean) => {
       this.zone.run(() => {
         this.isSignedIn.next(isSignedIn);

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -52,6 +52,7 @@ export class SignInService {
           this.subscribeToAuth2User();
         });
         resolve(gapi.auth2);
+        this.router.initialNavigation();
       });
     });
   }

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -8,7 +8,7 @@ import {ActivatedRouteSnapshot, NavigationEnd, Router} from '@angular/router';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {AsyncSubject} from 'rxjs/AsyncSubject';
 import {Observable} from 'rxjs/Observable';
 
 declare const gapi: any;
@@ -19,7 +19,7 @@ const SIGNED_IN_USER = 'signedInUser';
 @Injectable()
 export class SignInService {
   // Expose "current user details" as an Observable
-  private isSignedIn = new BehaviorSubject<boolean>(false);
+  private isSignedIn = new AsyncSubject<boolean>();
   public isSignedIn$ = this.isSignedIn.asObservable();
   // Expose "current user details" as an Observable
   public clientId = environment.clientId;
@@ -52,7 +52,6 @@ export class SignInService {
           this.subscribeToAuth2User();
         });
         resolve(gapi.auth2);
-        this.router.initialNavigation();
       });
     });
   }
@@ -63,6 +62,10 @@ export class SignInService {
     if (gapi.auth2.getAuthInstance().isSignedIn.get()) {
       this.zone.run(() => {
         this.isSignedIn.next(true);
+      });
+    } else if (gapi.auth2.getAuthInstance().isSignedIn.get() === false) {
+      this.zone.run(() => {
+        this.isSignedIn.next(false);
       });
     }
     gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn: boolean) => {


### PR DESCRIPTION
The goal of this change is to avoid the flicker of the signed-out screen, as described in [[RW-458]](https://precisionmedicineinitiative.atlassian.net/secure/RapidBoard.jspa?rapidView=23&projectKey=RW&view=planning&selectedIssue=RW-458)