### PR TITLE
[RW-755][risk=no] Avoid n^2 regex pattern

### DIFF
--- a/ui/src/app/views/account-creation/component.spec.ts
+++ b/ui/src/app/views/account-creation/component.spec.ts
@@ -120,4 +120,15 @@ describe('AccountCreationComponent', () => {
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeFalsy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeFalsy();
   }));
+
+  it('handles long username with mismatch at end', fakeAsync(() => {
+    page.readPageData();
+
+    simulateInput(
+      page.fixture, page.usernameField, 'thisisaverylongusernamewithnowspaceswillitwork t');
+    tick(300);
+    tick();
+    expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeTruthy();
+    expect(page.usernameField.classes.unsuccessfulInput).toBeTruthy();
+  }));
 });

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -93,10 +93,10 @@ export class AccountCreationComponent {
       return true;
     }
     // Include alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
-    if (username.includes('..')) {
-      return false;
+    if (username.includes('..') || username.endsWith('.')) {
+      return true;
     }
-    return !(new RegExp(/^[\w-][\w-.]*$/).test(username));
+    return !(new RegExp(/^[\w-][\w.-]*$/).test(username));
   }
 
   usernameChanged(): void {

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -96,7 +96,7 @@ export class AccountCreationComponent {
     if (username.includes('..') || username.endsWith('.')) {
       return true;
     }
-    return !(new RegExp(/^[\w-][\w.-]*$/).test(username));
+    return !(new RegExp(/^[\w'-][\w.'-]*$/).test(username));
   }
 
   usernameChanged(): void {

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -93,7 +93,10 @@ export class AccountCreationComponent {
       return true;
     }
     // Include alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
-    return !(new RegExp(/^[\w-']([.]{0,1}[\w-']+)*$/).test(username));
+    if (username.includes('..')) {
+      return false;
+    }
+    return !(new RegExp(/^[\w-][\w-.]*$/).test(username));
   }
 
   usernameChanged(): void {


### PR DESCRIPTION
A mismatch at the end of the string means we have to traverse a graph with binary branching for the `.` vs `.char`. Add regression test.

Also drop `'` from valid username characters, was this included by mistake?