### PR TITLE
[RW-760] Add optional notebook log dump to bug reporting

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -91,6 +91,8 @@ configurations {
   generatedCompile
 }
 
+project.ext.GAE_VERSION = '1.9.64'
+
 buildscript {    // Configuration for building
   repositories {
     jcenter()    // Bintray's repository - a fast Maven Central mirror & more
@@ -189,8 +191,8 @@ dependencies {
   compile 'com.google.api-client:google-api-client-appengine:1.23.0'
   compile 'mysql:mysql-connector-java:+'
   compile 'com.google.cloud.sql:mysql-socket-factory:+'
-  compile 'com.google.appengine:appengine:+'
-  compile 'com.google.appengine:appengine-api-1.0-sdk:+'
+  compile "com.google.appengine:appengine:${GAE_VERSION}"
+  compile "com.google.appengine:appengine-api-1.0-sdk:${GAE_VERSION}"
   compile('org.springframework.boot:spring-boot-starter-web:+') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
@@ -232,6 +234,9 @@ dependencies {
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.+'
+  testCompile "com.google.appengine:appengine-testing:${GAE_VERSION}"
+  testCompile "com.google.appengine:appengine-api-stubs:${GAE_VERSION}"
+  testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"
   testCompile 'com.google.truth:truth:+'
   testCompile 'org.springframework.boot:spring-boot-starter-test:+'
   testCompile 'com.h2database:h2:+'

--- a/api/src/main/java/org/pmiops/workbench/api/BugReportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BugReportController.java
@@ -1,18 +1,33 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.collect.ImmutableList;
+
 import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.activation.DataHandler;
 import javax.inject.Provider;
 import javax.mail.Message;
 import javax.mail.MessagingException;
+import javax.mail.Multipart;
 import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.EmailException;
+import org.pmiops.workbench.notebooks.ApiException;
+import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.BugReport;
+import org.pmiops.workbench.notebooks.NotebooksService;
+import org.pmiops.workbench.notebooks.api.JupyterApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,16 +35,29 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class BugReportController implements BugReportApiDelegate {
+  private static final Logger log = Logger.getLogger(BugReportController.class.getName());
+  private static final List<String> notebookLogFiles =
+      ImmutableList.of("delocalization.log", "jupyter.log", "localization.log");
+
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final Provider<JupyterApi> jupyterApiProvider;
+  private final Provider<User> userProvider;
 
   @Autowired
-  BugReportController(Provider<WorkbenchConfig> workbenchConfigProvider) {
+  BugReportController(
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      Provider<User> userProvider,
+      Provider<JupyterApi> jupyterApiProvider) {
     this.workbenchConfigProvider = workbenchConfigProvider;
+    this.userProvider = userProvider;
+    this.jupyterApiProvider = jupyterApiProvider;
   }
 
   @Override
   public ResponseEntity<BugReport> sendBugReport(BugReport bugReport) {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
+    User user = userProvider.get();
+    JupyterApi jupyterApi = jupyterApiProvider.get();
     Properties props = new Properties();
     Session session = Session.getDefaultInstance(props, null);
     try {
@@ -44,7 +72,32 @@ public class BugReportController implements BugReportApiDelegate {
       msg.addRecipient(Message.RecipientType.TO, new InternetAddress(
           workbenchConfig.admin.supportGroup, "AofU Workbench Engineers"));
       msg.setSubject("[AofU Bug Report]: " + bugReport.getShortDescription());
-      msg.setText(bugReport.getReproSteps());
+
+      Multipart multipart = new MimeMultipart();
+      MimeBodyPart textPart = new MimeBodyPart();
+      textPart.setText(bugReport.getReproSteps());
+      multipart.addBodyPart(textPart);
+
+      // If requested, try to pull logs from the notebook cluster using the researcher's creds. Some
+      // or all of these log files might be missing, or the cluster may not even exist, so ignore
+      // failures here.
+      if (Optional.ofNullable(bugReport.getIncludeNotebookLogs()).orElse(false) &&
+          BillingProjectStatus.READY.equals(user.getFreeTierBillingProjectStatus())) {
+        for (String fileName : BugReportController.notebookLogFiles) {
+          try {
+            String logContent = jupyterApi.getRootContents(
+                user.getFreeTierBillingProjectName(), NotebooksService.DEFAULT_CLUSTER_NAME,
+                fileName, "file", "text", /* content */ 1).getContent();
+            MimeBodyPart attachPart = new MimeBodyPart();
+            attachPart.setDataHandler(new DataHandler(logContent, "text/plain"));
+            attachPart.setFileName(fileName);
+            multipart.addBodyPart(attachPart);
+          } catch (ApiException e) {
+            log.info(String.format("failed to retrieve notebook log '%s', continuing", fileName));
+          }
+        }
+      }
+      msg.setContent(multipart);
       Transport.send(msg);
     } catch (MessagingException e) {
       throw new EmailException("Error sending bug report", e);

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -482,6 +482,73 @@ paths:
   # "workspaces/..." fragment into a single "path" var, as is used in Jupyter's
   # own Swagger definition. Note: this does not initialize any parent
   # directories. The Leo proxy localize API can be used for this purpose.
+  /notebooks/{googleProject}/{clusterName}/api/contents/{fileName}:
+    parameters:
+      - in: path
+        name: googleProject
+        description: googleProject
+        required: true
+        type: string
+      - in: path
+        name: clusterName
+        description: clusterName
+        required: true
+        type: string
+      - in: path
+        name: fileName
+        description: fileName
+        required: true
+        type: string
+    get:
+      summary: Get contents of file or directory
+      description: "A client can optionally specify a type and/or format argument via URL parameter. When given, the Contents service shall return a model in the requested type and/or format. If the request cannot be satisfied, e.g. type=text is requested, but the file is binary, then the request shall fail with 400 and have a JSON response containing a 'reason' field, with the value 'bad format' or 'bad type', depending on what was requested."
+      tags:
+        - jupyter
+      operationId: getRootContents
+      parameters:
+        - name: type
+          in: query
+          description: File type ('file', 'directory')
+          type: string
+          enum:
+            - file
+            - directory
+        - name: format
+          in: query
+          description: "How file content should be returned ('text', 'base64')"
+          type: string
+          enum:
+            - text
+            - base64
+        - name: content
+          in: query
+          description: "Return content (0 for no content, 1 for return content)"
+          type: integer
+      responses:
+        404:
+          description: No item found
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+        200:
+          description: Contents of file or directory
+          headers:
+            Last-Modified:
+              description: Last modified date for file
+              type: string
+              format: dateTime
+          schema:
+            $ref: '#/definitions/JupyterContents'
+        500:
+          description: Model key error
   /notebooks/{googleProject}/{clusterName}/api/contents/workspaces/{workspaceDir}/{fileName}:
     parameters:
       - in: path

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -108,7 +108,6 @@ paths:
         - bugReport
       description: Sends an email to developers about a user reported bug
       operationId: sendBugReport
-      # TODO(dmohs): security: []
       parameters:
         - in: body
           name: bugReport
@@ -1228,7 +1227,6 @@ definitions:
     type: object
     required:
       - shortDescription
-      - reproSteps
       - contactEmail
     properties:
       shortDescription:
@@ -1237,6 +1235,11 @@ definitions:
       reproSteps:
         description: Steps to reproduce the bug
         type: string
+      includeNotebookLogs:
+        description:
+          Whether or not to include notebook server logs in the bug
+          report.
+        type: boolean
       contactEmail:
         description: The email with which to contact the bug reporter.
         type: string

--- a/api/src/test/java/org/pmiops/workbench/api/BugReportControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BugReportControllerTest.java
@@ -1,0 +1,177 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.mail.MailServicePb;
+import com.google.appengine.api.mail.dev.LocalMailService;
+import com.google.appengine.tools.development.ApiProxyLocal;
+import com.google.appengine.tools.development.testing.LocalMailServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.apphosting.api.ApiProxy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import javax.inject.Provider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.model.BillingProjectStatus;
+import org.pmiops.workbench.model.BugReport;
+import org.pmiops.workbench.notebooks.ApiException;
+import org.pmiops.workbench.notebooks.api.JupyterApi;
+import org.pmiops.workbench.notebooks.model.JupyterContents;
+import org.pmiops.workbench.test.FakeClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class BugReportControllerTest {
+  private static final Instant NOW = Instant.now();
+  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
+  private static final String FC_PROJECT_ID = "fc-project";
+  private static final String USER_EMAIL = "falco@lombardi.com";
+
+  private static final JupyterContents TEST_CONTENTS =
+      new JupyterContents().content("log contents");
+
+  @TestConfiguration
+  @Import({BugReportController.class})
+  @MockBean({JupyterApi.class})
+  static class Configuration {
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+
+    @Bean
+    WorkbenchConfig workbenchConfig() {
+      WorkbenchConfig config = new WorkbenchConfig();
+      config.admin = new WorkbenchConfig.AdminConfig();
+      config.admin.supportGroup = "support@asdf.com";
+      config.admin.verifiedSendingAddress = "sender@asdf.com";
+      return config;
+    }
+
+    @Bean
+    User user() {
+      // Allows for wiring of the initial Provider<User>; actual mocking of the
+      // user is achieved via setUserProvider().
+      return null;
+    }
+  }
+
+  @Mock
+  Provider<User> userProvider;
+  @Autowired
+  JupyterApi jupyterApi;
+  @Autowired
+  BugReportController bugReportController;
+
+  private LocalServiceTestHelper gaeHelper =
+      new LocalServiceTestHelper(new LocalMailServiceTestConfig());
+  private LocalMailService mailService;
+
+  @Before
+  public void setUp() {
+    gaeHelper.setUp();
+    User user = new User();
+    user.setEmail(USER_EMAIL);
+    user.setUserId(123L);
+    user.setFreeTierBillingProjectName(FC_PROJECT_ID);
+    user.setFreeTierBillingProjectStatus(BillingProjectStatus.READY);
+    user.setDisabled(false);
+    when(userProvider.get()).thenReturn(user);
+    bugReportController.setUserProvider(userProvider);
+
+    ApiProxyLocal proxy = (ApiProxyLocal) ApiProxy.getDelegate();
+    mailService = (LocalMailService) proxy.getService(LocalMailService.PACKAGE);
+
+    CLOCK.setInstant(NOW);
+  }
+
+  @After
+  public void tearDown() {
+    gaeHelper.tearDown();
+  }
+
+  @Test
+  public void testSendBugReport() throws Exception {
+    bugReportController.sendBugReport(
+        new BugReport()
+          .contactEmail(USER_EMAIL)
+          .includeNotebookLogs(false)
+          .reproSteps("press button")
+          .shortDescription("bug"));
+    assertThat(mailService.getSentMessages().size()).isEqualTo(1);
+    verify(jupyterApi, never()).getRootContents(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testSendBugReportWithNotebooks() throws Exception {
+    when(jupyterApi.getRootContents(any(), any(), any(), any(), any(), any()))
+        .thenReturn(TEST_CONTENTS);
+    bugReportController.sendBugReport(
+        new BugReport()
+          .contactEmail(USER_EMAIL)
+          .includeNotebookLogs(true)
+          .reproSteps("press button")
+          .shortDescription("bug"));
+
+    assertThat(mailService.getSentMessages().size()).isEqualTo(1);
+    MailServicePb.MailMessage msg = mailService.getSentMessages().get(0);
+    assertThat(msg.attachments().size()).isEqualTo(3);
+    verify(jupyterApi).getRootContents(
+        eq(FC_PROJECT_ID), any(), eq("delocalization.log"), any(), any(), any());
+    verify(jupyterApi).getRootContents(
+        eq(FC_PROJECT_ID), any(), eq("localization.log"), any(), any(), any());
+    verify(jupyterApi).getRootContents(
+        eq(FC_PROJECT_ID), any(), eq("jupyter.log"), any(), any(), any());
+  }
+
+  @Test
+  public void testSendBugReportWithNotebookErrors() throws Exception {
+    when(jupyterApi.getRootContents(any(), any(), any(), any(), any(), any()))
+        .thenReturn(TEST_CONTENTS);
+    when(jupyterApi.getRootContents(any(), any(), eq("jupyter.log"), any(), any(), any()))
+        .thenThrow(new ApiException(404, "not found"));
+    bugReportController.sendBugReport(
+        new BugReport()
+          .contactEmail(USER_EMAIL)
+          .includeNotebookLogs(true)
+          .reproSteps("press button")
+          .shortDescription("bug"));
+
+    assertThat(mailService.getSentMessages().size()).isEqualTo(1);
+    MailServicePb.MailMessage msg = mailService.getSentMessages().get(0);
+    assertThat(msg.attachments().size()).isEqualTo(2);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/api/BugReportControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BugReportControllerTest.java
@@ -15,7 +15,6 @@ import com.google.appengine.tools.development.testing.LocalMailServiceTestConfig
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.apphosting.api.ApiProxy;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
@@ -33,7 +32,6 @@ import org.pmiops.workbench.model.BugReport;
 import org.pmiops.workbench.notebooks.ApiException;
 import org.pmiops.workbench.notebooks.api.JupyterApi;
 import org.pmiops.workbench.notebooks.model.JupyterContents;
-import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -55,8 +53,6 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class BugReportControllerTest {
-  private static final Instant NOW = Instant.now();
-  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
   private static final String FC_PROJECT_ID = "fc-project";
   private static final String USER_EMAIL = "falco@lombardi.com";
 
@@ -67,11 +63,6 @@ public class BugReportControllerTest {
   @Import({BugReportController.class})
   @MockBean({JupyterApi.class})
   static class Configuration {
-    @Bean
-    Clock clock() {
-      return CLOCK;
-    }
-
     @Bean
     WorkbenchConfig workbenchConfig() {
       WorkbenchConfig config = new WorkbenchConfig();
@@ -114,8 +105,6 @@ public class BugReportControllerTest {
 
     ApiProxyLocal proxy = (ApiProxyLocal) ApiProxy.getDelegate();
     mailService = (LocalMailService) proxy.getService(LocalMailService.PACKAGE);
-
-    CLOCK.setInstant(NOW);
   }
 
   @After

--- a/ui/src/app/views/bug-report/component.css
+++ b/ui/src/app/views/bug-report/component.css
@@ -9,3 +9,7 @@
 .form-section:first-child {
   margin-top: 0;
 }
+
+.notebook-logs {
+  display: inline-block;
+}

--- a/ui/src/app/views/bug-report/component.html
+++ b/ui/src/app/views/bug-report/component.html
@@ -7,18 +7,24 @@
         <div class="form-section">
           <label>Description:</label>
           <input id="bug-report-short-descr" type="text" class="input" name="short-description" autofocus
-              [(ngModel)]="shortDescription">
+              [(ngModel)]="bugReport.shortDescription">
         </div>
         <div class="form-section">
           <label>How to Reproduce:</label>
           <textarea id="bug-report-repro-steps" class="input" name="repro-steps"
-              [(ngModel)]="reproSteps">
+              [(ngModel)]="bugReport.reproSteps">
           </textarea>
+        </div>
+        <div class="form-section">
+          <clr-checkbox id="bug-report-notebook-logs" class="notebook-logs" name="notebook-logs"
+              [(ngModel)]="bugReport.includeNotebookLogs">
+          </clr-checkbox>
+          <label>Attach notebook logs?</label>
         </div>
         <div class="form-section">
           <label>Contact Email:</label>
           <input id="bug-report-contact-email" type="text" class="input" name="contact-email"
-              [(ngModel)]="contactEmail">
+              [(ngModel)]="bugReport.contactEmail">
         </div>
       </div>
     </div>

--- a/ui/src/app/views/bug-report/component.ts
+++ b/ui/src/app/views/bug-report/component.ts
@@ -13,34 +13,35 @@ import {BugReport} from 'generated';
 })
 export class BugReportComponent implements OnInit {
   reporting = false;
-  shortDescription: string;
-  reproSteps: string;
-  contactEmail: string;
-  bugReport: BugReport = {shortDescription: '', reproSteps: '', contactEmail: ''};
-
+  bugReport: BugReport = this.emptyReport();
 
   constructor(
     private bugReportService: BugReportService,
     public profileStorageService: ProfileStorageService
   ) {}
 
+  private emptyReport(): BugReport {
+    return {
+      shortDescription: '',
+      reproSteps: '',
+      includeNotebookLogs: true,
+      contactEmail: ''
+    };
+  }
+
   ngOnInit() {
   }
 
   reportBug() {
     this.reporting = true;
-    this.shortDescription = '';
-    this.reproSteps = '';
+    this.bugReport = this.emptyReport();
     this.profileStorageService.profile$.subscribe((profile) => {
-      this.contactEmail = profile.contactEmail;
+      this.bugReport.contactEmail = profile.contactEmail;
     });
   }
 
   send() {
     this.reporting = false;
-    this.bugReport.shortDescription = this.shortDescription;
-    this.bugReport.reproSteps = this.reproSteps;
-    this.bugReport.contactEmail = this.contactEmail;
-    this.bugReportService.sendBugReport(this.bugReport).subscribe((bugReport: BugReport) => {});
+    this.bugReportService.sendBugReport(this.bugReport).subscribe(() => {});
   }
 }


### PR DESCRIPTION
If requested, makes a best effort to grab notebook logs from the researcher's cluster and attaches them to the bug report email. We have no other way of accessing these logs currently, because only the user has access to their own cluster.

It should be possible to refactor this code to use the Jira attachment API, once we switch bug reporting to use that.