### PR TITLE
Making member comparison case-insensitive [risk=no]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -289,7 +289,7 @@ public class FireCloudServiceImpl implements FireCloudService {
       // group; so instead, fetch all the group memberships. (There won't be that many for our
       // users anyway.)
       for (ManagedGroupAccessResponse group : endUserGroupsApiProvider.get().getGroups()) {
-        if (groupName.equals(group.getGroupName()) && MEMBER_ROLE.equals(group.getRole())) {
+        if (groupName.equals(group.getGroupName()) && MEMBER_ROLE.equalsIgnoreCase(group.getRole())) {
           return true;
         }
       }

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -236,7 +236,7 @@ public class FireCloudServiceImplTest {
   @Test
   public void testIsUserMemberOfGroup_noNameMatch() throws Exception {
     when(endUserGroupsApi.getGroups()).thenReturn(
-        Lists.newArrayList(new ManagedGroupAccessResponse().groupName("blah").role("member")));
+        Lists.newArrayList(new ManagedGroupAccessResponse().groupName("blah").role("Member")));
     assertThat(service.isUserMemberOfGroup("group")).isFalse();
   }
 


### PR DESCRIPTION
(It turns out the roles returned from FireCloud are "Member" not "member"... local testing confirmed this fix.)