### PR TITLE
[RW-805][risk=no] Set user email verification in the right place

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -33,7 +33,6 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.GatewayTimeoutException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership.CreationStatusEnum;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -236,6 +235,8 @@ public class ProfileController implements ProfileApiDelegate {
       }
 
       user.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
+      // If the user is logged in, then we know that they have followed the account creation instructions sent to
+      // their initial contact email address.
       user.setEmailVerificationStatus(EmailVerificationStatus.SUBSCRIBED);
       try {
         return userDao.save(user);
@@ -314,7 +315,7 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   private ResponseEntity<Profile> getProfileResponse(User user) {
-    return ResponseEntity.ok(profileService.getProfile(user, /* checkEmailVerification */ true));
+    return ResponseEntity.ok(profileService.getProfile(user));
   }
 
   @Override
@@ -519,7 +520,7 @@ public class ProfileController implements ProfileApiDelegate {
     IdVerificationListResponse response = new IdVerificationListResponse();
     List<Profile> responseList = new ArrayList<Profile>();
     for (User user : userService.getNonVerifiedUsers()) {
-      responseList.add(profileService.getProfile(user, /* checkEmailVerification */ false));
+      responseList.add(profileService.getProfile(user));
     }
     response.setProfileList(responseList);
     return ResponseEntity.ok(response);

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -236,6 +236,7 @@ public class ProfileController implements ProfileApiDelegate {
       }
 
       user.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
+      user.setEmailVerificationStatus(EmailVerificationStatus.SUBSCRIBED);
       try {
         return userDao.save(user);
       } catch (ObjectOptimisticLockingFailureException e) {
@@ -467,7 +468,6 @@ public class ProfileController implements ProfileApiDelegate {
     if (updatedProfile.getContactEmail() != null) {
       if (!updatedProfile.getContactEmail().equals(user.getContactEmail())) {
         mailChimpService.addUserContactEmail(updatedProfile.getContactEmail());
-        user.setEmailVerificationStatus(EmailVerificationStatus.PENDING);
         user.setContactEmail(updatedProfile.getContactEmail());
       }
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -468,7 +468,6 @@ public class ProfileController implements ProfileApiDelegate {
 
     if (updatedProfile.getContactEmail() != null) {
       if (!updatedProfile.getContactEmail().equals(user.getContactEmail())) {
-        mailChimpService.addUserContactEmail(updatedProfile.getContactEmail());
         user.setContactEmail(updatedProfile.getContactEmail());
       }
     }

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.mailchimp.MailChimpService;
 import org.pmiops.workbench.model.BlockscoreIdVerificationStatus;
 import org.pmiops.workbench.model.InstitutionalAffiliation;
 import org.pmiops.workbench.model.Profile;
@@ -31,18 +30,15 @@ public class ProfileService {
       };
 
   private final FireCloudService fireCloudService;
-  private final MailChimpService mailChimpService;
   private final UserDao userDao;
 
   @Autowired
-  public ProfileService(FireCloudService fireCloudService, MailChimpService mailChimpService,
-      UserDao userDao) {
+  public ProfileService(FireCloudService fireCloudService, UserDao userDao) {
     this.fireCloudService = fireCloudService;
-    this.mailChimpService = mailChimpService;
     this.userDao = userDao;
   }
 
-  public Profile getProfile(User user, boolean checkEmailVerification) {
+  public Profile getProfile(User user) {
     // Fetch the user's authorities, since they aren't loaded during normal request interception.
     User userWithAuthorities = userDao.findUserWithAuthorities(user.getUserId());
     if (userWithAuthorities != null) {

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -6,12 +6,9 @@ import java.util.stream.Collectors;
 
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.mailchimp.MailChimpService;
 import org.pmiops.workbench.model.BlockscoreIdVerificationStatus;
-import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.InstitutionalAffiliation;
 import org.pmiops.workbench.model.Profile;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,27 +95,6 @@ public class ProfileService {
     profile.setInstitutionalAffiliations(user.getInstitutionalAffiliations()
         .stream().map(TO_CLIENT_INSTITUTIONAL_AFFILIATION)
         .collect(Collectors.toList()));
-    EmailVerificationStatus userEmailVerificationStatus = user.getEmailVerificationStatus();
-    // if verification is pending or unverified, need to query MailChimp and update DB accordingly
-    // Note: This is pretty slow, we shouldn't be calling it on every Profile lookup. Leave it
-    // for now as we're in the process of switching off Mailchimp (related: RW-705).
-    if (checkEmailVerification &&
-        !userEmailVerificationStatus.equals(EmailVerificationStatus.SUBSCRIBED)) {
-      if (userEmailVerificationStatus.equals(EmailVerificationStatus.UNVERIFIED) && user.getContactEmail() != null) {
-        try {
-          mailChimpService.addUserContactEmail(user.getContactEmail());
-          userEmailVerificationStatus = EmailVerificationStatus.PENDING;
-        } catch (WorkbenchException e) {
-          if (e.getErrorResponse().getStatusCode() == 400) {
-            profile.setContactEmailFailure(true);
-          }
-        }
-      } else if (userEmailVerificationStatus.equals(EmailVerificationStatus.PENDING)) {
-        userEmailVerificationStatus = EmailVerificationStatus.fromValue(mailChimpService.getMember(user.getContactEmail()));
-      }
-      user.setEmailVerificationStatus(userEmailVerificationStatus);
-      userDao.save(user);
-    }
     profile.setEmailVerificationStatus(user.getEmailVerificationStatus());
     return profile;
   }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -145,7 +145,7 @@ public class ProfileControllerTest {
     idVerificationRequest = new IdVerificationRequest();
     idVerificationRequest.setFirstName("Bob");
     UserService userService = new UserService(userProvider, userDao, adminActionHistoryDao, clock, fireCloudService, configProvider);
-    ProfileService profileService = new ProfileService(fireCloudService, mailChimpService, userDao);
+    ProfileService profileService = new ProfileService(fireCloudService, userDao);
     this.profileController = new ProfileController(profileService, userProvider, userAuthenticationProvider,
         userDao, clock, userService, fireCloudService, directoryService,
         cloudStorageService, blockscoreService, mailChimpService, notebooksService, Providers.of(config), environment);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -459,23 +459,6 @@ public class ProfileControllerTest {
   }
 
   @Test
-  public void testMe_succeedsOnMailchimpFailure() throws Exception {
-    createUser();
-    when(fireCloudService.isRequesterEnabledInFirecloud()).thenReturn(true);
-    user = userDao.findUserByEmail(PRIMARY_EMAIL);
-    user.setEmailVerificationStatus(EmailVerificationStatus.UNVERIFIED);
-    userDao.save(user);
-    when(mailChimpService.addUserContactEmail(CONTACT_EMAIL)).thenThrow(new WorkbenchException(new ErrorResponse().statusCode(400)));
-    Profile profile = profileController.getMe().getBody();
-    assertProfile(profile, PRIMARY_EMAIL, CONTACT_EMAIL, FAMILY_NAME, GIVEN_NAME,
-        DataAccessLevel.UNREGISTERED, TIMESTAMP, true, true);
-    verify(fireCloudService).registerUser(CONTACT_EMAIL, GIVEN_NAME, FAMILY_NAME);
-    verify(fireCloudService).createAllOfUsBillingProject(profile.getFreeTierBillingProjectName());
-    verify(fireCloudService).addUserToBillingProject(
-        PRIMARY_EMAIL, profile.getFreeTierBillingProjectName());
-  }
-
-  @Test
   public void testGetBillingProjects_empty() throws Exception {
     when(fireCloudService.getBillingProjectMemberships()).thenReturn(
         ImmutableList.<org.pmiops.workbench.firecloud.model.BillingProjectMembership>of());


### PR DESCRIPTION
## Addresses
Partly addresses https://precisionmedicineinitiative.atlassian.net/browse/RW-805
There is more work to do, so this PR does not complete 805.
Relates to https://github.com/all-of-us/workbench/pull/912

## Changes
* Set the user's email verification status in the right place. We no longer need to use mailchimp to know if the user's email is verified now.
* Remove outdated test