### PR TITLE
[RW-528] Don't double-create accounts, don't check for username ''

### DIFF
--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -34,8 +34,8 @@
     <div class="form-section">
       <button type="submit"
           class="btn btn-primary short-button"
-          [disabled]="creatingAcccount"
-          [clrLoading]="creatingAcccount">
+          [disabled]="creatingAccount"
+          [clrLoading]="creatingAccount">
         Next
       </button>
     </div>

--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -34,6 +34,7 @@
     <div class="form-section">
       <button type="submit"
           class="btn btn-primary short-button"
+          [disabled]="creatingAcccount"
           [clrLoading]="creatingAcccount">
         Next
       </button>

--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -32,10 +32,12 @@
     </div>
 
     <div class="form-section">
-      <button (click)="createAccount()" class="btn btn-primary short-button">Next</button>
-      <span class="spinner spinner-inline" *ngIf="creatingAcccount">
-        Creating account...
-      </span>
+      <button type="submit"
+          class="btn btn-primary short-button"
+          [disabled]="creatingAcccount">
+        Next
+      </button>
+      <span class="spinner spinner-inline" *ngIf="creatingAcccount"></span>
     </div>
     <div *ngIf="showAllFieldsRequiredError" class="error">
       All fields are required.

--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -34,10 +34,9 @@
     <div class="form-section">
       <button type="submit"
           class="btn btn-primary short-button"
-          [disabled]="creatingAcccount">
+          [clrLoading]="creatingAcccount">
         Next
       </button>
-      <span class="spinner spinner-inline" *ngIf="creatingAcccount"></span>
     </div>
     <div *ngIf="showAllFieldsRequiredError" class="error">
       All fields are required.

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -102,6 +102,7 @@ export class AccountCreationComponent {
 
   usernameChanged(): void {
     this.usernameConflictError = false;
+    // TODO: This should use a debounce, rather than manual setTimeout()s.
     clearTimeout(this.usernameCheckTimeout);
     this.usernameCheckTimeout = setTimeout(() => {
       if (!this.profile.username.trim()) {

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -35,7 +35,7 @@ export class AccountCreationComponent {
   showAllFieldsRequiredError: boolean;
   showPasswordsDoNotMatchError: boolean;
   showPasswordLengthError: boolean;
-  creatingAcccount: boolean;
+  creatingAccount: boolean;
   accountCreated: boolean;
   usernameConflictError = false;
   gsuiteDomain: string;
@@ -91,12 +91,12 @@ export class AccountCreationComponent {
       profile: this.profile, password: this.password,
       invitationKey: this.invitationKeyService.invitationKey
     };
-    this.creatingAcccount = true;
+    this.creatingAccount = true;
     this.profileService.createAccount(request).subscribe(() => {
-      this.creatingAcccount = false;
+      this.creatingAccount = false;
       this.accountCreated = true;
     }, () => {
-      this.creatingAcccount = false;
+      this.creatingAccount = false;
     });
   }
 

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -104,7 +104,7 @@ export class AccountCreationComponent {
     this.usernameConflictError = false;
     clearTimeout(this.usernameCheckTimeout);
     this.usernameCheckTimeout = setTimeout(() => {
-      if (!this.profile.username) {
+      if (!this.profile.username.trim()) {
         return;
       }
       this.profileService.isUsernameTaken(this.profile.username).subscribe((response) => {

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -30,9 +30,6 @@ export class AccountCreationComponent {
     familyName: '',
     contactEmail: ''
   };
-  givenName: string;
-  familyName: string;
-  username: string;
   password: string;
   passwordAgain: string;
   showAllFieldsRequiredError: boolean;
@@ -45,6 +42,9 @@ export class AccountCreationComponent {
   usernameCheckTimeout: NodeJS.Timer;
   contactEmailCheckTimeout: NodeJS.Timer;
 
+  // TODO: Injecting the parent component is a bad separation of concerns, as
+  // well as injecting LoginComponent. Should look at refactoring these
+  // interactions.
   constructor(
     private profileService: ProfileService,
     private invitationKeyService: InvitationKeyComponent,
@@ -104,6 +104,9 @@ export class AccountCreationComponent {
     this.usernameConflictError = false;
     clearTimeout(this.usernameCheckTimeout);
     this.usernameCheckTimeout = setTimeout(() => {
+      if (!this.profile.username) {
+        return;
+      }
       this.profileService.isUsernameTaken(this.profile.username).subscribe((response) => {
         this.usernameConflictError = response.isTaken;
       });

--- a/ui/src/app/views/invitation-key/component.spec.ts
+++ b/ui/src/app/views/invitation-key/component.spec.ts
@@ -1,6 +1,7 @@
 import {DebugElement} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
 import {UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
@@ -44,8 +45,10 @@ class InvitationKeyPage {
 
 describe('InvitationKeyComponent', () => {
   let invitationKeyPage: InvitationKeyPage;
+  let profileServiceStub: ProfileServiceStub;
 
   beforeEach(fakeAsync(() => {
+    profileServiceStub = new ProfileServiceStub();
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
@@ -63,7 +66,7 @@ describe('InvitationKeyComponent', () => {
       providers: [
         { provide: LoginComponent, useValue: {}},
         { provide: SignInService, useValue: {}},
-        { provide: ProfileService, useValue: new ProfileServiceStub() },
+        { provide: ProfileService, useValue: profileServiceStub },
         {
           provide: ServerConfigService,
           useValue: new ServerConfigServiceStub({
@@ -116,4 +119,25 @@ describe('InvitationKeyComponent', () => {
     expect(app.invitationKeyInvalid).toBeFalsy();
   }));
 
+  it('should allow account creation', fakeAsync(() => {
+    const fixture = invitationKeyPage.fixture;
+    fixture.debugElement.componentInstance.invitationKey = 'dummy';
+    updateAndTick(fixture);
+    simulateClick(fixture, invitationKeyPage.nextButton);
+
+    const createDebugEl = fixture.debugElement.query(
+      By.css('app-account-creation'));
+    const createComponent = createDebugEl.componentInstance;
+    createComponent.profile.username = 'researcher';
+    createComponent.profile.givenName = 'Falco';
+    createComponent.profile.familyName = 'Lombardi';
+    createComponent.profile.contactEmail = 'fake@asdf.com';
+    createComponent.password = 'passworD';
+    createComponent.passwordAgain = 'passworD';
+    updateAndTick(fixture);
+    createDebugEl.query(By.css('button[type=submit]')).nativeElement.click();
+
+    updateAndTick(fixture);
+    expect(profileServiceStub.accountCreates).toEqual(1);
+  }));
 });

--- a/ui/src/testing/stubs/profile-service-stub.ts
+++ b/ui/src/testing/stubs/profile-service-stub.ts
@@ -21,6 +21,7 @@ export class ProfileStubVariables {
 
 export class ProfileServiceStub {
   public profile: Profile;
+  public accountCreates = 0;
 
   constructor() {
     this.profile = ProfileStubVariables.PROFILE_STUB;
@@ -30,6 +31,16 @@ export class ProfileServiceStub {
     return new Observable<Profile>(observer => {
       setTimeout(() => {
         observer.next(this.profile);
+        observer.complete();
+      }, 0);
+    });
+  }
+
+  createAccount(): Observable<Profile> {
+    this.accountCreates++;
+    return new Observable<Profile>(observer => {
+      setTimeout(() => {
+        observer.next(undefined);
         observer.complete();
       }, 0);
     });


### PR DESCRIPTION
- We were submitting both on form submit and click, so one would generally fail with a 409
- We were doing username checks on empty string, which was a 403 error
- Add regression test
- Clean up dead properties
