### PR TITLE
[risk=low] Bump Guava to 26.0

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -274,7 +274,7 @@ dependencies {
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile 'com.google.guava:guava:22.0'
+  compile 'com.google.guava:guava:25.1-jre'
   compile 'org.springframework.retry:spring-retry:1.1.5.RELEASE'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -274,7 +274,7 @@ dependencies {
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile 'com.google.guava:guava:25.1-jre'
+  compile 'com.google.guava:guava:26.0-jre'
   compile 'org.springframework.retry:spring-retry:1.1.5.RELEASE'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compile 'javax.servlet:javax.servlet-api:3.0.1'
   compile 'joda-time:joda-time:2.10'
   compile 'javax.inject:javax.inject:1'
-  compile 'com.google.guava:guava:25.1-jre'
+  compile 'com.google.guava:guava:26.0-jre'
   compile 'org.hibernate:hibernate-ehcache:5.0.12.Final'
   compile 'org.apache.commons:commons-lang3:3.0'
   compile('org.springframework.boot:spring-boot-starter-web') {

--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -120,7 +120,7 @@ dependencies {
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.0'
-  compile 'com.google.guava:guava:25.1-jre'
+  compile 'com.google.guava:guava:26.0-jre'
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502
   compile 'org.json:json:20160810'


### PR DESCRIPTION
I just looked back at the history and see possible complications per https://github.com/all-of-us/workbench/pull/958... Will review what happened there.

The reason I want this is that the Google `Truth.assertWithMessage()` fails with older guava versions.