### PR TITLE
Disable Phys Meas for the time being

### DIFF
--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -4,7 +4,7 @@ export const CRITERIA_TYPES = [
   { name: 'ICD10 Codes',  type: 'icd10' },
   // { name: 'PheCodes',     type: 'phecode' },
   { name: 'CPT Codes',    type: 'cpt' },
-  { name: 'Physical Measurements',    type: 'pm' },
+  // { name: 'Physical Measurements',    type: 'pm' },
   // { name: 'Medications',  type: 'meds' },
   // { name: 'Labs',         type: 'labs' },
   // { name: 'Vitals',       type: 'vitals' },


### PR DESCRIPTION
We have a pair of errors from stackdriver that most likely are generated by the fact that there is not yet any data in the Physical Measurement trees.  While those errors are being investigated, we'll just turn off access to PM in the UI.  Besides, the UI for PM needs to be redone anyways.