### PR TITLE
[RW-847][risk=low] Switch local/test to FC/Leo dev 

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -1,7 +1,7 @@
 // Configuration for the local development environment.
 {
   "firecloud": {
-    "baseUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
+    "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-local-",
     "clusterMaxAgeDays": 7,
@@ -9,7 +9,7 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
-    "leoBaseUrl": "https://leonardo.dsde-dev.broadinstitute.org",
+    "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2
   },

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -1,13 +1,15 @@
 // Configuration for the local development environment.
 {
   "firecloud": {
+    "baseUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
-    "billingProjectPrefix": "aou-test-f1-",
+    "billingProjectPrefix": "aou-rw-local-",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
+    "leoBaseUrl": "https://leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -1,5 +1,6 @@
 {
   "firecloud": {
+    "baseUrl": "https://api.firecloud.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-stable-",
     "clusterMaxAgeDays": 14,
@@ -7,6 +8,7 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",
+    "leoBaseUrl": "https://notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-stable",
     "billingRetryCount": 2
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -1,6 +1,6 @@
 {
   "firecloud": {
-    "baseUrl": "https://api.firecloud.org",
+    "baseUrl": "https:\/\/api.firecloud.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-stable-",
     "clusterMaxAgeDays": 14,
@@ -8,7 +8,7 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",
-    "leoBaseUrl": "https://notebooks.firecloud.org",
+    "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-stable",
     "billingRetryCount": 2
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -1,6 +1,6 @@
 {
   "firecloud": {
-    "baseUrl": "https://api.firecloud.org",
+    "baseUrl": "https:\/\/api.firecloud.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-staging-",
     "clusterMaxAgeDays": 7,
@@ -8,7 +8,7 @@
     "debugEndpoints": false,
     "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-staging-scripts/setup_notebook_cluster.sh",
-    "leoBaseUrl": "https://notebooks.firecloud.org",
+    "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-staging",
     "billingRetryCount": 2
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -1,5 +1,6 @@
 {
   "firecloud": {
+    "baseUrl": "https://api.firecloud.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-staging-",
     "clusterMaxAgeDays": 7,
@@ -7,6 +8,7 @@
     "debugEndpoints": false,
     "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-staging-scripts/setup_notebook_cluster.sh",
+    "leoBaseUrl": "https://notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-staging",
     "billingRetryCount": 2
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -1,7 +1,7 @@
 // Configuration for the all-of-us-workbench-test.
 {
   "firecloud": {
-    "baseUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
+    "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
     "billingProjectPrefix": "aou-rw-test-",
     "clusterMaxAgeDays": 7,
@@ -9,7 +9,7 @@
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
-    "leoBaseUrl": "https://leonardo.dsde-dev.broadinstitute.org",
+    "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -1,13 +1,15 @@
 // Configuration for the all-of-us-workbench-test.
 {
   "firecloud": {
+    "baseUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
     "billingAccountId": "014D91-FCB792-33D2C0",
-    "billingProjectPrefix": "aou-test-f1-",
+    "billingProjectPrefix": "aou-rw-test-",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
     "enforceRegistered": false,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-workbench-test-scripts/setup_notebook_cluster.sh",
+    "leoBaseUrl": "https://leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -948,12 +948,13 @@ def delete_clusters(cmd_name, *args)
   op.parse.validate
   gcc.validate
 
+  api_url = get_leo_api_url(gcc.project)
   ServiceAccountContext.new(gcc.project).run do
     Dir.chdir("tools") do
       common = Common.new
       common.run_inline %W{
          gradle --info manageClusters
-        -PappArgs=['delete','#{op.opts.min_age_days}','#{op.opts.cluster_ids}',#{op.opts.dry_run}]}
+        -PappArgs=['delete','#{api_url}','#{op.opts.min_age_days}','#{op.opts.cluster_ids}',#{op.opts.dry_run}]}
     end
   end
 end
@@ -971,10 +972,13 @@ def list_clusters(cmd_name, *args)
   op.parse.validate
   gcc.validate
 
+  api_url = get_leo_api_url(gcc.project)
   ServiceAccountContext.new(gcc.project).run do
     Dir.chdir("tools") do
       common = Common.new
-      common.run_inline %W{gradle --info manageClusters -PappArgs=['list']}
+      common.run_inline %W{
+        gradle --info manageClusters -PappArgs=['list','#{api_url}']
+      }
     end
   end
 end
@@ -1155,6 +1159,11 @@ def migrate_workbench_data()
   Dir.chdir("db") do
     common.run_inline(%W{gradle --info update -PrunList=data -Pcontexts=cloud})
   end
+end
+
+def get_leo_api_url(project)
+  config_json = get_config(project)
+  return JSON.parse(File.read("config/#{config_json}"))["firecloud"]["leoBaseUrl"]
 end
 
 def get_auth_domain(project)

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -19,6 +19,7 @@ public class WorkbenchConfig {
 
   public static class FireCloudConfig {
     public boolean debugEndpoints;
+    public String baseUrl;
     public String billingAccountId;
     public String billingProjectPrefix;
     public Integer clusterMaxAgeDays;
@@ -26,6 +27,7 @@ public class WorkbenchConfig {
     public String registeredDomainName;
     public boolean enforceRegistered;
     public String jupyterUserScriptUri;
+    public String leoBaseUrl;
     public Integer billingRetryCount;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -33,6 +33,7 @@ public class FireCloudConfig {
   public ApiClient fireCloudApiClient(UserAuthentication userAuthentication,
       WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(workbenchConfig.firecloud.baseUrl);
     apiClient.setAccessToken(userAuthentication.getCredentials());
     apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
     return apiClient;
@@ -43,6 +44,7 @@ public class FireCloudConfig {
   public ApiClient allOfUsApiClient(WorkbenchEnvironment workbenchEnvironment,
       WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(workbenchConfig.firecloud.baseUrl);
     try {
       apiClient.setAccessToken(
           ServiceAccounts.workbenchAccessToken(workbenchEnvironment, BILLING_SCOPES));

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
@@ -32,6 +32,7 @@ public class NotebooksConfig {
   public ApiClient notebooksApiClient(UserAuthentication userAuthentication,
       WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(workbenchConfig.firecloud.leoBaseUrl);
     apiClient.setAccessToken(userAuthentication.getCredentials());
     apiClient.setDebugging(workbenchConfig.firecloud.debugEndpoints);
     return apiClient;
@@ -42,6 +43,7 @@ public class NotebooksConfig {
   public ApiClient workbenchServiceAccountClient(
       WorkbenchEnvironment workbenchEnvironment, WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(workbenchConfig.firecloud.leoBaseUrl);
     try {
       apiClient.setAccessToken(
           ServiceAccounts.workbenchAccessToken(workbenchEnvironment, NOTEBOOK_SCOPES));

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -50,7 +50,7 @@ public class ManageClusters {
         .collect(Collectors.toSet());
   }
 
-  private static ClusterApi newApiClient(apiUrl) throws IOException {
+  private static ClusterApi newApiClient(String apiUrl) throws IOException {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(apiUrl);
     GoogleCredential credential = GoogleCredential.getApplicationDefault()
@@ -81,7 +81,7 @@ public class ManageClusters {
         clusterId(c), creator, status, c.getCreatedDate());
   }
 
-  private static void listClusters(apiUrl) throws IOException, ApiException {
+  private static void listClusters(String apiUrl) throws IOException, ApiException {
     AtomicInteger count = new AtomicInteger();
     newApiClient(apiUrl).listClusters(null, false).stream()
         .sorted(Comparator.comparing(c -> Instant.parse(c.getCreatedDate())))

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -50,8 +50,9 @@ public class ManageClusters {
         .collect(Collectors.toSet());
   }
 
-  private static ClusterApi newApiClient() throws IOException {
+  private static ClusterApi newApiClient(apiUrl) throws IOException {
     ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(apiUrl);
     GoogleCredential credential = GoogleCredential.getApplicationDefault()
         .createScoped(Arrays.asList(BILLING_SCOPES));
     credential.refreshToken();
@@ -80,9 +81,9 @@ public class ManageClusters {
         clusterId(c), creator, status, c.getCreatedDate());
   }
 
-  private static void listClusters() throws IOException, ApiException {
+  private static void listClusters(apiUrl) throws IOException, ApiException {
     AtomicInteger count = new AtomicInteger();
-    newApiClient().listClusters(null, false).stream()
+    newApiClient(apiUrl).listClusters(null, false).stream()
         .sorted(Comparator.comparing(c -> Instant.parse(c.getCreatedDate())))
         .forEachOrdered((c) -> {
               System.out.println(formatTabular(c));
@@ -91,13 +92,14 @@ public class ManageClusters {
     System.out.println(String.format("listed %d clusters", count.get()));
   }
 
-  private static void deleteClusters(@Nullable Instant oldest, Set<String> ids, boolean dryRun)
+  private static void deleteClusters(
+      String apiUrl, @Nullable Instant oldest, Set<String> ids, boolean dryRun)
       throws IOException, ApiException {
     Set<String> remaining = new HashSet<>(ids);
     String dryMsg = dryRun? "[DRY RUN]: would have... " : "";
 
     AtomicInteger deleted = new AtomicInteger();
-    ClusterApi api = newApiClient();
+    ClusterApi api = newApiClient(apiUrl);
     api.listClusters(null, false).stream()
         .sorted(Comparator.comparing(c -> Instant.parse(c.getCreatedDate())))
         .filter((c) -> {
@@ -141,30 +143,31 @@ public class ManageClusters {
       args = Arrays.copyOfRange(args, 1, args.length);
       switch (cmd) {
         case "list":
-          if (args.length > 0) {
-            throw new IllegalArgumentException("Expected 0 args. Got " + Arrays.asList(args));
+          if (args.length > 1) {
+            throw new IllegalArgumentException("Expected 1 arg. Got " + Arrays.asList(args));
           }
-          listClusters();
+          listClusters(args[0]);
           return;
 
         case "delete":
           // User-friendly command-line parsing is done in devstart.rb, so we do only simple
           // positional argument parsing here.
-          if (args.length != 3) {
+          if (args.length != 4) {
             throw new IllegalArgumentException(
-                "Expected 3 args (min_age, ids, dry_run). Got " + Arrays.asList(args));
+                "Expected 4 args (api_url, min_age, ids, dry_run). Got " + Arrays.asList(args));
           }
+          String apiUrl = args[0];
           Instant oldest = null;
-          if (!args[0].isEmpty()) {
-            Duration age = Duration.ofDays(Long.parseLong(args[0]));
+          if (!args[1].isEmpty()) {
+            Duration age = Duration.ofDays(Long.parseLong(args[1]));
             oldest = Clock.systemUTC().instant().minus(age);
             log.info("only clusters created before " + oldest + " will be considered");
           }
 
           // Note: IDs are optional, this set may be empty.
-          Set<String> ids = commaDelimitedStringToSet(args[1]);
-          boolean dryRun = Boolean.valueOf(args[2]);
-          deleteClusters(oldest, ids, dryRun);
+          Set<String> ids = commaDelimitedStringToSet(args[2]);
+          boolean dryRun = Boolean.valueOf(args[3]);
+          deleteClusters(apiUrl, oldest, ids, dryRun);
           return;
 
         default:

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -80,8 +80,7 @@ export function getConfiguration(signInService: SignInService): Configuration {
   });
 }
 
-export function getLeoConfiguration(
-    signInService: SignInService, configService: ConfigService): LeoConfiguration {
+export function getLeoConfiguration(signInService: SignInService): LeoConfiguration {
   return new LeoConfiguration({
     basePath: environment.leoApiUrl,
     accessToken: () => signInService.currentAccessToken

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -80,9 +80,10 @@ export function getConfiguration(signInService: SignInService): Configuration {
   });
 }
 
-export function getLeoConfiguration(signInService: SignInService): LeoConfiguration {
+export function getLeoConfiguration(
+    signInService: SignInService, configService: ConfigService): LeoConfiguration {
   return new LeoConfiguration({
-    // TODO(RW-847): Inject the baseUrl according to the environment.
+    basePath: environment.leoApiUrl,
     accessToken: () => signInService.currentAccessToken
   });
 }

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -8,6 +8,7 @@ import {WorkspaceData} from 'app/resolvers/workspace';
 import {SignInService} from 'app/services/sign-in.service';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
+import {environment} from 'environments/environment';
 
 import {
   Cluster,
@@ -80,9 +81,6 @@ enum Tabs {
   templateUrl: './component.html',
 })
 export class WorkspaceComponent implements OnInit, OnDestroy {
-  // Keep in sync with api/src/main/resources/notebooks.yaml.
-  private static readonly leoBaseUrl = 'https://notebooks.firecloud.org';
-
   @ViewChild(WorkspaceShareComponent)
   shareModal: WorkspaceShareComponent;
 
@@ -229,8 +227,9 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.pollCluster().subscribe((c) => {
       // Use lower level *withHttpInfo() method to work around
       // https://github.com/DataBiosphere/leonardo/issues/444
-      this.leoNotebooksService.setCookieWithHttpInfo(c.clusterNamespace, c.clusterName)
-        .subscribe(() => {
+      this.leoNotebooksService.setCookieWithHttpInfo(c.clusterNamespace, c.clusterName, {
+        withCredentials: true
+      }).subscribe(() => {
           this.clusterLoading = false;
         });
     });
@@ -270,7 +269,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   openCluster(notebookName?: string): void {
-    let leoNotebookUrl = WorkspaceComponent.leoBaseUrl + '/notebooks/'
+    let leoNotebookUrl = environment.leoApiUrl + '/notebooks/'
       + this.cluster.clusterNamespace + '/'
       + this.cluster.clusterName;
     if (notebookName) {
@@ -298,7 +297,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
       if (e.source !== notebook) {
         return;
       }
-      if (e.origin !== WorkspaceComponent.leoBaseUrl) {
+      if (e.origin !== environment.leoApiUrl) {
         return;
       }
       if (e.data.type !== 'bootstrap-auth.request') {
@@ -309,7 +308,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         'body': {
           'googleClientId': this.signInService.clientId
         }
-      }, WorkspaceComponent.leoBaseUrl);
+      }, environment.leoApiUrl);
     };
     window.addEventListener('message', authHandler);
     this.notebookAuthListeners.push(authHandler);

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -4,6 +4,7 @@ export const environment = {
   displayTag: 'Local->Local',
   allOfUsApiUrl: 'http://localhost:8081',
   clientId: testEnvironmentBase.clientId,
+  leoApiUrl: 'https://leonardo.dsde-dev.broadinstitute.org',
   publicApiUrl: 'http://localhost:8083',
   debug: true,
   testing: false

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -2,6 +2,7 @@ export const environment = {
   displayTag: 'Stable',
   allOfUsApiUrl: 'https://api-dot-all-of-us-rw-stable.appspot.com',
   clientId: '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com',
+  leoBaseUrl: 'https://notebooks.firecloud.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-stable.appspot.com',
   debug: false,
   testing: true

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -2,6 +2,7 @@ export const environment = {
   displayTag: 'Staging',
   allOfUsApiUrl: 'https://api-dot-all-of-us-rw-staging.appspot.com',
   clientId: '657299777109-kvb5qafr70bl01i6bnpgsiq5nt6v1o8u.apps.googleusercontent.com',
+  leoBaseUrl: 'https://notebooks.firecloud.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-staging.appspot.com',
   debug: false,
   testing: true

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -3,5 +3,7 @@
 export const testEnvironmentBase = {
   allOfUsApiUrl: 'https://api-dot-all-of-us-workbench-test.appspot.com',
   clientId: '602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com',
+  // Keep in sync with config_test.json.
+  leoApiUrl: 'https://leonardo.dsde-dev.broadinstitute.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-workbench-test.appspot.com'
 };


### PR DESCRIPTION
Note that this doubly encodes the Leo API URL on client (environment.ts) and server (config.json).

Alternative considered:
Add the leoBaseUrl to the ServerConfigResponse.
+ (+) Single definition
- (-) Higher complexity introduced by instantiating Notebook-related services in an asynchronous manner
- (-) Possible race conditions if notebook requests get made before we get back the server config response