### PR TITLE
[RW-1033][risk=no] Handle more profile conflict errors

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -237,7 +237,7 @@ public class ProfileController implements ProfileApiDelegate {
     Boolean twoFactorEnabled = Optional.ofNullable(user.getTwoFactorEnabled()).orElse(false);
     if (!twoFactorEnabled) {
       user.setTwoFactorEnabled(directoryService.getUser(user.getEmail()).getIsEnrolledIn2Sv());
-      saveUserWithConflictHandling(user);
+      user = saveUserWithConflictHandling(user);
     }
 
     // On first sign-in, create a FC user, billing project, and set the first sign in time.
@@ -267,11 +267,12 @@ public class ProfileController implements ProfileApiDelegate {
     // first confirm whether Firecloud claims the project setup is complete.
     BillingProjectStatus status;
     try {
+      String billingProjectName = user.getFreeTierBillingProjectName();
       status = fireCloudService.getBillingProjectMemberships().stream()
           .filter(m -> m.getProjectName() != null)
           .filter(m -> m.getCreationStatus() != null)
           .filter(m -> fcToWorkbenchBillingMap.containsKey(m.getCreationStatus()))
-          .filter(m -> user.getFreeTierBillingProjectName().equals(m.getProjectName()))
+          .filter(m -> billingProjectName.equals(m.getProjectName()))
           .map(m -> fcToWorkbenchBillingMap.get(m.getCreationStatus()))
           // Should be at most one matching billing project; though we're not asserting this.
           .findFirst()

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -237,7 +237,7 @@ public class ProfileController implements ProfileApiDelegate {
     Boolean twoFactorEnabled = Optional.ofNullable(user.getTwoFactorEnabled()).orElse(false);
     if (!twoFactorEnabled) {
       user.setTwoFactorEnabled(directoryService.getUser(user.getEmail()).getIsEnrolledIn2Sv());
-      userDao.save(user);
+      saveUserWithConflictHandling(user);
     }
 
     // On first sign-in, create a FC user, billing project, and set the first sign in time.
@@ -549,9 +549,8 @@ public class ProfileController implements ProfileApiDelegate {
       }
     }
 
-
     // This does not update the name in Google.
-    userDao.save(user);
+    saveUserWithConflictHandling(user);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 


### PR DESCRIPTION
Currently, you will consistently get an initial profile conflict error when you first login *if* you had first enabled 2SV.