### PR TITLE
[RW-1033][RW-712][risk=low] Retry IDV failures and navigate on completed registration

### DIFF
--- a/ui/src/app/services/profile-storage.service.ts
+++ b/ui/src/app/services/profile-storage.service.ts
@@ -24,17 +24,14 @@ export class ProfileStorageService {
     this.reload();
   }
 
-  reload() {
-    if (this.activeCall) {
-      return;
-    }
-    this.activeCall = true;
-
-    // Conflict 409s are not retries automatically. These have a likelihood to
-    // occur on initial user login since we lazily initialize several things via
-    // the /me profile endpoint.
+  /**
+   * A retry policy which may be used in combination with Observable.retryWhen()
+   * which retries conflict errors. This may be used with profile related
+   * endpoints.
+   */
+  public static conflictRetryPolicy(): (errors: Observable<any>) => Observable<any> {
     let retries = 0;
-    this.profileService.getMe().retryWhen((errs) => {
+    return (errs) => {
       return errs.flatMap((err) => {
         if (err.status !== 409) {
           throw err;
@@ -44,12 +41,26 @@ export class ProfileStorageService {
         }
         return timer(retries * ProfileStorageService.RETRY_DELAY_MS);
       });
-    }).subscribe((profile) => {
-      this.profile.next(profile);
-      this.activeCall = false;
-    }, (err) => {
-      this.errorHandlingService.profileLoadError = true;
-      this.activeCall = false;
-    });
+    };
+  }
+
+  reload() {
+    if (this.activeCall) {
+      return;
+    }
+    this.activeCall = true;
+
+    // Conflict 409s are not retries automatically. These have a likelihood to
+    // occur on initial user login since we lazily initialize several things via
+    // the /me profile endpoint.
+    this.profileService.getMe()
+      .retryWhen(ProfileStorageService.conflictRetryPolicy())
+      .subscribe((profile) => {
+        this.profile.next(profile);
+        this.activeCall = false;
+      }, (err) => {
+        this.errorHandlingService.profileLoadError = true;
+        this.activeCall = false;
+      });
   }
 }

--- a/ui/src/app/views/unregistered/component.html
+++ b/ui/src/app/views/unregistered/component.html
@@ -2,6 +2,9 @@
   <p *ngSwitchCase="IdVerificationStatus.REJECTED">
     Identity verification rejected, please create an account with an approved contact email or contact the DRC PI for your institution.
   </p>
+  <p *ngSwitchCase="IdVerificationStatus.VERIFIED">
+    Identity verified, completing additional researcher registration and redirecting...
+  </p>
   <p *ngSwitchDefault>
     Awaiting identity verification, please contact the DRC PI from your institution for approval.
   </p>

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
+import {Observable} from 'rxjs/Observable';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
@@ -27,6 +28,27 @@ import {
 } from 'generated';
 
 
+class FailingProfileStub extends ProfileServiceStub {
+  constructor(private fails: number) {
+    super();
+  }
+
+  submitTermsOfService(extraHttpRequestParams?: any): Observable<Profile> {
+    if (this.fails-- > 0) {
+      throw {status: 409};
+    }
+    return super.submitTermsOfService(extraHttpRequestParams);
+  }
+}
+
+class TrainingCompletesRegistrationStub extends ProfileServiceStub {
+  completeEthicsTraining(extraHttpRequestParams?: any): Observable<Profile> {
+    const obs = super.completeEthicsTraining(extraHttpRequestParams);
+    this.profile.dataAccessLevel = DataAccessLevel.Registered;
+    return obs;
+  }
+}
+
 @Component({
   selector: 'app-test',
   template: '<router-outlet></router-outlet>'
@@ -43,6 +65,7 @@ describe('UnregisteredComponent', () => {
   let fixture: ComponentFixture<FakeAppComponent>;
   let de: DebugElement;
   let router: Router;
+  let unregisteredComponent: UnregisteredComponent;
   let profileStub: ProfileServiceStub;
   let profileStorageStub: ProfileStorageServiceStub;
 
@@ -85,6 +108,8 @@ describe('UnregisteredComponent', () => {
     router.navigateByUrl('/unregistered');
     tick();
     fixture.detectChanges();
+
+    unregisteredComponent = de.children[1].componentInstance;
   }));
 
   const loadProfileWithRegistrationSettings = (p: any) => {
@@ -101,6 +126,13 @@ describe('UnregisteredComponent', () => {
     profileStorageStub.profile.next(profile);
   };
 
+  const expectAllRegistrationSubmitted = (p: Profile) => {
+    expect(p.requestedIdVerification).toBeTruthy();
+    expect(p.termsOfServiceCompletionTime).toBeTruthy();
+    expect(p.ethicsTrainingCompletionTime).toBeTruthy();
+    expect(p.demographicSurveyCompletionTime).toBeTruthy();
+  }
+
   it('should show unregistered for unregistered', fakeAsync(() => {
     loadProfileWithRegistrationSettings({
       dataAccessLevel: DataAccessLevel.Unregistered
@@ -116,11 +148,43 @@ describe('UnregisteredComponent', () => {
       requestedIdVerification: false,
     });
 
+    expectAllRegistrationSubmitted(profileStub.profile);
+  }));
+
+  it('should retry failed registration steps', fakeAsync(() => {
+    profileStub = new FailingProfileStub(2);
+    // Hacky, but unfortunately profileStub does not directly implement ProfileService.
+    (unregisteredComponent as any).profileService = profileStub;
+
+    loadProfileWithRegistrationSettings({
+      dataAccessLevel: DataAccessLevel.Unregistered,
+      idVerificationStatus: IdVerificationStatus.UNVERIFIED,
+      requestedIdVerification: false,
+    });
+
+    // Tick the retry delays.
+    tick(1000);
+    tick(1000);
+
     expect(de.nativeElement.textContent).toContain('Awaiting identity verification');
-    expect(profileStub.profile.requestedIdVerification).toBeTruthy();
-    expect(profileStub.profile.termsOfServiceCompletionTime).toBeTruthy();
-    expect(profileStub.profile.ethicsTrainingCompletionTime).toBeTruthy();
-    expect(profileStub.profile.demographicSurveyCompletionTime).toBeTruthy();
+    expectAllRegistrationSubmitted(profileStub.profile);
+  }));
+
+  fit('should redirect if profile becomes completed', fakeAsync(() => {
+    profileStub = new TrainingCompletesRegistrationStub();
+    // Hacky, but unfortunately profileStub does not directly implement ProfileService.
+    (unregisteredComponent as any).profileService = profileStub;
+
+    loadProfileWithRegistrationSettings({
+      dataAccessLevel: DataAccessLevel.Unregistered,
+      idVerificationStatus: IdVerificationStatus.UNVERIFIED,
+      requestedIdVerification: false,
+    });
+
+    tick();
+    fixture.detectChanges();
+
+    expect(de.queryAll(By.css('app-fake-root')).length).toEqual(1);
   }));
 
   it('should navigate away for registered users', fakeAsync(() => {

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -34,7 +34,8 @@ class FailingProfileStub extends ProfileServiceStub {
   }
 
   submitTermsOfService(extraHttpRequestParams?: any): Observable<Profile> {
-    if (this.fails-- > 0) {
+    this.fails--;
+    if (this.fails >= 0) {
       throw {status: 409};
     }
     return super.submitTermsOfService(extraHttpRequestParams);
@@ -109,7 +110,9 @@ describe('UnregisteredComponent', () => {
     tick();
     fixture.detectChanges();
 
-    unregisteredComponent = de.children[1].componentInstance;
+    // Grab the rendered component from within the fake app container. We don't
+    // specify a custom selector so it gets rendered as 'ng-component'.
+    unregisteredComponent = de.query(By.css('ng-component')).componentInstance;
   }));
 
   const loadProfileWithRegistrationSettings = (p: any) => {
@@ -131,7 +134,7 @@ describe('UnregisteredComponent', () => {
     expect(p.termsOfServiceCompletionTime).toBeTruthy();
     expect(p.ethicsTrainingCompletionTime).toBeTruthy();
     expect(p.demographicSurveyCompletionTime).toBeTruthy();
-  }
+  };
 
   it('should show unregistered for unregistered', fakeAsync(() => {
     loadProfileWithRegistrationSettings({
@@ -153,8 +156,7 @@ describe('UnregisteredComponent', () => {
 
   it('should retry failed registration steps', fakeAsync(() => {
     profileStub = new FailingProfileStub(2);
-    // Hacky, but unfortunately profileStub does not directly implement ProfileService.
-    (unregisteredComponent as any).profileService = profileStub;
+    unregisteredComponent.setProfileService(profileStub);
 
     loadProfileWithRegistrationSettings({
       dataAccessLevel: DataAccessLevel.Unregistered,
@@ -172,8 +174,7 @@ describe('UnregisteredComponent', () => {
 
   it('should redirect if profile becomes completed', fakeAsync(() => {
     profileStub = new TrainingCompletesRegistrationStub();
-    // Hacky, but unfortunately profileStub does not directly implement ProfileService.
-    (unregisteredComponent as any).profileService = profileStub;
+    unregisteredComponent.setProfileService(profileStub);
 
     loadProfileWithRegistrationSettings({
       dataAccessLevel: DataAccessLevel.Unregistered,

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -170,7 +170,7 @@ describe('UnregisteredComponent', () => {
     expectAllRegistrationSubmitted(profileStub.profile);
   }));
 
-  fit('should redirect if profile becomes completed', fakeAsync(() => {
+  it('should redirect if profile becomes completed', fakeAsync(() => {
     profileStub = new TrainingCompletesRegistrationStub();
     // Hacky, but unfortunately profileStub does not directly implement ProfileService.
     (unregisteredComponent as any).profileService = profileStub;

--- a/ui/src/app/views/unregistered/component.ts
+++ b/ui/src/app/views/unregistered/component.ts
@@ -1,8 +1,8 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute, NavigationError, Router} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
-import {Subscription} from 'rxjs/Subscription';
 import {timer} from 'rxjs/observable/timer';
+import {Subscription} from 'rxjs/Subscription';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
@@ -24,8 +24,8 @@ export class UnregisteredComponent implements OnInit, OnDestroy {
   private profileSub: Subscription;
 
   constructor(
-    private serverConfigService: ServerConfigService,
     private profileService: ProfileService,
+    private serverConfigService: ServerConfigService,
     private profileStorageService: ProfileStorageService,
     private activatedRoute: ActivatedRoute,
     private router: Router) {}
@@ -90,6 +90,11 @@ export class UnregisteredComponent implements OnInit, OnDestroy {
     if (this.profileSub) {
       this.profileSub.unsubscribe();
     }
+  }
+
+  /** Exposed for testing. */
+  setProfileService(svc: ProfileService) {
+    this.profileService = svc;
   }
 
   private navigateAway() {

--- a/ui/src/testing/stubs/profile-service-stub.ts
+++ b/ui/src/testing/stubs/profile-service-stub.ts
@@ -1,7 +1,14 @@
-import {DataAccessLevel} from 'generated';
-import {BillingProjectStatus, Profile} from 'generated';
+import {Http} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import {InvitationVerificationRequest} from '../../generated/model/invitationVerificationRequest';
+
+import {
+  BillingProjectStatus,
+  DataAccessLevel,
+  Profile,
+  ProfileService,
+  UsernameTakenResponse,
+} from 'generated';
 
 export class ProfileStubVariables {
   static PROFILE_STUB = {
@@ -17,15 +24,20 @@ export class ProfileStubVariables {
   };
 }
 
-export class ProfileServiceStub {
+export class ProfileServiceStub extends ProfileService {
   public profile: Profile;
   public accountCreates = 0;
 
-  constructor() {
+  /**
+   * Http can optionally be provided e.g. with a fake/mock. If not specified,
+   * methods which are not overridden by this stub will throw errors.
+   */
+  constructor(http?: Http) {
+    super(http, null, null);
     this.profile = ProfileStubVariables.PROFILE_STUB;
   }
 
-  getMe(): Observable<Profile> {
+  public getMe(): Observable<Profile> {
     return new Observable<Profile>(observer => {
       setTimeout(() => {
         observer.next(this.profile);
@@ -34,7 +46,7 @@ export class ProfileServiceStub {
     });
   }
 
-  createAccount(): Observable<Profile> {
+  public createAccount(): Observable<Profile> {
     this.accountCreates++;
     return new Observable<Profile>(observer => {
       setTimeout(() => {
@@ -44,7 +56,7 @@ export class ProfileServiceStub {
     });
   }
 
-  invitationKeyVerification(request?: InvitationVerificationRequest): Observable<{}> {
+  public invitationKeyVerification(request?: InvitationVerificationRequest): Observable<{}> {
     if (request.invitationKey === 'dummy') {
       return new Observable(observer => { observer.next(this.profile); });
     } else {
@@ -53,12 +65,13 @@ export class ProfileServiceStub {
     }
   }
 
-  isUsernameTaken(username: string): Observable<boolean> {
-    if (username === ProfileStubVariables.PROFILE_STUB.username) {
-      return new Observable(observer => { observer.next(true); });
-    } else {
-      return new Observable(observer => { observer.next(false); });
-    }
+  public isUsernameTaken(username: string, extraHttpRequestParams?: any):
+      Observable<UsernameTakenResponse> {
+    return new Observable(observer => {
+      observer.next({
+        isTaken: username === ProfileStubVariables.PROFILE_STUB.username
+      });
+    });
   }
 
   private now(): number {


### PR DESCRIPTION
- Return conflict errors from registration-related profile methods as needed.
- For users who are already ID verified, and are missing other fields, we'll now submit the rest and redirect after.
- Retry registration API conflict errors