### PR TITLE
[RW-662] Null check to authResponse

### DIFF
--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -76,7 +76,7 @@ export class SignInService {
     } else {
       const authResponse = gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true);
       if (authResponse !== null) {
-        return gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true).access_token;
+        return authResponse.access_token;
       } else {
         return null;
       }

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -74,7 +74,12 @@ export class SignInService {
     if (!gapi.auth2) {
       return null;
     } else {
-      return gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true).access_token;
+      const authResponse = gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true);
+      if (authResponse !== null) {
+        return gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true).access_token;
+      } else {
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
Check whether the response came back before checking access token. I believe that if there is no AuthResponse, the user is signed out.