### PR TITLE
Retry billing project creation twice

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -8,7 +8,8 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
-    "registeredDomainName": "all-of-us-registered-test"
+    "registeredDomainName": "all-of-us-registered-test",
+    "billingRetryCount": 2
   },
   "auth": {
     "serviceAccountApiUsers": [ "all-of-us-workbench-test@appspot.gserviceaccount.com" ]

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -7,7 +7,8 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",
-    "registeredDomainName": "all-of-us-registered-stable"
+    "registeredDomainName": "all-of-us-registered-stable",
+    "billingRetryCount": 2
   },
   "auth": {
     "serviceAccountApiUsers": [ "all-of-us-rw-stable@appspot.gserviceaccount.com" ]

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -7,7 +7,8 @@
     "debugEndpoints": false,
     "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-staging-scripts/setup_notebook_cluster.sh",
-    "registeredDomainName": "all-of-us-registered-staging"
+    "registeredDomainName": "all-of-us-registered-staging",
+    "billingRetryCount": 2
   },
   "auth": {
     "serviceAccountApiUsers": [ "all-of-us-rw-staging@appspot.gserviceaccount.com" ]

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -8,7 +8,8 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
-    "registeredDomainName": "all-of-us-registered-test"
+    "registeredDomainName": "all-of-us-registered-test",
+    "billingRetryCount": 2
   },
   "auth": {
     "serviceAccountApiUsers": [ "all-of-us-workbench-test@appspot.gserviceaccount.com" ]

--- a/api/db/changelog/db.changelog-41-billing-project-retry.xml
+++ b/api/db/changelog/db.changelog-41-billing-project-retry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="brubenst" id="changelog-41-billing-project-retry">
+    <addColumn tableName="user">
+      <column name="billing_project_retry" type="INTEGER" />
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -48,4 +48,5 @@
   <include file="changelog/db.changelog-38.xml"/>
   <include file="changelog/db.changelog-39-add-cluster-retry-number.xml"/>
   <include file="changelog/db.changelog-40-remove-blockscore.xml"/>
+  <include file="changelog/db.changelog-41-billing-project-retry.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -25,6 +25,7 @@ public class WorkbenchConfig {
     public String registeredDomainName;
     public boolean enforceRegistered;
     public String jupyterUserScriptUri;
+    public Integer billingRetryCount;
   }
 
   public static class AuthConfig {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -183,6 +183,16 @@ public class UserService {
     });
   }
 
+  public User setBillingRetryCount(int billingRetryCount) {
+    return updateWithRetries(new Function<User, User>() {
+      @Override
+      public User apply(User user) {
+        user.setBillingProjectRetries(billingRetryCount);
+        return user;
+      }
+    });
+  }
+
   public List<User> getNonVerifiedUsers() {
     return userDao.findUserNotValidated();
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -193,6 +193,17 @@ public class UserService {
     });
   }
 
+  public User setBillingProjectNameAndStatus(String name, BillingProjectStatus status) {
+    return updateWithRetries(new Function<User, User>() {
+      @Override
+      public User apply(User user) {
+        user.setFreeTierBillingProjectName(name);
+        user.setFreeTierBillingProjectStatus(status);
+        return user;
+      }
+    });
+  }
+
   public List<User> getNonVerifiedUsers() {
     return userDao.findUserNotValidated();
   }

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -57,6 +57,7 @@ public class User {
   private String areaOfResearch;
   private Boolean twoFactorEnabled = false;
   private Integer clusterCreateRetries;
+  private Integer billingProjectRetries;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -296,5 +297,14 @@ public class User {
 
   public void setClusterCreateRetries(Integer clusterCreateRetries) {
     this.clusterCreateRetries = clusterCreateRetries;
+  }
+
+  @Column(name = "billing_project_retries")
+  public Integer getBillingProjectRetries() {
+    return billingProjectRetries;
+  }
+
+  public void setBillingProjectRetries(Integer billingProjectRetries) {
+    this.billingProjectRetries = billingProjectRetries;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -50,6 +50,12 @@ public interface FireCloudService {
   void addUserToBillingProject(String email, String projectName);
 
   /**
+   * Removes the specified user from the specified billing project.
+   * Only used for errored billing projects
+   */
+  void removeUserFromBillingProject(String email, String projectName);
+
+  /**
    * Creates a new FC workspace.
    */
   void createWorkspace(String projectName, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -156,6 +156,15 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
+  public void removeUserFromBillingProject(String email, String projectName) {
+    BillingApi billingApi = billingApiProvider.get();
+    retryHandler.run((context) -> {
+      billingApi.removeUserFromBillingProject(projectName, USER_FC_ROLE, email);
+      return null;
+    });
+  }
+
+  @Override
   public void createWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     WorkspaceIngest workspaceIngest = new WorkspaceIngest();

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -145,6 +145,49 @@ paths:
               - openid
               - email
               - profile
+      delete:
+        responses:
+          '200':
+            description: Successfully Removed User From Billing Project
+          '403':
+            description: You must be a project owner to add a user to a billing project
+            schema:
+              $ref: '#/definitions/ErrorReport'
+          '404':
+            description: User not found
+            schema:
+              $ref: '#/definitions/ErrorReport'
+          '500':
+            description: Rawls Internal Error
+            schema:
+              $ref: '#/definitions/ErrorReport'
+        description: remove user or group from billing project the caller owns
+        parameters:
+          - in: path
+            description: Project ID
+            name: projectId
+            required: true
+            type: string
+          - in: path
+            description: role of user for project
+            name: workbenchRole
+            required: true
+            type: string
+            enum: ["user", "owner"]
+          - in: path
+            description: email of user or group to remove
+            name: email
+            required: true
+            type: string
+        tags:
+          - billing
+        summary: remove user or group from billing project the caller owns
+        operationId: removeUserFromBillingProject
+        security:
+          - authorization:
+              - openid
+              - email
+              - profile
 
   /api/billing/{projectId}/googleRole/{role}/{email}:
     put:


### PR DESCRIPTION
Open question (which is somewhat rhetorical): Should we log the error message we get back from Firecloud? I assume yes, but it will involve reworking what we get back from list billing projects to include a bit more info than just the status.