### PR TITLE
[RW-1033][risk=no] Avoid spurious profile reload

### DIFF
--- a/ui/src/app/views/signed-in/component.ts
+++ b/ui/src/app/views/signed-in/component.ts
@@ -71,11 +71,11 @@ export class SignedInComponent implements OnInit {
       });
     });
 
+    // TODO: Remove or move into CSS.
     document.body.style.backgroundColor = '#f1f2f2';
     this.signInService.isSignedIn$.subscribe(signedIn => {
       if (signedIn) {
         this.profileImage = this.signInService.profileImage;
-        this.profileStorageService.reload();
       } else {
         navigateLogin(this.router, this.router.routerState.snapshot.url);
       }


### PR DESCRIPTION
ProfileStorageService does an initial `reload()` upon creation. The only reason to call `reload()` again here is if the logged in user were to change - we no longer allow this to occur in a single client session (by forcing a hard page reload).

Currently going to any signed in page will result in to calls to `/me` (1) from the ProfileStorageService ctor and (2) from this code, which introduces more chances for conflict exceptions.

Also, please let me know whether this inline styling is needed.