### PR TITLE
[RW-934][risk=no] Upgrade GAE-gradle and swagger gen libraries

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -126,8 +126,8 @@ buildscript {    // Configuration for building
   }
   dependencies {
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.3.RELEASE'
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
-    classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.9.0'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
+    classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.12.0'
     classpath 'io.swagger:swagger-codegen:2.2.3'
     classpath 'org.owasp:dependency-check-gradle:3.1.0'
   }

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -45,8 +45,8 @@ buildscript {    // Configuration for building
   }
   dependencies {
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.3.RELEASE'
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
-    classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.9.0'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
+    classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.12.0'
     classpath 'io.swagger:swagger-codegen:2.2.3'
   }
 }


### PR DESCRIPTION
Huge kudos to @biopete for finding the source of the issue. 

See [RW-934](https://precisionmedicineinitiative.atlassian.net/browse/RW-934). We started to see errors in overnight processes with swagger validation. This update seems to fix the problem. 