### PR TITLE
Adding retry logic to FireCloud calls on 502 / 503.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -96,8 +96,8 @@ public class ExceptionUtils {
       } catch (IOException e) {
         numAttempts++;
         if (isGoogleServiceUnavailableException(e)) {
-          if (numAttempts > 1 && numAttempts < MAX_ATTEMPTS) {
-            log.log(Level.SEVERE,
+          if (numAttempts < MAX_ATTEMPTS) {
+            log.log(Level.WARNING,
                 String.format("Service unavailable, attempt %s; retrying...", numAttempts), e);
             try {
               // Sleep with some backoff.

--- a/api/src/main/java/org/pmiops/workbench/utils/Sleeper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/Sleeper.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.utils;
+
+/**
+ * Used for sleeping. Can be mocked out to avoid sleeps in tests.
+ */
+public class Sleeper {
+
+  public void sleep(long millis) throws InterruptedException {
+    Thread.sleep(millis);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.firecloud;
 
+import java.rmi.ServerError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -7,12 +8,19 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.exceptions.ConflictException;
+import org.pmiops.workbench.exceptions.ForbiddenException;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.ServerUnavailableException;
+import org.pmiops.workbench.exceptions.UnauthorizedException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.GroupsApi;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.firecloud.model.Enabled;
 import org.pmiops.workbench.firecloud.model.Me;
+import org.pmiops.workbench.test.FakeSleeper;
 import org.pmiops.workbench.test.Providers;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -41,14 +49,64 @@ public class FireCloudServiceImplTest {
   public void setup() {
     service = new FireCloudServiceImpl(Providers.of(workbenchConfig),
         Providers.of(profileApi), Providers.of(billingApi), Providers.of(groupsApi),
-        Providers.of(workspacesApi));
+        Providers.of(workspacesApi), new FakeSleeper());
   }
 
-  @Test(expected = ApiException.class)
+  @Test(expected = ServerErrorException.class)
   public void testIsRequesterEnabledInFirecloud_throws() throws ApiException {
     when(profileApi.me()).thenThrow(new ApiException());
     service.isRequesterEnabledInFirecloud();
   }
+
+  @Test
+  public void testIsRequesterEnabledInFirecloud_throwsNotFound() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(404, "blah"));
+    assertThat(service.isRequesterEnabledInFirecloud()).isFalse();
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testIsRequesterEnabledInFirecloud_throwsForbidden() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(403, "blah"));
+    service.isRequesterEnabledInFirecloud();
+  }
+
+  @Test(expected = ConflictException.class)
+  public void testIsRequesterEnabledInFirecloud_throwsConflict() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(409, "blah"));
+    service.isRequesterEnabledInFirecloud();
+  }
+  
+  public void testIsRequesterEnabledInFirecloud_throwsUnauthorized() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(401, "blah"));
+    assertThat(service.isRequesterEnabledInFirecloud()).isFalse();
+  }
+
+  @Test
+  public void testIsRequesterEnabledInFirecloud_retryTwiceSuccess() throws ApiException {
+    Me me = new Me();
+    Enabled enabled = new Enabled();
+    enabled.setGoogle(true);
+    enabled.setLdap(true);
+    me.setEnabled(enabled);
+    when(profileApi.me()).thenThrow(new ApiException(503, "blah"))
+        .thenThrow(new ApiException(502, "foo"))
+        .thenReturn(me);
+    assertThat(service.isRequesterEnabledInFirecloud()).isTrue();
+  }
+
+  @Test(expected = ServerUnavailableException.class)
+  public void testIsRequesterEnabledInFirecloud_retryTwiceFail() throws ApiException {
+    Me me = new Me();
+    Enabled enabled = new Enabled();
+    enabled.setGoogle(true);
+    enabled.setLdap(true);
+    me.setEnabled(enabled);
+    when(profileApi.me()).thenThrow(new ApiException(503, "blah"))
+        .thenThrow(new ApiException(502, "foo"))
+        .thenThrow(new ApiException(504, "xxx"));
+    service.isRequesterEnabledInFirecloud();
+  }
+
 
   @Test
   public void testIsRequesterEnabledInFirecloud_enabledNull() throws ApiException {
@@ -107,5 +165,23 @@ public class FireCloudServiceImplTest {
     me.setEnabled(enabled);
     when(profileApi.me()).thenReturn(me);
     assertThat(service.isRequesterEnabledInFirecloud()).isTrue();
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void testGetMe_throwsNotFound() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(404, "blah"));
+    service.getMe();
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testGetMe_throwsForbidden() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(403, "blah"));
+    service.getMe();
+  }
+
+  @Test(expected = UnauthorizedException.class)
+  public void testGetMe_throwsUnauthorized() throws ApiException {
+    when(profileApi.me()).thenThrow(new ApiException(401, "blah"));
+    service.getMe();
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/test/FakeSleeper.java
+++ b/api/src/test/java/org/pmiops/workbench/test/FakeSleeper.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.test;
+
+import org.pmiops.workbench.utils.Sleeper;
+
+public class FakeSleeper extends Sleeper {
+
+  @Override
+  public void sleep(long millis) throws InterruptedException {
+    // Do nothing.
+  }
+}


### PR DESCRIPTION
Changing FireCloud and Google 502 / 503 exceptions to be logged at warning level.