### PR TITLE
Js/rw 267 drugs

### DIFF
--- a/ui/src/app/cohort-review/cohort-review.module.ts
+++ b/ui/src/app/cohort-review/cohort-review.module.ts
@@ -18,6 +18,7 @@ import {ReviewNavComponent} from './review-nav/review-nav.component';
 import {DetailConditionsComponent} from './detail-conditions/detail-conditions.component';
 import {DetailDrugsComponent} from './detail-drugs/detail-drugs.component';
 import {DetailHeaderComponent} from './detail-header/detail-header.component';
+import {DetailObservationsComponent} from './detail-observations/detail-observations.component';
 import {DetailProceduresComponent} from './detail-procedures/detail-procedures.component';
 import {DetailTabsComponent} from './detail-tabs/detail-tabs.component';
 
@@ -89,6 +90,7 @@ import {CohortSearchModule} from '../cohort-search/cohort-search.module';
     DetailTabsComponent,
     DetailConditionsComponent,
     DetailDrugsComponent,
+    DetailObservationsComponent,
     DetailProceduresComponent,
   ],
   providers: [ReviewStateService]

--- a/ui/src/app/cohort-review/cohort-review.module.ts
+++ b/ui/src/app/cohort-review/cohort-review.module.ts
@@ -16,6 +16,7 @@ import {TablePage} from './table-page/table-page';
 import {ReviewNavComponent} from './review-nav/review-nav.component';
 
 import {DetailConditionsComponent} from './detail-conditions/detail-conditions.component';
+import {DetailDrugsComponent} from './detail-drugs/detail-drugs.component';
 import {DetailHeaderComponent} from './detail-header/detail-header.component';
 import {DetailProceduresComponent} from './detail-procedures/detail-procedures.component';
 import {DetailTabsComponent} from './detail-tabs/detail-tabs.component';
@@ -56,7 +57,7 @@ import {CohortSearchModule} from '../cohort-search/cohort-search.module';
     NgxPopperModule,
     // Ours
     // TODO: Remove this once the dependency on ComboChartComponent is broken.
-    CohortSearchModule
+    CohortSearchModule,
   ],
   declarations: [
     /* Scaffolding and Pages */
@@ -84,8 +85,10 @@ import {CohortSearchModule} from '../cohort-search/cohort-search.module';
     ParticipantStatusComponent,
     SidebarContentComponent,
     DetailHeaderComponent,
+
     DetailTabsComponent,
     DetailConditionsComponent,
+    DetailDrugsComponent,
     DetailProceduresComponent,
   ],
   providers: [ReviewStateService]

--- a/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.css
+++ b/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.css
@@ -1,0 +1,7 @@
+.date-col {
+  width: 6.5rem;
+}
+
+.vocab-col {
+  width: 7rem;
+}

--- a/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.html
+++ b/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.html
@@ -1,0 +1,71 @@
+<clr-datagrid
+  [clrDgLoading]="loading"
+  (clrDgRefresh)="update($event)"
+  class="datagrid-compact"
+>
+  <clr-dg-placeholder>No Medications Data</clr-dg-placeholder>
+  <clr-dg-column [clrDgField]="'itemDate'" class="date-col">
+    Date
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'standardVocabulary'" class="vocab-col">
+    Standard Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'standardName'">
+    Standard Name
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'signature'">
+    Signature
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'sourceVocabulary'" class="vocab-col">
+    Source Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'sourceValue'">
+    Source Value
+  </clr-dg-column>
+
+  <clr-dg-column>
+    Age At Event
+  </clr-dg-column>
+
+  <clr-dg-row *ngFor="let drug of drugs">
+    <clr-dg-cell>
+      {{ drug.itemDate | date:'yyyy-MM-dd HH:mm:ss' }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ drug.standardVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ drug.standardName }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ drug.signature }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ drug.sourceVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell
+        [popper]="drug.sourceName"
+        [popperTrigger]="'hover'"
+        [popperPlacement]="'left'"
+        [popperTarget]="sourceValue">
+      <span #sourceValue>{{ drug.sourceValue }}</span>
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ drug.age }}
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    {{ pagination.firstItem + 1 }} - {{ pagination.lastItem + 1 }} of
+    {{ totalCount }} Records
+    <clr-dg-pagination #pagination
+      [clrDgTotalItems]="totalCount"
+      [clrDgPageSize]="request.pageSize"
+      [clrDgPage]="request.page + 1">
+    </clr-dg-pagination>
+  </clr-dg-footer>
+
+</clr-datagrid>

--- a/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.ts
+++ b/ui/src/app/cohort-review/detail-drugs/detail-drugs.component.ts
@@ -1,0 +1,110 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {ClrDatagridStateInterface} from '@clr/angular';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+
+import {
+  CohortReviewService,
+  PageFilterRequest,
+  PageFilterType,
+  ParticipantDrug,
+  ParticipantDrugsColumns as Columns,
+  SortOrder,
+} from 'generated';
+
+@Component({
+  selector: 'app-detail-drugs',
+  templateUrl: './detail-drugs.component.html',
+  styleUrls: ['./detail-drugs.component.css']
+})
+export class DetailDrugsComponent implements OnInit, OnDestroy {
+  /* Maps string values to Enum values */
+  readonly reverseColumnEnum = {
+    itemDate: Columns.ItemDate,
+    standardVocabulary: Columns.StandardVocabulary,
+    standardName: Columns.StandardName,
+    sourceValue: Columns.SourceValue,
+    sourceVocabulary: Columns.SourceVocabulary,
+    sourceName: Columns.SourceName,
+
+    age: Columns.Age,
+    signature: Columns.Signature,
+  };
+
+  loading = false;
+
+  drugs: ParticipantDrug[];
+  request;
+  totalCount: number;
+  apiCaller: (any) => Observable<any>;
+  subscription: Subscription;
+
+  constructor(
+    private route: ActivatedRoute,
+    private reviewApi: CohortReviewService,
+  ) {}
+
+  ngOnInit() {
+    console.dir(this.route);
+    this.subscription = this.route.data
+      .map(({participant}) => participant)
+      .withLatestFrom(
+        this.route.parent.data.map(({cohort}) => cohort),
+        this.route.parent.data.map(({workspace}) => workspace),
+      )
+      .subscribe(([participant, cohort, workspace]) => {
+        this.loading = true;
+
+        this.apiCaller = (request) => this.reviewApi.getParticipantData(
+          workspace.namespace,
+          workspace.id,
+          cohort.id,
+          workspace.cdrVersionId,
+          participant.participantId,
+          request
+        );
+
+        this.request = <PageFilterRequest>{
+          page: 0,
+          pageSize: 50,
+          includeTotal: true,
+          sortOrder: SortOrder.Asc,
+          sortColumn: Columns.ItemDate,
+          pageFilterType: PageFilterType.ParticipantDrugs,
+        };
+
+        this.callApi();
+      });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  callApi() {
+    this.loading = true;
+    this.apiCaller(this.request).subscribe(resp => {
+      this.drugs = resp.items;
+      this.totalCount = resp.count;
+      this.request = resp.pageRequest;
+      this.request.pageFilterType = PageFilterType.ParticipantDrugs;
+      this.loading = false;
+    });
+  }
+
+  update(state: ClrDatagridStateInterface) {
+    console.log('Datagrid state: ');
+    console.dir(state);
+    const page = Math.floor(state.page.from / state.page.size);
+    const pageSize = state.page.size;
+    this.request = {...this.request, page, pageSize};
+
+    if (state.sort) {
+      const sortby = <string>(state.sort.by);
+      this.request.sortColumn = this.reverseColumnEnum[sortby];
+      this.request.sortOrder = state.sort.reverse ? SortOrder.Desc : SortOrder.Asc;
+    }
+    this.callApi();
+  }
+}

--- a/ui/src/app/cohort-review/detail-observations/detail-observations.component.css
+++ b/ui/src/app/cohort-review/detail-observations/detail-observations.component.css
@@ -1,0 +1,7 @@
+.date-col {
+  width: 6.5rem;
+}
+
+.vocab-col {
+  width: 7rem;
+}

--- a/ui/src/app/cohort-review/detail-observations/detail-observations.component.html
+++ b/ui/src/app/cohort-review/detail-observations/detail-observations.component.html
@@ -1,0 +1,64 @@
+<clr-datagrid
+  [clrDgLoading]="loading"
+  (clrDgRefresh)="update($event)"
+  class="datagrid-compact"
+>
+  <clr-dg-placeholder>No Medications Data</clr-dg-placeholder>
+  <clr-dg-column [clrDgField]="'itemDate'" class="date-col">
+    Date
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'standardVocabulary'" class="vocab-col">
+    Standard Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'standardName'">
+    Standard Name
+  </clr-dg-column>
+
+  <clr-dg-column [clrDgField]="'sourceVocabulary'" class="vocab-col">
+    Source Vocabulary
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'sourceValue'">
+    Source Value
+  </clr-dg-column>
+
+  <clr-dg-column>
+    Age At Event
+  </clr-dg-column>
+
+  <clr-dg-row *ngFor="let observation of observations">
+    <clr-dg-cell>
+      {{ observation.itemDate | date:'yyyy-MM-dd HH:mm:ss' }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ observation.standardVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ observation.standardName }}
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ observation.sourceVocabulary }}
+    </clr-dg-cell>
+    <clr-dg-cell
+        [popper]="observation.sourceName || ''"
+        [popperTrigger]="'hover'"
+        [popperPlacement]="'left'"
+        [popperTarget]="sourceValue">
+      <span #sourceValue>{{ observation.sourceValue || '' }}</span>
+    </clr-dg-cell>
+    <clr-dg-cell>
+      {{ observation.age }}
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    {{ pagination.firstItem + 1 }} - {{ pagination.lastItem + 1 }} of
+    {{ totalCount }} Records
+    <clr-dg-pagination #pagination
+      [clrDgTotalItems]="totalCount"
+      [clrDgPageSize]="request.pageSize"
+      [clrDgPage]="request.page + 1">
+    </clr-dg-pagination>
+  </clr-dg-footer>
+
+</clr-datagrid>

--- a/ui/src/app/cohort-review/detail-observations/detail-observations.component.ts
+++ b/ui/src/app/cohort-review/detail-observations/detail-observations.component.ts
@@ -1,0 +1,108 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {ClrDatagridStateInterface} from '@clr/angular';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+
+import {
+  CohortReviewService,
+  PageFilterRequest,
+  PageFilterType,
+  ParticipantObservation,
+  ParticipantObservationsColumns as Columns,
+  SortOrder,
+} from 'generated';
+
+@Component({
+  selector: 'app-detail-observations',
+  templateUrl: './detail-observations.component.html',
+  styleUrls: ['./detail-observations.component.css']
+})
+export class DetailObservationsComponent implements OnInit, OnDestroy {
+  /* Maps string values to Enum values */
+  readonly reverseColumnEnum = {
+    itemDate: Columns.ItemDate,
+    standardVocabulary: Columns.StandardVocabulary,
+    standardName: Columns.StandardName,
+    sourceValue: Columns.SourceValue,
+    sourceVocabulary: Columns.SourceVocabulary,
+    sourceName: Columns.SourceName,
+    age: Columns.Age,
+  };
+
+  loading = false;
+
+  observations: ParticipantObservation[];
+  request;
+  totalCount: number;
+  apiCaller: (any) => Observable<any>;
+  subscription: Subscription;
+
+  constructor(
+    private route: ActivatedRoute,
+    private reviewApi: CohortReviewService,
+  ) {}
+
+  ngOnInit() {
+    console.dir(this.route);
+    this.subscription = this.route.data
+      .map(({participant}) => participant)
+      .withLatestFrom(
+        this.route.parent.data.map(({cohort}) => cohort),
+        this.route.parent.data.map(({workspace}) => workspace),
+      )
+      .subscribe(([participant, cohort, workspace]) => {
+        this.loading = true;
+
+        this.apiCaller = (request) => this.reviewApi.getParticipantData(
+          workspace.namespace,
+          workspace.id,
+          cohort.id,
+          workspace.cdrVersionId,
+          participant.participantId,
+          request
+        );
+
+        this.request = <PageFilterRequest>{
+          page: 0,
+          pageSize: 50,
+          includeTotal: true,
+          sortOrder: SortOrder.Asc,
+          sortColumn: Columns.ItemDate,
+          pageFilterType: PageFilterType.ParticipantObservations,
+        };
+
+        this.callApi();
+      });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  callApi() {
+    this.loading = true;
+    this.apiCaller(this.request).subscribe(resp => {
+      this.observations = resp.items;
+      this.totalCount = resp.count;
+      this.request = resp.pageRequest;
+      this.request.pageFilterType = PageFilterType.ParticipantObservations;
+      this.loading = false;
+    });
+  }
+
+  update(state: ClrDatagridStateInterface) {
+    console.log('Datagrid state: ');
+    console.dir(state);
+    const page = Math.floor(state.page.from / state.page.size);
+    const pageSize = state.page.size;
+    this.request = {...this.request, page, pageSize};
+
+    if (state.sort) {
+      const sortby = <string>(state.sort.by);
+      this.request.sortColumn = this.reverseColumnEnum[sortby];
+      this.request.sortOrder = state.sort.reverse ? SortOrder.Desc : SortOrder.Asc;
+    }
+    this.callApi();
+  }
+}

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
@@ -23,7 +23,7 @@
   <clr-tab>
     <button clrTabLink id="detail-drugs-tab">Drugs</button>
     <clr-tab-content id="detail-drugs-content" *clrIfActive>
-      <em>Charts go here</em>
+      <app-detail-drugs></app-detail-drugs>
     </clr-tab-content>
   </clr-tab>
 

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
@@ -37,7 +37,7 @@
   <clr-tab>
     <button clrTabLink id="detail-observations-tab">Observations</button>
     <clr-tab-content id="detail-observations-content" *clrIfActive>
-      <em>Charts go here</em>
+      <app-detail-observations></app-detail-observations>
     </clr-tab-content>
   </clr-tab>
 

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.ts
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.ts
@@ -1,6 +1,5 @@
 import {Component, OnInit} from '@angular/core';
 
-
 @Component({
   selector: 'app-detail-tabs',
   templateUrl: './detail-tabs.component.html',


### PR DESCRIPTION
Implements UI support for the drugs and observations tabs in `cohort-review` as `detail-observations` and `detail-drugs`.

Same comment applies as with the [pr for procedures](https://github.com/all-of-us/workbench/pull/669): it is entirely likely that we will want to either merge all the `detail-*` tab components (or have them all derive from a common base class at least); however, I believe it will behoove us to wait and see what _all_ the tabs looks like before doing so.