### PR TITLE
[RW-1055][risk=no] Drop the login "from" feature for now

### DIFF
--- a/ui/src/app/guards/sign-in-guard.service.ts
+++ b/ui/src/app/guards/sign-in-guard.service.ts
@@ -9,7 +9,6 @@ import {
 import {Observable} from 'rxjs/Observable';
 
 import {SignInService} from 'app/services/sign-in.service';
-import {navigateLogin} from 'app/utils';
 
 
 declare const gapi: any;
@@ -20,7 +19,7 @@ export class SignInGuard implements CanActivate, CanActivateChild {
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     return this.signInService.isSignedIn$.do(
-      isSignedIn => isSignedIn || navigateLogin(this.router, state.url));
+      isSignedIn => isSignedIn || this.router.navigate(['/login']));
   }
   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     return this.canActivate(route, state);

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -19,18 +19,6 @@ export function deepCopy(obj: Object): Object {
 }
 
 /**
- * Navigate a signed out user to the login page from the given relative Angular
- * path.
- */
-export function navigateLogin(router: Router, fromUrl: string): Promise<boolean> {
-  const params = {};
-  if (fromUrl && fromUrl !== '/') {
-    params['from'] = fromUrl;
-  }
-  return router.navigate(['/login', params]);
-}
-
-/**
  * Determine whether the given access level is >= registered. This is the
  * minimum required level to do most things in the Workbench app (outside of
  * local/test development).

--- a/ui/src/app/views/login/component.spec.ts
+++ b/ui/src/app/views/login/component.spec.ts
@@ -128,41 +128,5 @@ describe('LoginComponent', () => {
 
     expect(de.queryAll(By.css('app-fake-root')).length).toEqual(1);
   }));
-
-  it('should navigate to "from" on sign in', fakeAsync(() => {
-    router.navigate(['/login', {'from': '/ok'}]);
-    tick();
-    fixture.detectChanges();
-
-    signInService.signIn();
-    tick();
-    fixture.detectChanges();
-
-    expect(de.queryAll(By.css('app-fake-other')).length).toEqual(1);
-  }));
-
-  it('should navigate to root on bad "from"', fakeAsync(() => {
-    router.navigate(['/login', {'from': 'asdfasdf'}]);
-    tick();
-    fixture.detectChanges();
-
-    signInService.signIn();
-    tick();
-    fixture.detectChanges();
-
-    expect(de.queryAll(By.css('app-fake-root')).length).toEqual(1);
-  }));
-
-  it('should navigate to root on "from" nav error', fakeAsync(() => {
-    router.navigate(['/login', {'from': '/error'}]);
-    tick();
-    fixture.detectChanges();
-
-    signInService.signIn();
-    tick();
-    fixture.detectChanges();
-
-    expect(de.queryAll(By.css('app-fake-root')).length).toEqual(1);
-  }));
 });
 

--- a/ui/src/app/views/login/component.ts
+++ b/ui/src/app/views/login/component.ts
@@ -16,7 +16,6 @@ import {SignInService} from 'app/services/sign-in.service';
 })
 export class LoginComponent implements OnInit {
   showCreateAccount = false;
-  currentUrl: string;
   backgroundImgSrc = '/assets/images/login-group.png';
   smallerBackgroundImgSrc = '/assets/images/login-standing.png';
   googleIcon = '/assets/icons/google-icon.png';
@@ -25,26 +24,15 @@ export class LoginComponent implements OnInit {
     /* Ours */
     private signInService: SignInService,
     /* Angular's */
-    private activatedRoute: ActivatedRoute,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
-    this.currentUrl = this.router.url;
     document.body.style.backgroundColor = '#e2e3e5';
 
     this.signInService.isSignedIn$.subscribe((signedIn) => {
-      if (signedIn === true) {
-        if (this.activatedRoute.snapshot.params.from === undefined) {
-          this.router.navigateByUrl('/');
-        } else {
-          this.router.navigateByUrl(this.activatedRoute.snapshot.params.from)
-            .catch(() => {
-              // "from" might be invalid, e.g. if we just changed users; just
-              // ignore failed navigates in this particular case.
-              this.router.navigateByUrl('/');
-            });
-        }
+      if (signedIn) {
+        this.router.navigateByUrl('/');
       }
     });
   }

--- a/ui/src/app/views/signed-in/component.ts
+++ b/ui/src/app/views/signed-in/component.ts
@@ -8,7 +8,7 @@ import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {SignInService} from 'app/services/sign-in.service';
-import {hasRegisteredAccess, navigateLogin} from 'app/utils';
+import {hasRegisteredAccess} from 'app/utils';
 import {BugReportComponent} from 'app/views/bug-report/component';
 
 import {Authority} from 'generated';
@@ -77,17 +77,22 @@ export class SignedInComponent implements OnInit {
       if (signedIn) {
         this.profileImage = this.signInService.profileImage;
       } else {
-        navigateLogin(this.router, this.router.routerState.snapshot.url);
+        this.navigateSignOut();
       }
     });
   }
 
   signOut(): void {
     this.signInService.signOut();
+    this.navigateSignOut();
+  }
+
+  private navigateSignOut(): void {
     // Force a hard browser reload here. We want to ensure that no local state
     // is persisting across user sessions, as this can lead to subtle bugs.
-    window.location.assign('/login');
+    window.location.assign('/');
   }
+
 
   get reviewWorkspaceActive(): boolean {
     return this.locationService.path().startsWith('/admin/review-workspace');


### PR DESCRIPTION
Unfortunately we can’t fix this without doing a deeper rework of our sign in flow (switching to server side oauth) or breaking certain users' ability to login (reverting to the previous pop-up approach) because we can’t generate a dynamic redirect URI while also matchin our redirect whitelist. I tried tacking on query parameters and hash fragments, nothing makes it through, and GoogleAuth doesn't appear to have any capability to attach extras onto the sign in call.

Secondarily, this removes the navigation on user signout, as this caused a navigate/reload combo which made the page half-navigate and half-render on sign out before reloading the page.