### PR TITLE
Js/rw 594

### DIFF
--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -223,7 +223,7 @@ export class DemographicsComponent implements OnInit, OnDestroy {
           operator: 'between',
           operands: [lo, hi],
         });
-        const paramId = attr.hashCode();
+        const paramId = `age-param${attr.hashCode()}`;
         return this.ageNode
           .set('parameterId', paramId)
           .set('attribute', attr);

--- a/ui/src/app/cohort-search/multi-select/multi-select.component.spec.ts
+++ b/ui/src/app/cohort-search/multi-select/multi-select.component.spec.ts
@@ -4,11 +4,18 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from '@clr/angular';
-import {fromJS, List} from 'immutable';
+import {fromJS, List, Map} from 'immutable';
 
 import {MultiSelectComponent} from './multi-select.component';
 
 import {CohortSearchActions} from '../redux';
+
+// Default test data
+const optA = Map({name: 'A', count: 10, parameterId: 'paramA'});
+const optB = Map({name: 'B', count: 10, parameterId: 'paramB'});
+const optC = Map({name: 'C', count: 10, parameterId: 'paramC'});
+// Default select options - no default selection
+const options = List([optA, optB, optC]);
 
 describe('MultiSelectComponent', () => {
   let fixture: ComponentFixture<MultiSelectComponent>;
@@ -45,12 +52,73 @@ describe('MultiSelectComponent', () => {
 
     fixture = TestBed.createComponent(MultiSelectComponent);
     component = fixture.componentInstance;
-    component.options = List();
+    component.options = options;
     component.initialSelection = List();
     fixture.detectChanges();
   });
 
+  // Helper function - lots of the tests below start by setting an option as
+  // initially selected
+  const initializeWithOptA = () => {
+    component.select(optA);
+    fixture.detectChanges();
+    expect(component.selectedOptions.size).toEqual(1);
+    // use immutable's in-house equality func for immutable objects
+    expect(component.selectedOptions.get(0).equals(optA)).toBeTruthy();
+  };
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should select items', () => {
+    expect(component.selectedOptions.size).toEqual(0);
+    initializeWithOptA();
+  });
+
+  /*
+   * In an earlier version, the selection set stored hashes of the parameter
+   * objects.  However, the parameter objects are slightly different when
+   * generated directly from a criterion and loaded from a previously generated
+   * cohort (we map some properties to others, etc), so this failed when
+   * cloning workspaces.  The below test is to ensure that we continue to
+   * recognize "equivalent" parameters when determining what has and hasn't
+   * been selected
+   */
+  it('should recognize equivalent initial selections', () => {
+    // Simulate the normal case - we're editing some parameters we made in the same session
+    initializeWithOptA();
+    // Simulate the clone case - initially selected optA is slightly different,
+    // as if its gone through the API and back
+    const newOptA = optA.set('value', 'whatever');
+
+    // newOptA is equivalent but not equal to the original optA
+    expect(optA.equals(newOptA)).toBeFalsy();
+    expect(optA.hashCode()).not.toEqual(newOptA.hashCode());
+
+    component.initialSelection = List([newOptA]);
+    fixture.detectChanges();
+    expect(component.selectedOptions.size).toEqual(1);
+    expect(component.selectedOptions.get(0).equals(optA)).toBeTruthy();
+  });
+
+  it('should merge initial and subsequent selections', () => {
+    initializeWithOptA();
+    component.select(optB);
+    fixture.detectChanges();
+    expect(component.selectedOptions.size).toEqual(2);
+    expect(component.selectedOptions.equals(List([optA, optB]))).toBeTruthy();
+  });
+
+  it('should unselect', () => {
+    component.select(optA);
+    fixture.detectChanges();
+    expect(component.selectedOptions.size).toEqual(1);
+    expect(component.selectedOptions.get(0).equals(optA)).toBeTruthy();
+
+    component.unselect(optA);
+    fixture.detectChanges();
+    expect(component.selectedOptions.size).toEqual(0);
+    expect(component.selectedOptions.get(0)).toEqual(undefined);
   });
 });

--- a/ui/src/app/cohort-search/multi-select/multi-select.component.ts
+++ b/ui/src/app/cohort-search/multi-select/multi-select.component.ts
@@ -14,7 +14,7 @@ export class MultiSelectComponent implements OnInit, OnDestroy {
   @Input() includeSearchBox = true;
   @Input() options = List();
   @Input() set initialSelection(opts) {
-    const _selections = opts.map(opt => opt.hashCode()).toSet();
+    const _selections = opts.map(opt => opt.get('parameterId')).toSet();
     this.selected = this.selected.union(_selections);
   }
 
@@ -39,20 +39,20 @@ export class MultiSelectComponent implements OnInit, OnDestroy {
   get filteredOptions() {
     return this.options
       .filter(opt => this.regex.test(opt.get('name', '')))
-      .filter(opt => !this.selected.has(opt.hashCode()));
+      .filter(opt => !this.selected.has(opt.get('parameterId')));
   }
 
   get selectedOptions() {
-    return this.options.filter(opt => this.selected.has(opt.hashCode()));
+    return this.options.filter(opt => this.selected.has(opt.get('parameterId')));
   }
 
   select(opt) {
-    this.selected = this.selected.add(opt.hashCode());
+    this.selected = this.selected.add(opt.get('parameterId'));
     this.actions.addParameter(opt);
   }
 
   unselect(opt) {
-    this.selected = this.selected.delete(opt.hashCode());
+    this.selected = this.selected.delete(opt.get('parameterId'));
     this.actions.removeParameter(opt.get('parameterId'));
   }
 


### PR DESCRIPTION
Changes:

`parameterId`s for search group parameters of type `DEMO AGE` are now cast to string with a prefix rather than remaining raw integers (apparently the hashing algo allowed negative integral outputs which apparently caused some issues, ~although I'm not 100% how~)

Edit: here's how.  Somewhere in the lookup procedure immutable cast the maps to lists of tuples (I think) and the negative integer was interpreted as an offset from the tail of the list rather than as a key in a map by `getIn`; and of course, there isn't an IndexError in js, its just `undefined`.

Similarly, when repopulating the demographics form we now rely on a selection's `parameterId` rather than a hash of the parameter.  This should be faster, but more importantly, in the transition from criteria to parameter the shape of the data changes in some ways, so a parameter loaded via cloning and a criteria loaded via the API would not have the same hash.