### PR TITLE
[RW-510] [RW-511] Renaming not to ifNot, fixing log message order

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -392,7 +392,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter.setColumnName("person_id");
     filter.setValueNumber(new BigDecimal(1L));
     ResultFilters resultFilters = makeResultFilters(filter);
-    resultFilters.setNot(true);
+    resultFilters.setIfNot(true);
     tableQuery.setFilters(resultFilters);
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
@@ -802,7 +802,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     filter3.setValueNumber(new BigDecimal(3L));
     ResultFilters resultFilters = new ResultFilters();
     ResultFilters anyOf = makeAnyOf(filter1, filter2);
-    anyOf.setNot(true);
+    anyOf.setIfNot(true);
     resultFilters.setAllOf(ImmutableList.of(makeResultFilters(filter3), anyOf));
     tableQuery.setFilters(resultFilters);
     FieldSet fieldSet = new FieldSet();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -431,7 +431,7 @@ public class FieldSetQueryBuilder {
       throw new BadRequestException("Exactly one of allOf, anyOf, or columnFilter must be "
           + "specified for result filters");
     }
-    if (resultFilters.getNot() != null && resultFilters.getNot()) {
+    if (resultFilters.getIfNot() != null && resultFilters.getIfNot()) {
       whereSql.append("not ");
     }
     if (resultFilters.getColumnFilter() != null) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -239,7 +239,7 @@ public class FieldSetQueryBuilder {
         ColumnConfig columnConfig = queryState.mainTableColumns.get(columnName);
         if (columnConfig == null) {
           throw new BadRequestException(
-              String.format("No column %s found on table %s", tableName, columnName));
+              String.format("No column %s found on table %s", columnName, tableName));
         }
         SelectedColumn selectedColumn = new SelectedColumn();
         selectedColumn.columnInfo = new ColumnInfo(columnName, columnConfig);
@@ -256,8 +256,8 @@ public class FieldSetQueryBuilder {
         ColumnConfig columnConfig = aliasConfig.get(columnEnd);
         if (columnConfig == null) {
           throw new BadRequestException(
-              String.format("No column %s found on table %s", tableNameAndAlias.tableName,
-                  columnEnd));
+              String.format("No column %s found on table %s", columnEnd,
+                  tableNameAndAlias.tableName));
         }
         SelectedColumn selectedColumn = new SelectedColumn();
         selectedColumn.columnInfo = new ColumnInfo(columnName, columnConfig);
@@ -396,8 +396,7 @@ public class FieldSetQueryBuilder {
       columnConfig = aliasConfig.get(columnEnd);
       if (columnConfig == null) {
         throw new BadRequestException(
-            String.format("No column %s found on table %s", tableNameAndAlias.tableName,
-                columnEnd));
+            String.format("No column %s found on table %s", columnEnd, tableNameAndAlias.tableName));
       }
       return new ColumnInfo(
           String.format("%s.%s", tableNameAndAlias.alias, columnEnd),

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -228,7 +228,7 @@ definitions:
       A list of filters applied to the results of a query. Only results matching the filter criteria
       should be returned. Exactly one of "allOf", "anyOf", and "columnFilter" should be set.
     properties:
-      not:
+      if_not:
         description: >
          Set to true if a result matching allOf or anyOf below should result in a result *not*
          being returned.


### PR DESCRIPTION
("not" is a reserved word in Python, and hence Swagger generates this field as "_not"; using something else like ifNot produces nicer Python client lib code.)