### PR TITLE
[risk=no] workspace/build -> workspaces/build for consistency

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -138,7 +138,7 @@ const routes: Routes = [
         component: SettingsComponent,
         data: {title: 'Settings'}
       }, {
-        path: 'workspace/build',
+        path: 'workspaces/build',
         component: WorkspaceEditComponent,
         data: {title: 'Create Workspace', mode: WorkspaceEditMode.Create}
       }

--- a/ui/src/app/views/homepage/component.ts
+++ b/ui/src/app/views/homepage/component.ts
@@ -130,7 +130,7 @@ export class HomepageComponent implements OnInit, OnDestroy {
   }
 
   addWorkspace(): void {
-    this.router.navigate(['workspace/build'], {relativeTo : this.route});
+    this.router.navigate(['workspaces/build'], {relativeTo : this.route});
   }
 
   navigateToProfile(): void {

--- a/ui/src/app/views/workspace-list/component.ts
+++ b/ui/src/app/views/workspace-list/component.ts
@@ -93,7 +93,7 @@ export class WorkspaceListComponent implements OnInit, OnDestroy {
   }
 
   addWorkspace(): void {
-    this.router.navigate(['workspace/build']);
+    this.router.navigate(['workspaces/build']);
   }
 
   get twoFactorBannerEnabled() {


### PR DESCRIPTION
Consistent with the rest of the `/workspaces` URLs, as well as the pattern used for `/cohorts/build`.