### PR TITLE
[RW-948][risk=no] Use a less confusing ID verification list name

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -31,7 +31,7 @@
     "projectId": "all-of-us-workbench-test"
   },
   "admin": {
-    "adminIdVerification": "stable-environment-manual-id-verification-requests@fake-research-aou.org",
+    "adminIdVerification": "manual-id-verification-requests@fake-research-aou.org",
     "supportGroup": "all-of-us-workbench-eng@googlegroups.com",
     "verifiedSendingAddress": "all-of-us-workbench-eng@googlegroups.com"
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -30,7 +30,7 @@
     "projectId": "all-of-us-rw-stable"
   },
   "admin": {
-    "adminIdVerification": "stable-environment-manual-id-verification-requests@fake-research-aou.org",
+    "adminIdVerification": "manual-id-verification-requests@fake-research-aou.org",
     "supportGroup": "all-of-us-workbench-eng@googlegroups.com",
     "verifiedSendingAddress": "all-of-us-workbench-eng@googlegroups.com"
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -30,7 +30,7 @@
     "projectId": "all-of-us-rw-staging"
   },
   "admin": {
-    "adminIdVerification": "stable-environment-manual-id-verification-requests@fake-research-aou.org",
+    "adminIdVerification": "manual-id-verification-requests@fake-research-aou.org",
     "supportGroup": "all-of-us-workbench-eng@googlegroups.com",
     "verifiedSendingAddress": "all-of-us-workbench-eng@googlegroups.com"
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -31,7 +31,7 @@
     "projectId": "all-of-us-workbench-test"
   },
   "admin": {
-    "adminIdVerification": "stable-environment-manual-id-verification-requests@fake-research-aou.org",
+    "adminIdVerification": "manual-id-verification-requests@fake-research-aou.org",
     "supportGroup": "all-of-us-workbench-eng@googlegroups.com",
     "verifiedSendingAddress": "all-of-us-workbench-eng@googlegroups.com"
   },


### PR DESCRIPTION
I realize from the PR history that using this list in all environments was intentional. That said, it's very confusing to find this in our configs, and most reasonable people would assume this was a bug. Fixing this now to avoid future developers burning time looking into this.