### PR TITLE
[RW-520] [RW-608] Update spinner treatments for workspaces and notebooks

### DIFF
--- a/ui/src/app/views/workspace-list/component.css
+++ b/ui/src/app/views/workspace-list/component.css
@@ -18,6 +18,31 @@
   flex-wrap: wrap;
 }
 
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  flex-flow: row wrap;
+  margin-top: 1.5rem;
+  width: 100%;
+}
+
+.spinner {
+  margin-top: 1rem;
+}
+
+.spinner-header {
+  color: #007CBB;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.spinner-text {
+  text-align: center;
+  /* This forces the flex layout to put the text on a new line. */
+  margin-left: calc(50% - 90px);
+  margin-right: calc(50% - 90px);
+}
+
 .card {
   width: 12rem;
   height: 9rem;

--- a/ui/src/app/views/workspace-list/component.css
+++ b/ui/src/app/views/workspace-list/component.css
@@ -39,8 +39,7 @@
 .spinner-text {
   text-align: center;
   /* This forces the flex layout to put the text on a new line. */
-  margin-left: calc(50% - 90px);
-  margin-right: calc(50% - 90px);
+  width: 100%;
 }
 
 .card {

--- a/ui/src/app/views/workspace-list/component.html
+++ b/ui/src/app/views/workspace-list/component.html
@@ -31,8 +31,13 @@
     </div>
   </div>
   <div class="card-area">
-    <div *ngIf="workspacesLoading" style="margin-top: 1.5rem;">
-      <span class="spinner spinner-lg" style="padding-top: 1rem"></span>
+    <div *ngIf="workspacesLoading" class="spinner-container">
+      <span class="spinner spinner-lg"></span>
+      <p *ngIf="billingProjectInitialized === false" class="spinner-text">
+        <span class="spinner-header">Initializing Researcher Account</span>
+        <br>
+        May take a few minutes
+      </p>
     </div>
     <div class="card" *ngFor="let workspaceResponse of workspaceList" routerLink="/workspace/{{workspaceResponse.workspace.namespace}}/{{workspaceResponse.workspace.id}}">
       <h5 class="workspace-name">{{workspaceResponse.workspace.name}}</h5>

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -48,8 +48,7 @@ h3 {
 .spinner-text {
   text-align: center;
   /* This forces the flex layout to put the text on a new line. */
-  margin-left: calc(50% - 75px);
-  margin-right: calc(50% - 75px);
+  width: 100%;
 }
 
 .notebook-table-row {

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -29,8 +29,27 @@ h3 {
   margin: 1rem 0rem 0rem 1rem;
 }
 
-.cluster-spinner {
-  display: inline-block;
+.spinner-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+}
+
+.spinner {
+  margin-top: 1rem;
+}
+
+.spinner-header {
+  color: #007CBB;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.spinner-text {
+  text-align: center;
+  /* This forces the flex layout to put the text on a new line. */
+  margin-left: calc(50% - 75px);
+  margin-right: calc(50% - 75px);
 }
 
 .notebook-table-row {

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -34,7 +34,10 @@
             + New Notebook
           </button>
           <span *ngIf="awaitingReview" class="tooltip-content">Workspace is awaiting review</span>
-          <span *ngIf="clusterLoading" class="tooltip-content">Your account is still being set up, try again later</span>
+          <span *ngIf="cluster && clusterLoading" class="tooltip-content">
+            Your notebook server is still being initialized - this may take up
+            to 5 minutes. Please try again later.
+          </span>
         </span>
       </div>
     </div>
@@ -92,7 +95,15 @@
       </div>
     </clr-modal>
     <div *ngIf="tabOpen===Tabs.Notebooks">
-      <clr-datagrid [clrDgLoading]="notebooksLoading || clusterLoading">
+      <div *ngIf="notebooksLoading || clusterLoading" class="spinner-container">
+        <span class="spinner spinner-lg"></span>
+        <p *ngIf="clusterLongWait" class="spinner-text">
+          <span class="spinner-header">Initializing Notebook Server</span><br>
+          May take up to<br>
+          5 minutes
+        </p>
+      </div>
+      <clr-datagrid *ngIf="!notebooksLoading && !clusterLoading">
         <clr-dg-column [clrDgField]="'notebook.name'" [clrDgSortBy]="notebookNameComparator">
           Name
           <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -99,8 +99,7 @@
         <span class="spinner spinner-lg"></span>
         <p *ngIf="clusterLongWait" class="spinner-text">
           <span class="spinner-header">Initializing Notebook Server</span><br>
-          May take up to<br>
-          5 minutes
+          May take up to 5 minutes
         </p>
       </div>
       <clr-datagrid *ngIf="!notebooksLoading && !clusterLoading">


### PR DESCRIPTION
Demo: https://calbach-dot-all-of-us-workbench-test.appspot.com

You'll need to create a new account to hit the initialization flows.

Also:
- Serializes `getProfile` -> `getWorkspaces` on the list workspaces page; partially addressing RW-608 (@UrsaStutsman FYI).
- Fixing notebooksLoading logic (now we don't get a flash of an empty table on initial load)