### PR TITLE
Use --aot in test, --prod elsewhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
                 --promote
             else
               echo "Not master branch or tagged release, skipping deploy; building only"
-              yarn run build --aot --no-watch --no-progress
+              ./project.rb build --environment test
             fi
 
 workflows:

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,7 +1,0 @@
-export const environment: object = {
-  displayTag: null,
-  allOfUsApiUrl: 'https://api-dot-all-of-us-workbench.appspot.com',
-  publicApiUrl: 'https://public-api-dot-all-of-us-workbench.appspot.com',
-  debug: false,
-  testing: false
-};


### PR DESCRIPTION
Also unifies the Circle and deploy usage of `yarn build`, and adds a command so that you can run a standalone `build` with the same settings.

`--prod` takes about 2 minute
`--aot` takes about 1 minute

On normal Circle runs, check that `--aot` works. `--prod` felt slightly too slow for this case.

`--aot` seems to catch most of the compilation errors one would hit with `--prod`. `--prod` includes `--aot`, but primarily adds tree-shaking and uglification.