### PR TITLE
Revert "Upgrade okhttp per Snyk security warning (#797)"

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -175,8 +175,6 @@ clean.doFirst {
   delete("${projectDir}/$swaggerTargetFolder")
 }
 
-project.ext.OKHTTP_VERSION = '2.7.3'
-
 repositories {   // repositories for Jar's you access in your code
   jcenter()
 }
@@ -218,8 +216,8 @@ dependencies {
   }
   compile 'com.google.code.gson:gson:+'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-  compile "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"
-  compile "com.squareup.okhttp:logging-interceptor:${OKHTTP_VERSION}"
+  compile 'com.squareup.okhttp:okhttp:2.6.0'
+  compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
   compile 'joda-time:joda-time:+'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
@@ -245,8 +243,8 @@ dependencies {
   generatedCompile 'org.springframework.boot:spring-boot-starter-data-rest'
   generatedCompile 'io.springfox:springfox-swagger2:2.6.1'
   generatedCompile 'io.springfox:springfox-swagger-ui:2.6.1'
-  generatedCompile "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"
-  generatedCompile "com.squareup.okhttp:logging-interceptor:${OKHTTP_VERSION}"
+  generatedCompile 'com.squareup.okhttp:okhttp:2.6.0'
+  generatedCompile 'com.squareup.okhttp:logging-interceptor:2.6.0'
   generatedCompile 'com.google.code.gson:gson:+'
   generatedCompile 'joda-time:joda-time:+'
   generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -124,8 +124,8 @@ dependencies {
   compile 'org.apache.commons:commons-lang3:3.0'
   compile 'com.google.code.gson:gson:+'
   compile 'org.hibernate:hibernate-validator:+'
-  compile "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"
-  compile "com.squareup.okhttp:logging-interceptor:${OKHTTP_VERSION}"
+  compile 'com.squareup.okhttp:okhttp:2.6.0'
+  compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
 }
 
 


### PR DESCRIPTION
This reverts commit 0a0cbfb0caa20ac991abd14d27b8cc86ff559c0f.

Broke Blockscore client in integration tests (at least).