### PR TITLE
Setting maintenance window settings for project setup script.

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1234,7 +1234,7 @@ def create_project_resources(gcc)
   common.run_inline %W{gcloud sql instances create #{INSTANCE_NAME} --tier=db-n1-standard-2
                        --activation-policy=ALWAYS --backup-start-time 00:00
                        --failover-replica-name #{FAILOVER_INSTANCE_NAME} --enable-bin-log
-                       --database-version MYSQL_5_7 --project #{gcc.project} --storage-auto-increase --async}
+                       --database-version MYSQL_5_7 --project #{gcc.project} --storage-auto-increase --async --maintenance-release-channel preview --maintenance-window-day SAT --maintenance-window-hour 5}
   common.status "Waiting for database instance to become ready..."
   loop do
     sleep 3.0


### PR DESCRIPTION
I'm going to add a note in the environment setup documentation about how in prod you should change the maintenance release channel / timing to production / later. For all other environments we're using "preview" so we find out earlier if a new version of Cloud SQL gives us trouble.