### PR TITLE
RW-486: Breadcrumbs

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -45,48 +45,83 @@ const routes: Routes = [
     children: [
       {
         path: '',
-        component: WorkspaceListComponent,
-        data: {title: 'View Workspaces'}
-      }, {
-        /* TODO The children under ./views need refactoring to use the data
-         * provided by the route rather than double-requesting it.
-         */
-        path: 'workspace/:ns/:wsid',
-        runGuardsAndResolvers: 'always',
-        resolve: {
-          workspace: WorkspaceResolver,
-        },
-        children: [{
+        data: { breadcrumb: 'Workspaces' },
+        children: [
+          {
             path: '',
-            component: WorkspaceComponent,
-            data: {title: 'View Workspace Details'}
-          }, {
-            path: 'edit',
-            component: WorkspaceEditComponent,
-            data: {title: 'Edit Workspace', mode: WorkspaceEditMode.Edit}
-          }, {
-            path: 'clone',
-            component: WorkspaceEditComponent,
-            data: {title: 'Clone Workspace', mode: WorkspaceEditMode.Clone}
-          }, {
-            path: 'share',
-            component: WorkspaceShareComponent,
-            data: {title: 'Share Workspace'}
-          }, {
-            path: 'cohorts/build',
-            loadChildren: './cohort-search/cohort-search.module#CohortSearchModule',
-          }, {
-            path: 'cohorts/:cid/review',
-            loadChildren: './cohort-review/cohort-review.module#CohortReviewModule',
-          }, {
-            path: 'cohorts/:cid/edit',
-            component: CohortEditComponent,
-            data: {title: 'Edit Cohort'},
-            resolve: {
-              cohort: CohortResolver,
+            component: WorkspaceListComponent,
+            data: {title: 'View Workspaces'}
+          },
+          {
+            /* TODO The children under ./views need refactoring to use the data
+             * provided by the route rather than double-requesting it.
+             */
+            path: 'workspace/:ns/:wsid',
+            data: {
+              title: 'View Workspace Details',
+              breadcrumb: ':wsid'
             },
-        }],
-      }, {
+            runGuardsAndResolvers: 'always',
+            resolve: {
+              workspace: WorkspaceResolver,
+            },
+            children: [{
+              path: '',
+              component: WorkspaceComponent,
+              data: {
+                title: 'View Workspace Details',
+                breadcrumb: 'View Workspace Details'
+              }
+            }, {
+              path: 'edit',
+              component: WorkspaceEditComponent,
+              data: {
+                title: 'Edit Workspace',
+                mode: WorkspaceEditMode.Edit,
+                breadcrumb: 'Edit Workspace'
+              }
+            }, {
+              path: 'clone',
+              component: WorkspaceEditComponent,
+              data: {
+                title: 'Clone Workspace',
+                mode: WorkspaceEditMode.Clone,
+                breadcrumb: 'Clone Workspace'
+              }
+            }, {
+              path: 'share',
+              component: WorkspaceShareComponent,
+              data: {
+                title: 'Share Workspace',
+                breadcrumb: 'Share Workspace'
+              }
+            }, {
+              path: 'cohorts/build',
+              loadChildren: './cohort-search/cohort-search.module#CohortSearchModule',
+              data: {
+                breadcrumb: 'Cohort Builder'
+              }
+            }, {
+              path: 'cohorts/:cid/review',
+              loadChildren: './cohort-review/cohort-review.module#CohortReviewModule',
+              data: {
+                breadcrumb: 'Cohort Review'
+              }
+            }, {
+              path: 'cohorts/:cid/edit',
+              component: CohortEditComponent,
+              data: {
+                title: 'Edit Cohort',
+                breadcrumb: 'Edit Cohort'
+              },
+              resolve: {
+                cohort: CohortResolver,
+              },
+            }],
+          }
+        ]
+      },
+      {
         path: 'admin/review-workspace',
         component: AdminReviewWorkspaceComponent,
         data: {title: 'Review Workspaces'}

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -92,6 +92,7 @@ export function getConfiguration(signInService: SignInService): Configuration {
     AdminReviewWorkspaceComponent,
     AdminReviewIdVerificationComponent,
     AppComponent,
+    BreadcrumbComponent,
     BugReportComponent,
     CohortEditComponent,
     ErrorHandlerComponent,
@@ -106,7 +107,6 @@ export function getConfiguration(signInService: SignInService): Configuration {
     WorkspaceEditComponent,
     WorkspaceNavBarComponent,
     WorkspaceShareComponent,
-    BreadcrumbComponent,
   ],
   providers: [
     {

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -21,6 +21,7 @@ import {AccountCreationComponent} from './views/account-creation/component';
 import {AdminReviewIdVerificationComponent} from './views/admin-review-id-verification/component';
 import {AdminReviewWorkspaceComponent} from './views/admin-review-workspace/component';
 import {AppComponent, overriddenUrlKey} from './views/app/component';
+import {BreadcrumbComponent} from './views/breadcrumb/component';
 import {BugReportComponent} from './views/bug-report/component';
 import {CohortEditComponent} from './views/cohort-edit/component';
 import {ErrorHandlerComponent} from './views/error-handler/component';
@@ -35,7 +36,6 @@ import {WorkspaceListComponent} from './views/workspace-list/component';
 import {WorkspaceNavBarComponent} from './views/workspace-nav-bar/component';
 import {WorkspaceShareComponent} from './views/workspace-share/component';
 import {WorkspaceComponent} from './views/workspace/component';
-import {BreadcrumbComponent} from "./views/breadcrumb/component";
 
 /* Our Modules */
 import {AppRoutingModule} from './app-routing.module';

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -35,6 +35,7 @@ import {WorkspaceListComponent} from './views/workspace-list/component';
 import {WorkspaceNavBarComponent} from './views/workspace-nav-bar/component';
 import {WorkspaceShareComponent} from './views/workspace-share/component';
 import {WorkspaceComponent} from './views/workspace/component';
+import {BreadcrumbComponent} from "./views/breadcrumb/component";
 
 /* Our Modules */
 import {AppRoutingModule} from './app-routing.module';
@@ -105,6 +106,7 @@ export function getConfiguration(signInService: SignInService): Configuration {
     WorkspaceEditComponent,
     WorkspaceNavBarComponent,
     WorkspaceShareComponent,
+    BreadcrumbComponent,
   ],
   providers: [
     {

--- a/ui/src/app/views/breadcrumb/component.css
+++ b/ui/src/app/views/breadcrumb/component.css
@@ -1,0 +1,28 @@
+.breadcrumb-container {
+  margin-left: 3.25rem;
+  display: inline-block;
+}
+
+.breadcrumb {
+  display: inline;
+}
+
+.breadcrumb a {
+  font-weight: 100;
+  color: #c3c3c3;
+  text-decoration: none;
+}
+
+.breadcrumb:after {
+  font-size: .5rem;
+  font-weight: 100;
+  color: #c3c3c3;
+  content: "  >";
+}
+
+.breadcrumb-last a {
+  color: #262262;
+  font-weight: 400;
+  font-size: 1rem;
+  text-decoration: none;
+}

--- a/ui/src/app/views/breadcrumb/component.html
+++ b/ui/src/app/views/breadcrumb/component.html
@@ -1,0 +1,6 @@
+<div class="breadcrumb-container">
+  <div *ngFor="let breadcrumb of breadcrumbs; let last = last"
+       [ngClass]="{'breadcrumb-last': last, 'breadcrumb': !last}">
+    <a [routerLink]="[breadcrumb.url]">{{ breadcrumb.label | titlecase }}</a>
+  </div>
+</div>

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -13,7 +13,7 @@ export interface Breadcrumb {
     '../../styles/inputs.css',
     './component.css'],
   templateUrl: './component.html',
-  selector: 'breadcrumb'
+  selector: 'app-breadcrumb'
 })
 
 export class BreadcrumbComponent {
@@ -26,64 +26,6 @@ export class BreadcrumbComponent {
     this.router.events.filter(event => event instanceof NavigationEnd).subscribe(event => {
       this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
     });
-  }
-
-  /**
-   * Returns array of Breadcrumb objects that represent the breadcrumb trail.
-   * Derived from current route in conjunction with the overall route structure.
-   *
-   * @param {ActivatedRoute} route
-   * @param {string} url
-   * @param {Breadcrumb[]} breadcrumbs
-   * @returns {Array<Breadcrumb>}
-   */
-  private buildBreadcrumbs(route: ActivatedRoute,
-                           url: string = '',
-                           breadcrumbs: Breadcrumb[] = []): Array<Breadcrumb> {
-
-    const ROUTE_DATA_BREADCRUMB: string = "breadcrumb";
-
-    //get the child routes
-    let children: ActivatedRoute[] = route.children;
-
-    //return if there are no more children
-    if (children.length === 0) {
-      return breadcrumbs;
-    }
-
-    //iterate over children
-    for (let child of children) {
-
-      //verify primary route
-      if (child.outlet !== PRIMARY_OUTLET) {
-        continue;
-      }
-
-      //verify the custom data property "breadcrumb" is specified on the route
-      if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
-        return this.buildBreadcrumbs(child, url, breadcrumbs);
-      }
-
-      //get the route's URL segment
-      let routeURL: string = child.snapshot.url.map(segment => segment.path).join("/");
-
-      //append route URL to URL
-      if (routeURL.length > 0) {
-        url += `/${routeURL}`;
-      }
-
-      const label = child.snapshot.data[ROUTE_DATA_BREADCRUMB];
-
-      //make a new breadcrumb if needed
-      if (!breadcrumbs.some(b => b.url === url)) {
-        let breadcrumb = BreadcrumbComponent.makeBreadcrumb(label, url, child);
-        breadcrumbs.push(breadcrumb);
-      }
-
-      //recursive
-      return this.buildBreadcrumbs(child, url, breadcrumbs);
-    }
-
   }
 
   /**
@@ -102,8 +44,8 @@ export class BreadcrumbComponent {
     try {
       const paramValues = route.paramMap['source']['_value'];
       let newLabel = label;
-      for (let k in paramValues) {
-        newLabel = newLabel.replace(":" + k, paramValues[k]);
+      for (const k of Object.keys(paramValues)) {
+        newLabel = newLabel.replace(':' + k, paramValues[k]);
       }
       return {
         label: newLabel,
@@ -116,6 +58,64 @@ export class BreadcrumbComponent {
         url: url
       };
     }
+  }
+
+  /**
+   * Returns array of Breadcrumb objects that represent the breadcrumb trail.
+   * Derived from current route in conjunction with the overall route structure.
+   *
+   * @param {ActivatedRoute} route
+   * @param {string} url
+   * @param {Breadcrumb[]} breadcrumbs
+   * @returns {Array<Breadcrumb>}
+   */
+  private buildBreadcrumbs(route: ActivatedRoute,
+                           url: string = '',
+                           breadcrumbs: Breadcrumb[] = []): Array<Breadcrumb> {
+
+    const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
+
+    // get the child routes
+    const children: ActivatedRoute[] = route.children;
+
+    // return if there are no more children
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+
+    // iterate over children
+    for (const child of children) {
+
+      // verify primary route
+      if (child.outlet !== PRIMARY_OUTLET) {
+        continue;
+      }
+
+      // verify the custom data property "breadcrumb" is specified on the route
+      if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
+        return this.buildBreadcrumbs(child, url, breadcrumbs);
+      }
+
+      // get the route's URL segment
+      const routeURL: string = child.snapshot.url.map(segment => segment.path).join('/');
+
+      // append route URL to URL
+      if (routeURL.length > 0) {
+        url += `/${routeURL}`;
+      }
+
+      const label = child.snapshot.data[ROUTE_DATA_BREADCRUMB];
+
+      // make a new breadcrumb if needed
+      if (!breadcrumbs.some(b => b.url === url)) {
+        const breadcrumb = BreadcrumbComponent.makeBreadcrumb(label, url, child);
+        breadcrumbs.push(breadcrumb);
+      }
+
+      // recursive
+      return this.buildBreadcrumbs(child, url, breadcrumbs);
+    }
+
   }
 
 }

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -27,11 +27,6 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
    * paramMap to do any necessary variable replacement. For example, if we
    * have a label value of ':wsid' as defined in a route's breadcrumb, we can
    * do substitution with the 'wsid' value in the route's paramMap.
-   *
-   * @param {String} label
-   * @param {String} url
-   * @param {ActivatedRoute} route
-   * @returns {Breadcrumb}
    */
   private static makeBreadcrumb(label: string,
                                 url: string,
@@ -39,13 +34,9 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
     let newLabel = label;
     // Perform variable substitution in label only if needed.
     if (newLabel.indexOf(':') >= 0) {
-      try {
-        const paramMap = route.snapshot.paramMap;
-        for (const k of paramMap.keys) {
-          newLabel = newLabel.replace(':' + k, paramMap.get(k));
-        }
-      } catch (e) {
-        console.log(e);
+      const paramMap = route.snapshot.paramMap;
+      for (const k of paramMap.keys) {
+        newLabel = newLabel.replace(':' + k, paramMap.get(k));
       }
     }
     return {
@@ -70,25 +61,16 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
   /**
    * Returns array of Breadcrumb objects that represent the breadcrumb trail.
    * Derived from current route in conjunction with the overall route structure.
-   *
-   * @param {ActivatedRoute} route
-   * @param {string} url
-   * @param {Breadcrumb[]} breadcrumbs
-   * @returns {Array<Breadcrumb>}
    */
   private buildBreadcrumbs(route: ActivatedRoute,
                            url: string = '',
                            breadcrumbs: Breadcrumb[] = []): Array<Breadcrumb> {
-
     const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
     const children: ActivatedRoute[] = route.children;
     if (children.length === 0) {
       return breadcrumbs;
     }
     for (const child of children) {
-      if (child.outlet !== PRIMARY_OUTLET) {
-        continue;
-      }
       if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
         return this.buildBreadcrumbs(child, url, breadcrumbs);
       }
@@ -97,6 +79,7 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
         url += `/${routeURL}`;
       }
       const label = child.snapshot.data[ROUTE_DATA_BREADCRUMB];
+      // Prevent processing children with duplicate urls
       if (!breadcrumbs.some(b => b.url === url)) {
         const breadcrumb = BreadcrumbComponent.makeBreadcrumb(label, url, child);
         breadcrumbs.push(breadcrumb);

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -1,0 +1,121 @@
+import {Component} from '@angular/core';
+import {ActivatedRoute, NavigationEnd, PRIMARY_OUTLET, Router} from '@angular/router';
+
+export interface Breadcrumb {
+  label: string;
+  url: string;
+}
+
+@Component({
+  styleUrls: ['../../styles/buttons.css',
+    '../../styles/cards.css',
+    '../../styles/headers.css',
+    '../../styles/inputs.css',
+    './component.css'],
+  templateUrl: './component.html',
+  selector: 'breadcrumb'
+})
+
+export class BreadcrumbComponent {
+
+  breadcrumbs: Breadcrumb[];
+
+  constructor(
+      private activatedRoute: ActivatedRoute,
+      private router: Router) {
+    this.router.events.filter(event => event instanceof NavigationEnd).subscribe(event => {
+      this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
+    });
+  }
+
+  /**
+   * Returns array of Breadcrumb objects that represent the breadcrumb trail.
+   * Derived from current route in conjunction with the overall route structure.
+   *
+   * @param {ActivatedRoute} route
+   * @param {string} url
+   * @param {Breadcrumb[]} breadcrumbs
+   * @returns {Array<Breadcrumb>}
+   */
+  private buildBreadcrumbs(route: ActivatedRoute,
+                           url: string = '',
+                           breadcrumbs: Breadcrumb[] = []): Array<Breadcrumb> {
+
+    const ROUTE_DATA_BREADCRUMB: string = "breadcrumb";
+
+    //get the child routes
+    let children: ActivatedRoute[] = route.children;
+
+    //return if there are no more children
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+
+    //iterate over children
+    for (let child of children) {
+
+      //verify primary route
+      if (child.outlet !== PRIMARY_OUTLET) {
+        continue;
+      }
+
+      //verify the custom data property "breadcrumb" is specified on the route
+      if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
+        return this.buildBreadcrumbs(child, url, breadcrumbs);
+      }
+
+      //get the route's URL segment
+      let routeURL: string = child.snapshot.url.map(segment => segment.path).join("/");
+
+      //append route URL to URL
+      if (routeURL.length > 0) {
+        url += `/${routeURL}`;
+      }
+
+      const label = child.snapshot.data[ROUTE_DATA_BREADCRUMB];
+
+      //make a new breadcrumb if needed
+      if (!breadcrumbs.some(b => b.url === url)) {
+        let breadcrumb = BreadcrumbComponent.makeBreadcrumb(label, url, child);
+        breadcrumbs.push(breadcrumb);
+      }
+
+      //recursive
+      return this.buildBreadcrumbs(child, url, breadcrumbs);
+    }
+
+  }
+
+  /**
+   * Generate a breadcrumb using the default label and url.
+   * Uses the route's paramMap to do any necessary variable replacement.
+   *
+   * @param {String} label
+   * @param {String} url
+   * @param {ActivatedRoute} route
+   * @returns {Breadcrumb}
+   */
+  private static makeBreadcrumb(
+      label: string,
+      url: string,
+      route: ActivatedRoute): Breadcrumb {
+    try {
+      const paramValues = route.paramMap['source']['_value'];
+      let newLabel = label;
+      for (let k in paramValues) {
+        newLabel = newLabel.replace(":" + k, paramValues[k]);
+      }
+      return {
+        label: newLabel,
+        url: url
+      };
+    } catch (e) {
+      console.log(e);
+      return {
+        label: label,
+        url: url
+      };
+    }
+  }
+
+}

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -6,7 +6,6 @@ export interface Breadcrumb {
   label: string;
   url: string;
 }
-
 @Component({
   selector: 'app-breadcrumb',
   templateUrl: './component.html',
@@ -17,15 +16,11 @@ export interface Breadcrumb {
     './component.css']
 })
 export class BreadcrumbComponent implements OnInit, OnDestroy {
-
   subscription: Subscription;
   breadcrumbs: Breadcrumb[];
-
   constructor(
       private activatedRoute: ActivatedRoute,
       private router: Router) {}
-
-
 
   /**
    * Generate a breadcrumb using the default label and url. Uses the route's
@@ -43,23 +38,22 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
       url: string,
       route: ActivatedRoute
   ): Breadcrumb {
-    try {
-      const paramValues = route.paramMap['source']['_value'];
-      let newLabel = label;
-      for (const k of Object.keys(paramValues)) {
-        newLabel = newLabel.replace(':' + k, paramValues[k]);
+    let newLabel = label;
+    // Perform variable substitution in label only if needed.
+    if (newLabel.indexOf(':') >= 0) {
+      try {
+        const paramMap = route.snapshot.paramMap;
+        for (const k of paramMap.keys) {
+          newLabel = newLabel.replace(':' + k, paramMap.get(k));
+        }
+      } catch (e) {
+        console.log(e);
       }
-      return {
-        label: newLabel,
-        url: url
-      };
-    } catch (e) {
-      console.log(e);
-      return {
-        label: label,
-        url: url
-      };
     }
+    return {
+      label: newLabel,
+      url: url
+    };
   }
 
   ngOnInit() {

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -33,11 +33,9 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
    * @param {ActivatedRoute} route
    * @returns {Breadcrumb}
    */
-  private static makeBreadcrumb(
-      label: string,
-      url: string,
-      route: ActivatedRoute
-  ): Breadcrumb {
+  private static makeBreadcrumb(label: string,
+                                url: string,
+                                route: ActivatedRoute): Breadcrumb {
     let newLabel = label;
     // Perform variable substitution in label only if needed.
     if (newLabel.indexOf(':') >= 0) {

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute, NavigationEnd, PRIMARY_OUTLET, Router} from '@angular/router';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -16,19 +16,16 @@ export interface Breadcrumb {
     '../../styles/inputs.css',
     './component.css']
 })
-export class BreadcrumbComponent implements OnDestroy {
+export class BreadcrumbComponent implements OnInit, OnDestroy {
 
   subscription: Subscription;
   breadcrumbs: Breadcrumb[];
 
   constructor(
       private activatedRoute: ActivatedRoute,
-      private router: Router) {
-    this.subscription = this.router.events.filter(event => event instanceof NavigationEnd)
-        .subscribe(event => {
-          this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
-        });
-  }
+      private router: Router) {}
+
+
 
   /**
    * Generate a breadcrumb using the default label and url. Uses the route's
@@ -63,6 +60,15 @@ export class BreadcrumbComponent implements OnDestroy {
         url: url
       };
     }
+  }
+
+  ngOnInit() {
+    this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
+
+    this.subscription = this.router.events.filter(event => event instanceof NavigationEnd)
+      .subscribe(event => {
+        this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
+      });
   }
 
   ngOnDestroy() {

--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -5,7 +5,7 @@
           style="width: 1.5rem; height: 1.5rem; fill: #6cace4"></clr-icon>
     </div>
     <img [src]="headerImg" class="header-image" routerLink="/">
-    <breadcrumb></breadcrumb>
+    <app-breadcrumb></app-breadcrumb>
   </div>
     <clr-dropdown style="margin-right: 1rem; margin-bottom: 0.5rem;">
     <div style="display: flex; justify-content: space-around; align-items: center" clrDropdownTrigger>

--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -5,8 +5,9 @@
           style="width: 1.5rem; height: 1.5rem; fill: #6cace4"></clr-icon>
     </div>
     <img [src]="headerImg" class="header-image" routerLink="/">
+    <breadcrumb></breadcrumb>
   </div>
-  <clr-dropdown style="margin-right: 1rem; margin-bottom: 0.5rem;">
+    <clr-dropdown style="margin-right: 1rem; margin-bottom: 0.5rem;">
     <div style="display: flex; justify-content: space-around; align-items: center" clrDropdownTrigger>
       <img [src]="profileImage" style="border-radius: 100px; height: 42px; width: 42px">
       <h6 style="padding: 0.5rem;">

--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -7,7 +7,7 @@
     <img [src]="headerImg" class="header-image" routerLink="/">
     <app-breadcrumb></app-breadcrumb>
   </div>
-    <clr-dropdown style="margin-right: 1rem; margin-bottom: 0.5rem;">
+  <clr-dropdown style="margin-right: 1rem; margin-bottom: 0.5rem;">
     <div style="display: flex; justify-content: space-around; align-items: center" clrDropdownTrigger>
       <img [src]="profileImage" style="border-radius: 100px; height: 42px; width: 42px">
       <h6 style="padding: 0.5rem;">


### PR DESCRIPTION
## Addresses:
https://precisionmedicineinitiative.atlassian.net/browse/RW-486

## Changes:
* Add new breadcrumb component
* Re-organized the workspace routes a little bit so the breadcrumb trail makes sense
* Added links for all of the workspace sub pages

## Notes:
* I still need to add tests for this but wanted to get through the AoU commit->PR process before the day is out.
* An artifact of using routes for breadcrumbs is that when we add it to any branch of the routing tree, we need to add it to all of the branch children as well.

## Screen Captures:
Workspaces:
![screen shot 2018-04-12 at 3 10 53 pm](https://user-images.githubusercontent.com/116679/38698732-0d0a4990-3e64-11e8-965d-a698b05de9e9.png)

Workspace
![screen shot 2018-04-12 at 3 12 11 pm](https://user-images.githubusercontent.com/116679/38698745-19a96e6a-3e64-11e8-9e81-5b31a94e3f60.png)

Cohort Builder
![screen shot 2018-04-12 at 3 12 25 pm](https://user-images.githubusercontent.com/116679/38698807-4e48ed9e-3e64-11e8-8747-064266d4ea8d.png)

Edit Workspace
![screen shot 2018-04-12 at 3 12 36 pm](https://user-images.githubusercontent.com/116679/38698825-5dd212ea-3e64-11e8-8c15-52b41593be2f.png)

Share Workspace
![screen shot 2018-04-12 at 3 12 44 pm](https://user-images.githubusercontent.com/116679/38698840-663be168-3e64-11e8-92e9-2397cb09185a.png)

Clone Workspace
![screen shot 2018-04-12 at 3 12 57 pm](https://user-images.githubusercontent.com/116679/38698848-6cca2cc4-3e64-11e8-94cb-ca24812c9db4.png)
