### PR TITLE
Map all DirectoryService Google exceptions with the same logic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.EmailException;
-import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -347,12 +346,8 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<UsernameTakenResponse> isUsernameTaken(String username) {
-    try {
-      return ResponseEntity.ok(
-          new UsernameTakenResponse().isTaken(directoryService.isUsernameTaken(username)));
-    } catch (IOException e) {
-      throw ExceptionUtils.convertGoogleIOException(e);
-    }
+    return ResponseEntity.ok(
+        new UsernameTakenResponse().isTaken(directoryService.isUsernameTaken(username)));
   }
 
   @Override
@@ -366,16 +361,12 @@ public class ProfileController implements ProfileApiDelegate {
     if (userService.getContactEmailTaken(request.getProfile().getContactEmail())) {
       throw new ConflictException("That contact email is already taken.");
     }
-    com.google.api.services.admin.directory.model.User googleUser;
-    try {
-      verifyInvitationKey(request.getInvitationKey());
-      googleUser = directoryService.createUser(request.getProfile().getGivenName(),
-      request.getProfile().getFamilyName(), request.getProfile().getUsername(),
-      request.getPassword());
-    }
-    catch (IOException e) {
-      throw ExceptionUtils.convertGoogleIOException(e);
-    }
+
+    verifyInvitationKey(request.getInvitationKey());
+    com.google.api.services.admin.directory.model.User googleUser =
+        directoryService.createUser(request.getProfile().getGivenName(),
+            request.getProfile().getFamilyName(), request.getProfile().getUsername(),
+            request.getPassword());
 
     // Create a user that has no data access or FC user associated.
     // We create this account before they sign in so we can keep track of which users we have

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -37,21 +37,11 @@ public class ExceptionUtils {
     return false;
   }
 
-  public static boolean isGoogleBadRequestException(IOException e) {
-    if (e instanceof GoogleJsonResponseException) {
-      int code = ((GoogleJsonResponseException) e).getDetails().getCode();
-      return code == 400;
-    }
-    return false;
-  }
-
   public static RuntimeException convertGoogleIOException(IOException e) {
     if (isGoogleServiceUnavailableException(e)) {
       throw new ServerUnavailableException(e);
     } else if (isGoogleConflictException(e)) {
       throw new ConflictException(e);
-    } else if (isGoogleBadRequestException(e)) {
-      throw new BadRequestException(e);
     }
     throw new ServerErrorException(e);
   }

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -83,7 +83,7 @@ public class DirectoryServiceImpl implements DirectoryService {
       if (e.getDetails().getCode() == HttpStatus.NOT_FOUND.value()) {
         return null;
       }
-      throw e;
+      throw ExceptionUtils.convertGoogleIOException(e);
     }
   }
 
@@ -120,7 +120,7 @@ public class DirectoryServiceImpl implements DirectoryService {
         // Deleting a user that doesn't exist will have no effect.
         return;
       }
-      throw e;
+      throw ExceptionUtils.convertGoogleIOException(e);
     }
   }
 }


### PR DESCRIPTION
Follow-up cleanup from #756

Also drop `BadRequest` from the autoconversion; these are unexpected for all of these calls, and would generally imply a programming error, rather than an actual client error.