### PR TITLE
[RW-712][risk=no] enforceRegistered in stable

### DIFF
--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -6,7 +6,7 @@
     "clusterMaxAgeDays": 14,
     "clusterIdleMaxAgeDays": 7,
     "debugEndpoints": false,
-    "enforceRegistered": false,
+    "enforceRegistered": true,
     "jupyterUserScriptUri": "gs:\/\/all-of-us-rw-stable-scripts/setup_notebook_cluster.sh",
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-stable",


### PR DESCRIPTION
(+) Makes staging, stable, prod all consistent w.r.t. user registration. Now exercise the same codepaths.
(-) New users in stable will need to be ID verified. For now we can have a process where users request this via slack in `#workbench-beta` (will need to communicate this change).
(-) In terms of business need, this verification is only required in production, since other environments will only contain synthetic.

Note: if users want to create many accounts without waiting on human verification, they can still use the test environment.