### PR TITLE
Changing FireCloudService to no longer throw ApiException.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
@@ -4,10 +4,6 @@ import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.exceptions.ConflictException;
-import org.pmiops.workbench.exceptions.ExceptionUtils;
-import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.AuthDomainRequest;
 import org.pmiops.workbench.model.Authority;
@@ -39,15 +35,7 @@ public class AuthDomainController implements AuthDomainApiDelegate {
   @AuthorityRequired({Authority.MANAGE_GROUP})
   @Override
   public ResponseEntity<EmptyResponse> createAuthDomain(String groupName) {
-    try {
-      fireCloudService.createGroup(groupName);
-    } catch (ApiException e) {
-      if (e.getCode() == 409) {
-        throw new ConflictException(e.getResponseBody());
-      } else {
-        throw new ServerErrorException(e.getResponseBody());
-      }
-    }
+    fireCloudService.createGroup(groupName);
     return ResponseEntity.ok(new EmptyResponse());
   }
 
@@ -56,11 +44,7 @@ public class AuthDomainController implements AuthDomainApiDelegate {
   public ResponseEntity<Void> removeUserFromAuthDomain(String groupName, AuthDomainRequest request) {
     User user = userDao.findUserByEmail(request.getEmail());
     DataAccessLevel previousAccess = user.getDataAccessLevel();
-    try {
-      fireCloudService.removeUserFromGroup(request.getEmail(), groupName);
-    } catch (ApiException e) {
-      ExceptionUtils.convertFirecloudException(e);
-    }
+    fireCloudService.removeUserFromGroup(request.getEmail(), groupName);
     // TODO(calbach): Teardown any active clusters here.
     user.setDataAccessLevel(DataAccessLevel.REVOKED);
     user.setDisabled(true);
@@ -79,11 +63,7 @@ public class AuthDomainController implements AuthDomainApiDelegate {
   public ResponseEntity<Void> addUserToAuthDomain(String groupName, AuthDomainRequest request) {
     User user = userDao.findUserByEmail(request.getEmail());
     DataAccessLevel previousAccess = user.getDataAccessLevel();
-    try {
-      fireCloudService.addUserToGroup(request.getEmail(), groupName);
-    } catch (ApiException e) {
-      ExceptionUtils.convertFirecloudException(e);
-    }
+    fireCloudService.addUserToGroup(request.getEmail(), groupName);
     // TODO(blrubenstein): Parameterize this.
     user.setDataAccessLevel(DataAccessLevel.REGISTERED);
     user.setDisabled(false);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -6,7 +6,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
@@ -14,10 +13,8 @@ import org.json.JSONObject;
 import org.pmiops.workbench.db.dao.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.Cluster;
@@ -128,19 +125,9 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterLocalizeResponse> localize(
       String projectName, String clusterName, ClusterLocalizeRequest body) {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
-    try {
-      fcWorkspace = fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
-          .getWorkspace();
-    } catch (ApiException e) {
-      if (e.getCode() == 404) {
-        log.log(Level.INFO, "Firecloud workspace not found", e);
-        throw new NotFoundException(String.format(
-            "workspace %s/%s not found or not accessible",
-            body.getWorkspaceNamespace(), body.getWorkspaceId()));
-      }
-      throw ExceptionUtils.convertFirecloudException(e);
-    }
+    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+        fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
+            .getWorkspace();
     CdrVersion cdrVersion =
         workspaceService.getRequired(body.getWorkspaceNamespace(), body.getWorkspaceId()).getCdrVersion();
 

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -125,9 +125,14 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterLocalizeResponse> localize(
       String projectName, String clusterName, ClusterLocalizeRequest body) {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        fireCloudService.getWorkspace(body.getWorkspaceNamespace(), body.getWorkspaceId())
-            .getWorkspace();
+    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
+    try {
+      fcWorkspace = fireCloudService.getWorkspace(body.getWorkspaceNamespace(),
+          body.getWorkspaceId()).getWorkspace();
+    } catch (NotFoundException e) {
+      throw new NotFoundException(String.format("workspace %s/%s not found or not accessible",
+          body.getWorkspaceNamespace(), body.getWorkspaceId()));
+    }
     CdrVersion cdrVersion =
         workspaceService.getRequired(body.getWorkspaceNamespace(), body.getWorkspaceId()).getCdrVersion();
 

--- a/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
@@ -9,8 +9,6 @@ import org.pmiops.workbench.google.GoogleRetryHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-
 @Service
 public class UserInfoService {
 
@@ -28,7 +26,7 @@ public class UserInfoService {
     this.retryHandler = retryHandler;
   }
 
-  public Userinfoplus getUserInfo(String token) throws IOException {
+  public Userinfoplus getUserInfo(String token) {
     GoogleCredential credential = new GoogleCredential().setAccessToken(token);
     Oauth2 oauth2 = new Oauth2.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName(APPLICATION_NAME).build();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -9,8 +9,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.AdminActionHistory;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.ConflictException;
-import org.pmiops.workbench.exceptions.ExceptionUtils;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.DataAccessLevel;
@@ -88,12 +86,8 @@ public class UserService {
           && user.getEthicsTrainingCompletionTime() != null
           && user.getTermsOfServiceCompletionTime() != null
           && user.getEmailVerificationStatus().equals(EmailVerificationStatus.SUBSCRIBED)) {
-        try {
-          this.fireCloudService.addUserToGroup(user.getEmail(),
-              configProvider.get().firecloud.registeredDomainName);
-        } catch (ApiException e) {
-          ExceptionUtils.convertFirecloudException(e);
-        }
+        this.fireCloudService.addUserToGroup(user.getEmail(),
+            configProvider.get().firecloud.registeredDomainName);
         user.setDataAccessLevel(DataAccessLevel.REGISTERED);
       }
     }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -24,12 +24,12 @@ public interface FireCloudService {
   /**
    * @return true if the user making the current request is enabled in FireCloud, false otherwise.
    */
-  boolean isRequesterEnabledInFirecloud() throws ApiException;
+  boolean isRequesterEnabledInFirecloud();
 
   /**
    * @return the FireCloud profile for the requesting user.
    */
-  Me getMe() throws ApiException;
+  Me getMe();
 
   /**
    * Registers the user in Firecloud.
@@ -37,43 +37,44 @@ public interface FireCloudService {
    * @param firstName the user's first name
    * @param lastName the user's last name
    */
-  void registerUser(String contactEmail, String firstName, String lastName) throws ApiException;
+  void registerUser(String contactEmail, String firstName, String lastName);
 
   /**
    * Creates a billing project owned by AllOfUs.
    */
-  void createAllOfUsBillingProject(String projectName) throws ApiException;
+  void createAllOfUsBillingProject(String projectName);
 
   /**
    * Adds the specified user to the specified billing project.
    */
-  void addUserToBillingProject(String email, String projectName) throws ApiException;
+  void addUserToBillingProject(String email, String projectName);
 
   /**
    * Creates a new FC workspace.
    */
-  void createWorkspace(String projectName, String workspaceName) throws ApiException;
+  void createWorkspace(String projectName, String workspaceName);
 
-  void grantGoogleRoleToUser(String projectName, String role, String email) throws ApiException;
+  void grantGoogleRoleToUser(String projectName, String role, String email);
 
   void cloneWorkspace(String fromProject, String fromName, String toProject, String toName);
 
   /**
    * Retrieves all billing project memberships for the user from FireCloud.
    */
-  List<BillingProjectMembership> getBillingProjectMemberships() throws ApiException;
+  List<BillingProjectMembership> getBillingProjectMemberships();
 
-  WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, List<WorkspaceACLUpdate> aclUpdates) throws ApiException;
+  WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName,
+      List<WorkspaceACLUpdate> aclUpdates);
 
-  WorkspaceResponse getWorkspace(String projectName, String workspaceName) throws ApiException;
+  WorkspaceResponse getWorkspace(String projectName, String workspaceName);
 
-  List<WorkspaceResponse> getWorkspaces() throws ApiException;
+  List<WorkspaceResponse> getWorkspaces();
 
-  void deleteWorkspace(String projectName, String workspaceName) throws ApiException;
+  void deleteWorkspace(String projectName, String workspaceName);
 
-  ManagedGroupWithMembers createGroup(String groupName) throws ApiException;
+  ManagedGroupWithMembers createGroup(String groupName);
 
-  void addUserToGroup(String email, String groupName) throws ApiException;
+  void addUserToGroup(String email, String groupName);
 
-  void removeUserFromGroup(String email, String groupName) throws ApiException;
+  void removeUserFromGroup(String email, String groupName);
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -89,7 +89,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public boolean isRequesterEnabledInFirecloud() throws ApiException {
+  public boolean isRequesterEnabledInFirecloud() {
     ProfileApi profileApi = profileApiProvider.get();
     try {
       Me me = retryHandler.runAndThrowChecked((context) -> profileApi.me());
@@ -106,14 +106,13 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public Me getMe() throws ApiException {
+  public Me getMe() {
     ProfileApi profileApi = profileApiProvider.get();
     return retryHandler.run((context) -> profileApi.me());
   }
 
   @Override
-  public void registerUser(String contactEmail, String firstName, String lastName)
-      throws ApiException {
+  public void registerUser(String contactEmail, String firstName, String lastName) {
     ProfileApi profileApi = profileApiProvider.get();
     Profile profile = new Profile();
     profile.setFirstName(firstName);
@@ -136,7 +135,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void createAllOfUsBillingProject(String projectName) throws ApiException {
+  public void createAllOfUsBillingProject(String projectName)  {
     BillingApi billingApi = billingApiProvider.get();
     CreateRawlsBillingProjectFullRequest request = new CreateRawlsBillingProjectFullRequest();
     request.setBillingAccount("billingAccounts/"+configProvider.get().firecloud.billingAccountId);
@@ -148,7 +147,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void addUserToBillingProject(String email, String projectName) throws ApiException {
+  public void addUserToBillingProject(String email, String projectName) {
     BillingApi billingApi = billingApiProvider.get();
     retryHandler.run((context) -> {
       billingApi.addUserToBillingProject(projectName, USER_FC_ROLE, email);
@@ -157,7 +156,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void createWorkspace(String projectName, String workspaceName) throws ApiException {
+  public void createWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     WorkspaceIngest workspaceIngest = new WorkspaceIngest();
     workspaceIngest.setName(workspaceName);
@@ -177,7 +176,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void grantGoogleRoleToUser(String projectName, String role, String email) throws ApiException {
+  public void grantGoogleRoleToUser(String projectName, String role, String email) {
     BillingApi billingApi = billingApiProvider.get();
     retryHandler.run((context) -> {
       billingApi.grantGoogleRoleToUser(projectName, role, email);
@@ -199,7 +198,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
 
   @Override
-  public List<BillingProjectMembership> getBillingProjectMemberships() throws ApiException {
+  public List<BillingProjectMembership> getBillingProjectMemberships() {
     return retryHandler.run((context) -> profileApiProvider.get().billing());
   }
 
@@ -208,7 +207,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName, List<WorkspaceACLUpdate> aclUpdates) throws ApiException {
+  public WorkspaceACLUpdateResponseList updateWorkspaceACL(String projectName, String workspaceName,
+      List<WorkspaceACLUpdate> aclUpdates) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     // TODO: set authorization domain here
     return retryHandler.run((context) ->
@@ -216,20 +216,20 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public WorkspaceResponse getWorkspace(String projectName, String workspaceName) throws ApiException {
+  public WorkspaceResponse getWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     return retryHandler.run((context) ->
       workspacesApi.getWorkspace(projectName, workspaceName));
   }
 
   @Override
-  public List<WorkspaceResponse> getWorkspaces() throws ApiException {
+  public List<WorkspaceResponse> getWorkspaces() {
     return retryHandler.run((context) ->
         workspacesApiProvider.get().listWorkspaces());
   }
 
   @Override
-  public void deleteWorkspace(String projectName, String workspaceName) throws ApiException {
+  public void deleteWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     retryHandler.run((context) -> {
       workspacesApi.deleteWorkspace(projectName, workspaceName);
@@ -238,14 +238,14 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public ManagedGroupWithMembers createGroup(String groupName) throws ApiException {
+  public ManagedGroupWithMembers createGroup(String groupName) {
     GroupsApi groupsApi = groupsApiProvider.get();
     return retryHandler.run((context) ->
       groupsApi.createGroup(groupName));
   }
 
   @Override
-  public void addUserToGroup(String email, String groupName) throws ApiException {
+  public void addUserToGroup(String email, String groupName) {
     GroupsApi groupsApi = groupsApiProvider.get();
     retryHandler.run((context) -> {
       groupsApi.addUserToGroup(groupName, "member", email);
@@ -254,7 +254,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void removeUserFromGroup(String email, String groupName) throws ApiException {
+  public void removeUserFromGroup(String email, String groupName) {
     GroupsApi groupsApi = groupsApiProvider.get();
     retryHandler.run((context) -> {
       groupsApi.removeUserFromGroup(groupName, "member", email);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -33,9 +33,9 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership.CreationStatusEnum;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -61,7 +61,6 @@ import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfigurati
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -345,7 +344,7 @@ public class ProfileControllerTest {
     Profile profile = profileController.getMe().getBody();
 
     String projectName = profile.getFreeTierBillingProjectName();
-    doThrow(new ApiException(HttpStatus.CONFLICT.value(), "conflict"))
+    doThrow(new ConflictException())
         .when(fireCloudService).createAllOfUsBillingProject(projectName);
 
     // When a conflict occurs in dev, log the exception but continue.
@@ -361,7 +360,7 @@ public class ProfileControllerTest {
     createUser();
     when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
 
-    ApiException conflict = new ApiException(HttpStatus.CONFLICT.value(), "conflict");
+    ConflictException conflict = new ConflictException();
     doThrow(conflict)
         .doThrow(conflict)
         .doNothing()
@@ -384,7 +383,7 @@ public class ProfileControllerTest {
     createUser();
     when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
 
-    doThrow(new ApiException(HttpStatus.CONFLICT.value(), "conflict"))
+    doThrow(new ConflictException())
         .when(fireCloudService).createAllOfUsBillingProject(anyString());
 
     try {

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -57,7 +57,6 @@ import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
@@ -919,20 +918,6 @@ public class WorkspacesControllerTest {
   }
 
   @Test(expected = NotFoundException.class)
-  public void testCloneNotFound() throws Exception {
-    doThrow(new ApiException(404, "")).when(fireCloudService).getWorkspace("doesnot", "exist");
-    CloneWorkspaceRequest req = new CloneWorkspaceRequest();
-    Workspace modWorkspace = new Workspace();
-    modWorkspace.setName("cloned");
-    modWorkspace.setNamespace("cloned-ns");
-    req.setWorkspace(modWorkspace);
-    ResearchPurpose modPurpose = new ResearchPurpose();
-    modPurpose.setAncestry(true);
-    modWorkspace.setResearchPurpose(modPurpose);
-    workspacesController.cloneWorkspace("doesnot", "exist", req);
-  }
-
-  @Test(expected = NotFoundException.class)
   public void testClonePermissionDenied() throws Exception {
     Workspace workspace = createDefaultWorkspace();
     workspace = workspacesController.createWorkspace(workspace).getBody();
@@ -948,7 +933,7 @@ public class WorkspacesControllerTest {
 
     // Permission denied manifests as a 404 in Firecloud.
     when(fireCloudService.getWorkspace(workspace.getNamespace(), workspace.getName()))
-        .thenThrow(new ApiException(404, ""));
+        .thenThrow(new NotFoundException());
     CloneWorkspaceRequest req = new CloneWorkspaceRequest();
     Workspace modWorkspace = new Workspace();
     modWorkspace.setName("cloned");


### PR DESCRIPTION
Changing clients to catch WorkbenchExceptions or just throw them back to the client.

Note there are some cases here where we would have returned a 500 before (for ServerErrorException) but now return whatever error FireCloud gave us... in general I think that's OK.