### PR TITLE
[RW-620] [RW-623] Improve CreateCluster interactions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -63,7 +63,7 @@ public class ExceptionUtils {
   public static RuntimeException convertNotebookException(
       org.pmiops.workbench.notebooks.ApiException e) {
     log.log(e.getCode() >= 500 ? Level.SEVERE : Level.WARNING, "Exception calling notebooks API " + e.getResponseBody(), e);
-    if (isSocketTimeoutException(e)) {
+    if (isSocketTimeoutException(e.getCause())) {
       throw new GatewayTimeoutException();
     }
     throw codeToException(e.getCode());

--- a/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
@@ -1,0 +1,15 @@
+package org.pmiops.workbench.exceptions;
+
+import java.net.SocketTimeoutException;
+import org.junit.Test;
+import org.pmiops.workbench.notebooks.ApiException;
+
+
+public class ExceptionUtilsTest {
+
+  @Test(expected=GatewayTimeoutException.class)
+  public void convertNotebookException() throws Exception {
+    ApiException cause = new ApiException(new SocketTimeoutException());
+    ExceptionUtils.convertNotebookException(cause);
+  }
+}

--- a/ui/src/app/views/settings/component.ts
+++ b/ui/src/app/views/settings/component.ts
@@ -29,10 +29,14 @@ export class SettingsComponent implements OnInit {
     this.clusterService.listClusters()
       .subscribe((resp) => {
         const cluster = resp.defaultCluster;
-        if (cluster.status !== ClusterStatus.CREATING) {
+        if (cluster.status === ClusterStatus.RUNNING ||
+            cluster.status === ClusterStatus.ERROR) {
           this.cluster = cluster;
           return;
         }
+        setTimeout(() => this.pollCluster(), 10000);
+      }, () => {
+        // Also retry on errors.
         setTimeout(() => this.pollCluster(), 10000);
       });
   }


### PR DESCRIPTION
- Fix bug in throwing 504s
- Retry polling on errors
- Shift cluster create slightly later

Considered making `CreateCluster()` async, but longer-term I don't think we really want this. Better to get a concrete status from this call before continuing. As Leo improves the CreateCluster endpoint, this will get faster.