### PR TITLE
[RW-1118][risk=low] Update cohort breadcrumb displays

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -114,38 +114,45 @@ const routes: Routes = [
             },
             {
               path: 'cohorts',
-              component: CohortListComponent,
-              data: {
-                title: 'View Cohorts',
-                breadcrumb: 'Cohorts'
-              }
-            },
-            {
-              path: 'cohorts/build',
-              loadChildren: './cohort-search/cohort-search.module#CohortSearchModule',
-              data: {
-                breadcrumb: 'Add a Cohort'
-              }
-            }, {
-              path: 'cohorts/:cid/review',
-              loadChildren: './cohort-review/cohort-review.module#CohortReviewModule',
-              data: {
-                title: 'Cohort',
-                breadcrumb: 'Param: Cohort Name'
-              },
-              resolve: {
-                cohort: CohortResolver,
-              }
-            }, {
-              path: 'cohorts/:cid/edit',
-              component: CohortEditComponent,
-              data: {
-                title: 'Edit Cohort',
-                breadcrumb: 'Param: Cohort Name'
-              },
-              resolve: {
-                cohort: CohortResolver,
-              },
+              data: { breadcrumb: 'Cohorts' },
+              children: [
+                {
+                  path: '',
+                  component: CohortListComponent,
+                  data: {
+                    title: 'View Cohorts',
+                  },
+                },
+                {
+                  path: 'build',
+                  loadChildren: './cohort-search/cohort-search.module#CohortSearchModule',
+                  data: {
+                    breadcrumb: 'Add a Cohort'
+                  }
+                },
+                {
+                  path: ':cid/review',
+                  loadChildren: './cohort-review/cohort-review.module#CohortReviewModule',
+                  data: {
+                    title: 'Cohort',
+                    breadcrumb: 'Param: Cohort Name'
+                  },
+                  resolve: {
+                    cohort: CohortResolver,
+                  }
+                },
+                {
+                  path: ':cid/edit',
+                  component: CohortEditComponent,
+                  data: {
+                    title: 'Edit Cohort',
+                    breadcrumb: 'Param: Cohort Name'
+                  },
+                  resolve: {
+                    cohort: CohortResolver,
+                  }
+                }
+              ]
             }]
           }
         ]

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -130,14 +130,18 @@ const routes: Routes = [
               path: 'cohorts/:cid/review',
               loadChildren: './cohort-review/cohort-review.module#CohortReviewModule',
               data: {
-                breadcrumb: 'Cohort'
+                title: 'Cohort',
+                breadcrumb: 'Param: Cohort Name'
+              },
+              resolve: {
+                cohort: CohortResolver,
               }
             }, {
               path: 'cohorts/:cid/edit',
               component: CohortEditComponent,
               data: {
                 title: 'Edit Cohort',
-                breadcrumb: 'Edit Cohort'
+                breadcrumb: 'Param: Cohort Name'
               },
               resolve: {
                 cohort: CohortResolver,

--- a/ui/src/app/cohort-review/routing/routing.module.ts
+++ b/ui/src/app/cohort-review/routing/routing.module.ts
@@ -32,6 +32,7 @@ const routes: Routes = [{
     component: CreateReviewPage,
     data: {
       title: 'Create a New Cohort Review',
+      breadcrumb: 'Create a New Cohort Review',
     },
   }, {
     path: '',

--- a/ui/src/app/views/breadcrumb/component.ts
+++ b/ui/src/app/views/breadcrumb/component.ts
@@ -82,6 +82,9 @@ export class BreadcrumbComponent implements OnInit, OnDestroy {
       if (label === 'Param: Workspace Name') {
         label = child.snapshot.data['workspace'].name;
       }
+      if (label === 'Param: Cohort Name') {
+        label = child.snapshot.data['cohort'].name;
+      }
       // Prevent processing children with duplicate urls
       if (!breadcrumbs.some(b => b.url === url)) {
         const breadcrumb = BreadcrumbComponent.makeBreadcrumb(label, url, child);


### PR DESCRIPTION
# Addresses
https://precisionmedicineinitiative.atlassian.net/browse/RW-1118

# Changes
Updated the breadcrumb displays for the following cohort pages:
* Create new cohort
* Review cohort
* View cohort page (Overview/Participants)
* Edit Cohort

## Create
![screen shot 2018-08-14 at 11 07 52 am](https://user-images.githubusercontent.com/116679/44146119-305c4ee8-a05c-11e8-978a-022f7333d46a.png)

## Review
![screen shot 2018-08-14 at 11 08 14 am](https://user-images.githubusercontent.com/116679/44146124-38611a74-a05c-11e8-9b86-023a80ef9700.png)

## Overview
![screen shot 2018-08-14 at 11 08 31 am](https://user-images.githubusercontent.com/116679/44146138-45b5579e-a05c-11e8-96f5-54342f050bb7.png)

## Participants
![screen shot 2018-08-14 at 11 08 40 am](https://user-images.githubusercontent.com/116679/44146147-532dffde-a05c-11e8-9987-b2391bc9f49e.png)

## Edit
![screen shot 2018-08-14 at 11 08 55 am](https://user-images.githubusercontent.com/116679/44146153-5a500d84-a05c-11e8-97da-4e1aeeaca703.png)
