### PR TITLE
[RW-680][RW-432][risk=low] Notebook redirect instead of modal

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -11,6 +11,7 @@ import {AdminReviewWorkspaceComponent} from './views/admin-review-workspace/comp
 import {CohortEditComponent} from './views/cohort-edit/component';
 import {HomepageComponent} from './views/homepage/component';
 import {LoginComponent} from './views/login/component';
+import {NotebookRedirectComponent} from './views/notebook-redirect/component';
 import {ProfilePageComponent} from './views/profile-page/component';
 import {SettingsComponent} from './views/settings/component';
 import {SignedInComponent} from './views/signed-in/component';
@@ -117,7 +118,19 @@ const routes: Routes = [
               resolve: {
                 cohort: CohortResolver,
               },
-            }],
+            }, {
+              path: 'notebooks/create',
+              component: NotebookRedirectComponent,
+              data: {
+                title: 'Creating a new Notebook'
+              }
+            }, {
+              path: 'notebooks/:nbName',
+              component: NotebookRedirectComponent,
+              data: {
+                title: 'Opening a Notebook'
+              }
+            }]
           }
         ]
       },

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -46,34 +46,35 @@ const routes: Routes = [
     canActivateChild: [SignInGuard],
     runGuardsAndResolvers: 'always',
     children: [
+      {
+        path: '',
+        component: HomepageComponent,
+        data: {title: 'Homepage'},
+      }, {
+      path: 'workspaces',
+      data: {breadcrumb: 'Workspaces'},
+      children: [
         {
           path: '',
-          component: HomepageComponent,
-          data: {title: 'Homepage'},
-        }, {
-        path: 'workspaces',
-        data: {breadcrumb: 'Workspaces'},
-        children: [
-          {
-            path: '',
-            component: WorkspaceListComponent,
-            data: {title: 'View Workspaces'}
+          component: WorkspaceListComponent,
+          data: {title: 'View Workspaces'}
+        },
+        {
+          /* TODO The children under ./views need refactoring to use the data
+           * provided by the route rather than double-requesting it.
+           */
+          path: ':ns/:wsid',
+          component: WorkspaceNavBarComponent,
+          data: {
+            title: 'View Workspace Details',
+            breadcrumb: 'Param: Workspace Name'
           },
-          {
-            /* TODO The children under ./views need refactoring to use the data
-             * provided by the route rather than double-requesting it.
-             */
-            path: ':ns/:wsid',
-            component: WorkspaceNavBarComponent,
-            data: {
-              title: 'View Workspace Details',
-              breadcrumb: 'Param: Workspace Name'
-            },
-            runGuardsAndResolvers: 'always',
-            resolve: {
-              workspace: WorkspaceResolver,
-            },
-            children: [{
+          runGuardsAndResolvers: 'always',
+          resolve: {
+            workspace: WorkspaceResolver,
+          },
+          children: [
+            {
               path: '',
               component: WorkspaceComponent,
               data: {
@@ -118,18 +119,6 @@ const routes: Routes = [
               resolve: {
                 cohort: CohortResolver,
               },
-            }, {
-              path: 'notebooks/create',
-              component: NotebookRedirectComponent,
-              data: {
-                title: 'Creating a new Notebook'
-              }
-            }, {
-              path: 'notebooks/:nbName',
-              component: NotebookRedirectComponent,
-              data: {
-                title: 'Opening a Notebook'
-              }
             }]
           }
         ]
@@ -154,6 +143,21 @@ const routes: Routes = [
         path: 'workspaces/build',
         component: WorkspaceEditComponent,
         data: {title: 'Create Workspace', mode: WorkspaceEditMode.Create}
+      }, {
+        // The notebook redirect pages are interstitial pages, so we want to
+        // them special chrome treatment - we therefore put them outside the
+        // normal /workspaces hierarchy.
+        path: 'workspaces/:ns/:wsid/notebooks/create',
+        component: NotebookRedirectComponent,
+        data: {
+          title: 'Creating a new Notebook'
+        }
+      }, {
+        path: 'workspaces/:ns/:wsid/notebooks/:nbName',
+        component: NotebookRedirectComponent,
+        data: {
+          title: 'Opening a Notebook'
+        }
       }
     ]
   }

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -145,8 +145,8 @@ const routes: Routes = [
         data: {title: 'Create Workspace', mode: WorkspaceEditMode.Create}
       }, {
         // The notebook redirect pages are interstitial pages, so we want to
-        // them special chrome treatment - we therefore put them outside the
-        // normal /workspaces hierarchy.
+        // give them special chrome treatment - we therefore put them outside
+        // the normal /workspaces hierarchy.
         path: 'workspaces/:ns/:wsid/notebooks/create',
         component: NotebookRedirectComponent,
         data: {

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -80,8 +80,7 @@ export function getConfiguration(signInService: SignInService): Configuration {
   });
 }
 
-export function getLeoConfiguration(
-    signInService: SignInService, configService: ConfigService): LeoConfiguration {
+export function getLeoConfiguration(signInService: SignInService): LeoConfiguration {
   return new LeoConfiguration({
     basePath: environment.leoApiUrl,
     accessToken: () => signInService.currentAccessToken

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -31,6 +31,7 @@ import {HomepageComponent} from './views/homepage/component';
 import {InitialErrorComponent} from './views/initial-error/component';
 import {InvitationKeyComponent} from './views/invitation-key/component';
 import {LoginComponent} from './views/login/component';
+import {NotebookRedirectComponent} from './views/notebook-redirect/component';
 import {PageTemplateSignedOutComponent} from './views/page-template-signed-out/component';
 import {ProfilePageComponent} from './views/profile-page/component';
 import {RoutingSpinnerComponent} from './views/routing-spinner/component';
@@ -119,6 +120,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     InitialErrorComponent,
     InvitationKeyComponent,
     LoginComponent,
+    NotebookRedirectComponent,
     PageTemplateSignedOutComponent,
     ProfilePageComponent,
     RoutingSpinnerComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -17,6 +17,7 @@ import {ServerConfigService} from './services/server-config.service';
 import {SignInService} from './services/sign-in.service';
 import {StatusCheckService} from './services/status-check.service';
 import {WorkspaceStorageService} from './services/workspace-storage.service';
+import {WINDOW_REF} from './utils';
 
 import {AccountCreationSuccessComponent} from './views/account-creation-success/component';
 import {AccountCreationComponent} from './views/account-creation/component';
@@ -165,6 +166,10 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
       useClass: InterceptedHttp,
       deps: [XHRBackend, RequestOptions, ErrorHandlingService]
     },
+    {
+      provide: WINDOW_REF,
+      useValue: window
+    }
   ],
   // This specifies the top-level components, to load first.
   bootstrap: [AppComponent, ErrorHandlerComponent, InitialErrorComponent]

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -80,7 +80,8 @@ export function getConfiguration(signInService: SignInService): Configuration {
   });
 }
 
-export function getLeoConfiguration(signInService: SignInService): LeoConfiguration {
+export function getLeoConfiguration(
+    signInService: SignInService, configService: ConfigService): LeoConfiguration {
   return new LeoConfiguration({
     basePath: environment.leoApiUrl,
     accessToken: () => signInService.currentAccessToken

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -1,6 +1,8 @@
 import {Router} from '@angular/router';
 import {fromJS} from 'immutable';
 
+export const WINDOW_REF = 'window-ref';
+
 export function isBlank(toTest: String): boolean {
   if (toTest === null) {
     return true;

--- a/ui/src/app/views/notebook-redirect/component.css
+++ b/ui/src/app/views/notebook-redirect/component.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
+  margin-top: 2rem;
 }
 
 .spinner {

--- a/ui/src/app/views/notebook-redirect/component.css
+++ b/ui/src/app/views/notebook-redirect/component.css
@@ -1,0 +1,21 @@
+.spinner-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+}
+
+.spinner {
+  margin-top: 1rem;
+}
+
+.spinner-header {
+  color: #007CBB;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.spinner-text {
+  text-align: center;
+  /* This forces the flex layout to put the text on a new line. */
+  width: 100%;
+}

--- a/ui/src/app/views/notebook-redirect/component.html
+++ b/ui/src/app/views/notebook-redirect/component.html
@@ -1,0 +1,15 @@
+<h2 *ngIf="notebookName">Loading Notebook '{{notebookName}}'</h2>
+<h2 *ngIf="!notebookName">Creating a New Notebook</h2>
+<div [ngSwitch]="progress" class="spinner-container">
+  <span class="spinner spinner-lg"></span>
+  <p *ngSwitchCase="Progress.Initializing" class="spinner-text">
+    <span class="spinner-header">Initializing Notebook Server</span><br>
+    May take up to 5 minutes
+  </p>
+  <p *ngSwitchCase="Progress.Configuring" class="spinner-text">
+    Configuring Notebook Server
+  </p>
+  <p *ngSwitchCase="Progress.Redirecting" class="spinner-text">
+    Redirecting to the Notebook Server
+  </p>
+</div>

--- a/ui/src/app/views/notebook-redirect/component.html
+++ b/ui/src/app/views/notebook-redirect/component.html
@@ -3,13 +3,23 @@
 <div [ngSwitch]="progress" class="spinner-container">
   <span class="spinner spinner-lg"></span>
   <p *ngSwitchCase="Progress.Initializing" class="spinner-text">
-    <span class="spinner-header">Initializing Notebook Server</span><br>
+    <span class="spinner-header">Initializing notebook server</span><br>
     May take up to 5 minutes
   </p>
-  <p *ngSwitchCase="Progress.Configuring" class="spinner-text">
-    Configuring Notebook Server
+  <p *ngSwitchCase="Progress.Resuming" class="spinner-text">
+    <span class="spinner-header">Resuming notebook server</span><br>
+    May take up to 1 minute
+  </p>
+  <p *ngSwitchCase="Progress.Authenticating" class="spinner-text">
+    Authenticating with the notebook server
+  </p>
+  <p *ngSwitchCase="Progress.Copying" class="spinner-text">
+    Copying notebook onto the notebook server
+  </p>
+  <p *ngSwitchCase="Progress.Creating" class="spinner-text">
+    Creating the new notebook
   </p>
   <p *ngSwitchCase="Progress.Redirecting" class="spinner-text">
-    Redirecting to the Notebook Server
+    Redirecting to the notebook server
   </p>
 </div>

--- a/ui/src/app/views/notebook-redirect/component.spec.ts
+++ b/ui/src/app/views/notebook-redirect/component.spec.ts
@@ -1,0 +1,223 @@
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {Response, ResponseOptions} from '@angular/http';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ActivatedRoute} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ClarityModule} from '@clr/angular';
+import {AsyncSubject} from 'rxjs/AsyncSubject';
+import {Observable} from 'rxjs/Observable';
+
+import {WINDOW_REF} from 'app/utils';
+import {NotebookRedirectComponent} from 'app/views/notebook-redirect/component';
+import {environment} from 'environments/environment';
+import {ClusterServiceStub} from 'testing/stubs/cluster-service-stub';
+import {JupyterServiceStub} from 'testing/stubs/jupyter-service-stub';
+import {LeoClusterServiceStub} from 'testing/stubs/leo-cluster-service-stub';
+import {NotebooksServiceStub} from 'testing/stubs/notebooks-service-stub';
+import {WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
+import {simulateClick, updateAndTick} from 'testing/test-helpers';
+
+import {
+  ClusterLocalizeRequest,
+  ClusterLocalizeResponse,
+  ClusterService,
+  ClusterStatus
+} from 'generated';
+import {
+  ClusterService as LeoClusterService,
+  JupyterService,
+  NotebooksService,
+} from 'notebooks-generated';
+
+
+class BlockingNotebooksStub extends NotebooksServiceStub {
+  private blocker = new AsyncSubject<null>();
+
+  public block() {
+    this.blocker = new AsyncSubject<null>();
+  }
+
+  public release() {
+    this.blocker.next(null);
+    this.blocker.complete();
+  }
+
+  public setCookieWithHttpInfo(
+      googleProject: string, clusterName: string,
+      extraHttpRequestParams?: any): Observable<Response> {
+    return this.blocker.flatMap(() => {
+      return super.setCookieWithHttpInfo(
+        googleProject, clusterName, extraHttpRequestParams);
+    });
+  }
+}
+
+class BlockingClusterStub extends ClusterServiceStub {
+  private blocker = new AsyncSubject<null>();
+
+  public block() {
+    this.blocker = new AsyncSubject<null>();
+  }
+
+  public release() {
+    this.blocker.next(null);
+    this.blocker.complete();
+  }
+
+  localize(projectName: string, clusterName: string,
+      req: ClusterLocalizeRequest, extraHttpRequestParams?: any): Observable<{}> {
+    return this.blocker.flatMap(() => {
+      return super.localize(projectName, clusterName, req, extraHttpRequestParams);
+    });
+  }
+}
+
+describe('NotebookRedirectComponent', () => {
+  let fixture: ComponentFixture<NotebookRedirectComponent>;
+  let blockingClusterStub: BlockingClusterStub;
+  let blockingNotebooksStub: BlockingNotebooksStub;
+  let fakeWindow: any;
+
+  beforeEach(fakeAsync(() => {
+    blockingClusterStub = new BlockingClusterStub();
+    blockingClusterStub.cluster.status = ClusterStatus.Creating;
+    blockingNotebooksStub = new BlockingNotebooksStub();
+
+    fakeWindow = {location: {href: ''}};
+    TestBed.configureTestingModule({
+      declarations: [
+        NotebookRedirectComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        RouterTestingModule,
+        ClarityModule.forRoot()
+      ],
+      providers: [
+        { provide: WINDOW_REF, useFactory: () => fakeWindow },
+        { provide: ClusterService, useFactory: () => blockingClusterStub },
+        { provide: LeoClusterService, useValue: new LeoClusterServiceStub() },
+        { provide: NotebooksService, useFactory: () => blockingNotebooksStub },
+        { provide: JupyterService, useValue: new JupyterServiceStub() },
+        { provide: ActivatedRoute, useValue: {
+          snapshot: {
+            params: {
+              'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+              'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+            },
+          }
+        }},
+      ]}).compileComponents();
+  }));
+
+  function spinnerText() {
+    return fixture.debugElement.query(By.css('.spinner-text'))
+      .nativeElement.textContent;
+  }
+
+  beforeEach(fakeAsync(() => {
+    fixture = TestBed.createComponent(NotebookRedirectComponent);
+    blockingClusterStub.release();
+    blockingNotebooksStub.release();
+  }));
+
+  it('should render', fakeAsync(() => {
+    updateAndTick(fixture);
+    expect(fixture.componentRef).toBeTruthy();
+
+    // Tears down the retrying subscription.
+    fixture.destroy();
+  }));
+
+  it('should redirect', fakeAsync(() => {
+    updateAndTick(fixture);
+    expect(fakeWindow.location.href).toEqual('');
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    tick(10000);
+    updateAndTick(fixture);
+
+    expect(fakeWindow.location.href.startsWith(environment.leoApiUrl)).toBeTruthy();
+    expect(fakeWindow.location.href).toContain('/notebooks');
+  }));
+
+  it('should display "Initializing" until ready', fakeAsync(() => {
+    updateAndTick(fixture);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Initializing');
+
+    tick(10000);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Initializing');
+
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    tick(10000);
+    fixture.detectChanges();
+    expect(spinnerText()).not.toContain('Initializing');
+  }));
+
+  it('should display "Resuming" until resumed', fakeAsync(() => {
+    blockingClusterStub.cluster.status = ClusterStatus.Stopped;
+    updateAndTick(fixture);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Resuming');
+
+    tick(10000);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Resuming');
+
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    tick(10000);
+    fixture.detectChanges();
+    expect(spinnerText()).not.toContain('Resuming');
+  }));
+
+  it('should display "Authenticating" while setting cookies', fakeAsync(() => {
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    blockingNotebooksStub.block();
+    updateAndTick(fixture);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Authenticating');
+
+    blockingNotebooksStub.release();
+    tick();
+    fixture.detectChanges();
+    expect(spinnerText()).not.toContain('Authenticating');
+  }));
+
+  it('should display "Creating" while creating a new notebook', fakeAsync(() => {
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    blockingClusterStub.block();
+    updateAndTick(fixture);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Creating');
+
+    blockingClusterStub.release();
+    tick();
+    fixture.detectChanges();
+    expect(spinnerText()).not.toContain('Creating');
+  }));
+
+  it('should display "Copying" while localizing', fakeAsync(() => {
+    updateAndTick(fixture);
+
+    fixture.componentInstance.notebookName = 'foo.ipynb';
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    blockingClusterStub.block();
+    tick(10000);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Copying');
+
+    blockingClusterStub.release();
+    tick();
+    fixture.detectChanges();
+    expect(spinnerText()).not.toContain('Copying');
+  }));
+
+  it('should display "Redirecting" while redirecting', fakeAsync(() => {
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    updateAndTick(fixture);
+    fixture.detectChanges();
+    expect(spinnerText()).toContain('Redirecting');
+  }));
+});

--- a/ui/src/app/views/notebook-redirect/component.ts
+++ b/ui/src/app/views/notebook-redirect/component.ts
@@ -1,0 +1,131 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Headers, Http, Response} from '@angular/http';
+import {ActivatedRoute} from '@angular/router';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+
+import {SignInService} from 'app/services/sign-in.service';
+
+import {
+  Cluster,
+  ClusterService,
+  ClusterStatus,
+} from 'generated';
+import {
+  JupyterService,
+  NotebooksService,
+} from 'notebooks-generated';
+
+enum Progress {
+  Unknown,
+  Initializing,
+  Configuring,
+  Redirecting
+}
+
+@Component({
+  styleUrls: ['../../styles/buttons.css',
+              '../../styles/cards.css',
+              '../../styles/headers.css',
+              '../../styles/inputs.css',
+              './component.css'],
+  templateUrl: './component.html',
+})
+export class NotebookRedirectComponent implements OnInit, OnDestroy {
+  Progress = Progress;
+
+  progress = Progress.Unknown;
+  notebookName: string;
+
+  private wsId: string;
+  private wsNamespace: string;
+  private loadingSub: Subscription;
+  private cluster: Cluster;
+
+  constructor(
+    private route: ActivatedRoute,
+    private clusterService: ClusterService,
+    private signInService: SignInService,
+    private leoNotebooksService: NotebooksService,
+    private jupyterService: JupyterService,
+    private http: Http) {}
+
+  ngOnInit(): void {
+    this.wsNamespace = this.route.snapshot.params['ns'];
+    this.wsId = this.route.snapshot.params['wsid'];
+    this.notebookName = this.route.snapshot.params['nbName'];
+
+    this.loadingSub = this.clusterService.listClusters()
+      .flatMap((resp) => {
+        const c = resp.defaultCluster;
+        // TODO:
+        //  - Resume here if suspended. Throw an error from the resume Obs.
+        //  - Fail if the cluster enters permanent error mode.
+        if (c.status === ClusterStatus.Running) {
+          return Observable.from([c]);
+        }
+        this.progress = Progress.Initializing;
+        throw Error(`cluster has status ${c.status}`);
+      })
+      .retryWhen(errs => errs.delay(10000))
+      .do((c) => {
+        this.cluster = c;
+        this.progress = Progress.Configuring;
+      })
+      .flatMap(c => this.initializeNotebookCookies(c))
+      .flatMap(c => {
+        // This will contain the Jupyter-local path to the localized notebook.
+        if (this.notebookName) {
+          return this.localizeNotebooks([this.notebookName])
+            .map(localDir => `${localDir}/${this.notebookName}`);
+        }
+        return this.newNotebook();
+      })
+      .subscribe((nbName) => {
+        this.progress = Progress.Redirecting;
+        window.location.href = `${this.clusterUrl(this.cluster)}/notebooks/${nbName}`;
+      });
+  }
+
+  ngOnDestroy(): void {
+    if (this.loadingSub) {
+      this.loadingSub.unsubscribe();
+    }
+  }
+
+  private clusterUrl(cluster: Cluster): string {
+    return environment.leoApiUrl + '/notebooks/'
+      + cluster.clusterNamespace + '/'
+      + cluster.clusterName;
+  }
+
+  private initializeNotebookCookies(cluster: Cluster): Observable<Cluster> {
+    return this.leoNotebooksService.setCookieWithHttpInfo(c.clusterNamespace, c.clusterName, {
+      withCredentials: true
+    }).map(_ => cluster);
+  }
+
+  private newNotebook(): Observable<string> {
+    return this.localizeNotebooks([]).flatMap((localDir) => {
+      // Use the Jupyter Server API directly to create a new notebook. This
+      // API handles notebook name collisions and matches the behavior of
+      // clicking "new notebook" in the Jupyter UI.
+      const workspaceDir = this.clusterLocalDirectory.replace(/^workspaces\//, '');
+      return this.jupyterService.postContents(
+        this.cluster.clusterNamespace, this.cluster.clusterName,
+        workspaceDir, {
+          'type': 'notebook'
+        }).map(resp => `${localDir}/${resp.json().name}`);
+    });
+  }
+
+  private localizeNotebooks(notebookNames: Array<string>): Observable<string> {
+    return this.clusterService
+      .localize(this.cluster.clusterNamespace, this.cluster.clusterName, {
+        workspaceNamespace: this.wsNamespace,
+        workspaceId: this.wsId,
+        notebookNames: notebookNames
+      })
+      .map(resp => resp.clusterLocalDirectory);
+  }
+}

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -29,6 +29,16 @@ h3 {
   margin: 1rem 0rem 0rem 1rem;
 }
 
+.spinner-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+}
+
+.spinner {
+  margin-top: 1rem;
+}
+
 .notebook-table-row {
   cursor: pointer;
 }

--- a/ui/src/app/views/workspace/component.css
+++ b/ui/src/app/views/workspace/component.css
@@ -29,28 +29,6 @@ h3 {
   margin: 1rem 0rem 0rem 1rem;
 }
 
-.spinner-container {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: center;
-}
-
-.spinner {
-  margin-top: 1rem;
-}
-
-.spinner-header {
-  color: #007CBB;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-.spinner-text {
-  text-align: center;
-  /* This forces the flex layout to put the text on a new line. */
-  width: 100%;
-}
-
 .notebook-table-row {
   cursor: pointer;
 }

--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -9,16 +9,6 @@
         <button class="btn btn-link final" [class.selected]="tabOpen === Tabs.Cohorts" (click)="tabOpen = Tabs.Cohorts">
           Cohorts ({{cohortList.length}})
         </button>
-        <div class="alert {{alertCategory}}" *ngIf="showAlerts">
-          <div class="alert-items">
-            <div class="alert-item static">
-              <div class="alert-icon-wrapper">
-                <clr-icon class="alert-icon" shape="check-circle"></clr-icon>
-              </div>
-              <span class="alert-text">{{alertMsg}}</span>
-            </div>
-          </div>
-        </div>
       </div>
       <div>
         <span role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-top-left">
@@ -30,15 +20,11 @@
         </span>
         <span role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-top-left">
           <button *ngIf="tabOpen===Tabs.Notebooks" class="btn btn-primary btn-create"
-                  [disabled]="clusterLoading || awaitingReview || !writePermission" (click)="newNotebook()">
+                  [disabled]="awaitingReview || !writePermission" (click)="newNotebook()">
             + New Notebook
           </button>
           <span *ngIf="awaitingReview" class="tooltip-content">Workspace is awaiting review</span>
           <span *ngIf="!writePermission" class="tooltip-content">Write permission required to create notebooks</span>
-          <span *ngIf="cluster && clusterLoading" class="tooltip-content">
-            Your notebook server is still being initialized - this may take up
-            to 5 minutes. Please try again later.
-          </span>
         </span>
       </div>
     </div>
@@ -87,30 +73,11 @@
       </div>
     </clr-modal>
 
-    <clr-modal [(clrModalOpen)]="clusterPulled">
-      <h3 class="modal-title">Notebook Server Ready:</h3>
-      <div class="modal-body">Your notebook server is ready, please confirm to open in a new tab</div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="openCluster(launchedNotebookName)">Ok</button>
-        <button type="button" class="btn btn-primary" (click)="cancelCluster()">Cancel</button>
-      </div>
-    </clr-modal>
-    <clr-modal [(clrModalOpen)]="localizeNotebooksError">
-      <h3 class="modal-title">Error:</h3>
-      <div class="modal-body">Could not load your notebook. Please <a (click)="submitNotebookLocalizeBugReport()">submit a bug report.</a></div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="localizeNotebooksError = false">Ok</button>
-      </div>
-    </clr-modal>
     <div *ngIf="tabOpen===Tabs.Notebooks">
-      <div *ngIf="notebooksLoading || clusterLoading" class="spinner-container">
+      <div *ngIf="notebooksLoading" class="spinner-container">
         <span class="spinner spinner-lg"></span>
-        <p *ngIf="clusterLongWait" class="spinner-text">
-          <span class="spinner-header">Initializing Notebook Server</span><br>
-          May take up to 5 minutes
-        </p>
       </div>
-      <clr-datagrid *ngIf="!notebooksLoading && !clusterLoading">
+      <clr-datagrid *ngIf="!notebooksLoading">
         <clr-dg-column [clrDgField]="'notebook.name'" [clrDgSortBy]="notebookNameComparator">
           Name
           <clr-dg-string-filter [clrDgStringFilter]="notebookNameFilter"></clr-dg-string-filter>

--- a/ui/src/testing/stubs/cluster-service-stub.ts
+++ b/ui/src/testing/stubs/cluster-service-stub.ts
@@ -1,6 +1,12 @@
 import {Observable} from 'rxjs/Observable';
 
-import {Cluster, ClusterListResponse, ClusterLocalizeRequest, ClusterStatus} from 'generated';
+import {
+  Cluster,
+  ClusterListResponse,
+  ClusterLocalizeRequest,
+  ClusterLocalizeResponse,
+  ClusterStatus
+} from 'generated';
 
 export class ClusterServiceStub {
 
@@ -26,9 +32,11 @@ export class ClusterServiceStub {
 
   localize(projectName: string, clusterName: string, req: ClusterLocalizeRequest,
       extraHttpRequestParams?: any): Observable<{}> {
-    return new Observable<{}>(observer => {
+    return new Observable<ClusterLocalizeResponse>(observer => {
       setTimeout(() => {
-        observer.next({});
+        observer.next({
+          clusterLocalDirectory: 'workspaces/${req.workspaceId}'
+        });
         observer.complete();
       }, 0);
     });

--- a/ui/src/testing/stubs/leo-cluster-service-stub.ts
+++ b/ui/src/testing/stubs/leo-cluster-service-stub.ts
@@ -1,0 +1,14 @@
+import {Observable} from 'rxjs/Observable';
+
+export class LeoClusterServiceStub {
+
+  public startCluster(googleProject: string, clusterName: string,
+      extraHttpRequestParams?: any): Observable<{}> {
+    return new Observable<{}>(observer => {
+      setTimeout(() => {
+        observer.next({});
+        observer.complete();
+      }, 0);
+    });
+  }
+}


### PR DESCRIPTION
- Add a new notebook page which waits for the cluster to load, sets up auth, and localizes or creates a notebook.
- Drop the notebook spinner from the workspaces page, instead opening/creating a notebook brings you to the new redirect page.
- Rough out a framework for a loading UX with more detailed messaging on this page (UX input pending).
- ~~Fix a bug in postMessaging of the clientId to Leonardo (I may split this out to get that in sooner)~~ https://github.com/all-of-us/workbench/pull/950

TODO
- ~~Unit test for the new view~~
- UX is a placeholder, getting input from Lou on this
- ~~Related: UX pending - we may not want the nav bar on this view~~

~~For future PRs~~
- ~~Integrate cluster "resume" into this new page~~