### PR TITLE
[RW-872][risk=low] Don't store enum ordinals for WorkspaceAccessLevel

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceServiceImpl.java
@@ -162,10 +162,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       WorkspaceACLUpdate currentUpdate = new WorkspaceACLUpdate();
       currentUpdate.setEmail(currentWorkspaceUser.getUser().getEmail());
       currentUpdate.setCanCompute(false);
-      if (currentWorkspaceUser.getRole() == WorkspaceAccessLevel.OWNER) {
+      WorkspaceAccessLevel access =
+          WorkspaceUserRole.accessLevelFromStorage(currentWorkspaceUser.getRole());
+      if (access == WorkspaceAccessLevel.OWNER) {
         currentUpdate.setCanShare(true);
         currentUpdate.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
-      } else if (currentWorkspaceUser.getRole() == WorkspaceAccessLevel.WRITER) {
+      } else if (access == WorkspaceAccessLevel.WRITER) {
         currentUpdate.setCanShare(false);
         currentUpdate.setAccessLevel(WorkspaceAccessLevel.WRITER.toString());
       } else {

--- a/api/src/main/java/org/pmiops/workbench/db/model/WorkspaceUserRole.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/WorkspaceUserRole.java
@@ -1,5 +1,8 @@
 package org.pmiops.workbench.db.model;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -14,12 +17,25 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 @Entity
 @Table(name = "user_workspace")
 public class WorkspaceUserRole {
+  private static final BiMap<WorkspaceAccessLevel, Short> CLIENT_TO_STORAGE_WORKSPACE_ACCESS =
+      ImmutableBiMap.<WorkspaceAccessLevel, Short>builder()
+      .put(WorkspaceAccessLevel.NO_ACCESS, (short) 0)
+      .put(WorkspaceAccessLevel.READER, (short) 1)
+      .put(WorkspaceAccessLevel.WRITER, (short) 2)
+      .put(WorkspaceAccessLevel.OWNER, (short) 3)
+      .build();
+  public static WorkspaceAccessLevel accessLevelFromStorage(Short level) {
+    return CLIENT_TO_STORAGE_WORKSPACE_ACCESS.inverse().get(level);
+  }
+
+  public static Short accessLevelToStorage(WorkspaceAccessLevel level) {
+    return CLIENT_TO_STORAGE_WORKSPACE_ACCESS.get(level);
+  }
+
   private long userWorkspaceId;
   private User user;
   private Workspace workspace;
-  private WorkspaceAccessLevel role;
-
-
+  private Short role;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +47,7 @@ public class WorkspaceUserRole {
   public void setUserWorkspaceId(long userWorkspaceId) {
     this.userWorkspaceId = userWorkspaceId;
   }
-  
+
   @ManyToOne
   @JoinColumn(name="user_id")
   public User getUser() {
@@ -52,13 +68,12 @@ public class WorkspaceUserRole {
     this.workspace = workspace;
   }
 
-
   @Column(name="role")
-  public WorkspaceAccessLevel getRole() {
+  public Short getRole() {
     return this.role;
   }
 
-  public void setRole(WorkspaceAccessLevel role) {
+  public void setRole(Short role) {
     this.role = role;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/model/WorkspaceUserRoleTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/model/WorkspaceUserRoleTest.java
@@ -1,0 +1,20 @@
+package org.pmiops.workbench.db.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class WorkspaceUserRoleTest {
+  @Test
+  public void testWorkspaceAccessLevelConversion() {
+    for (WorkspaceAccessLevel level : WorkspaceAccessLevel.values()) {
+      Short storageLevel = WorkspaceUserRole.accessLevelToStorage(level);
+      assertThat(storageLevel).isNotNull();
+      assertThat(level).isEqualTo(WorkspaceUserRole.accessLevelFromStorage(storageLevel));
+    }
+  }
+}


### PR DESCRIPTION
See ticket for background. Looking for feedback on this pattern. If it looks good, will apply to all other stored enum values as well.