### PR TITLE
[RW-782] Gate homepage -> workspaces on data access, if enforceRegistered

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -19,10 +19,12 @@ public class ConfigController implements ConfigApiDelegate {
 
   @Override
   public ResponseEntity<ConfigResponse> getConfig() {
+    WorkbenchConfig config = configProvider.get();
     return ResponseEntity.ok(
       new ConfigResponse()
-        .gsuiteDomain(configProvider.get().googleDirectoryService.gSuiteDomain)
-        .projectId(configProvider.get().server.projectId)
-        .publicApiKeyForErrorReports(configProvider.get().server.publicApiKeyForErrorReports));
+        .gsuiteDomain(config.googleDirectoryService.gSuiteDomain)
+        .projectId(config.server.projectId)
+        .enforceRegistered(config.firecloud.enforceRegistered)
+        .publicApiKeyForErrorReports(config.server.publicApiKeyForErrorReports));
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -834,6 +834,11 @@ definitions:
       projectId:
         type: string
         description: The cloud project in which this app is running.
+      enforceRegistered:
+        type: boolean
+        description: |
+          Whether the user's data access level should gate other Workbench functionality, namely
+          to functionality requiring CDR access.
       publicApiKeyForErrorReports:
         type: string
         description: |

--- a/ui/src/app/views/homepage/component.css
+++ b/ui/src/app/views/homepage/component.css
@@ -209,8 +209,12 @@
     cursor: pointer;
 }
 
-.card *.button:hover {
+.card *.button:active:hover {
     background: #4356a7;
+}
+
+.card *.button:disabled {
+    cursor: auto;
 }
 
 .bottom-banner {

--- a/ui/src/app/views/homepage/component.html
+++ b/ui/src/app/views/homepage/component.html
@@ -54,12 +54,12 @@
         <div class="description">Here you can view all workspaces you have created, or that have been
             shared with you.</div>
         <button class="button btn btn-primary tooltip" (click)="listWorkspaces()"
-            [disabled]="!FCAccountInitialized || !hasCdrAccess()">
+            [disabled]="!hasCdrAccess()">
           GO TO WORKSPACES
-          <span *ngIf="!FCAccountInitialized" class="tooltip-content">
+          <span *ngIf="!profile" class="tooltip-content">
               Your account is being initialized, please wait.
           </span>
-          <span *ngIf="billingProjectInitialized && !hasCdrAccess()" class="tooltip-content">
+          <span *ngIf="profile && !hasCdrAccess()" class="tooltip-content">
               You must complete profile setup before accessing data.
           </span>
         </button>

--- a/ui/src/app/views/homepage/component.html
+++ b/ui/src/app/views/homepage/component.html
@@ -38,7 +38,7 @@
         <div class="title">Create your own workspace</div>
         <div class="description">Here you can create and name a workspace.
             Within a workspace you can create notebooks and build cohorts.</div>
-        <button class="button tooltip" (click)="addWorkspace()"
+        <button class="button btn btn-primary tooltip" (click)="addWorkspace()"
             [disabled]="!billingProjectInitialized || !hasCdrAccess()">
           CREATE WORKSPACE
           <span *ngIf="!billingProjectInitialized" class="tooltip-content">
@@ -53,7 +53,7 @@
         <div class="title">View your workspaces</div>
         <div class="description">Here you can view all workspaces you have created, or that have been
             shared with you.</div>
-        <button class="button tooltip" (click)="listWorkspaces()"
+        <button class="button btn btn-primary tooltip" (click)="listWorkspaces()"
             [disabled]="!FCAccountInitialized || !hasCdrAccess()">
           GO TO WORKSPACES
           <span *ngIf="!FCAccountInitialized" class="tooltip-content">

--- a/ui/src/app/views/homepage/component.html
+++ b/ui/src/app/views/homepage/component.html
@@ -38,22 +38,30 @@
         <div class="title">Create your own workspace</div>
         <div class="description">Here you can create and name a workspace.
             Within a workspace you can create notebooks and build cohorts.</div>
-        <button class="button tooltip" (click)="addWorkspace()" [disabled]="!billingProjectInitialized">
-            CREATE WORKSPACE
-            <span *ngIf="!billingProjectInitialized" class="tooltip-content">
-                Your billing project is currently being created, please wait.
-            </span>
+        <button class="button tooltip" (click)="addWorkspace()"
+            [disabled]="!billingProjectInitialized || !hasCdrAccess()">
+          CREATE WORKSPACE
+          <span *ngIf="!billingProjectInitialized" class="tooltip-content">
+              Your billing project is currently being created, please wait.
+          </span>
+          <span *ngIf="billingProjectInitialized && !hasCdrAccess()" class="tooltip-content">
+              You must complete profile setup before accessing data.
+          </span>
         </button>
     </div>
     <div class="card">
         <div class="title">View your workspaces</div>
         <div class="description">Here you can view all workspaces you have created, or that have been
             shared with you.</div>
-        <button class="button tooltip" (click)="listWorkspaces()" [disabled]="!FCAccountInitialized">
-            GO TO WORKSPACES
-            <span *ngIf="!FCAccountInitialized" class="tooltip-content">
-                Your account is being initialized, please wait.
-            </span>
+        <button class="button tooltip" (click)="listWorkspaces()"
+            [disabled]="!FCAccountInitialized || !hasCdrAccess()">
+          GO TO WORKSPACES
+          <span *ngIf="!FCAccountInitialized" class="tooltip-content">
+              Your account is being initialized, please wait.
+          </span>
+          <span *ngIf="billingProjectInitialized && !hasCdrAccess()" class="tooltip-content">
+              You must complete profile setup before accessing data.
+          </span>
         </button>
     </div>
 </div>

--- a/ui/src/app/views/homepage/component.ts
+++ b/ui/src/app/views/homepage/component.ts
@@ -44,7 +44,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
       'value': this.numberOfTotalTasks - this.completedTasks
     }
   ];
-  FCAccountInitialized = false;
   billingProjectInitialized = false;
   billingProjectQuery: NodeJS.Timer;
   firstSignIn: Date;
@@ -75,7 +74,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
           this.profileStorageService.reload();
         }, 10000);
       }
-      this.FCAccountInitialized = true;
       this.profile = profile;
       this.reloadSpinner();
       if (profile.firstSignInTime === null) {
@@ -143,12 +141,14 @@ export class HomepageComponent implements OnInit, OnDestroy {
    this.router.navigate(['workspaces']);
   }
 
+  // The user is FC initialized and has access to the CDR, if enforced in this
+  // environment.
   hasCdrAccess(): boolean {
-    if (!this.enforceRegistered) {
-      return true;
-    }
     if (!this.profile) {
       return false;
+    }
+    if (!this.enforceRegistered) {
+      return true;
     }
     return [
       DataAccessLevel.Registered,


### PR DESCRIPTION
Demo (manually hacked with `hasDataAccess()` always returning `false`):
https://calbach-dot-all-of-us-workbench-test.appspot.com/

`enforceRegistered` is not `true` anywhere currently, though I would like to move to requiring it in staging/stable per RW-712.

These pages are changing, so the UI details I think are not too critical. In general, I do think we need a more directed initial profile setup flow than what we currently have, so ultimately this data access check might manifest differently. The main thing is just getting the plumbing and logic setup here. 

Also, update the button styling so the disabled homepage buttons don't look clickable.
