### PR TITLE
[RW-431][RW-512] Don't set a Firecloud contact email

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -111,7 +111,6 @@ public class FireCloudServiceImpl implements FireCloudService {
       throws ApiException {
     ProfileApi profileApi = profileApiProvider.get();
     Profile profile = new Profile();
-    profile.setContactEmail(contactEmail);
     profile.setFirstName(firstName);
     profile.setLastName(lastName);
     // TODO: make these fields not required in Firecloud and stop passing them in, or prompt for


### PR DESCRIPTION
This is actually not required when creating a Firecloud account.