### PR TITLE
[RW-321][risk=low] Make flexible dependency versions fixed

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -140,6 +140,7 @@ configurations {
 }
 
 project.ext.GAE_VERSION = '1.9.64'
+project.ext.SBF_VERSION = '2.0.3.RELEASE'
 
 buildscript {    // Configuration for building
   repositories {
@@ -239,8 +240,8 @@ dependencies {
   providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
   compile project(":common-api")
   compile 'com.google.api-client:google-api-client-appengine:1.23.0'
-  compile 'mysql:mysql-connector-java:+'
-  compile 'com.google.cloud.sql:mysql-socket-factory:+'
+  compile 'mysql:mysql-connector-java:8.0.11'
+  compile 'com.google.cloud.sql:mysql-socket-factory:1.0.10'
   compile "com.google.appengine:appengine:${GAE_VERSION}"
   compile "com.google.appengine:appengine-api-1.0-sdk:${GAE_VERSION}"
   compile('org.springframework.boot:spring-boot-starter-web:+') {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -140,7 +140,6 @@ configurations {
 }
 
 project.ext.GAE_VERSION = '1.9.64'
-project.ext.SBF_VERSION = '2.0.3.RELEASE'
 
 buildscript {    // Configuration for building
   repositories {
@@ -244,7 +243,7 @@ dependencies {
   compile 'com.google.cloud.sql:mysql-socket-factory:1.0.10'
   compile "com.google.appengine:appengine:${GAE_VERSION}"
   compile "com.google.appengine:appengine-api-1.0-sdk:${GAE_VERSION}"
-  compile('org.springframework.boot:spring-boot-starter-web:+') {
+  compile('org.springframework.boot:spring-boot-starter-web') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
@@ -252,7 +251,7 @@ dependencies {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
-  compile('org.springframework.boot:spring-boot-starter-actuator:+') {
+  compile('org.springframework.boot:spring-boot-starter-actuator') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -268,8 +268,8 @@ dependencies {
   }
   compile 'com.google.code.gson:gson:2.8.5'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-  compile 'com.squareup.okhttp:okhttp:2.6.0'
-  compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
+  compile 'com.squareup.okhttp:okhttp:2.7.4'
+  compile 'com.squareup.okhttp:logging-interceptor:2.7.4'
   compile 'joda-time:joda-time:2.10'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -285,7 +285,7 @@ dependencies {
   testCompile "com.google.appengine:appengine-api-stubs:${GAE_VERSION}"
   testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"
   testCompile 'com.google.truth:truth:0.42'
-  testCompile 'org.springframework.boot:spring-boot-starter-test:+'
+  testCompile 'org.springframework.boot:spring-boot-starter-test'
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -261,12 +261,12 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
   compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0'
-  compile 'com.google.apis:google-api-services-oauth2:+'
+  compile 'com.google.apis:google-api-services-oauth2:v2-rev139-1.23.0'
   compile 'com.google.cloud:google-cloud-bigquery:0.30.0-beta'
   compile ('com.google.cloud:google-cloud-storage:1.8.0') {
     exclude group: 'com.google.guava', module:'guava-jdk5'
   }
-  compile 'com.google.code.gson:gson:+'
+  compile 'com.google.code.gson:gson:2.8.5'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
   compile 'com.squareup.okhttp:okhttp:2.6.0'
   compile 'com.squareup.okhttp:logging-interceptor:2.6.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -299,7 +299,7 @@ dependencies {
   generatedCompile 'com.squareup.okhttp:okhttp:2.6.0'
   generatedCompile 'com.squareup.okhttp:logging-interceptor:2.6.0'
   generatedCompile 'com.google.code.gson:gson:+'
-  generatedCompile 'joda-time:joda-time:+'
+  generatedCompile 'joda-time:joda-time:2.10'
   generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'
 
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -286,8 +286,8 @@ dependencies {
   testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"
   testCompile 'com.google.truth:truth:0.42'
   testCompile 'org.springframework.boot:spring-boot-starter-test'
-  testCompile 'com.h2database:h2:+'
-  testCompile 'org.liquibase:liquibase-core:+'
+  testCompile 'com.h2database:h2:1.4.194'
+  testCompile 'org.liquibase:liquibase-core:3.5.3'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
 
   // For Swagger generation. These should include dependencies found in the Swagger codegen

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -298,9 +298,9 @@ dependencies {
   generatedCompile 'io.springfox:springfox-swagger-ui:2.6.1'
   generatedCompile 'com.squareup.okhttp:okhttp:2.6.0'
   generatedCompile 'com.squareup.okhttp:logging-interceptor:2.6.0'
-  generatedCompile 'com.google.code.gson:gson:+'
+  generatedCompile 'com.google.code.gson:gson:2.8.5'
   generatedCompile 'joda-time:joda-time:2.10'
-  generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'
+  generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.6'
 
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -255,7 +255,7 @@ dependencies {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
-  compile 'org.springframework.security:spring-security-web:+'
+  compile 'org.springframework.security:spring-security-web:4.2.2.RELEASE'
 
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
   compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -281,10 +281,10 @@ dependencies {
   compile 'org.json:json:20160810'
 
   testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:1.+'
+  testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile "com.google.appengine:appengine-api-stubs:${GAE_VERSION}"
   testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"
-  testCompile 'com.google.truth:truth:+'
+  testCompile 'com.google.truth:truth:0.42'
   testCompile 'org.springframework.boot:spring-boot-starter-test:+'
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -270,7 +270,7 @@ dependencies {
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
   compile 'com.squareup.okhttp:okhttp:2.6.0'
   compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
-  compile 'joda-time:joda-time:+'
+  compile 'joda-time:joda-time:2.10'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'

--- a/api/tools/build.gradle
+++ b/api/tools/build.gradle
@@ -120,14 +120,14 @@ repositories {   // repositories for Jar's you access in your code
 
 dependencies {
   compile 'org.springframework.boot:spring-boot-starter-data-jpa'
-  compile 'commons-io:commons-io:+'
-  compile 'joda-time:joda-time:+'
-  compile 'com.github.fge:json-patch:+'
+  compile 'commons-io:commons-io:2.6'
+  compile 'joda-time:joda-time:2.10'
+  compile 'com.github.fge:json-patch:1.9'
   compile 'io.swagger:swagger-annotations:1.5.9'
   compile 'com.google.cloud.sql:mysql-socket-factory:1.0.9'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile 'com.google.code.gson:gson:+'
-  compile 'org.hibernate:hibernate-validator:+'
+  compile 'com.google.code.gson:gson:2.8.5'
+  compile 'org.hibernate:hibernate-validator:5.3.5.Final'
   compile 'com.squareup.okhttp:okhttp:2.6.0'
   compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
 }

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -22,7 +22,7 @@ repositories {   // repositories for Jar's you access in your code
 dependencies {
   // To show the dependency tree, try: ./project.rb gradle dependencies --configuration compile
   compile 'javax.servlet:javax.servlet-api:3.0.1'
-  compile 'joda-time:joda-time:+'
+  compile 'joda-time:joda-time:2.10'
   compile 'javax.inject:javax.inject:1'
   compile 'com.google.guava:guava:25.1-jre'
   compile 'org.hibernate:hibernate-ehcache:5.0.12.Final'

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -37,8 +37,8 @@ dependencies {
   }
 
   testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:1.+'
-  testCompile 'com.google.truth:truth:+'
+  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'com.google.truth:truth:0.42'
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   compile 'com.google.guava:guava:25.1-jre'
   compile 'org.hibernate:hibernate-ehcache:5.0.12.Final'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile('org.springframework.boot:spring-boot-starter-web:+') {
+  compile('org.springframework.boot:spring-boot-starter-web') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -39,8 +39,8 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile 'com.google.truth:truth:0.42'
-  testCompile 'com.h2database:h2:+'
-  testCompile 'org.liquibase:liquibase-core:+'
+  testCompile 'com.h2database:h2:1.4.194'
+  testCompile 'org.liquibase:liquibase-core:3.5.3'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
 }
 

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -37,7 +37,6 @@ configurations {
 }
 
 project.ext.GAE_VERSION = '1.9.64'
-project.ext.SBF_VERSION = '2.0.3.RELEASE'
 
 buildscript {    // Configuration for building
   repositories {
@@ -100,7 +99,7 @@ dependencies {
   compile 'com.google.cloud.sql:mysql-socket-factory:1.0.10'
   compile "com.google.appengine:appengine:${GAE_VERSION}"
   compile "com.google.appengine:appengine-api-1.0-sdk:${GAE_VERSION}"
-  compile('org.springframework.boot:spring-boot-starter-web:+') {
+  compile('org.springframework.boot:spring-boot-starter-web') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
@@ -108,7 +107,7 @@ dependencies {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
-  compile('org.springframework.boot:spring-boot-starter-actuator:+') {
+  compile('org.springframework.boot:spring-boot-starter-actuator') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
@@ -129,7 +128,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.+'
   testCompile 'com.google.truth:truth:+'
-  testCompile 'org.springframework.boot:spring-boot-starter-test:+'
+  testCompile 'org.springframework.boot:spring-boot-starter-test'
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -36,6 +36,9 @@ configurations {
   generatedCompile
 }
 
+project.ext.GAE_VERSION = '1.9.64'
+project.ext.SBF_VERSION = '2.0.3.RELEASE'
+
 buildscript {    // Configuration for building
   repositories {
     jcenter()    // Bintray's repository - a fast Maven Central mirror & more
@@ -93,10 +96,10 @@ dependencies {
   // To show the dependency tree, try: ./project.rb gradle dependencies --configuration compile
   providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
   compile project(":common-api")
-  compile 'mysql:mysql-connector-java:+'
-  compile 'com.google.cloud.sql:mysql-socket-factory:+'
-  compile 'com.google.appengine:appengine:+'
-  compile 'com.google.appengine:appengine-api-1.0-sdk:+'
+  compile 'mysql:mysql-connector-java:8.0.11'
+  compile 'com.google.cloud.sql:mysql-socket-factory:1.0.10'
+  compile "com.google.appengine:appengine:${GAE_VERSION}"
+  compile "com.google.appengine:appengine-api-1.0-sdk:${GAE_VERSION}"
   compile('org.springframework.boot:spring-boot-starter-web:+') {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -142,7 +142,7 @@ dependencies {
   generatedCompile 'com.squareup.okhttp:okhttp:2.7.5'
   generatedCompile 'com.squareup.okhttp:logging-interceptor:2.7.5'
   generatedCompile 'com.google.code.gson:gson:2.8.5'
-  generatedCompile 'joda-time:joda-time:+'
+  generatedCompile 'joda-time:joda-time:2.10'
   generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'
 
 }

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -143,7 +143,7 @@ dependencies {
   generatedCompile 'com.squareup.okhttp:logging-interceptor:2.7.5'
   generatedCompile 'com.google.code.gson:gson:2.8.5'
   generatedCompile 'joda-time:joda-time:2.10'
-  generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'
+  generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.6'
 
 }
 

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -129,8 +129,8 @@ dependencies {
   testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile 'com.google.truth:truth:0.42'
   testCompile 'org.springframework.boot:spring-boot-starter-test'
-  testCompile 'com.h2database:h2:+'
-  testCompile 'org.liquibase:liquibase-core:+'
+  testCompile 'com.h2database:h2:1.4.194'
+  testCompile 'org.liquibase:liquibase-core:3.5.3'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
 
   // For Swagger generation. These should include dependencies found in the Swagger codegen

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -141,7 +141,7 @@ dependencies {
   generatedCompile 'io.springfox:springfox-swagger-ui:2.6.1'
   generatedCompile 'com.squareup.okhttp:okhttp:2.7.5'
   generatedCompile 'com.squareup.okhttp:logging-interceptor:2.7.5'
-  generatedCompile 'com.google.code.gson:gson:+'
+  generatedCompile 'com.google.code.gson:gson:2.8.5'
   generatedCompile 'joda-time:joda-time:+'
   generatedCompile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:+'
 

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -126,8 +126,8 @@ dependencies {
   compile 'org.json:json:20160810'
 
   testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:1.+'
-  testCompile 'com.google.truth:truth:+'
+  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'com.google.truth:truth:0.42'
   testCompile 'org.springframework.boot:spring-boot-starter-test'
   testCompile 'com.h2database:h2:+'
   testCompile 'org.liquibase:liquibase-core:+'

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -116,7 +116,7 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
   compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
-  compile 'joda-time:joda-time:+'
+  compile 'joda-time:joda-time:2.10'
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     exclude module: 'spring-boot-starter-tomcat'
     exclude group: 'org.slf4j', module: 'jul-to-slf4j'
   }
-  compile 'org.springframework.security:spring-security-web:+'
+  compile 'org.springframework.security:spring-security-web:4.2.2.RELEASE'
 
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
   compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'


### PR DESCRIPTION
## Addresses 
* Lock dependency versions: https://precisionmedicineinitiative.atlassian.net/browse/RW-321
* Upgrade okhttp version: https://precisionmedicineinitiative.atlassian.net/browse/RW-699

This PR sets all flexibly specified versions to the actual version that gets pulled in. While there, I addressed the okhttp story since it was easy.

This PR does not address many reported snyk errors. In the cases where there are fixes, they require code changes which is not in scope. Several others have no remediation. I am detailing those here for reference.

## Choosing not to upgrade
Upgrading the following library causes problems for some developers. Choosing to ignore this until we have a better solution. 
```
✗ Medium severity vulnerability found in com.google.guava:guava
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236
  Introduced through: com.google.cloud.sql:mysql-socket-factory@1.0.10, project :common-api@*, com.google.guava:guava@22.0, com.google.cloud:google-cloud-bigquery@0.30.0-beta, com.google.cloud:google-cloud-storage@1.8.0, com.google.truth:truth@0.42
  From: com.google.cloud.sql:mysql-socket-factory@1.0.10 > com.google.cloud.sql:jdbc-socket-factory-core@1.0.10 > com.google.guava:guava@22.0
  From: project :common-api@* > com.google.guava:guava@22.0
  From: com.google.guava:guava@22.0
  and 33 more...
```

## Out of scope
Any spring library upgrade causes compilation problems somewhere in the stack. 
```
✗ Low severity vulnerability found in org.springframework:spring-webmvc
  Description: Multipart Content Pollution
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-32199
  Introduced through: org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE
  From: project :common-api@* > org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE

✗ Medium severity vulnerability found in org.springframework:spring-webmvc
  Description: Cross-Site Tracing (XST)
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31690
  Introduced through: org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE
  From: project :common-api@* > org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE

✗ Medium severity vulnerability found in org.springframework:spring-web
  Description: Authentication Bypass
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31644
  Introduced through: org.springframework.security:spring-security-web@4.2.2.RELEASE, org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.security:spring-security-web@4.2.2.RELEASE > org.springframework:spring-web@4.3.8.RELEASE
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-web@4.3.8.RELEASE
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE > org.springframework:spring-web@4.3.8.RELEASE
  and 2 more...

✗ Medium severity vulnerability found in org.springframework:spring-web
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31689
  Introduced through: org.springframework.security:spring-security-web@4.2.2.RELEASE, org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.security:spring-security-web@4.2.2.RELEASE > org.springframework:spring-web@4.3.8.RELEASE
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-web@4.3.8.RELEASE
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE > org.springframework:spring-web@4.3.8.RELEASE
  and 2 more...

✗ High severity vulnerability found in org.springframework:spring-webmvc
  Description: Directory Traversal
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-32202
  Introduced through: org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE
  From: project :common-api@* > org.springframework.boot:1.5.3.RELEASE@* > org.springframework:spring-webmvc@4.3.8.RELEASE

✗ High severity vulnerability found in org.springframework.security:spring-security-core
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-31509
  Introduced through: org.springframework.security:spring-security-web@4.2.2.RELEASE
  From: org.springframework.security:spring-security-web@4.2.2.RELEASE > org.springframework.security:spring-security-core@4.2.2.RELEASE

✗ High severity vulnerability found in org.springframework.security:spring-security-core
  Description: Access Restriction Bypass
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-32123
  Introduced through: org.springframework.security:spring-security-web@4.2.2.RELEASE
  From: org.springframework.security:spring-security-web@4.2.2.RELEASE > org.springframework.security:spring-security-core@4.2.2.RELEASE

✗ High severity vulnerability found in org.springframework.data:spring-data-commons
  Description: Arbitrary Code Execution
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKDATA-32219
  Introduced through: org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE, project :common-api@*
  From: org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE > org.springframework.data:spring-data-jpa@1.11.3.RELEASE > org.springframework.data:spring-data-commons@1.13.3.RELEASE
  From: project :common-api@* > org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE > org.springframework.data:spring-data-jpa@1.11.3.RELEASE > org.springframework.data:spring-data-commons@1.13.3.RELEASE

✗ High severity vulnerability found in org.springframework.data:spring-data-commons
  Description: Denial of Service (DoS)
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKDATA-32231
  Introduced through: org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE, project :common-api@*
  From: org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE > org.springframework.data:spring-data-jpa@1.11.3.RELEASE > org.springframework.data:spring-data-commons@1.13.3.RELEASE
  From: project :common-api@* > org.springframework.boot:spring-boot-starter-data-jpa@1.5.3.RELEASE > org.springframework.data:spring-data-jpa@1.11.3.RELEASE > org.springframework.data:spring-data-commons@1.13.3.RELEASE
```

## No Remediation
```
✗ High severity vulnerability found in org.mortbay.jetty:jetty
  Description: Arbitrary Command Execution
  Info: https://snyk.io/vuln/SNYK-JAVA-ORGMORTBAYJETTY-32091
  Introduced through: com.google.oauth-client:google-oauth-client-jetty@1.23.0
  From: com.google.oauth-client:google-oauth-client-jetty@1.23.0 > org.mortbay.jetty:jetty@6.1.26

✗ High severity vulnerability found in com.h2database:h2
  Description: Arbitrary Code Execution
  Info: https://snyk.io/vuln/SNYK-JAVA-COMH2DATABASE-31685
  Introduced through: com.h2database:h2@1.4.194
  From: com.h2database:h2@1.4.194

✗ High severity vulnerability found in ch.qos.logback:logback-core
  Description: Arbitrary Code Execution
  Info: https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-30208
  Introduced through: org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework.boot:spring-boot-starter@1.5.3.RELEASE > org.springframework.boot:spring-boot-starter-logging@1.5.3.RELEASE > ch.qos.logback:logback-classic@1.1.11 > ch.qos.logback:logback-core@1.1.11
  From: project :common-api@* > org.springframework.boot:1.5.3.RELEASE@* > org.springframework.boot:spring-boot-starter@1.5.3.RELEASE > org.springframework.boot:spring-boot-starter-logging@1.5.3.RELEASE > ch.qos.logback:logback-classic@1.1.11 > ch.qos.logback:logback-core@1.1.11

✗ High severity vulnerability found in ch.qos.logback:logback-classic
  Description: Arbitrary Code Execution
  Info: https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-31407
  Introduced through: org.springframework.boot:1.5.3.RELEASE@*, project :common-api@*
  From: org.springframework.boot:1.5.3.RELEASE@* > org.springframework.boot:spring-boot-starter@1.5.3.RELEASE > org.springframework.boot:spring-boot-starter-logging@1.5.3.RELEASE > ch.qos.logback:logback-classic@1.1.11
  From: project :common-api@* > org.springframework.boot:1.5.3.RELEASE@* > org.springframework.boot:spring-boot-starter@1.5.3.RELEASE > org.springframework.boot:spring-boot-starter-logging@1.5.3.RELEASE > ch.qos.logback:logback-classic@1.1.11

```

