### PR TITLE
[RW-712][risk=low] Disable workspaces button for unregistered users

### DIFF
--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -1,6 +1,8 @@
 import {Router} from '@angular/router';
 import {fromJS} from 'immutable';
 
+import {DataAccessLevel} from 'generated';
+
 export const WINDOW_REF = 'window-ref';
 
 export function isBlank(toTest: String): boolean {
@@ -26,4 +28,16 @@ export function navigateLogin(router: Router, fromUrl: string): Promise<boolean>
     params['from'] = fromUrl;
   }
   return router.navigate(['/login', params]);
+}
+
+/**
+ * Determine whether the given access level is >= registered. This is the
+ * minimum required level to do most things in the Workbench app (outside of
+ * local/test development).
+ */
+export function hasRegisteredAccess(access: DataAccessLevel): boolean {
+  return [
+    DataAccessLevel.Registered,
+    DataAccessLevel.Protected
+  ].includes(access);
 }

--- a/ui/src/app/views/homepage/component.ts
+++ b/ui/src/app/views/homepage/component.ts
@@ -1,7 +1,7 @@
 import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
-import {ServerConfigService} from 'app/services/server-config.service';
+import {hasRegisteredAccess} from 'app/utils';
 import {BugReportComponent} from 'app/views/bug-report/component';
 
 import {
@@ -52,12 +52,10 @@ export class HomepageComponent implements OnInit, OnDestroy {
           'dolore. Mirum est notare, quam littera gothica quam nunc.',
           icon: '/assets/icons/explore.svg'
       }];
-  private enforceRegistered: boolean;
   @ViewChild(BugReportComponent)
   bugReportComponent: BugReportComponent;
 
   constructor(
-    private serverConfigService: ServerConfigService,
     private profileService: ProfileService,
     private profileStorageService: ProfileStorageService,
     private route: ActivatedRoute,
@@ -65,9 +63,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.serverConfigService.getConfig().subscribe((config) => {
-      this.enforceRegistered = config.enforceRegistered;
-    });
     this.profileStorageService.profile$.subscribe((profile) => {
       if (this.firstSignIn === undefined) {
         this.firstSignIn = new Date(profile.firstSignInTime);
@@ -139,21 +134,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
 
   listWorkspaces(): void {
    this.router.navigate(['workspaces']);
-  }
-
-  // The user is FC initialized and has access to the CDR, if enforced in this
-  // environment.
-  hasCdrAccess(): boolean {
-    if (!this.profile) {
-      return false;
-    }
-    if (!this.enforceRegistered) {
-      return true;
-    }
-    return [
-      DataAccessLevel.Registered,
-      DataAccessLevel.Protected
-    ].includes(this.profile.dataAccessLevel);
   }
 
   get twoFactorBannerEnabled() {

--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -38,6 +38,7 @@
       <button class="btn btn-primary nav-link"
           [class.active]="workspacesActive"
           routerLink="/workspaces"
+          [attr.disabled]="hasDataAccess"
           (click)="sidenavToggle = false">My Workspaces</button>
       <button class="btn btn-primary nav-link"
           [class.active]="reviewWorkspaceActive"

--- a/ui/src/app/views/signed-in/component.ts
+++ b/ui/src/app/views/signed-in/component.ts
@@ -6,8 +6,9 @@ import {
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
+import {ServerConfigService} from 'app/services/server-config.service';
 import {SignInService} from 'app/services/sign-in.service';
-import {navigateLogin} from 'app/utils';
+import {hasRegisteredAccess, navigateLogin} from 'app/utils';
 import {BugReportComponent} from 'app/views/bug-report/component';
 
 import {Authority} from 'generated';
@@ -20,6 +21,7 @@ import {Authority} from 'generated';
   templateUrl: './component.html'
 })
 export class SignedInComponent implements OnInit {
+  hasDataAccess = true;
   hasReviewResearchPurpose = false;
   hasReviewIdVerification = false;
   headerImg = '/assets/images/all-of-us-logo.svg';
@@ -47,6 +49,7 @@ export class SignedInComponent implements OnInit {
     /* Ours */
     public errorHandlingService: ErrorHandlingService,
     private signInService: SignInService,
+    private serverConfigService: ServerConfigService,
     private profileStorageService: ProfileStorageService,
     /* Angular's */
     private locationService: Location,
@@ -54,14 +57,18 @@ export class SignedInComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.serverConfigService.getConfig().subscribe((config) => {
+      this.profileStorageService.profile$.subscribe((profile) => {
+        this.hasDataAccess =
+          !config.enforceRegistered || hasRegisteredAccess(profile.dataAccessLevel);
 
-    this.profileStorageService.profile$.subscribe((profile) => {
-      this.hasReviewResearchPurpose =
-        profile.authorities.includes(Authority.REVIEWRESEARCHPURPOSE);
-      this.hasReviewIdVerification =
-        profile.authorities.includes(Authority.REVIEWIDVERIFICATION);
-      this.givenName = profile.givenName;
-      this.familyName = profile.familyName;
+        this.hasReviewResearchPurpose =
+          profile.authorities.includes(Authority.REVIEWRESEARCHPURPOSE);
+        this.hasReviewIdVerification =
+          profile.authorities.includes(Authority.REVIEWIDVERIFICATION);
+        this.givenName = profile.givenName;
+        this.familyName = profile.familyName;
+      });
     });
 
     document.body.style.backgroundColor = '#f1f2f2';


### PR DESCRIPTION
Factor this out into a utility as I will soon be using it on the IDV redirect page. Remove the now dead usage in the homepage. I tried putting a tooltip in here as well, but we may need to do something special since the standard tooltip approach generates z-index problems in the side bar.

Note: it was technically a bit of a regression to not disable "add workspace" and "list workspaces" for users without data access. This won't matter once I get my IDV redirect checked in though, so just leave it in this state for now.