### PR TITLE
Better CircleCI release URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
               --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
-              --circle-url "${CIRCLE_BUILD_URL}" \
+              --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file circle-sa-key.json \
               --promote
 


### PR DESCRIPTION
There are multiple test logs to link to in the release ticket, so the workflow link is better here, e.g. https://circleci.com/workflow-run/08953d2e-570b-41bf-8a2e-6df1ec38e456