### PR TITLE
[RW-930][risk=no] Add unregistered view and guard to redirect to it

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 import {NavigationEnd, Router, RouterModule, Routes} from '@angular/router';
 
+import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
 import {AdminReviewIdVerificationComponent} from './views/admin-review-id-verification/component';
@@ -14,6 +15,7 @@ import {NotebookRedirectComponent} from './views/notebook-redirect/component';
 import {ProfilePageComponent} from './views/profile-page/component';
 import {SettingsComponent} from './views/settings/component';
 import {SignedInComponent} from './views/signed-in/component';
+import {UnregisteredComponent} from './views/unregistered/component';
 import {WorkspaceEditComponent, WorkspaceEditMode} from './views/workspace-edit/component';
 import {WorkspaceListComponent} from './views/workspace-list/component';
 import {WorkspaceNavBarComponent} from './views/workspace-nav-bar/component';
@@ -34,13 +36,19 @@ const routes: Routes = [
     path: '',
     component: SignedInComponent,
     canActivate: [SignInGuard],
-    canActivateChild: [SignInGuard],
+    canActivateChild: [SignInGuard, RegistrationGuard],
     runGuardsAndResolvers: 'always',
     children: [
       {
         path: '',
         component: HomepageComponent,
         data: {title: 'Homepage'},
+      }, {
+        path: 'unregistered',
+        component: UnregisteredComponent,
+        data: {
+          title: 'Awaiting ID Verification'
+        }
       }, {
       path: 'workspaces',
       data: {breadcrumb: 'Workspaces'},
@@ -176,6 +184,7 @@ const routes: Routes = [
     {onSameUrlNavigation: 'reload', paramsInheritanceStrategy: 'always'})],
   exports: [RouterModule],
   providers: [
+    RegistrationGuard,
     SignInGuard,
     WorkspaceResolver,
   ]

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -40,6 +40,7 @@ import {ProfilePageComponent} from './views/profile-page/component';
 import {RoutingSpinnerComponent} from './views/routing-spinner/component';
 import {SettingsComponent} from './views/settings/component';
 import {SignedInComponent} from './views/signed-in/component';
+import {UnregisteredComponent} from './views/unregistered/component';
 import {WorkspaceEditComponent} from './views/workspace-edit/component';
 import {WorkspaceListComponent} from './views/workspace-list/component';
 import {WorkspaceNavBarComponent} from './views/workspace-nav-bar/component';
@@ -129,6 +130,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     RoutingSpinnerComponent,
     SettingsComponent,
     SignedInComponent,
+    UnregisteredComponent,
     WorkspaceComponent,
     WorkspaceEditComponent,
     WorkspaceNavBarComponent,

--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  Router, RouterStateSnapshot
+} from '@angular/router';
+import {Observable} from 'rxjs/Observable';
+
+import {ProfileStorageService} from 'app/services/profile-storage.service';
+import {ServerConfigService} from 'app/services/server-config.service';
+import {hasRegisteredAccess} from 'app/utils';
+
+
+@Injectable()
+export class RegistrationGuard implements CanActivate, CanActivateChild {
+  constructor(
+    private serverConfigService: ServerConfigService,
+    private profileStorageService: ProfileStorageService,
+    private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    if (route.routeConfig.path === 'unregistered' ||
+        route.routeConfig.path.startsWith('admin/')) {
+      // Leave /admin unguarded in order to allow bootstrapping of verified users.
+      return Observable.from([true]);
+    }
+    return this.serverConfigService.getConfig()
+      .flatMap((config) => {
+        if (!config.enforceRegistered) {
+          return Observable.from([true]);
+        }
+        return this.profileStorageService.profile$
+          .first()
+          .map(profile => hasRegisteredAccess(profile.dataAccessLevel));
+      })
+      .do((ok) => {
+        if (ok) {
+          return;
+        }
+        const params = {};
+        if (state.url && state.url !== '/' && !state.url.startsWith('/unregistered')) {
+          params['from'] = state.url;
+        }
+        this.router.navigate(['/unregistered', params]);
+      });
+  }
+
+  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    return this.canActivate(route, state);
+  }
+}

--- a/ui/src/app/services/profile-storage.service.ts
+++ b/ui/src/app/services/profile-storage.service.ts
@@ -49,6 +49,7 @@ export class ProfileStorageService {
       this.activeCall = false;
     }, (err) => {
       this.errorHandlingService.profileLoadError = true;
+      this.activeCall = false;
     });
   }
 }

--- a/ui/src/app/views/unregistered/component.html
+++ b/ui/src/app/views/unregistered/component.html
@@ -1,0 +1,8 @@
+<div [ngSwitch]="idvStatus">
+  <p *ngSwitchCase="IdVerificationStatus.REJECTED">
+    Identity verification rejected, please create an account with an approved contact email or contact the DRC PI for your institution.
+  </p>
+  <p *ngSwitchDefault>
+    Awaiting identity verification, please contact the DRC PI from your institution for approval.
+  </p>
+</div>

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -1,0 +1,88 @@
+import {Component, DebugElement, Injectable} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {
+  ActivatedRouteSnapshot,
+  Resolve,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ClarityModule} from '@clr/angular';
+
+import {ProfileStorageService} from 'app/services/profile-storage.service';
+import {ServerConfigService} from 'app/services/server-config.service';
+import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
+import {ProfileServiceStub} from 'testing/stubs/profile-service-stub';
+import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-stub';
+import {UnregisteredComponent} from 'app/views/unregistered/component';
+import {updateAndTick} from 'testing/test-helpers';
+
+import {
+  ProfileService,
+} from 'generated';
+
+
+@Component({
+  selector: 'app-test',
+  template: '<router-outlet></router-outlet>'
+})
+class FakeAppComponent {}
+
+@Component({
+  selector: 'app-fake-root',
+  template: '<div class="fake-root"></div>'
+})
+class FakeRootComponent {}
+
+describe('UnregisteredComponent', () => {
+  let fixture: ComponentFixture<FakeAppComponent>;
+  let de: DebugElement;
+  let router: Router;
+  let profileStorageStub: ProfileStorageServiceStub;
+
+  beforeEach(fakeAsync(() => {
+    profileStorageStub = new ProfileStorageServiceStub();
+    TestBed.configureTestingModule({
+      declarations: [
+        FakeAppComponent,
+        FakeRootComponent,
+        UnregisteredComponent,
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        RouterTestingModule.withRoutes([
+          {path: '', component: FakeRootComponent},
+          {path: 'unregistered', component: UnregisteredComponent},
+        ]),
+        ClarityModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ServerConfigService,
+          useValue: new ServerConfigServiceStub({
+            enforceRegistered: true
+          })
+        },
+        { provide: ProfileService, useValue: profileStorageStub },
+        { provide: ProfileStorageService, useValue: new ProfileStorageServiceStub() },
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(fakeAsync(() => {
+    fixture = TestBed.createComponent(FakeAppComponent);
+    de = fixture.debugElement;
+    router = TestBed.get(Router);
+  }));
+
+  fit('should show unregistered for unregistered', fakeAsync(() => {
+    router.navigateByUrl('/unregistered');
+    tick();
+    fixture.detectChanges();
+
+    expect(de.nativeElement.textContent).toContain('Awaiting identity verification');
+  }));
+});
+

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -112,7 +112,7 @@ describe('UnregisteredComponent', () => {
   it('should submit incomplete registration steps', fakeAsync(() => {
     loadProfileWithRegistrationSettings({
       dataAccessLevel: DataAccessLevel.Unregistered,
-      idVerificationStatus: IdVerificationStatus.Unverified,
+      idVerificationStatus: IdVerificationStatus.UNVERIFIED,
       requestedIdVerification: false,
     });
 

--- a/ui/src/app/views/unregistered/component.ts
+++ b/ui/src/app/views/unregistered/component.ts
@@ -1,0 +1,92 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute, NavigationError, Router} from '@angular/router';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+
+import {ProfileStorageService} from 'app/services/profile-storage.service';
+import {ServerConfigService} from 'app/services/server-config.service';
+import {hasRegisteredAccess} from 'app/utils';
+
+import {
+  DataAccessLevel,
+  IdVerificationStatus,
+  ProfileService,
+} from 'generated';
+
+@Component({
+  templateUrl: './component.html',
+  styleUrls: ['./component.css']
+})
+export class UnregisteredComponent implements OnInit, OnDestroy {
+  IdVerificationStatus = IdVerificationStatus;
+  idvStatus: IdVerificationStatus;
+  private profileSub: Subscription;
+
+  constructor(
+    private serverConfigService: ServerConfigService,
+    private profileService: ProfileService,
+    private profileStorageService: ProfileStorageService,
+    private activatedRoute: ActivatedRoute,
+    private router: Router) {}
+
+  ngOnInit() {
+    this.serverConfigService.getConfig().subscribe((config) => {
+      if (!config.enforceRegistered) {
+        this.navigateAway();
+        return;
+      }
+      this.profileSub = this.profileStorageService.profile$
+        .first()
+        .flatMap((profile) => {
+          if (hasRegisteredAccess(profile.dataAccessLevel)) {
+            this.navigateAway();
+            return Observable.from([profile]);
+          }
+          this.idvStatus = profile.idVerificationStatus;
+
+          let obs = Observable.from([profile]);
+          // For now, we automatically submit ID verification as there's nothing
+          // else to do in the application and only manual verification is supported.
+          if (!profile.requestedIdVerification) {
+            obs = obs.flatMap((p) => {
+              return this.profileService.submitIdVerification().map((_) => p);
+            });
+          }
+
+          // For now, we automatically submit all placeholder user setup steps.
+          // Per RW-695, ID verification is sufficient for data access for
+          // initial internal data access.
+          if (!profile.termsOfServiceCompletionTime) {
+            obs = obs.flatMap((p) => {
+              return this.profileService.submitTermsOfService().map((_) => p);
+            });
+          }
+          if (!profile.ethicsTrainingCompletionTime) {
+            obs = obs.flatMap((p) => {
+              return this.profileService.completeEthicsTraining().map((_) => p);
+            });
+          }
+          if (!profile.demographicSurveyCompletionTime) {
+            obs = obs.flatMap((p) => {
+              return this.profileService.submitDemographicsSurvey().map((_) => p);
+            });
+          }
+          return obs;
+        })
+        .subscribe();
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.profileSub) {
+      this.profileSub.unsubscribe();
+    }
+  }
+
+  private navigateAway() {
+    this.router.navigateByUrl(this.activatedRoute.snapshot.params.from || '/')
+      .catch(() => {
+        this.router.navigateByUrl('/');
+      });
+  }
+}

--- a/ui/src/testing/stubs/profile-service-stub.ts
+++ b/ui/src/testing/stubs/profile-service-stub.ts
@@ -11,11 +11,9 @@ export class ProfileStubVariables {
     freeTierBillingProjectName: 'all-of-us-free-abcdefg',
     freeTierBillingProjectStatus: BillingProjectStatus.Ready,
     dataAccessLevel: DataAccessLevel.Registered,
-    fullName:  'Tester MacTesterson><script>alert("hello");</script>',
     givenName: 'Tester!@#$%^&*()><script>alert("hello");</script>',
     familyName: 'MacTesterson!@#$%^&*()><script>alert("hello");</script>',
     phoneNumber: '999-999-9999',
-    invitationKey: 'dummyKey'
   };
 }
 
@@ -61,5 +59,29 @@ export class ProfileServiceStub {
     } else {
       return new Observable(observer => { observer.next(false); });
     }
+  }
+
+  private now(): number {
+    return Math.floor(new Date().getTime() / 1000);
+  }
+
+  public submitIdVerification(extraHttpRequestParams?: any): Observable<Profile> {
+    this.profile.requestedIdVerification = true;
+    return Observable.from([this.profile]);
+  }
+
+  public submitTermsOfService(extraHttpRequestParams?: any): Observable<Profile> {
+    this.profile.termsOfServiceCompletionTime = this.now();
+    return Observable.from([this.profile]);
+  }
+
+  public submitDemographicsSurvey(extraHttpRequestParams?: any): Observable<Profile> {
+    this.profile.demographicSurveyCompletionTime = this.now();
+    return Observable.from([this.profile]);
+  }
+
+  public completeEthicsTraining(extraHttpRequestParams?: any): Observable<Profile> {
+    this.profile.ethicsTrainingCompletionTime = this.now();
+    return Observable.from([this.profile]);
   }
 }

--- a/ui/src/testing/stubs/profile-storage-service-stub.ts
+++ b/ui/src/testing/stubs/profile-storage-service-stub.ts
@@ -5,7 +5,7 @@ import {ProfileStubVariables} from 'testing/stubs/profile-service-stub';
 import {Profile} from 'generated';
 
 export class ProfileStorageServiceStub {
-  private profile = new ReplaySubject<Profile>(1);
+  public profile = new ReplaySubject<Profile>(1);
   public profile$ = this.profile.asObservable();
   constructor() {}
 


### PR DESCRIPTION
This changed logic only applies when enforceRegistered is enabled. This currently affects staging/prod, but soon will also affect stable.

New logic:
- For nearly all signed in pages, guard according to data access level.
- If the user does not have registered access, redirect them to the new "unregistered" page.
- The unregistered page will submit IDV request, ToS, demographics, training, if any of the above have not already been submitted.

If a registered access user hits the unregistered page, they will be redirected according to the "from" parameter (if any), or the dashboard homepage otherwise.