### PR TITLE
Eliminate account creation lorem ipsum

### DIFF
--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -1,6 +1,5 @@
 <form (ngSubmit)="createAccount()" *ngIf="!accountCreated">
   <h2>Create your account</h2>
-  <div>Lorem ipsum dolor sit amet, conser adipscing elit.</div>
   <div class="form-area">
     <div class="form-section">
       <input type="text" class="long-input" id="givenName" name="givenName" autofocus [(ngModel)]="profile.givenName" placeholder="Given Name">

--- a/ui/src/app/views/invitation-key/component.html
+++ b/ui/src/app/views/invitation-key/component.html
@@ -3,9 +3,6 @@
   <div *ngIf="!invitationKeyVerifed" class="form-area">
     <div class="form-section">
       <h2>Enter your Invitation Key:</h2>
-      <div class="invitation-help-text">Lorem ipsum dolor sit amet, conser adipiscing elit. Aenean euisimod bibendum
-        laoreet. Proin gravida sit amet lacus accumsan et viverra justo commodo.
-      </div>
       <input type="text" class="input" [(ngModel)]="invitationKey" placeholder="Invitation Key">
       <div *ngIf="invitationKeyReq" class="alert alert-danger">
         <strong> Invitation Key is required.</strong>
@@ -18,9 +15,6 @@
       Next
     </button>
     <h4>Need an invitation key?</h4>
-    <div class="invitation-help-text">Lorem ipsum dolor sit amet, conser adipiscing elit. Aenean euisimod bibendum
-      laoreet.
-    </div>
     <input type="text" class="input" [(ngModel)]="invitationKeyRequestEmail" placeholder="Email Address" style="display: block;">
     <button id="requestKey" (click)="requestKey()" class="btn btn-secondary" style="width: 9rem; height: 1.8rem">
       Request Invite Key

--- a/ui/src/app/views/invitation-key/component.html
+++ b/ui/src/app/views/invitation-key/component.html
@@ -14,6 +14,8 @@
     <button id="next" (click)="next()" class="btn btn-primary" style="width: 10rem; height: 2rem">
       Next
     </button>
+    <!-- 
+    TODO: Find a contact person to re-implement
     <h4>Need an invitation key?</h4>
     <input type="text" class="input" [(ngModel)]="invitationKeyRequestEmail" placeholder="Email Address" style="display: block;">
     <button id="requestKey" (click)="requestKey()" class="btn btn-secondary" style="width: 9rem; height: 1.8rem">
@@ -22,6 +24,7 @@
     <div *ngIf="requestSent">
       <strong> The invitation key request has been sent.</strong>
     </div>
+    -->
   </div>
   <div *ngIf="invitationKeyVerifed">
     <app-account-creation></app-account-creation>


### PR DESCRIPTION
This is to remove the lorem ipsum text from our UI before the April 16th launch. We should consider whether we want a contact to ask for an invitation key from.