### PR TITLE
[risk=no] Spell out AoU in drug criteria hint

### DIFF
--- a/ui/src/app/cohort-search/modal/modal.component.html
+++ b/ui/src/app/cohort-search/modal/modal.component.html
@@ -30,7 +30,7 @@
         <a href="https://mor.nlm.nih.gov/RxNav/" target="_blank">
           Explore
         </a>
-        drugs by brand names outside of AoU
+        drugs by brand names outside of All of Us
       </div>
       <button
         (click)="cancel()"


### PR DESCRIPTION
I'm not sure how intentional this language was, so feel free to run by the rest of CB team if you think this change would be controversial. In general our product guidance has been to spell out any program-specific acronyms.