### PR TITLE
[RW-723] Injectable service for sharing, rather than component data passing

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -16,6 +16,7 @@ import {ProfileStorageService} from './services/profile-storage.service';
 import {ServerConfigService} from './services/server-config.service';
 import {SignInService} from './services/sign-in.service';
 import {StatusCheckService} from './services/status-check.service';
+import {WorkspaceShareService} from './services/workspace-share.service';
 import {WorkspaceStorageService} from './services/workspace-storage.service';
 
 import {AccountCreationSuccessComponent} from './views/account-creation-success/component';
@@ -137,6 +138,7 @@ export function getConfiguration(signInService: SignInService): Configuration {
     SignInService,
     StatusCheckService,
     GoogleAnalyticsEventsService,
+    WorkspaceShareService,
     WorkspaceStorageService,
     {
       provide: Http,

--- a/ui/src/app/services/workspace-share.service.ts
+++ b/ui/src/app/services/workspace-share.service.ts
@@ -1,0 +1,11 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class WorkspaceShareService {
+
+  public shareModalOpen: Boolean;
+
+  constructor() {
+    this.shareModalOpen = false;
+  }
+}

--- a/ui/src/app/views/workspace-nav-bar/component.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.ts
@@ -3,6 +3,8 @@ import {ActivatedRoute, Router} from '@angular/router';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
 
+import {WorkspaceShareService} from 'app/services/workspace-share.service';
+
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 
 import {
@@ -32,7 +34,8 @@ export class WorkspaceNavBarComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private workspacesService: WorkspacesService
+    private workspacesService: WorkspacesService,
+    private workspaceShareService: WorkspaceShareService,
   ) {}
 
   ngOnInit(): void {
@@ -54,7 +57,7 @@ export class WorkspaceNavBarComponent implements OnInit {
   }
 
   share(): void {
-    this.shareModal.open();
+    this.workspaceShareService.shareModalOpen = true;
   }
 
   get writePermission(): boolean {

--- a/ui/src/app/views/workspace-share/component.html
+++ b/ui/src/app/views/workspace-share/component.html
@@ -1,4 +1,4 @@
-<clr-modal [(clrModalOpen)]="sharing" [clrModalSize]="'lg'">
+<clr-modal [(clrModalOpen)]="workspaceShareService.shareModalOpen" [clrModalSize]="'lg'">
   <div class="modal-title">
     <h3 class="modal-title-text">Share {{workspace.name}}</h3>
   </div>

--- a/ui/src/app/views/workspace-share/component.spec.ts
+++ b/ui/src/app/views/workspace-share/component.spec.ts
@@ -103,8 +103,7 @@ describe('WorkspaceShareComponent', () => {
       ]}).compileComponents().then(() => {
         workspaceSharePage = new WorkspaceSharePage(TestBed);
         workspaceSharePage.fixture.componentRef.instance.profileStorageService.reload();
-        workspaceSharePage.fixture.componentRef
-          .instance.workspaceShareService.shareModalOpen = true;
+        TestBed.get(WorkspaceShareService).shareModalOpen = true;
     });
       tick();
   }));

--- a/ui/src/app/views/workspace-share/component.spec.ts
+++ b/ui/src/app/views/workspace-share/component.spec.ts
@@ -9,6 +9,7 @@ import {ClarityModule} from '@clr/angular';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
+import {WorkspaceShareService} from 'app/services/workspace-share.service';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 
 import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-stub';
@@ -92,6 +93,7 @@ describe('WorkspaceShareComponent', () => {
         { provide: WorkspacesService, useValue: new WorkspacesServiceStub() },
         { provide: ActivatedRoute, useValue: activatedRouteStub },
         { provide: ProfileStorageService, useValue: new ProfileStorageServiceStub() },
+        { provide: WorkspaceShareService, useClass: WorkspaceShareService },
         {
           provide: ServerConfigService,
           useValue: new ServerConfigServiceStub({
@@ -101,6 +103,8 @@ describe('WorkspaceShareComponent', () => {
       ]}).compileComponents().then(() => {
         workspaceSharePage = new WorkspaceSharePage(TestBed);
         workspaceSharePage.fixture.componentRef.instance.profileStorageService.reload();
+        workspaceSharePage.fixture.componentRef
+          .instance.workspaceShareService.shareModalOpen = true;
     });
       tick();
   }));

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -5,6 +5,7 @@ import {Observable} from 'rxjs/Observable';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
+import {WorkspaceShareService} from 'app/services/workspace-share.service';
 
 import {
   ShareWorkspaceResponse,
@@ -47,6 +48,7 @@ export class WorkspaceShareComponent implements OnInit {
       private route: ActivatedRoute,
       public profileStorageService: ProfileStorageService,
       private workspacesService: WorkspacesService,
+      private workspaceShareService: WorkspaceShareService,
       private serverConfigService: ServerConfigService
   ) {
     serverConfigService.getConfig().subscribe((config) => {
@@ -185,7 +187,7 @@ export class WorkspaceShareComponent implements OnInit {
   }
 
   open(): void {
-    this.sharing = true;
+    this.workspaceShareService.shareModalOpen = true;
   }
 
   get hasPermission(): boolean {

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -48,7 +48,7 @@ export class WorkspaceShareComponent implements OnInit {
       private route: ActivatedRoute,
       public profileStorageService: ProfileStorageService,
       private workspacesService: WorkspacesService,
-      public workspaceShareService: WorkspaceShareService,
+      private workspaceShareService: WorkspaceShareService,
       private serverConfigService: ServerConfigService
   ) {
     serverConfigService.getConfig().subscribe((config) => {

--- a/ui/src/app/views/workspace-share/component.ts
+++ b/ui/src/app/views/workspace-share/component.ts
@@ -48,7 +48,7 @@ export class WorkspaceShareComponent implements OnInit {
       private route: ActivatedRoute,
       public profileStorageService: ProfileStorageService,
       private workspacesService: WorkspacesService,
-      private workspaceShareService: WorkspaceShareService,
+      public workspaceShareService: WorkspaceShareService,
       private serverConfigService: ServerConfigService
   ) {
     serverConfigService.getConfig().subscribe((config) => {

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -130,7 +130,7 @@
     <div>
       <h6 class="collaborator-text">Collaborators:</h6>
       <span role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-top-left">
-        <button class="btn btn-secondary btn-short" [disabled]="!ownerPermission" (click)="navBar.share()">Share</button>
+        <button class="btn btn-secondary btn-short" [disabled]="!ownerPermission" (click)="workspaceShareService.shareModalOpen = true">Share</button>
         <span *ngIf="!ownerPermission" class="tooltip-content">
           Owner access is required to share the workspace.
         </span>

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -11,6 +11,7 @@ import {IconsModule} from 'app/icons/icons.module';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {SignInService} from 'app/services/sign-in.service';
+import {WorkspaceShareService} from 'app/services/workspace-share.service';
 import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 import {WorkspaceComponent} from 'app/views/workspace/component';
@@ -109,6 +110,7 @@ describe('WorkspaceComponent', () => {
         { provide: ProfileStorageService, useValue: new ProfileStorageServiceStub() },
         { provide: SignInService, useValue: SignInService },
         { provide: WorkspacesService, useValue: new WorkspacesServiceStub() },
+        { provide: WorkspaceShareService, useClass: WorkspaceShareService },
         { provide: ActivatedRoute, useValue: activatedRouteStub },
         {
           provide: ServerConfigService,

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -122,7 +122,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     private router: Router,
     private signInService: SignInService,
     private workspacesService: WorkspacesService,
-    private workspaceShareService: WorkspaceShareService,
+    public workspaceShareService: WorkspaceShareService,
   ) {
     const wsData: WorkspaceData = this.route.snapshot.data.workspace;
     this.workspace = wsData;

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Headers, Http, Response} from '@angular/http';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Comparator, StringFilter} from '@clr/angular';
@@ -6,7 +6,7 @@ import {Observable} from 'rxjs/Observable';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {SignInService} from 'app/services/sign-in.service';
-import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar/component';
+import {WorkspaceShareService} from 'app/services/workspace-share.service';
 
 import {
   Cluster,
@@ -19,6 +19,7 @@ import {
   WorkspaceAccessLevel,
   WorkspacesService,
 } from 'generated';
+
 
 
 /*
@@ -78,8 +79,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   // Keep in sync with api/src/main/resources/notebooks.yaml.
   private static readonly leoBaseUrl = 'https://notebooks.firecloud.org';
 
-  @ViewChild(WorkspaceNavBarComponent)
-  navBar: WorkspaceNavBarComponent;
   Tabs = Tabs;
 
   cohortNameFilter = new CohortNameFilter();
@@ -123,6 +122,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     private router: Router,
     private signInService: SignInService,
     private workspacesService: WorkspacesService,
+    private workspaceShareService: WorkspaceShareService,
   ) {
     const wsData: WorkspaceData = this.route.snapshot.data.workspace;
     this.workspace = wsData;


### PR DESCRIPTION
Hi! I decided to take a different approach to the workspace share modal, and open it via a service rather than passing data around components. I did a little digging, and this appears to be the generally preferred approach, given that we are doing this inside a router-outlet. https://stackoverflow.com/questions/37662456/angular-2-output-from-router-outlet 

This does not yet have tests, but I think will be considerably more isolated now. Opening a PR to get thoughts on the process.