### PR TITLE
[RW-696][RW-697][risk=no] Upgrade Jackson

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -205,9 +205,9 @@ dependencies {
   }
   compile 'org.springframework.security:spring-security-web:+'
 
-  compile 'com.fasterxml.jackson.core:jackson-annotations:+'
-  compile 'com.fasterxml.jackson.core:jackson-core:+'
-  compile 'com.fasterxml.jackson.core:jackson-databind:+'
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
   compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0'
   compile 'com.google.apis:google-api-services-oauth2:+'
   compile 'com.google.cloud:google-cloud-bigquery:0.30.0-beta'

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -111,9 +111,9 @@ dependencies {
   }
   compile 'org.springframework.security:spring-security-web:+'
 
-  compile 'com.fasterxml.jackson.core:jackson-annotations:+'
-  compile 'com.fasterxml.jackson.core:jackson-core:+'
-  compile 'com.fasterxml.jackson.core:jackson-databind:+'
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
   compile 'joda-time:joda-time:+'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'


### PR DESCRIPTION
## Addresses
https://precisionmedicineinitiative.atlassian.net/browse/RW-696
https://precisionmedicineinitiative.atlassian.net/browse/RW-697

## Changes
Upgraded jackson library to the latest. The recommended solution is to upgrade to 2.9.4 or higher. I chose to bump that to the latest version instead. 

See security warning here: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32043

Tested both unit tests and integration tests locally. Tested functionally via a versioned deployment.