### PR TITLE
[RW-1078][risk=no] fixed broken BQ test case.

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -471,7 +471,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter demo = createSearchParameter(demoAge, null);
     demo.attributes(Arrays.asList(new Attribute().operator(Operator.EQUAL).operands(Arrays.asList(age.toString()))));
     SearchRequest searchRequests = createSearchRequests(demoAge.getType(), Arrays.asList(demo), new ArrayList<>());
-    assertParticipants(controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequests), 1);
+    assertParticipants(controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequests), 2);
   }
 
   @Test


### PR DESCRIPTION
it's a data problem. The extra result that is now showing up in the test has a birthday of 08/01/1980. 