### PR TITLE
[RW-767][risk=low] Implement a notebook cluster cleanup cron

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -3,6 +3,7 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-test-f1-",
+    "clusterMaxAgeDays": 10,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -3,7 +3,8 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-test-f1-",
-    "clusterMaxAgeDays": 10,
+    "clusterMaxAgeDays": 7,
+    "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -2,6 +2,7 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-stable-",
+    "clusterMaxAgeDays": 14,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -3,6 +3,7 @@
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-stable-",
     "clusterMaxAgeDays": 14,
+    "clusterIdleMaxAgeDays": 7,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -2,7 +2,8 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-staging-",
-    "clusterMaxAgeDays": 5,
+    "clusterMaxAgeDays": 7,
+    "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
     "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-staging-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -2,6 +2,7 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-staging-",
+    "clusterMaxAgeDays": 5,
     "debugEndpoints": false,
     "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-staging-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -3,6 +3,7 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-test-f1-",
+    "clusterMaxAgeDays": 5,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -3,7 +3,8 @@
   "firecloud": {
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-test-f1-",
-    "clusterMaxAgeDays": 5,
+    "clusterMaxAgeDays": 7,
+    "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java
@@ -1,0 +1,139 @@
+package org.pmiops.workbench.api;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.inject.Provider;
+
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.model.CheckClustersResponse;
+import org.pmiops.workbench.notebooks.ApiException;
+import org.pmiops.workbench.notebooks.NotebooksConfig;
+import org.pmiops.workbench.notebooks.api.ClusterApi;
+import org.pmiops.workbench.notebooks.model.Cluster;
+import org.pmiops.workbench.notebooks.model.ClusterStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Offline cluster API. Handles cronjobs for cleanup and upgrade of older
+ * clusters. Methods here should be access restricted as, unlike
+ * ClusterController, these endpoints run as the Workbench service account.
+ */
+@RestController
+public class OfflineClusterController implements OfflineClusterApiDelegate {
+  private static final Logger log = Logger.getLogger(OfflineClusterController.class.getName());
+
+  private final Provider<ClusterApi> clusterApiProvider;
+  private final Provider<WorkbenchConfig> configProvider;
+  private final Clock clock;
+
+  @Autowired
+  OfflineClusterController(
+      @Qualifier(NotebooksConfig.SERVICE_CLUSTER_API) Provider<ClusterApi> clusterApiProvider,
+      Provider<WorkbenchConfig> configProvider,
+      Clock clock) {
+    this.clock = clock;
+    this.configProvider = configProvider;
+    this.clusterApiProvider = clusterApiProvider;
+  }
+
+  /**
+   * checkClusters deletes older clusters in order to force an upgrade on the
+   * next researcher login. This method is meant to be restricted to invocation
+   * by App Engine cron.
+   *
+   * The cluster deletion policy here aims to strike a balance between enforcing
+   * upgrades, cost savings, and minimizing user disruption. To this point, our
+   * goal is to only upgrade idle clusters if possible, as doing so gives us an
+   * assurance that a researcher is not actively using it. We delete clusters in
+   * the following cases:
+   *
+   * 1. It exceeds the max cluster age. Per environment, but O(weeks).
+   * 2. Since a cluster was last accessed, its spent over half its remaining
+   *    lifespan idle (as defined by [1]). This dynamic limit means that as the
+   *    upgrade horizon approaches, we'll be more aggressive in upgrading.
+   */
+  @Override
+  public ResponseEntity<CheckClustersResponse> checkClusters() {
+    WorkbenchConfig config = configProvider.get();
+    Instant now = clock.instant();
+    Duration maxAge = Duration.ofDays(config.firecloud.clusterMaxAgeDays);
+
+    ClusterApi clusterApi = clusterApiProvider.get();
+    List<Cluster> clusters;
+    try {
+      clusters = clusterApi.listClusters(null, false);
+    } catch (ApiException e) {
+      throw ExceptionUtils.convertNotebookException(e);
+    }
+
+    int errors = 0;
+    int activeDeletes = 0;
+    int unusedDeletes = 0;
+    for (Cluster c : clusters) {
+      String clusterId = c.getGoogleProject() + "/" + c.getClusterName();
+      if (ClusterStatus.UNKNOWN.equals(c.getStatus()) || c.getStatus() == null) {
+        log.warning(String.format("unknown cluster status for cluster '%s'", clusterId));
+        continue;
+      }
+      if (!ClusterStatus.RUNNING.equals(c.getStatus()) &&
+          !ClusterStatus.STOPPED.equals(c.getStatus())) {
+        // For now, we only handle running or stopped (suspended) clusters.
+        continue;
+      }
+
+      Instant created = Instant.parse(c.getCreatedDate());
+      Duration age = Duration.between(created, now);
+      Duration lifeRemaining = maxAge.minus(age);
+      Instant lastUsed = Instant.parse(c.getDateAccessed());
+      Duration unusedDuration = Duration.between(lastUsed, now);
+      if (lifeRemaining.isNegative()) {
+        log.info(String.format(
+            "deleting cluster '%s', exceeded max lifetime @ %s (>%s)",
+            clusterId, formatDuration(age), formatDuration(maxAge)));
+        activeDeletes++;
+      } else if (lifeRemaining.toMillis() < unusedDuration.toMillis()) {
+        log.info(String.format(
+            "deleting cluster '%s', unused for %s, more than its remaining lifespan (>%s)",
+            clusterId, formatDuration(unusedDuration), formatDuration(lifeRemaining)));
+        unusedDeletes++;
+      } else {
+        // Don't delete.
+        continue;
+      }
+      try {
+        clusterApi.deleteCluster(c.getGoogleProject(), c.getClusterName());
+      } catch (ApiException e) {
+        log.log(Level.WARNING, String.format("failed to delete cluster '%s'", clusterId), e);
+        errors++;
+      }
+    }
+    log.info(String.format(
+        "deleted %d old clusters and %d inactive clusters (with %d errors) of %d total clusters",
+        activeDeletes, unusedDeletes, errors, clusters.size()));
+    if (errors > 0) {
+      throw new ServerErrorException(
+          String.format("%d cluster deletion calls failed", errors));
+    }
+    return ResponseEntity.ok(
+        new CheckClustersResponse()
+          .clusterDeletionCount(activeDeletes + unusedDeletes - errors));
+  }
+
+  private static String formatDuration(Duration d) {
+    if ((d.toHours() % 24) == 0) {
+      return String.format("%dd", d.toDays());
+    }
+    return String.format("%dd %dh", d.toDays(), d.toHours() % 24);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java
@@ -6,9 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.inject.Provider;
-
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -91,7 +89,7 @@ public class OfflineClusterController implements OfflineClusterApiDelegate {
     for (Cluster c : clusters) {
       String clusterId = c.getGoogleProject() + "/" + c.getClusterName();
       try {
-        // Refetch the cluster to ensure freshnesss as this iteration may take
+        // Refetch the cluster to ensure freshness as this iteration may take
         // some time.
         c = clusterApi.getCluster(c.getGoogleProject(), c.getClusterName());
       } catch (ApiException e) {

--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -1,0 +1,30 @@
+package org.pmiops.workbench.auth;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
+import java.io.IOException;
+import java.util.List;
+import org.pmiops.workbench.config.WorkbenchEnvironment;
+
+public final class ServiceAccounts {
+  /**
+   * Retrieves an access token for the Workbench server service account. This
+   * should be used carefully, as this account is generally more privileged than
+   * an end user researcher account.
+   */
+  public static String workbenchAccessToken(
+      WorkbenchEnvironment workbenchEnvironment, List<String> scopes) throws IOException {
+    // When running locally, we get application default credentials in a different way than
+    // when running in Cloud.
+    if (workbenchEnvironment.isDevelopment()) {
+      GoogleCredential credential = GoogleCredential.getApplicationDefault().createScoped(scopes);
+      credential.refreshToken();
+      return credential.getAccessToken();
+    }
+    AppIdentityService appIdentity = AppIdentityServiceFactory.getAppIdentityService();
+    final AppIdentityService.GetAccessTokenResult accessTokenResult =
+        appIdentity.getAccessToken(scopes);
+    return accessTokenResult.getAccessToken();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -20,6 +20,7 @@ public class WorkbenchConfig {
     public boolean debugEndpoints;
     public String billingAccountId;
     public String billingProjectPrefix;
+    public Integer clusterMaxAgeDays;
     public String registeredDomainName;
     public boolean enforceRegistered;
     public String jupyterUserScriptUri;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -21,6 +21,7 @@ public class WorkbenchConfig {
     public String billingAccountId;
     public String billingProjectPrefix;
     public Integer clusterMaxAgeDays;
+    public Integer clusterIdleMaxAgeDays;
     public String registeredDomainName;
     public boolean enforceRegistered;
     public String jupyterUserScriptUri;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -1,10 +1,8 @@
 package org.pmiops.workbench.firecloud;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.appengine.api.appidentity.AppIdentityService;
-import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 import com.google.common.collect.ImmutableList;
-
+import java.io.IOException;
+import java.util.List;
 import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -18,9 +16,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.context.annotation.RequestScope;
-
-import java.io.IOException;
-import java.util.Arrays;
 
 @org.springframework.context.annotation.Configuration
 public class FireCloudConfig {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
@@ -1,7 +1,12 @@
 package org.pmiops.workbench.notebooks;
 
+import com.google.common.collect.ImmutableList;
+
+import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchEnvironment;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
 import org.pmiops.workbench.notebooks.api.JupyterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
@@ -10,9 +15,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.context.annotation.RequestScope;
 
+import java.io.IOException;
+import java.util.List;
+
 @org.springframework.context.annotation.Configuration
 public class NotebooksConfig {
+  public static final String SERVICE_CLUSTER_API = "svcClusterApi";
   private static final String NOTEBOOKS_CLIENT = "notebooksApiClient";
+  private static final String NOTEBOOKS_SERVICE_CLIENT = "notebooksSvcApiClient";
+
+  private static final List<String> NOTEBOOK_SCOPES = ImmutableList.of(
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/userinfo.email");
 
   @Bean(name=NOTEBOOKS_CLIENT)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -21,6 +35,21 @@ public class NotebooksConfig {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(userAuthentication.getCredentials());
     apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
+    return apiClient;
+  }
+
+  @Bean(name=NOTEBOOKS_SERVICE_CLIENT)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ApiClient workbenchServiceAccountClient(
+      WorkbenchEnvironment workbenchEnvironment, WorkbenchConfig workbenchConfig) {
+    ApiClient apiClient = new ApiClient();
+    try {
+      apiClient.setAccessToken(
+          ServiceAccounts.workbenchAccessToken(workbenchEnvironment, NOTEBOOK_SCOPES));
+      apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
+    } catch (IOException e) {
+      throw new ServerErrorException(e);
+    }
     return apiClient;
   }
 
@@ -44,6 +73,14 @@ public class NotebooksConfig {
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public JupyterApi jupyterApi(@Qualifier(NOTEBOOKS_CLIENT) ApiClient apiClient) {
     JupyterApi api = new JupyterApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  @Bean(name=SERVICE_CLUSTER_API)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ClusterApi serviceClusterApi(@Qualifier(NOTEBOOKS_SERVICE_CLIENT) ApiClient apiClient) {
+    ClusterApi api = new ClusterApi();
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -708,6 +708,7 @@ definitions:
       - status
       - createdDate
       - labels
+      - dateAccessed
     properties:
       clusterName:
         type: string
@@ -751,6 +752,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Instance'
+      dateAccessed:
+        type: string
+        description: |
+          The date and time the cluster was last accessed, in ISO-8601 format.
+          Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
 
   InstanceKey:
     description: ''
@@ -854,7 +860,7 @@ definitions:
       masterDiskSize:
         type: integer
         description: |
-          Optional, the size of the disk on the master node. Minimum size is 100GB. If unspecified, default size is 500GB.
+          Optional, the size in megabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
       workerMachineType:
         type: string
         description: |
@@ -864,7 +870,7 @@ definitions:
       workerDiskSize:
         type: integer
         description: |
-          Optional, the size of the disk on the master node. Minimum size is 100GB. If unspecified, default size is 500GB.
+          Optional, the size in megabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
           Ignored if numberOfWorkers is 0.
       numberOfWorkerLocalSSDs:
         type: integer

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -680,6 +680,23 @@ paths:
           schema:
             $ref: "#/definitions/AuditBigQueryResponse"
 
+  /v1/cron/checkClusters:
+    get:
+      security: []
+      tags:
+        - offlineCluster
+        - cron
+      description: >
+        Endpoint meant to be called offline to trigger cluster checks and
+        cleanup. Enforces upgrades for older cluster deployments. May be slow to
+        execute. Only executable via App Engine cronjob.
+      operationId: checkClusters
+      responses:
+        200:
+          description: Clusters were checked and handled successfully.
+          schema:
+            $ref: "#/definitions/CheckClustersResponse"
+
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
@@ -1580,3 +1597,12 @@ definitions:
         description: >
           Number of queries issues against the Curated data repository which are
           flagged as possible audit issues. See logs/alerts for details.
+
+  CheckClustersResponse:
+    type: object
+    properties:
+      clusterDeletionCount:
+        type: integer
+        format: int32
+        description: >
+          Number of clusters deleted during the check.

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineClusterControllerTest.java
@@ -13,12 +13,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.notebooks.NotebooksConfig;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
@@ -75,9 +72,6 @@ public class OfflineClusterControllerTest {
       return config;
     }
   }
-
-  @Captor
-  private ArgumentCaptor<Map<String, String>> mapCaptor;
 
   @Autowired
   ClusterApi clusterApi;

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineClusterControllerTest.java
@@ -1,0 +1,178 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.notebooks.NotebooksConfig;
+import org.pmiops.workbench.notebooks.api.ClusterApi;
+import org.pmiops.workbench.notebooks.model.Cluster;
+import org.pmiops.workbench.notebooks.model.ClusterStatus;
+import org.pmiops.workbench.test.FakeClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class OfflineClusterControllerTest {
+  private static final Instant NOW = Instant.parse("1988-12-26T00:00:00Z");
+  private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
+  private static final Duration MAX_AGE = Duration.ofDays(14);
+  private static final Duration IDLE_MAX_AGE = Duration.ofDays(7);
+
+  @TestConfiguration
+  @Import({
+    OfflineClusterController.class
+  })
+  static class Configuration {
+    @MockBean
+    @Qualifier(NotebooksConfig.SERVICE_CLUSTER_API)
+    private ClusterApi clusterApi;
+
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+
+    @Bean
+    public WorkbenchConfig workbenchConfig() {
+      WorkbenchConfig config = new WorkbenchConfig();
+      config.firecloud = new WorkbenchConfig.FireCloudConfig();
+      config.firecloud.clusterMaxAgeDays = (int) MAX_AGE.toDays();
+      config.firecloud.clusterIdleMaxAgeDays = (int) IDLE_MAX_AGE.toDays();
+      return config;
+    }
+  }
+
+  @Captor
+  private ArgumentCaptor<Map<String, String>> mapCaptor;
+
+  @Autowired
+  ClusterApi clusterApi;
+  @Autowired
+  OfflineClusterController controller;
+  private int projectIdIndex = 0;
+
+  @Before
+  public void setUp() {
+    CLOCK.setInstant(NOW);
+    projectIdIndex = 0;
+  }
+
+  private Cluster clusterWithAge(Duration age) {
+    return clusterWithAgeAndIdle(age, Duration.ZERO);
+  }
+
+  private Cluster clusterWithAgeAndIdle(Duration age, Duration idleTime) {
+    // There should only be one cluster per project, so increment an index for
+    // each cluster created per test.
+    return new Cluster()
+        .clusterName("all-of-us")
+        .googleProject(String.format("proj-%d", projectIdIndex++))
+        .status(ClusterStatus.RUNNING)
+        .createdDate(NOW.minus(age).toString())
+        .dateAccessed(NOW.minus(idleTime).toString());
+  }
+
+  private void stubClusters(List<Cluster> clusters) throws Exception {
+    when(clusterApi.listClusters(any(), any())).thenReturn(clusters);
+    for (Cluster c : clusters) {
+      when(clusterApi.getCluster(c.getGoogleProject(), c.getClusterName())).thenReturn(c);
+    }
+  }
+
+  @Test
+  public void testCheckClustersNoResults() throws Exception {
+    stubClusters(ImmutableList.of());
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(0);
+
+    verify(clusterApi, never()).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersActiveCluster() throws Exception {
+    stubClusters(ImmutableList.of(clusterWithAge(Duration.ofHours(10))));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(0);
+
+    verify(clusterApi, never()).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersActiveTooOld() throws Exception {
+    stubClusters(ImmutableList.of(clusterWithAge(MAX_AGE.plusMinutes(5))));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(1);
+
+    verify(clusterApi, times(1)).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersIdleYoung() throws Exception {
+    // Running for under the IDLE_MAX_AGE, idle for 10 hours
+    stubClusters(ImmutableList.of(
+        clusterWithAgeAndIdle(IDLE_MAX_AGE.minusMinutes(10), Duration.ofHours(10))));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(0);
+
+    verify(clusterApi, never()).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersIdleOld() throws Exception {
+    // Running for >IDLE_MAX_AGE, idle for 10 hours
+    stubClusters(ImmutableList.of(
+        clusterWithAgeAndIdle(IDLE_MAX_AGE.plusMinutes(15), Duration.ofHours(10))));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(1);
+
+    verify(clusterApi, times(1)).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersBrieflyIdleOld() throws Exception {
+    // Running for >IDLE_MAX_AGE, idle for only 15 minutes
+    stubClusters(ImmutableList.of(
+        clusterWithAgeAndIdle(IDLE_MAX_AGE.plusMinutes(15), Duration.ofMinutes(15))));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(0);
+
+    verify(clusterApi, never()).deleteCluster(any(), any());
+  }
+
+  @Test
+  public void testCheckClustersOtherStatusFiltered() throws Exception {
+    stubClusters(ImmutableList.of(
+        clusterWithAge(MAX_AGE.plusDays(10)).status(ClusterStatus.DELETING)));
+    assertThat(controller.checkClusters().getBody().getClusterDeletionCount()).isEqualTo(0);
+
+    verify(clusterApi, never()).deleteCluster(any(), any());
+  }
+}


### PR DESCRIPTION
- Update Leo APIs
- Factor out service account access token creation
- Add an endpoint which cleans up running notebook clusters
- Add configuration for the maximum allowed lifetime for a cluster

A follow up change will add the cronjob configuration for this.