### PR TITLE
[RW-745][risk=no] Attempt to fix Codacy globs

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,6 +4,6 @@ engines:
     base_sub_dir: ui
 exclude_paths:
   // These SQL files are templated for env var substitution, which causes lint complaints.
-  - '**/*.sql'
+  - '**.sql'
   // We use Typescript; JS files are for tool configuration only.
-  - '**/*.js'
+  - '**.js'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,6 +4,6 @@ engines:
     base_sub_dir: ui
 exclude_paths:
   // These SQL files are templated for env var substitution, which causes lint complaints.
-  - '*.sql'
+  - '**/*.sql'
   // We use Typescript; JS files are for tool configuration only.
-  - '*.js'
+  - '**/*.js'


### PR DESCRIPTION
This glob seemingly only matched files at the root. The config file documentation is quite sparse, but this new approach seems to be the way that many other repo's setup their globs.