### PR TITLE
Remove timestamp formatter

### DIFF
--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.html
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.html
@@ -16,7 +16,7 @@
     <clr-dg-cell *ngFor="let col of columns" class="cell">
       <ng-container [ngSwitch]="col.name">
         <span *ngSwitchCase="'itemDate'">
-          {{ datum.itemDate | date:'yyyy-MM-dd HH:mm:ss' }}
+          {{ datum.itemDate }}
         </span>
         <span *ngSwitchCase="'sourceVocabulary'"
           [style.width.%]="100"


### PR DESCRIPTION
BQ's default format looks like `2008-10-04 00:00:00.000 UTC`, which is good enough, particularly since it seems likely we'll drop support for timestamps and use only dates in the affected field.  If we begin using custom formats we'll need to either (A) parse the string into Dates before handing off to `DatePipe` or (B) find another solution besides `DatePipe`

@rushtong tagged as the reporter or the original error