### PR TITLE
[RW-1052][Risk=no] Block account creation until after username taken returns

### DIFF
--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -33,17 +33,19 @@
           </div>
         </clr-tooltip-content>
       </clr-tooltip>
-      <div *ngIf="usernameConflictError && usernameOffFocus" class="error" id="username-taken-error">
-        Username is already taken.
-      </div>
-      <div *ngIf="usernameInvalidError && usernameOffFocus" class="error" id="username-invalid-error">
-        Username is not a valid username.
+      <div style="height: 1.5rem;">
+        <div *ngIf="usernameConflictError" class="error" id="username-taken-error">
+          Username is already taken.
+        </div>
+        <div *ngIf="usernameInvalidError" class="error" id="username-invalid-error">
+          Username is not a valid username.
+        </div>
       </div>
     </div>
     <div class="form-section">
       <button type="submit"
           class="btn btn-primary short-button"
-          [disabled]="creatingAccount || usernameCheckInProgress || usernameConflictError"
+          [disabled]="creatingAccount || usernameCheckInProgress || isUsernameValidationError"
           [clrLoading]="creatingAccount">
         Next
       </button>

--- a/ui/src/app/views/account-creation/component.html
+++ b/ui/src/app/views/account-creation/component.html
@@ -43,7 +43,7 @@
     <div class="form-section">
       <button type="submit"
           class="btn btn-primary short-button"
-          [disabled]="creatingAccount"
+          [disabled]="creatingAccount || usernameCheckInProgress || usernameConflictError"
           [clrLoading]="creatingAccount">
         Next
       </button>

--- a/ui/src/app/views/account-creation/component.spec.ts
+++ b/ui/src/app/views/account-creation/component.spec.ts
@@ -2,7 +2,6 @@ import {DebugElement} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {ClarityModule} from '@clr/angular';
@@ -96,29 +95,28 @@ describe('AccountCreationComponent', () => {
     simulateEvent(page.fixture, page.usernameField, 'focus');
     simulateInput(page.fixture, page.usernameField, '.username');
     tick(300);
-    tick();
-    simulateEvent(page.fixture, page.usernameField, 'blur');
+    updateAndTick(page.fixture);
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeTruthy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeTruthy();
 
     // End with a period
     simulateInput(page.fixture, page.usernameField, 'username.');
     tick(300);
-    tick();
+    updateAndTick(page.fixture);
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeTruthy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeTruthy();
 
     // Contains special characters
     simulateInput(page.fixture, page.usernameField, 'user@name');
     tick(300);
-    tick();
+    updateAndTick(page.fixture);
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeTruthy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeTruthy();
 
 
     simulateInput(page.fixture, page.usernameField, 'blah');
     tick(300);
-    tick();
+    updateAndTick(page.fixture);
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeFalsy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeFalsy();
   }));
@@ -129,7 +127,7 @@ describe('AccountCreationComponent', () => {
     simulateInput(
       page.fixture, page.usernameField, 'thisisaverylongusernamewithnowspaceswillitwork t');
     tick(300);
-    tick();
+    updateAndTick(page.fixture);
     expect(page.fixture.debugElement.query(By.css('#username-invalid-error'))).toBeTruthy();
     expect(page.usernameField.classes.unsuccessfulInput).toBeTruthy();
   }));

--- a/ui/src/app/views/account-creation/component.spec.ts
+++ b/ui/src/app/views/account-creation/component.spec.ts
@@ -82,11 +82,11 @@ describe('AccountCreationComponent', () => {
 
   it('handles selecting username', fakeAsync(() => {
     page.readPageData();
-    expect(page.component.usernameOffFocus).toBeTruthy();
+    expect(page.component.usernameFocused).toBeFalsy();
     simulateEvent(page.fixture, page.usernameField, 'focus');
-    expect(page.component.usernameOffFocus).toBeFalsy();
+    expect(page.component.usernameFocused).toBeTruthy();
     simulateEvent(page.fixture, page.usernameField, 'blur');
-    expect(page.component.usernameOffFocus).toBeTruthy();
+    expect(page.component.usernameFocused).toBeFalsy();
   }));
 
   it('handles each username invalidity', fakeAsync(() => {

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -138,7 +138,7 @@ export class AccountCreationComponent implements AfterViewInit {
   }
 
   get showUsernameValidationError(): boolean {
-    if (isBlank(this.profile.username) || !this.usernameOffFocus) {
+    if (isBlank(this.profile.username)) {
       return false;
     }
     return this.isUsernameValidationError;

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -33,7 +33,7 @@ export class AccountCreationComponent implements AfterViewInit {
   accountCreated: boolean;
   usernameConflictError = false;
   gsuiteDomain: string;
-  usernameOffFocus = true;
+  usernameFocused = false;
   usernameCheckTimeout: NodeJS.Timer;
   usernameCheckInProgress = false;
 
@@ -128,11 +128,11 @@ export class AccountCreationComponent implements AfterViewInit {
   }
 
   leaveFocusUsername(): void {
-    this.usernameOffFocus = true;
+    this.usernameFocused = false;
   }
 
   enterFocusUsername(): void {
-    this.usernameOffFocus = false;
+    this.usernameFocused = true;
   }
 
   get isUsernameValidationError(): boolean {
@@ -147,7 +147,7 @@ export class AccountCreationComponent implements AfterViewInit {
   }
 
   get showUsernameValidationSuccess(): boolean {
-    if (isBlank(this.profile.username) || !this.usernameOffFocus || this.usernameCheckInProgress) {
+    if (isBlank(this.profile.username) || this.usernameFocused || this.usernameCheckInProgress) {
       return false;
     }
     return !this.isUsernameValidationError;

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -138,14 +138,14 @@ export class AccountCreationComponent implements AfterViewInit {
   }
 
   get showUsernameValidationError(): boolean {
-    if (isBlank(this.profile.username)) {
+    if (isBlank(this.profile.username) || this.usernameCheckInProgress) {
       return false;
     }
     return this.isUsernameValidationError;
   }
 
   get showUsernameValidationSuccess(): boolean {
-    if (isBlank(this.profile.username) || !this.usernameOffFocus) {
+    if (isBlank(this.profile.username) || !this.usernameOffFocus || this.usernameCheckInProgress) {
       return false;
     }
     return !this.isUsernameValidationError;

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -121,6 +121,8 @@ export class AccountCreationComponent implements AfterViewInit {
       this.profileService.isUsernameTaken(this.profile.username).subscribe((response) => {
         this.usernameCheckInProgress = false;
         this.usernameConflictError = response.isTaken;
+      }, () => {
+        this.usernameCheckInProgress = false;
       });
     }, 300);
   }

--- a/ui/src/app/views/account-creation/component.ts
+++ b/ui/src/app/views/account-creation/component.ts
@@ -35,6 +35,7 @@ export class AccountCreationComponent implements AfterViewInit {
   gsuiteDomain: string;
   usernameOffFocus = true;
   usernameCheckTimeout: NodeJS.Timer;
+  usernameCheckInProgress = false;
 
   @ViewChild('infoIcon') infoIcon: ElementRef;
 
@@ -111,11 +112,14 @@ export class AccountCreationComponent implements AfterViewInit {
     this.usernameConflictError = false;
     // TODO: This should use a debounce, rather than manual setTimeout()s.
     clearTimeout(this.usernameCheckTimeout);
+    this.usernameCheckInProgress = true;
     this.usernameCheckTimeout = setTimeout(() => {
       if (!this.profile.username.trim()) {
+        this.usernameCheckInProgress = false;
         return;
       }
       this.profileService.isUsernameTaken(this.profile.username).subscribe((response) => {
+        this.usernameCheckInProgress = false;
         this.usernameConflictError = response.isTaken;
       });
     }, 300);


### PR DESCRIPTION
This also changes the username field to display errors live, even when the username is in focus, because it was weird to not be able to click next and have no validation about why.


Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
