### PR TITLE
Modifier fixes

### DIFF
--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
@@ -46,10 +46,10 @@ export class ModifierPageComponent implements OnInit, OnDestroy {
     modType: 'EVENT_DATE',
     operators: [{
       name: 'Is On or Before',
-      value: 'GREATER_THAN_OR_EQUAL_TO',
+      value: 'LESS_THAN_OR_EQUAL_TO',
     }, {
       name: 'Is On or After',
-      value: 'LESS_THAN_OR_EQUAL_TO',
+      value: 'GREATER_THAN_OR_EQUAL_TO',
     }, {
       name: 'Is Between',
       value: 'BETWEEN',
@@ -94,7 +94,7 @@ export class ModifierPageComponent implements OnInit, OnDestroy {
       mods.forEach(mod => {
         const meta = this.modifiers.find(_mod => mod.get('name') === _mod.modType);
         if (meta) {
-          this.form.get(meta.name).setValue({
+          this.form.get(meta.name).patchValue({
             operator: mod.get('operator'),
             valueA: mod.getIn(['operands', 0]),
             valueB: mod.getIn(['operands', 1]),


### PR DESCRIPTION
This fixes two issues with the modifiers page.  First, for the category "event date", we erroneously had "on or before" mapped to "greater than or equal to" (and similarly for "on or after").  This is basically just a typo.  

Secondly, when reinstantiating the modifiers page with existing data (i.e. when editing an existing search group item) we need to use `patchValue` rather than `setValue`, as the latter will complain if there is no data for the secondary form field (`valueB`) as there often is not.  This is the bug discussed in RW-658.

There is another path to the kind of bug RW-658 discusses, and that is for the user to deliberately supply bad information (i.e. select an operator that needs two operands but only supply one).  However, form validation will need to be implemented alongside the UI as part of a fuller implementation of the modifiers page. Any form validation code written right now would just be discarded.