### PR TITLE
[RW-760] Consolidate notebook pattern matching, add regression test

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -66,7 +66,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   private static final int MAX_FC_CREATION_ATTEMPT_VALUES = 6;
   // If we later decide to tune this value, consider moving to the WorkbenchConfig.
   private static final int MAX_NOTEBOOK_SIZE_MB = 100;
-  private static final Pattern NOTEBOOK_PATTERN = Pattern.compile("([^\\s]+(\\.(?i)(ipynb))$)");
+  private static final Pattern NOTEBOOK_PATTERN = Pattern.compile("(.+(\\.(?i)(ipynb))$)");
   // "directory" for notebooks, within the workspace cloud storage bucket.
   private static final String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
 
@@ -752,8 +752,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     List<Blob> blobList = new ArrayList<>();
     blobList = cloudStorageService.getBlobList(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY);
     blobList = blobList.stream()
-        .filter(blob ->
-            blob.getName().matches("(.+(\\.(?i)(ipynb))$)"))
+        .filter(blob -> NOTEBOOK_PATTERN.matcher(blob.getName()).matches())
         .collect(Collectors.toList());
     return convertBlobToFileDetail(blobList, bucketName);
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -851,7 +851,7 @@ public class WorkspacesControllerTest {
     fcWorkspace.setBucketName("bucket2");
     stubGetWorkspace(fcWorkspace, WorkspaceAccessLevel.OWNER);
     String f1 = "notebooks/f1.ipynb";
-    String f2 = "notebooks/f2.ipynb";
+    String f2 = "notebooks/f2 with spaces.ipynb";
     String f3 = "notebooks/f3.vcf";
     // Note: mockBlob cannot be inlined into thenReturn() due to Mockito nuances.
     List<Blob> blobs = ImmutableList.of(


### PR DESCRIPTION
At some point these codepaths diverged and we started maintaining two regexes. The original regex did not capture notebook filenames with spaces. This was fixed in `listNotebooks()`, but not in `cloneWorkspace()`.