### PR TITLE
Implementing annotation queries using native SQL.

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -29,6 +29,7 @@ import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.ParticipantCounter;
 import org.pmiops.workbench.cohortbuilder.QueryBuilderFactory;
 import org.pmiops.workbench.cohortbuilder.querybuilder.DemoQueryBuilder;
+import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
 import org.pmiops.workbench.config.ConceptCacheConfiguration;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
@@ -64,7 +65,8 @@ import org.springframework.context.annotation.Import;
 @Import({DemoQueryBuilder.class, QueryBuilderFactory.class, CohortMaterializationService.class,
         BigQueryService.class, ParticipantCounter.class, DomainLookupService.class,
         CohortQueryBuilder.class, FieldSetQueryBuilder.class, QueryBuilderFactory.class,
-        TestJpaConfig.class, ConceptCacheConfiguration.class, TestBigQueryCdrSchemaConfig.class})
+        TestJpaConfig.class, ConceptCacheConfiguration.class, TestBigQueryCdrSchemaConfig.class,
+        AnnotationQueryBuilder.class})
 @ComponentScan(basePackages = "org.pmiops.workbench.cohortbuilder.*")
 public class CohortMaterializationServiceTest extends BigQueryBaseTest {
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -1196,7 +1196,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
         cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), request);
     ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED");
     assertResults(response2, p2Map);
-    assertThat(response2.getNextPageToken()).isNotNull();
+    assertThat(response2.getNextPageToken()).isNull();
   }
 
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.AnnotationQuery;
 import org.pmiops.workbench.model.CohortAnnotationDefinition;
 import org.pmiops.workbench.model.CohortAnnotationDefinitionListResponse;
 import org.pmiops.workbench.model.EmptyResponse;
@@ -87,6 +88,9 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
     private void validateColumnName(String columnName) {
         if (AnnotationQueryBuilder.RESERVED_COLUMNS.contains(columnName)) {
             throw new BadRequestException("Annotations are not allowed to be named " + columnName);
+        } else if (columnName.toUpperCase().contains(AnnotationQueryBuilder.DESCENDING_PREFIX)) {
+            throw new BadRequestException("Annotations are not allowed to contain " +
+              AnnotationQueryBuilder.DESCENDING_PREFIX);
         }
     }
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -1,12 +1,15 @@
 package org.pmiops.workbench.cohortbuilder;
 
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.QueryResult;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -15,20 +18,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletResponse;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cohortbuilder.QueryConfiguration.ColumnInfo;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig.ColumnConfig;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig.ColumnType;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig.TableConfig;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ForbiddenException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.ServerUnavailableException;
 import org.pmiops.workbench.model.ColumnFilter;
 import org.pmiops.workbench.model.FieldSet;
+import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.pmiops.workbench.model.Operator;
 import org.pmiops.workbench.model.ResultFilters;
 import org.pmiops.workbench.model.TableQuery;
 import org.pmiops.workbench.utils.OperatorUtils;
+import org.pmiops.workbench.utils.PaginationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +61,7 @@ public class FieldSetQueryBuilder {
       DateTimeFormat.forPattern(DATE_TIME_FORMAT_PATTERN).withZoneUTC();
 
   private final CohortQueryBuilder cohortQueryBuilder;
+  private final BigQueryService bigQueryService;
 
   /**
    * A container for state needed to turn a query into SQL. We pass this around to avoid having
@@ -85,8 +96,10 @@ public class FieldSetQueryBuilder {
   }
 
   @Autowired
-  public FieldSetQueryBuilder(CohortQueryBuilder cohortQueryBuilder) {
+  public FieldSetQueryBuilder(CohortQueryBuilder cohortQueryBuilder,
+      BigQueryService bigQueryService) {
     this.cohortQueryBuilder = cohortQueryBuilder;
+    this.bigQueryService = bigQueryService;
   }
 
   private ColumnConfig findPrimaryKey(Iterable<ColumnConfig> columnConfigs) {
@@ -436,7 +449,7 @@ public class FieldSetQueryBuilder {
     return orderBySql;
   }
 
-  public QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
+  private QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
       TableQueryAndConfig tableQueryAndConfig, long resultSize, long offset) {
     QueryState queryState = new QueryState();
     queryState.schemaConfig = tableQueryAndConfig.getConfig();
@@ -466,7 +479,7 @@ public class FieldSetQueryBuilder {
     return new QueryConfiguration(selectColumns.build(), jobConfiguration);
   }
 
-  public Map<String, Object> extractResults(TableQueryAndConfig tableQueryAndConfig,
+  private Map<String, Object> extractResults(TableQueryAndConfig tableQueryAndConfig,
       ImmutableList<ColumnInfo> columns,
       List<FieldValue> row) {
     TableQuery tableQuery = tableQueryAndConfig.getTableQuery();
@@ -501,4 +514,29 @@ public class FieldSetQueryBuilder {
     }
     return results;
   }
+
+  public Iterable<Map<String, Object>> materializeTableQuery(TableQueryAndConfig tableQueryAndConfig,
+      ParticipantCriteria criteria, int limit, long offset) {
+    QueryConfiguration queryConfiguration = buildQuery(criteria, tableQueryAndConfig, limit, offset);
+    QueryResult result;
+    QueryJobConfiguration jobConfiguration = queryConfiguration.getQueryJobConfiguration();
+    try {
+      result = bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(jobConfiguration));
+    } catch (BigQueryException e) {
+      if (e.getCode() == HttpServletResponse.SC_SERVICE_UNAVAILABLE) {
+        throw new ServerUnavailableException("BigQuery was temporarily unavailable, try again later", e);
+      } else if (e.getCode() == HttpServletResponse.SC_FORBIDDEN) {
+        throw new ForbiddenException("Access to the CDR is denied", e);
+      } else {
+        throw new ServerErrorException(
+            String.format("An unexpected error occurred materializing the cohort with "
+                    + "query = (%s), params = (%s)", jobConfiguration.getQuery(),
+                jobConfiguration.getNamedParameters()), e);
+      }
+
+    }
+    return Iterables.transform(result.iterateAll(),
+        (row) -> extractResults(tableQueryAndConfig, queryConfiguration.getSelectColumns(), row));
+  }
+
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -1,9 +1,13 @@
 package org.pmiops.workbench.cohortreview;
 
+import static org.junit.Assert.fail;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -18,6 +22,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AnnotationQuery;
 import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.CohortStatus;
+import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -158,6 +163,7 @@ public class AnnotationQueryBuilder {
     StringBuilder endSqlBuilder = new StringBuilder("\nLIMIT ");
     endSqlBuilder.append(limit);
     if (offset != 0L) {
+      // TODO: consider pagination based on values rather than offsets
       endSqlBuilder.append(" OFFSET ");
       endSqlBuilder.append(offset);
     }

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -1,0 +1,119 @@
+package org.pmiops.workbench.cohortreview;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
+import org.pmiops.workbench.db.model.CohortAnnotationDefinition;
+import org.pmiops.workbench.db.model.CohortReview;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.model.AnnotationQuery;
+import org.pmiops.workbench.model.AnnotationType;
+import org.pmiops.workbench.model.CohortStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public class AnnotationQueryBuilder {
+
+  private static final String PERSON_ID_COLUMN = "person_id";
+  private static final String REVIEW_STATUS_COLUMN = "review_status";
+
+  private static final ImmutableMap<AnnotationType, String> ANNOTATION_COLUMN_MAP =
+      ImmutableMap.of(
+          AnnotationType.BOOLEAN, "annotation_value_boolean",
+          AnnotationType.DATE, "annotation_value_date",
+          AnnotationType.INTEGER, "annotation_value_integer",
+          AnnotationType.STRING, "annotation_value_string");
+
+  private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  private final CohortAnnotationDefinitionDao cohortAnnotationDefinitionDao;
+
+  @Autowired
+  AnnotationQueryBuilder(NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+      CohortAnnotationDefinitionDao cohortAnnotationDefinitionDao) {
+    this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+    this.cohortAnnotationDefinitionDao = cohortAnnotationDefinitionDao;
+  }
+
+  private static final String ANNOTATION_JOIN_SQL =
+      " LEFT OUTER JOIN participant_cohort_annotations a%d "
+      + "ON a%d.participant_id = pcs.participant_id "
+      + "AND a%d.cohort_annotation_definition_id = %d"
+      + "AND a%d.cohort_review_id = %d";
+
+  private static final String ANNOTATION_VALUE_JOIN_SQL =
+      " LEFT OUTER JOIN cohort_annotation_enum_value ae%d "
+      + "ON ae%d.cohort_annotation_enum_value_id = a%d.cohort_annotation_enum_value_id";
+
+  private static final String WHERE_SQL =
+      " WHERE pcs.cohort_review_id = %d";
+
+  private static final ImmutableSet<CohortStatus> REVIEWED_STATUSES =
+      ImmutableSet.of(CohortStatus.INCLUDED, CohortStatus.EXCLUDED, CohortStatus.NEEDS_FURTHER_REVIEW);
+
+  public Iterable<Map<String, Object>> materializeAnnotationQuery(CohortReview cohortReview,
+      List<CohortStatus> statusFilter,
+      AnnotationQuery annotationQuery, int limit, long offset) {
+    Map<String, CohortAnnotationDefinition> annotationDefinitions = null;
+    List<String> columns = annotationQuery.getColumns();
+    StringBuilder selectBuilder = new StringBuilder("SELECT ");
+    StringBuilder fromBuilder = new StringBuilder(" FROM participant_cohort_status pcs");
+    int annotationCount = 0;
+    boolean firstColumn = true;
+    for (String column : columns) {
+      if (firstColumn) {
+        firstColumn = false;
+      } else {
+        selectBuilder.append(", ");
+      }
+      if (column.equals(PERSON_ID_COLUMN)) {
+        selectBuilder.append("pcs.participant_id person_id");
+      } else if (column.equals(REVIEW_STATUS_COLUMN)) {
+        selectBuilder.append("pcs.status review_status");
+      } else {
+        if (annotationDefinitions == null) {
+          annotationDefinitions =
+              Maps.uniqueIndex(
+                  cohortAnnotationDefinitionDao.findByCohortId(cohortReview.getCohortId()),
+                  CohortAnnotationDefinition::getColumnName);
+
+        }
+        CohortAnnotationDefinition definition = annotationDefinitions.get(column);
+        if (definition == null) {
+          throw new BadRequestException("Invalid annotation name: " + column);
+        }
+        annotationCount++;
+        fromBuilder.append(
+            String.format(ANNOTATION_JOIN_SQL, annotationCount, annotationCount, annotationCount,
+                definition.getCohortAnnotationDefinitionId(), cohortReview.getCohortReviewId()));
+        if (definition.getAnnotationType().equals(AnnotationType.ENUM)) {
+          selectBuilder.append(String.format("ae%d.name av%d", annotationCount, annotationCount));
+          fromBuilder.append(
+              String.format(ANNOTATION_VALUE_JOIN_SQL, annotationCount, annotationCount, annotationCount));
+        } else {
+          String columnName = ANNOTATION_COLUMN_MAP.get(definition.getAnnotationType());
+          if (columnName == null) {
+            throw new BadRequestException("Invalid annotation type: " + definition.getAnnotationType());
+          }
+          selectBuilder.append(String.format("a%d.%s av%d", annotationCount, columnName, annotationCount));
+        }
+      }
+    }
+    StringBuilder whereBuilder = new StringBuilder(
+        String.format(" WHERE pcs.cohort_review_id = %d", cohortReview.getCohortReviewId()));
+    if (!statusFilter.containsAll(REVIEWED_STATUSES)) {
+      whereBuilder.append(" AND pcs.status IN (");
+      whereBuilder.append(Joiner.on(", ").join(statusFilter.stream().map(CohortStatus::ordinal).toArray()));
+      whereBuilder.append(")");
+    }
+    StringBuilder sqlBuilder = new StringBuilder(selectBuilder);
+    sqlBuilder.append(fromBuilder);
+
+
+    return null;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -21,7 +21,9 @@ import org.pmiops.workbench.model.CohortStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
 
+@Service
 public class AnnotationQueryBuilder {
 
   public static final String PERSON_ID_COLUMN = "person_id";

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -71,7 +71,7 @@ public class AnnotationQueryBuilder {
   private static final String ANNOTATION_VALUE_JOIN_SQL =
       " LEFT OUTER JOIN cohort_annotation_enum_value ae%d "
       + "ON ae%d.cohort_annotation_enum_value_id = a%d.cohort_annotation_enum_value_id";
-  
+
   private static final ImmutableSet<CohortStatus> REVIEWED_STATUSES =
       ImmutableSet.of(CohortStatus.INCLUDED, CohortStatus.EXCLUDED, CohortStatus.NEEDS_FURTHER_REVIEW);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -202,7 +202,7 @@ public class AnnotationQueryBuilder {
     return namedParameterJdbcTemplate.query(sql, new RowMapper<Map<String, Object>>() {
       @Override
       public Map<String, Object> mapRow(ResultSet rs, int rowNum) throws SQLException {
-        ImmutableMap.Builder result = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Object> result = ImmutableMap.builder();
         List<String> columns = annotationQuery.getColumns();
         for (int i = 0; i < columns.size(); i++) {
           Object obj = rs.getObject(i);

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -183,7 +183,6 @@ public class CohortMaterializationService {
     }
 
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    response.setResults(new ArrayList<Object>());
     Iterable<Map<String, Object>> results;
     if (fieldSet == null || fieldSet.getTableQuery() != null) {
       ParticipantCriteria criteria = getParticipantCriteria(statusFilter, cohortReview,

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -1,15 +1,12 @@
 package org.pmiops.workbench.cohorts;
 
-import com.google.cloud.bigquery.BigQueryException;
-import com.google.cloud.bigquery.FieldValue;
-import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.QueryResult;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,13 +15,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
-import javax.servlet.http.HttpServletResponse;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.ParticipantCounter;
 import org.pmiops.workbench.cohortbuilder.ParticipantCriteria;
-import org.pmiops.workbench.cohortbuilder.QueryConfiguration;
 import org.pmiops.workbench.cohortbuilder.TableQueryAndConfig;
+import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig.ColumnConfig;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig.TableConfig;
@@ -33,9 +29,6 @@ import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus;
 import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus.Key;
 import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.exceptions.ForbiddenException;
-import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.exceptions.ServerUnavailableException;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.FieldSet;
 import org.pmiops.workbench.model.MaterializeCohortRequest;
@@ -44,6 +37,7 @@ import org.pmiops.workbench.model.SearchRequest;
 import org.pmiops.workbench.model.TableQuery;
 import org.pmiops.workbench.utils.PaginationToken;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.method.P;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -59,6 +53,7 @@ public class CohortMaterializationService {
   private final BigQueryService bigQueryService;
   private final ParticipantCounter participantCounter;
   private final FieldSetQueryBuilder fieldSetQueryBuilder;
+  private final AnnotationQueryBuilder annotationQueryBuilder;
   private final ParticipantCohortStatusDao participantCohortStatusDao;
   private final Provider<CdrBigQuerySchemaConfig> cdrSchemaConfigProvider;
 
@@ -66,11 +61,13 @@ public class CohortMaterializationService {
   public CohortMaterializationService(BigQueryService bigQueryService,
       ParticipantCounter participantCounter,
       FieldSetQueryBuilder fieldSetQueryBuilder,
+      AnnotationQueryBuilder annotationQueryBuilder,
       ParticipantCohortStatusDao participantCohortStatusDao,
       Provider<CdrBigQuerySchemaConfig> cdrSchemaConfigProvider) {
     this.bigQueryService = bigQueryService;
     this.participantCounter = participantCounter;
     this.fieldSetQueryBuilder = fieldSetQueryBuilder;
+    this.annotationQueryBuilder = annotationQueryBuilder;
     this.participantCohortStatusDao = participantCohortStatusDao;
     this.cdrSchemaConfigProvider = cdrSchemaConfigProvider;
   }
@@ -142,6 +139,26 @@ public class CohortMaterializationService {
     return new TableQueryAndConfig(tableQuery, cdrSchemaConfig);
   }
 
+
+  private ParticipantCriteria getParticipantCriteria(List<CohortStatus> statusFilter,
+      @Nullable CohortReview cohortReview, SearchRequest searchRequest) {
+    if (statusFilter.contains(CohortStatus.NOT_REVIEWED)) {
+      Set<Long> participantIdsToExclude;
+      if (statusFilter.size() < CohortStatus.values().length) {
+        // Find the participant IDs that have statuses which *aren't* in the filter.
+        Set<CohortStatus> statusesToExclude =
+            Sets.difference(ImmutableSet.copyOf(CohortStatus.values()), ImmutableSet.copyOf(statusFilter));
+        participantIdsToExclude = getParticipantIdsWithStatus(cohortReview, ImmutableList.copyOf(statusesToExclude));
+      } else {
+        participantIdsToExclude = ImmutableSet.of();
+      }
+      return new ParticipantCriteria(searchRequest, participantIdsToExclude);
+    } else {
+      Set<Long> participantIds = getParticipantIdsWithStatus(cohortReview, statusFilter);
+      return new ParticipantCriteria(participantIds);
+    }
+  }
+
   public MaterializeCohortResponse materializeCohort(@Nullable CohortReview cohortReview,
       SearchRequest searchRequest, MaterializeCohortRequest request) {
     long offset = 0L;
@@ -165,64 +182,42 @@ public class CohortMaterializationService {
       statusFilter = ALL_STATUSES;
     }
 
-    ParticipantCriteria criteria;
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    if (statusFilter.contains(CohortStatus.NOT_REVIEWED)) {
-      Set<Long> participantIdsToExclude;
-      if (statusFilter.size() < CohortStatus.values().length) {
-        // Find the participant IDs that have statuses which *aren't* in the filter.
-        Set<CohortStatus> statusesToExclude =
-            Sets.difference(ImmutableSet.copyOf(CohortStatus.values()), ImmutableSet.copyOf(statusFilter));
-        participantIdsToExclude = getParticipantIdsWithStatus(cohortReview, ImmutableList.copyOf(statusesToExclude));
-      } else {
-        participantIdsToExclude = ImmutableSet.of();
-      }
-      criteria = new ParticipantCriteria(searchRequest, participantIdsToExclude);
-    } else {
-      Set<Long> participantIds = getParticipantIdsWithStatus(cohortReview, statusFilter);
-      if (participantIds.isEmpty()) {
+    response.setResults(new ArrayList<Object>());
+    Iterable<Map<String, Object>> results;
+    if (fieldSet == null || fieldSet.getTableQuery() != null) {
+      ParticipantCriteria criteria = getParticipantCriteria(statusFilter, cohortReview,
+          searchRequest);
+      if (criteria.getParticipantIdsToInclude() != null
+          && criteria.getParticipantIdsToInclude().isEmpty()) {
         // There is no cohort review, or no participants matching the status filter;
         // return an empty response.
         return response;
       }
-      criteria = new ParticipantCriteria(participantIds);
-    }
-    TableQueryAndConfig tableQueryAndConfig = getTableQueryAndConfig(fieldSet);
-
-    QueryConfiguration queryConfiguration = fieldSetQueryBuilder.buildQuery(criteria,
-        tableQueryAndConfig, limit, offset);
-    QueryResult result;
-    QueryJobConfiguration jobConfiguration = queryConfiguration.getQueryJobConfiguration();
-    try {
-      result = bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(jobConfiguration));
-    } catch (BigQueryException e) {
-      if (e.getCode() == HttpServletResponse.SC_SERVICE_UNAVAILABLE) {
-        throw new ServerUnavailableException("BigQuery was temporarily unavailable, try again later", e);
-      } else if (e.getCode() == HttpServletResponse.SC_FORBIDDEN) {
-        throw new ForbiddenException("Access to the CDR is denied", e);
-      } else {
-        throw new ServerErrorException(
-            String.format("An unexpected error occurred materializing the cohort with "
-                + "query = (%s), params = (%s)", jobConfiguration.getQuery(),
-                jobConfiguration.getNamedParameters()), e);
+      results = fieldSetQueryBuilder.materializeTableQuery(getTableQueryAndConfig(fieldSet),
+          criteria, limit, offset);
+    } else if (fieldSet.getAnnotationQuery() != null) {
+      if (cohortReview == null) {
+        // There is no cohort review, so there are no annotations; return empty results.
+        return response;
       }
-
+      results = annotationQueryBuilder.materializeAnnotationQuery(cohortReview, statusFilter,
+          fieldSet.getAnnotationQuery(), limit, offset);
+    } else {
+      throw new BadRequestException("Must specify tableQuery or annotationQuery");
     }
-    Map<String, Integer> rm = bigQueryService.getResultMapper(result);
     int numResults = 0;
     boolean hasMoreResults = false;
-    ArrayList<Object> results = new ArrayList<>();
-    for (List<FieldValue> row : result.iterateAll()) {
+    ArrayList<Object> responseResults = new ArrayList<>();
+    for (Map<String, Object> resultMap : results) {
       if (numResults == pageSize) {
         hasMoreResults = true;
         break;
       }
-      Map<String, Object> resultMap = fieldSetQueryBuilder.extractResults(tableQueryAndConfig,
-          queryConfiguration.getSelectColumns(), row);
-      results.add(resultMap);
+      responseResults.add(resultMap);
       numResults++;
     }
-    response.setResults(results);
+    response.setResults(responseResults);
     if (hasMoreResults) {
       // TODO: consider pagination based on cursor / values rather than offset
       PaginationToken token = PaginationToken.of(offset + pageSize, paginationParameters);

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -215,7 +215,7 @@ definitions:
           An array of names of annotations, or "review status" or "person_id",
           each one optionally enclosed in "DESCENDING()" for descending
           sort order. Specifies the order that results should be returned. Defaults to "person_id"
-          (in ascending order).
+          (in ascending order). Annotations referenced in orderBy must also be present in columns.
         type: array
         items:
           type: string

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -122,6 +122,8 @@ definitions:
 
   MaterializeCohortResponse:
     type: object
+    required:
+      - results
     properties:
       results:
         description: >

--- a/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
@@ -224,6 +224,7 @@ public class CohortAnnotationDefinitionControllerTest {
         long annotationDefinitionId = 1;
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
+        request.setColumnName("ignore");
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
         when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);
@@ -261,6 +262,7 @@ public class CohortAnnotationDefinitionControllerTest {
         Workspace workspace = createWorkspace(namespace, name, badWorkspaceId);
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
+        request.setColumnName("ignore");
 
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
@@ -301,6 +303,7 @@ public class CohortAnnotationDefinitionControllerTest {
         Workspace workspace = createWorkspace(namespace, name, workspaceId);
 
         ModifyCohortAnnotationDefinitionRequest request = new ModifyCohortAnnotationDefinitionRequest();
+        request.setColumnName("ignore");
         WorkspaceAccessLevel owner = WorkspaceAccessLevel.OWNER;
 
         when(workspaceService.enforceWorkspaceAccessLevel(namespace, name, WorkspaceAccessLevel.WRITER)).thenReturn(owner);

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -117,11 +117,6 @@ public class AnnotationQueryBuilderTest {
     cohortReview.setReviewSize(3);
     cohortReviewDao.save(cohortReview);
 
-    participantCohortStatusDao.save(
-        makeStatus(cohortReview.getCohortReviewId(), 1L, CohortStatus.INCLUDED));
-    participantCohortStatusDao.save(
-        makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
-
     cohortAnnotationDefinitionDao.save(
         makeAnnotationDefinition(cohort.getCohortId(), "integer annotation",
             AnnotationType.INTEGER));
@@ -170,6 +165,19 @@ public class AnnotationQueryBuilderTest {
   public void testQueryEmptyReview() {
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, INCLUDED_ONLY,
         new AnnotationQuery(), 10, 0));
+  }
+
+  @Test
+  public void testQueryOneIncluded() {
+
+  }
+
+
+  private void saveReviewStatuses() {
+    participantCohortStatusDao.save(
+        makeStatus(cohortReview.getCohortReviewId(), 1L, CohortStatus.INCLUDED));
+    participantCohortStatusDao.save(
+        makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
   }
 
   private void assertResults(Iterable<Map<String, Object>> results,

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -1,0 +1,192 @@
+package org.pmiops.workbench.cohortreview;
+
+import static org.junit.Assert.fail;
+import static com.google.common.truth.Truth.assertThat;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.cdr.CdrVersionContext;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.CohortReviewDao;
+import org.pmiops.workbench.db.dao.ParticipantCohortAnnotationDao;
+import org.pmiops.workbench.db.dao.ParticipantCohortStatusDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.CdrVersion;
+import org.pmiops.workbench.db.model.Cohort;
+import org.pmiops.workbench.db.model.CohortAnnotationDefinition;
+import org.pmiops.workbench.db.model.CohortAnnotationEnumValue;
+import org.pmiops.workbench.db.model.CohortReview;
+import org.pmiops.workbench.db.model.ParticipantCohortStatus;
+import org.pmiops.workbench.db.model.ParticipantCohortStatusKey;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.model.AnnotationQuery;
+import org.pmiops.workbench.model.AnnotationType;
+import org.pmiops.workbench.model.CohortStatus;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class AnnotationQueryBuilderTest {
+
+  @TestConfiguration
+  @Import({
+      AnnotationQueryBuilder.class
+  })
+  static class Configuration {
+  }
+
+  private static final ImmutableList<CohortStatus> INCLUDED_ONLY =
+      ImmutableList.of(CohortStatus.INCLUDED);
+
+  @Autowired
+  private AnnotationQueryBuilder annotationQueryBuilder;
+
+  @Autowired
+  private WorkspaceDao workspaceDao;
+
+  @Autowired
+  private CdrVersionDao cdrVersionDao;
+
+  @Autowired
+  private CohortDao cohortDao;
+
+  @Autowired
+  private CohortReviewDao cohortReviewDao;
+
+  @Autowired
+  private CohortAnnotationDefinitionDao cohortAnnotationDefinitionDao;
+
+  @Autowired
+  private ParticipantCohortStatusDao participantCohortStatusDao;
+
+  @Autowired
+  private ParticipantCohortAnnotationDao participantCohortAnnotationDao;
+
+  private CohortReview cohortReview;
+
+  @Before
+  public void setUp() {
+    CdrVersion cdrVersion = new CdrVersion();
+    cdrVersionDao.save(cdrVersion);
+    CdrVersionContext.setCdrVersion(cdrVersion);
+
+
+    Workspace workspace = new Workspace();
+    workspace.setCdrVersion(cdrVersion);
+    workspace.setName("name");
+    workspace.setDataAccessLevel(DataAccessLevel.PROTECTED);
+    workspaceDao.save(workspace);
+
+    Cohort cohort = new Cohort();
+    cohort.setWorkspaceId(workspace.getWorkspaceId());
+    cohort.setName("males");
+    cohort.setType("AOU");
+    cohort.setCriteria("blah");
+    cohortDao.save(cohort);
+
+
+    cohortReview = new CohortReview();
+    cohortReview.setCdrVersionId(cdrVersion.getCdrVersionId());
+    cohortReview.setCohortId(cohort.getCohortId());
+    cohortReview.setMatchedParticipantCount(3);
+    cohortReview.setReviewedCount(2);
+    cohortReview.setReviewSize(3);
+    cohortReviewDao.save(cohortReview);
+
+    participantCohortStatusDao.save(
+        makeStatus(cohortReview.getCohortReviewId(), 1L, CohortStatus.INCLUDED));
+    participantCohortStatusDao.save(
+        makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
+
+    cohortAnnotationDefinitionDao.save(
+        makeAnnotationDefinition(cohort.getCohortId(), "integer annotation",
+            AnnotationType.INTEGER));
+    cohortAnnotationDefinitionDao.save(
+        makeAnnotationDefinition(cohort.getCohortId(), "string annotation",
+            AnnotationType.STRING));
+    cohortAnnotationDefinitionDao.save(
+        makeAnnotationDefinition(cohort.getCohortId(), "boolean annotation",
+            AnnotationType.BOOLEAN));
+    cohortAnnotationDefinitionDao.save(
+        makeAnnotationDefinition(cohort.getCohortId(), "date annotation",
+            AnnotationType.DATE));
+    cohortAnnotationDefinitionDao.save(
+        makeAnnotationDefinition(cohort.getCohortId(), "enum annotation",
+            AnnotationType.ENUM, "zebra", "aardvark"));
+  }
+
+  private CohortAnnotationDefinition makeAnnotationDefinition(long cohortId, String columnName,
+      AnnotationType annotationType, String... enumValues) {
+    CohortAnnotationDefinition cohortAnnotationDefinition = new CohortAnnotationDefinition();
+    cohortAnnotationDefinition.setAnnotationType(annotationType);
+    cohortAnnotationDefinition.setCohortId(cohortId);
+    cohortAnnotationDefinition.setColumnName(columnName);
+    if (enumValues.length > 0) {
+      for (int i = 0; i < enumValues.length; i++) {
+        CohortAnnotationEnumValue enumValue = new CohortAnnotationEnumValue();
+        enumValue.setOrder(i);
+        enumValue.setName(enumValues[i]);
+        cohortAnnotationDefinition.getEnumValues().add(enumValue);
+      }
+    }
+    return cohortAnnotationDefinition;
+  }
+
+  private ParticipantCohortStatus makeStatus(long cohortReviewId, long participantId, CohortStatus status) {
+    ParticipantCohortStatusKey key = new ParticipantCohortStatusKey();
+    key.setCohortReviewId(cohortReviewId);
+    key.setParticipantId(participantId);
+    ParticipantCohortStatus result = new ParticipantCohortStatus();
+    result.setStatus(status);
+    result.setParticipantKey(key);
+    return result;
+  }
+
+  @Test
+  public void testQueryEmptyReview() {
+    assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, INCLUDED_ONLY,
+        new AnnotationQuery(), 10, 0));
+  }
+
+  private void assertResults(Iterable<Map<String, Object>> results,
+      ImmutableMap<String, Object>... expectedResults) {
+    List<Map<String, Object>> actualResults = Lists.newArrayList(results);
+    if (actualResults.size() != expectedResults.length) {
+      fail("Expected " + expectedResults.length + ", got " + actualResults.size() + "; actual results: " +
+          actualResults);
+    }
+    for (int i = 0; i < actualResults.size(); i++) {
+      MapDifference<String, Object> difference =
+          Maps.difference((Map<String, Object>) actualResults.get(i), expectedResults[i]);
+      if (!difference.areEqual()) {
+        fail("Result " + i + " had difference: " + difference.entriesDiffering()
+            + "; unexpected entries: " + difference.entriesOnlyOnLeft()
+            + "; missing entries: " + difference.entriesOnlyOnRight());
+      }
+    }
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -287,7 +287,6 @@ public class AnnotationQueryBuilderTest {
         "boolean annotation", "date annotation", "enum annotation"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, INCLUDED_ONLY,
         annotationQuery, 10, 0), expectedResult);
-
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -65,6 +65,9 @@ public class AnnotationQueryBuilderTest {
 
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
+  private static final long INCLUDED_PERSON_ID = 1L;
+  private static final long EXCLUDED_PERSON_ID = 2L;
+
   private static final ImmutableList<CohortStatus> INCLUDED_ONLY =
       ImmutableList.of(CohortStatus.INCLUDED);
 
@@ -153,7 +156,7 @@ public class AnnotationQueryBuilderTest {
 
     expectedResult1 =
         ImmutableMap.<String, Object>builder()
-            .put("person_id", 1L)
+            .put("person_id", INCLUDED_PERSON_ID)
             .put("review_status", "INCLUDED")
             .put("integer annotation", 123)
             .put("string annotation", "foo")
@@ -163,7 +166,7 @@ public class AnnotationQueryBuilderTest {
             .build();
     expectedResult2 =
         ImmutableMap.<String, Object>builder()
-            .put("person_id", 2L)
+            .put("person_id", EXCLUDED_PERSON_ID)
             .put("review_status", "EXCLUDED")
             .put("integer annotation", 456)
             .put("boolean annotation", false)
@@ -210,7 +213,7 @@ public class AnnotationQueryBuilderTest {
     saveReviewStatuses();
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, INCLUDED_ONLY,
         new AnnotationQuery(), 10, 0),
-        ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED"));
+        ImmutableMap.of("person_id", INCLUDED_PERSON_ID, "review_status", "INCLUDED"));
 
   }
 
@@ -219,8 +222,8 @@ public class AnnotationQueryBuilderTest {
     saveReviewStatuses();
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         new AnnotationQuery(), 10, 0),
-        ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED"),
-        ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED"));
+        ImmutableMap.of("person_id", INCLUDED_PERSON_ID, "review_status", "INCLUDED"),
+        ImmutableMap.of("person_id", EXCLUDED_PERSON_ID, "review_status", "EXCLUDED"));
   }
 
   @Test
@@ -230,8 +233,8 @@ public class AnnotationQueryBuilderTest {
     annotationQuery.setOrderBy(ImmutableList.of("review_status"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         annotationQuery, 10, 0),
-        ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED"),
-        ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED"));
+        ImmutableMap.of("person_id", EXCLUDED_PERSON_ID, "review_status", "EXCLUDED"),
+        ImmutableMap.of("person_id", INCLUDED_PERSON_ID, "review_status", "INCLUDED"));
 
   }
 
@@ -242,19 +245,18 @@ public class AnnotationQueryBuilderTest {
     annotationQuery.setOrderBy(ImmutableList.of("DESCENDING(person_id)"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         annotationQuery, 10, 0),
-        ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED"),
-        ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED"));
+        ImmutableMap.of("person_id", EXCLUDED_PERSON_ID, "review_status", "EXCLUDED"),
+        ImmutableMap.of("person_id", INCLUDED_PERSON_ID, "review_status", "INCLUDED"));
 
   }
 
   @Test
   public void testQueryIncludedWithAnnotations() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
     ImmutableMap<String, Object> expectedResult =
         ImmutableMap.<String, Object>builder()
-            .put("person_id", 1L)
+            .put("person_id", INCLUDED_PERSON_ID)
             .put("review_status", "INCLUDED")
             .put("integer annotation", 123)
             .put("string annotation", "foo")
@@ -270,11 +272,10 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryIncludedWithAnnotationsNoReviewStatus() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
     ImmutableMap<String, Object> expectedResult =
         ImmutableMap.<String, Object>builder()
-            .put("person_id", 1L)
+            .put("person_id", INCLUDED_PERSON_ID)
             .put("integer annotation", 123)
             .put("string annotation", "foo")
             .put("boolean annotation", true)
@@ -292,10 +293,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotations() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
 
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         new AnnotationQuery(), 10, 0), expectedResult1, expectedResult2);
@@ -304,10 +303,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsLimit1() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
 
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         new AnnotationQuery(), 1, 0), expectedResult1);
@@ -316,10 +313,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsLimit1Offset1() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
 
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
         new AnnotationQuery(), 1, 1), expectedResult2);
@@ -328,10 +323,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsOrderByIntegerDescending() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
     AnnotationQuery annotationQuery = new AnnotationQuery();
     annotationQuery.setOrderBy(ImmutableList.of("DESCENDING(integer annotation)", "person_id"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
@@ -341,10 +334,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsOrderByBoolean() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
     AnnotationQuery annotationQuery = new AnnotationQuery();
     annotationQuery.setOrderBy(ImmutableList.of("boolean annotation", "person_id"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
@@ -354,10 +345,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsOrderByDateDescending() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
     AnnotationQuery annotationQuery = new AnnotationQuery();
     annotationQuery.setOrderBy(ImmutableList.of("DESCENDING(date annotation)", "person_id"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
@@ -367,10 +356,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsOrderByString() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
     AnnotationQuery annotationQuery = new AnnotationQuery();
     annotationQuery.setOrderBy(ImmutableList.of("string annotation", "person_id"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
@@ -380,10 +367,8 @@ public class AnnotationQueryBuilderTest {
   @Test
   public void testQueryAllWithAnnotationsOrderByEnum() throws Exception {
     saveReviewStatuses();
-    saveAnnotations(1L, 123, "foo", true, "2017-02-14",
-        "zebra");
-    saveAnnotations(2L, 456, null, false, "2017-02-15",
-        "aardvark");
+    saveAnnotations(INCLUDED_PERSON_ID, 123, "foo", true, "2017-02-14","zebra");
+    saveAnnotations(EXCLUDED_PERSON_ID, 456, null, false, "2017-02-15","aardvark");
     AnnotationQuery annotationQuery = new AnnotationQuery();
     annotationQuery.setOrderBy(ImmutableList.of("enum annotation", "person_id"));
     assertResults(annotationQueryBuilder.materializeAnnotationQuery(cohortReview, ALL_STATUSES,
@@ -392,9 +377,9 @@ public class AnnotationQueryBuilderTest {
 
   private void saveReviewStatuses() {
     participantCohortStatusDao.save(
-        makeStatus(cohortReview.getCohortReviewId(), 1L, CohortStatus.INCLUDED));
+        makeStatus(cohortReview.getCohortReviewId(), INCLUDED_PERSON_ID, CohortStatus.INCLUDED));
     participantCohortStatusDao.save(
-        makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
+        makeStatus(cohortReview.getCohortReviewId(), EXCLUDED_PERSON_ID, CohortStatus.EXCLUDED));
   }
 
   private void saveAnnotations(long personId, Integer integerValue, String stringValue,


### PR DESCRIPTION
Moving logic to generate an Iterable<Map<String, Object>> into FieldSetQueryBuilder and AnnotationQueryBuilder. (CohortMaterializationService then constructs a response from it.)

Adding logic to enforce that annotations can't be named "person_id" or "review_status". 

(I'm working on tests now.)