### PR TITLE
[risk=no] Yet another attempt at Codacy exclusion

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,3 +2,5 @@ engines:
   tslint:
     enabled: true
     base_sub_dir: ui
+exclude_paths:	
+  - ui/karma.conf.js


### PR DESCRIPTION
Hopefully I will have better luck with a more explicit file path. Unfortunately ignoring this file via the UI got overruled on the next Codacy run, where it presumably pulled in codacy.yml again. I've chipped away at the style rules to the point where this is the only remaining file with issues...