### PR TITLE
[RW-940][risk=low] Clean up public-ui environment files

### DIFF
--- a/public-ui/src/environments/environment.local.ts
+++ b/public-ui/src/environments/environment.local.ts
@@ -2,8 +2,6 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 
 export const environment = {
   displayTag: 'Local->Local',
-  clientId: testEnvironmentBase.clientId,
   publicApiUrl: 'http://localhost:8083',
-  debug: true,
-  testing: false
+  debug: true
 };

--- a/public-ui/src/environments/environment.prod.ts
+++ b/public-ui/src/environments/environment.prod.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  displayTag: '',
+  publicApiUrl: 'https://public-api-dot-all-of-us-rw-prod.appspot.com',
+  debug: false,
+};

--- a/public-ui/src/environments/environment.stable.ts
+++ b/public-ui/src/environments/environment.stable.ts
@@ -1,7 +1,5 @@
 export const environment = {
   displayTag: 'Stable',
-  clientId: '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-stable.appspot.com',
   debug: false,
-  testing: true
 };

--- a/public-ui/src/environments/environment.staging.ts
+++ b/public-ui/src/environments/environment.staging.ts
@@ -1,8 +1,5 @@
 export const environment = {
   displayTag: 'Staging',
-  allOfUsApiUrl: 'https://api-dot-all-of-us-rw-staging.appspot.com',
-  clientId: '657299777109-kvb5qafr70bl01i6bnpgsiq5nt6v1o8u.apps.googleusercontent.com',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-staging.appspot.com',
-  debug: false,
-  testing: true
+  debug: false
 };

--- a/public-ui/src/environments/environment.test.ts
+++ b/public-ui/src/environments/environment.test.ts
@@ -4,5 +4,4 @@ export const environment = {
   ...testEnvironmentBase,
   displayTag: 'Test',
   debug: false,
-  testing: true
 };

--- a/public-ui/src/environments/environment.ts
+++ b/public-ui/src/environments/environment.ts
@@ -4,5 +4,4 @@ export const environment = {
   ...testEnvironmentBase,
   displayTag: 'Local->Test',
   debug: true,
-  testing: false
 };


### PR DESCRIPTION
- clientId is not needed since data browser does not do login
- `testing` was unused
- `allOfUsApiUrl` was oddly included only in staging
- add a prod environment file