### PR TITLE
[RW-592] Remove share route

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -89,13 +89,6 @@ const routes: Routes = [
                 breadcrumb: 'Clone Workspace'
               }
             }, {
-              path: 'share',
-              component: WorkspaceShareComponent,
-              data: {
-                title: 'Share Workspace',
-                breadcrumb: 'Share Workspace'
-              }
-            }, {
               path: 'cohorts/build',
               loadChildren: './cohort-search/cohort-search.module#CohortSearchModule',
               data: {


### PR DESCRIPTION
This route has no attached component anymore, sharing is in a modal. Cleaning up.