### PR TITLE
[RW-608] Revert 401 client retries

### DIFF
--- a/ui/src/app/services/error-handling.service.ts
+++ b/ui/src/app/services/error-handling.service.ts
@@ -66,7 +66,6 @@ export class ErrorHandlingService {
   }
 
   // don't retry API calls unless the status code is 503.
-  // or if status code is 401. (since they may be early user initialization issue)
   public retryApi (observable: Observable<any>, toRun = 3): Observable<any> {
     let numberRuns = 0;
 
@@ -90,8 +89,6 @@ export class ErrorHandlingService {
               this.setUserDisabledError();
             }
             throw e;
-          case 401:
-            break;
           case 0:
             this.setNoServerResponse();
             throw e;


### PR DESCRIPTION
These retries were added to catch getWorkspaces when the FC user hadn't yet been initialized. #841 changed the flow to require billing account creation before we call `getWorkspaces()` on the workspaces list page.