### PR TITLE
[risk=low] Add missing withCredentials

### DIFF
--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -229,8 +229,9 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.pollCluster().subscribe((c) => {
       // Use lower level *withHttpInfo() method to work around
       // https://github.com/DataBiosphere/leonardo/issues/444
-      this.leoNotebooksService.setCookieWithHttpInfo(c.clusterNamespace, c.clusterName)
-        .subscribe(() => {
+      this.leoNotebooksService.setCookieWithHttpInfo(c.clusterNamespace, c.clusterName, {
+        withCredentials: true
+      }).subscribe(() => {
           this.clusterLoading = false;
         });
     });


### PR DESCRIPTION
Cookie seemingly wasn't getting set without this, though it worked during local testing (possibly my cookie hadn't expired yet).