### PR TITLE
[RW-859][RW-860] Separate demos from other gcs artifacts

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1267,6 +1267,8 @@ def deploy(cmd_name, args)
     common.status "Pushing GCS artifacts..."
     deploy_gcs_artifacts(cmd_name, %W{--project #{ctx.project}})
 
+    deploy_gcs_demos(cmd_name, %W{--project #{ctx.project}})
+
     # Keep the cloud proxy context open for the service account credentials.
     deploy_args = %W{
       --project #{gcc.project}

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1039,8 +1039,6 @@ def deploy_gcs_artifacts(cmd_name, args)
   op.parse.validate
   gcc.validate
   common.run_inline %W{gsutil cp scripts/setup_notebook_cluster.sh gs://#{gcc.project}-scripts/setup_notebook_cluster.sh}
-  common.run_inline %W{gsutil rm gs://#{gcc.project}-demos/**}
-  common.run_inline %W{gsutil cp demos/* gs://#{gcc.project}-demos/}
   # This file must be readable by all AoU researchers and the Leonardo service
   # account (https://github.com/DataBiosphere/leonardo/issues/220). Just make it
   # public since the script's source is public anyways.
@@ -1051,6 +1049,24 @@ Common.register_command({
   :invocation => "deploy-gcs-artifacts",
   :description => "Deploys any GCS artifacts associated with this environment.",
   :fn => ->(*args) { deploy_gcs_artifacts("deploy-gcs-artifacts", args) }
+})
+
+def deploy_gcs_demos(cmd_name, args)
+  ensure_docker cmd_name, args
+
+  common = Common.new
+  op = WbOptionsParser.new(cmd_name, args)
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate
+  common.run_inline %W{gsutil rm gs://#{gcc.project}-demos/**}
+  common.run_inline %W{gsutil cp demos/* gs://#{gcc.project}-demos/}
+end
+
+Common.register_command({
+  :invocation => "deploy-gcs-demos",
+  :description => "Deploys any GCS demos associated with this environment.",
+  :fn => ->(*args) { deploy_gcs_demos("deploy-gcs-demos", args) }
 })
 
 


### PR DESCRIPTION
I think that we should deploy demos to GCS separately from other artifacts, I just felt kind of weird pushing our startup script at the same time as demos. They are kind of separate things. (In that one is getting created by developers, and the other theoretically by scientists)

Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
