### PR TITLE
[RW-695] Add the contact email to the ID verification page

### DIFF
--- a/ui/src/app/views/admin-review-id-verification/component.html
+++ b/ui/src/app/views/admin-review-id-verification/component.html
@@ -1,16 +1,16 @@
 <h2>Review ID Verifications</h2>
   <clr-datagrid *ngIf="contentLoaded; else contentLoading">
     <clr-dg-column [style.width.%]="15">Status</clr-dg-column>
-    <clr-dg-column [style.width.%]="20">First Name</clr-dg-column>
-    <clr-dg-column [style.width.%]="20">Last Name</clr-dg-column>
-    <clr-dg-column [style.width.%]="30">User Name</clr-dg-column>
+    <clr-dg-column [style.width.%]="20">Name</clr-dg-column>
+    <clr-dg-column [style.width.%]="25">User Name</clr-dg-column>
+    <clr-dg-column [style.width.%]="25">Contact Email</clr-dg-column>
     <clr-dg-column [style.width.%]="15">Action</clr-dg-column>
     <clr-dg-placeholder>No rejected or unverified profiles found.</clr-dg-placeholder>
     <clr-dg-row *clrDgItems="let profile of profiles" class="table-row workspace-table-row">
       <clr-dg-cell>{{profile.blockscoreIdVerificationStatus | lowercase}}</clr-dg-cell>
-      <clr-dg-cell>{{profile.givenName}}</clr-dg-cell>
-      <clr-dg-cell>{{profile.familyName}}</clr-dg-cell>
+      <clr-dg-cell>{{profile.familyName}}, {{profile.givenName}}</clr-dg-cell>
       <clr-dg-cell>{{profile.username}}</clr-dg-cell>
+      <clr-dg-cell>{{profile.contactEmail}}</clr-dg-cell>
       <clr-dg-cell>
         <button class="btn" (click)="setIdVerificationStatus(profile,'VERIFIED')">Approve</button>
         <button class="btn" (click)="setIdVerificationStatus(profile,'REJECTED')">Reject</button>


### PR DESCRIPTION
- In the short term, contact email will be the way to manually verify an identity (combined with our email verification).
- Merge researcher first/last name into one column to free up some real estate.