### PR TITLE
[RW-1132][risk=low] Don't store cohort builder enum ordinals

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -101,7 +101,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     key.setCohortReviewId(cohortReviewId);
     key.setParticipantId(participantId);
     ParticipantCohortStatus result = new ParticipantCohortStatus();
-    result.setStatus(status);
+    result.setStatusEnum(status);
     result.setParticipantKey(key);
     return result;
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortAnnotationDefinitionController.java
@@ -46,7 +46,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                     return new CohortAnnotationDefinition()
                             .columnName(cohortAnnotationDefinition.getColumnName())
                             .cohortId(cohortAnnotationDefinition.getCohortId())
-                            .annotationType(cohortAnnotationDefinition.getAnnotationType())
+                            .annotationType(cohortAnnotationDefinition.getAnnotationTypeEnum())
                             .cohortAnnotationDefinitionId(cohortAnnotationDefinition.getCohortAnnotationDefinitionId())
                             .enumValues(enumValues);
                 }
@@ -61,7 +61,7 @@ public class CohortAnnotationDefinitionController implements CohortAnnotationDef
                             new org.pmiops.workbench.db.model.CohortAnnotationDefinition()
                                     .cohortId(cohortAnnotationDefinition.getCohortId())
                                     .columnName(cohortAnnotationDefinition.getColumnName())
-                                    .annotationType(cohortAnnotationDefinition.getAnnotationType());
+                                    .annotationTypeEnum(cohortAnnotationDefinition.getAnnotationType());
                     List<CohortAnnotationEnumValue> enumValuesList = (cohortAnnotationDefinition.getEnumValues() == null) ? new ArrayList<>() :
                             IntStream.range(0, cohortAnnotationDefinition.getEnumValues().size())
                                     .mapToObj(i -> new CohortAnnotationEnumValue()

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -95,7 +95,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       public org.pmiops.workbench.model.ParticipantCohortStatus apply(ParticipantCohortStatus participant) {
         return new org.pmiops.workbench.model.ParticipantCohortStatus()
           .participantId(participant.getParticipantKey().getParticipantId())
-          .status(participant.getStatus())
+          .status(participant.getStatusEnum())
           .birthDate(participant.getBirthDate().toString())
           .ethnicityConceptId(participant.getEthnicityConceptId())
           .ethnicity(participant.getEthnicity())
@@ -122,7 +122,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
           .creationTime(cohortReview.getCreationTime().toString())
           .matchedParticipantCount(cohortReview.getMatchedParticipantCount())
           .reviewedCount(cohortReview.getReviewedCount())
-          .reviewStatus(cohortReview.getReviewStatus())
+          .reviewStatus(cohortReview.getReviewStatusEnum())
           .reviewSize(cohortReview.getReviewSize())
           .page(pageRequest.getPage())
           .pageSize(pageRequest.getPageSize())
@@ -215,7 +215,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       cohortReview = cohortReviewService.findCohortReview(cohortId, cdrVersionId);
     } catch (NotFoundException nfe) {
       cohortReview = initializeCohortReview(cdrVersionId, cohort)
-        .reviewStatus(ReviewStatus.NONE)
+        .reviewStatusEnum(ReviewStatus.NONE)
         .reviewSize(0L);
       cohortReviewService.saveCohortReview(cohortReview);
     }
@@ -237,7 +237,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
     cohortReview
       .reviewSize(participantCohortStatuses.size())
-      .reviewStatus(ReviewStatus.CREATED);
+      .reviewStatusEnum(ReviewStatus.CREATED);
 
     //when saving ParticipantCohortStatuses to the database the long value of birthdate is mutated.
     cohortReviewService.saveFullCohortReview(cohortReview, participantCohortStatuses);
@@ -485,7 +485,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     ParticipantCohortStatus participantCohortStatus
       = cohortReviewService.findParticipantCohortStatus(cohortReview.getCohortReviewId(), participantId);
 
-    participantCohortStatus.setStatus(cohortStatusRequest.getStatus());
+    participantCohortStatus.setStatusEnum(cohortStatusRequest.getStatus());
     cohortReviewService.saveParticipantCohortStatus(participantCohortStatus);
     lookupGenderRaceEthnicityValues(Arrays.asList(participantCohortStatus));
 
@@ -549,7 +549,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       participantCohortStatuses.add(
         new ParticipantCohortStatus()
           .participantKey(new ParticipantCohortStatusKey(cohortReviewId, bigQueryService.getLong(row, rm.get("person_id"))))
-          .status(CohortStatus.NOT_REVIEWED)
+          .statusEnum(CohortStatus.NOT_REVIEWED)
           .birthDate(new Date(birthDate.getTime()))
           .genderConceptId(bigQueryService.getLong(row, rm.get("gender_concept_id")))
           .raceConceptId(bigQueryService.getLong(row, rm.get("race_concept_id")))
@@ -589,7 +589,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     cohortReview.matchedParticipantCount(cohortCount);
     cohortReview.setCreationTime(new Timestamp(System.currentTimeMillis()));
     cohortReview.reviewedCount(0L);
-    cohortReview.reviewStatus(ReviewStatus.NONE);
+    cohortReview.reviewStatusEnum(ReviewStatus.NONE);
     return cohortReview;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -109,15 +109,15 @@ public class AnnotationQueryBuilder {
                 cohortReview.getCohortReviewId()));
         parameters.put("def_" + annotationCount, definition.getCohortAnnotationDefinitionId());
         String sourceColumn;
-        if (definition.getAnnotationType().equals(AnnotationType.ENUM)) {
+        if (definition.getAnnotationTypeEnum().equals(AnnotationType.ENUM)) {
           sourceColumn = String.format("ae%d.name", annotationCount);
           fromBuilder.append(
               String.format(ANNOTATION_VALUE_JOIN_SQL, annotationCount, annotationCount, annotationCount));
         } else {
 
-          String columnName = ANNOTATION_COLUMN_MAP.get(definition.getAnnotationType());
+          String columnName = ANNOTATION_COLUMN_MAP.get(definition.getAnnotationTypeEnum());
           if (columnName == null) {
-            throw new ServerErrorException("Invalid annotation type: " + definition.getAnnotationType());
+            throw new ServerErrorException("Invalid annotation type: " + definition.getAnnotationTypeEnum());
           }
           sourceColumn = String.format("a%d.%s", annotationCount, columnName);
         }

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
 import org.pmiops.workbench.db.model.CohortAnnotationDefinition;
 import org.pmiops.workbench.db.model.CohortReview;
+import org.pmiops.workbench.db.model.StorageEnums;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.AnnotationQuery;
@@ -233,7 +234,7 @@ public class AnnotationQueryBuilder {
           if (obj != null) {
             String column = columns.get(i);
             if (column.equals(REVIEW_STATUS_COLUMN)) {
-              result.put(column, CohortStatus.values()[(Integer) obj].name());
+              result.put(column, StorageEnums.cohortStatusFromStorage((Short) obj).name());
             } else if (obj instanceof java.sql.Date) {
               result.put(column, DATE_FORMAT.format((java.sql.Date) obj));
             } else {

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -221,15 +221,15 @@ public class CohortReviewServiceImpl implements CohortReviewService {
     private void validateParticipantCohortAnnotation(ParticipantCohortAnnotation participantCohortAnnotation,
                                                      CohortAnnotationDefinition cohortAnnotationDefinition) {
 
-        if (cohortAnnotationDefinition.getAnnotationType().equals(AnnotationType.BOOLEAN)) {
+        if (cohortAnnotationDefinition.getAnnotationTypeEnum().equals(AnnotationType.BOOLEAN)) {
             if (participantCohortAnnotation.getAnnotationValueBoolean() == null) {
                 throw createBadRequestException(AnnotationType.BOOLEAN.name(), participantCohortAnnotation.getCohortAnnotationDefinitionId());
             }
-        } else if (cohortAnnotationDefinition.getAnnotationType().equals(AnnotationType.STRING)) {
+        } else if (cohortAnnotationDefinition.getAnnotationTypeEnum().equals(AnnotationType.STRING)) {
             if (StringUtils.isBlank(participantCohortAnnotation.getAnnotationValueString())) {
                 throw createBadRequestException(AnnotationType.STRING.name(), participantCohortAnnotation.getCohortAnnotationDefinitionId());
             }
-        } else if (cohortAnnotationDefinition.getAnnotationType().equals(AnnotationType.DATE)) {
+        } else if (cohortAnnotationDefinition.getAnnotationTypeEnum().equals(AnnotationType.DATE)) {
             if (StringUtils.isBlank(participantCohortAnnotation.getAnnotationValueDateString())) {
                 throw createBadRequestException(AnnotationType.DATE.name(), participantCohortAnnotation.getCohortAnnotationDefinitionId());
             }
@@ -243,11 +243,11 @@ public class CohortReviewServiceImpl implements CohortReviewService {
                         sdf.toPattern(),
                         participantCohortAnnotation.getCohortAnnotationDefinitionId()));
             }
-        } else if (cohortAnnotationDefinition.getAnnotationType().equals(AnnotationType.INTEGER)) {
+        } else if (cohortAnnotationDefinition.getAnnotationTypeEnum().equals(AnnotationType.INTEGER)) {
             if (participantCohortAnnotation.getAnnotationValueInteger() == null) {
                 throw createBadRequestException(AnnotationType.INTEGER.name(), participantCohortAnnotation.getCohortAnnotationDefinitionId());
             }
-        } else if (cohortAnnotationDefinition.getAnnotationType().equals(AnnotationType.ENUM)) {
+        } else if (cohortAnnotationDefinition.getAnnotationTypeEnum().equals(AnnotationType.ENUM)) {
             if (StringUtils.isBlank(participantCohortAnnotation.getAnnotationValueEnum())) {
                 throw createBadRequestException(AnnotationType.ENUM.name(), participantCohortAnnotation.getCohortAnnotationDefinitionId());
             }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -25,6 +25,7 @@ import org.pmiops.workbench.db.dao.ParticipantCohortStatusDao;
 import org.pmiops.workbench.db.model.CohortReview;
 import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus;
 import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus.Key;
+import org.pmiops.workbench.db.model.StorageEnums;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.FieldSet;
@@ -69,8 +70,11 @@ public class CohortMaterializationService {
     if (cohortReview == null) {
       return ImmutableSet.of();
     }
+    List<Short> dbStatusFilter = statusFilter.stream()
+        .map(StorageEnums::cohortStatusToStorage)
+        .collect(Collectors.toList());
     Set<Long> participantIds = participantCohortStatusDao.findByParticipantKey_CohortReviewIdAndStatusIn(
-        cohortReview.getCohortReviewId(), statusFilter)
+        cohortReview.getCohortReviewId(), dbStatusFilter)
         .stream()
         .map(ParticipantIdAndCohortStatus::getParticipantKey)
         .map(Key::getParticipantId)

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortService.java
@@ -34,7 +34,7 @@ public class CohortService {
       cr.setMatchedParticipantCount(fromReview.getMatchedParticipantCount());
       cr.setReviewSize(fromReview.getReviewSize());
       cr.setReviewedCount(fromReview.getReviewedCount());
-      cr.setReviewStatus(fromReview.getReviewStatus());
+      cr.setReviewStatusEnum(fromReview.getReviewStatusEnum());
       cr = cohortReviewDao.save(cr);
       participantCohortStatusDao.bulkCopyByCohortReview(
         fromReview.getCohortReviewId(), cr.getCohortReviewId());

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.db.dao;
 import java.util.List;
 import org.pmiops.workbench.db.model.ParticipantCohortStatus;
 import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus;
-import org.pmiops.workbench.model.CohortStatus;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -34,5 +33,5 @@ public interface ParticipantCohortStatusDao extends CrudRepository<ParticipantCo
             @Param("participantId") long participantId);
 
   List<ParticipantIdAndCohortStatus> findByParticipantKey_CohortReviewIdAndStatusIn(
-      Long cohortReviewId, List<CohortStatus> cohortStatuses);
+      Long cohortReviewId, List<Short> cohortStatuses);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/CohortAnnotationDefinition.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/CohortAnnotationDefinition.java
@@ -1,8 +1,8 @@
 package org.pmiops.workbench.db.model;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.pmiops.workbench.model.AnnotationType;
-
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,9 +13,9 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
-import java.util.Objects;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import javax.persistence.Transient;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.pmiops.workbench.model.AnnotationType;
 
 @Entity
 @Table(name = "cohort_annotation_definition")
@@ -24,7 +24,7 @@ public class CohortAnnotationDefinition {
     private long cohortAnnotationDefinitionId;
     private long cohortId;
     private String columnName;
-    private AnnotationType annotationType;
+    private Short annotationType;
     private SortedSet<CohortAnnotationEnumValue> enumValues = new TreeSet<>();
 
     @Id
@@ -72,17 +72,30 @@ public class CohortAnnotationDefinition {
     }
 
     @Column(name = "annotation_type")
-    public AnnotationType getAnnotationType() {
+    public Short getAnnotationType() {
         return annotationType;
     }
 
-    public void setAnnotationType(AnnotationType annotationType) {
+    public void setAnnotationType(Short annotationType) {
         this.annotationType = annotationType;
     }
 
-    public CohortAnnotationDefinition annotationType(AnnotationType annotationType) {
+    public CohortAnnotationDefinition annotationType(Short annotationType) {
         this.annotationType = annotationType;
         return this;
+    }
+
+    @Transient
+    public AnnotationType getAnnotationTypeEnum() {
+        return StorageEnums.annotationTypeFromStorage(getAnnotationType());
+    }
+
+    public void setAnnotationTypeEnum(AnnotationType annotationType) {
+        setAnnotationType(StorageEnums.annotationTypeToStorage(annotationType));
+    }
+
+    public CohortAnnotationDefinition annotationTypeEnum(AnnotationType annotationType) {
+        return this.annotationType(StorageEnums.annotationTypeToStorage(annotationType));
     }
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "cohortAnnotationDefinition", orphanRemoval = true, cascade = CascadeType.ALL)

--- a/api/src/main/java/org/pmiops/workbench/db/model/CohortReview.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/CohortReview.java
@@ -1,16 +1,16 @@
 package org.pmiops.workbench.db.model;
 
-import javax.persistence.GenerationType;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.pmiops.workbench.model.ReviewStatus;
-
+import java.sql.Timestamp;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.sql.Timestamp;
-import java.util.Objects;
+import javax.persistence.Transient;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.pmiops.workbench.model.ReviewStatus;
 
 @Entity
 @Table(name = "cohort_review")
@@ -24,7 +24,7 @@ public class CohortReview {
     private long matchedParticipantCount;
     private long reviewSize;
     private long reviewedCount;
-    private ReviewStatus reviewStatus;
+    private Short reviewStatus;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -145,17 +145,30 @@ public class CohortReview {
     }
 
     @Column(name = "review_status")
-    public ReviewStatus getReviewStatus() {
+    public Short getReviewStatus() {
         return reviewStatus;
     }
 
-    public void setReviewStatus(ReviewStatus reviewStatus) {
+    public void setReviewStatus(Short reviewStatus) {
         this.reviewStatus = reviewStatus;
     }
 
-    public CohortReview reviewStatus(ReviewStatus reviewStatus) {
+    public CohortReview reviewStatus(Short reviewStatus) {
         this.reviewStatus = reviewStatus;
         return this;
+    }
+
+    @Transient
+    public ReviewStatus getReviewStatusEnum() {
+        return StorageEnums.reviewStatusFromStorage(getReviewStatus());
+    }
+
+    public void setReviewStatusEnum(ReviewStatus reviewStatus) {
+        setReviewStatus(StorageEnums.reviewStatusToStorage(reviewStatus));
+    }
+
+    public CohortReview reviewStatusEnum(ReviewStatus reviewStatus) {
+        return this.reviewStatus(StorageEnums.reviewStatusToStorage(reviewStatus));
     }
 
     @Override

--- a/api/src/main/java/org/pmiops/workbench/db/model/ParticipantCohortStatus.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/ParticipantCohortStatus.java
@@ -1,8 +1,7 @@
 package org.pmiops.workbench.db.model;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.pmiops.workbench.model.CohortStatus;
-
+import java.sql.Date;
+import java.util.Objects;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
@@ -10,8 +9,8 @@ import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.sql.Date;
-import java.util.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.pmiops.workbench.model.CohortStatus;
 
 @Entity
 @Table(name = "participant_cohort_status")
@@ -19,7 +18,7 @@ public class ParticipantCohortStatus {
 
     // Important: Keep fields in sync with ParticipantCohortStatusDao.ALL_COLUMNS_EXCEPT_REVIEW_ID.
     private ParticipantCohortStatusKey participantKey;
-    private CohortStatus status;
+    private Short status;
     private Long genderConceptId;
     private String gender;
     private Date birthDate;
@@ -49,17 +48,30 @@ public class ParticipantCohortStatus {
     }
 
     @Column(name = "status")
-    public CohortStatus getStatus() {
+    public Short getStatus() {
         return status;
     }
 
-    public void setStatus(CohortStatus status) {
+    public void setStatus(Short status) {
         this.status = status;
     }
 
-    public ParticipantCohortStatus status(CohortStatus status) {
+    public ParticipantCohortStatus status(Short status) {
         this.status = status;
         return this;
+    }
+
+    @Transient
+    public CohortStatus getStatusEnum() {
+        return StorageEnums.cohortStatusFromStorage(getStatus());
+    }
+
+    public void setStatusEnum(CohortStatus status) {
+        setStatus(StorageEnums.cohortStatusToStorage(status));
+    }
+
+    public ParticipantCohortStatus statusEnum(CohortStatus status) {
+        return this.status(StorageEnums.cohortStatusToStorage(status));
     }
 
     @Column(name = "gender_concept_id")

--- a/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
@@ -2,10 +2,13 @@ package org.pmiops.workbench.db.model;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
+import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.BillingProjectStatus;
+import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmailVerificationStatus;
+import org.pmiops.workbench.model.ReviewStatus;
 import org.pmiops.workbench.model.UnderservedPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
@@ -163,6 +166,53 @@ public final class StorageEnums {
 
   public static Short workspaceAccessLevelToStorage(WorkspaceAccessLevel level) {
     return CLIENT_TO_STORAGE_WORKSPACE_ACCESS.get(level);
+  }
+
+  private static final BiMap<ReviewStatus, Short> CLIENT_TO_STORAGE_REVIEW_STATUS =
+      ImmutableBiMap.<ReviewStatus, Short>builder()
+      .put(ReviewStatus.NONE, (short) 0)
+      .put(ReviewStatus.CREATED, (short) 1)
+      .build();
+
+  public static ReviewStatus reviewStatusFromStorage(Short s) {
+    return CLIENT_TO_STORAGE_REVIEW_STATUS.inverse().get(s);
+  }
+
+  public static Short reviewStatusToStorage(ReviewStatus s) {
+    return CLIENT_TO_STORAGE_REVIEW_STATUS.get(s);
+  }
+
+  private static final BiMap<CohortStatus, Short> CLIENT_TO_STORAGE_COHORT_STATUS =
+      ImmutableBiMap.<CohortStatus, Short>builder()
+      .put(CohortStatus.EXCLUDED, (short) 0)
+      .put(CohortStatus.INCLUDED, (short) 1)
+      .put(CohortStatus.NEEDS_FURTHER_REVIEW, (short) 2)
+      .put(CohortStatus.NOT_REVIEWED, (short) 3)
+      .build();
+
+  public static CohortStatus cohortStatusFromStorage(Short s) {
+    return CLIENT_TO_STORAGE_COHORT_STATUS.inverse().get(s);
+  }
+
+  public static Short cohortStatusToStorage(CohortStatus s) {
+    return CLIENT_TO_STORAGE_COHORT_STATUS.get(s);
+  }
+
+  private static final BiMap<AnnotationType, Short> CLIENT_TO_STORAGE_ANNOTATION_TYPE =
+      ImmutableBiMap.<AnnotationType, Short>builder()
+      .put(AnnotationType.STRING, (short) 0)
+      .put(AnnotationType.ENUM, (short) 1)
+      .put(AnnotationType.DATE, (short) 2)
+      .put(AnnotationType.BOOLEAN, (short) 3)
+      .put(AnnotationType.INTEGER, (short) 4)
+      .build();
+
+  public static AnnotationType annotationTypeFromStorage(Short t) {
+    return CLIENT_TO_STORAGE_ANNOTATION_TYPE.inverse().get(t);
+  }
+
+  public static Short annotationTypeToStorage(AnnotationType t) {
+    return CLIENT_TO_STORAGE_ANNOTATION_TYPE.get(t);
   }
 
   /** Utility class. */

--- a/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
@@ -861,7 +861,7 @@ public class CohortAnnotationDefinitionControllerTest {
         return new org.pmiops.workbench.db.model.CohortAnnotationDefinition()
                 .cohortId(cohortId)
                 .cohortAnnotationDefinitionId(annotationDefinitionId)
-                .annotationType(annotationType)
+                .annotationTypeEnum(annotationType)
                 .columnName(columnName);
     }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerMockTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerMockTest.java
@@ -327,7 +327,7 @@ public class CohortReviewControllerMockTest {
     }
 
     private void assertCreateParticipantCohortAnnotation(ParticipantCohortAnnotation request, AnnotationType annotationType) throws Exception {
-        CohortAnnotationDefinition cohortAnnotationDefinition = new CohortAnnotationDefinition().annotationType(annotationType);
+        CohortAnnotationDefinition cohortAnnotationDefinition = new CohortAnnotationDefinition().annotationTypeEnum(annotationType);
         if (request.getAnnotationValueEnum() != null) {
             CohortAnnotationEnumValue cohortAnnotationEnumValue = new CohortAnnotationEnumValue().name(request.getAnnotationValueEnum());
             cohortAnnotationDefinition.setEnumValues(new TreeSet(Arrays.asList(cohortAnnotationEnumValue)));
@@ -378,7 +378,7 @@ public class CohortReviewControllerMockTest {
 
         return new ParticipantCohortStatus()
                 .participantKey(key)
-                .status(cohortStatus)
+                .statusEnum(cohortStatus)
                 .birthDate(dob)
                 .ethnicityConceptId(1L)
                 .genderConceptId(1L)
@@ -393,7 +393,7 @@ public class CohortReviewControllerMockTest {
                 .cdrVersionId(cdrVersionId)
                 .matchedParticipantCount(1000)
                 .creationTime(new Timestamp(System.currentTimeMillis()))
-                .reviewStatus(reviewStatus);
+                .reviewStatusEnum(reviewStatus);
     }
 
     private Cohort createCohort(long cohortId, long workspaceId, String definition) {

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -178,7 +178,7 @@ public class CohortReviewControllerTest {
       .participantId(2L);
 
     participantCohortStatus1 = new ParticipantCohortStatus()
-      .status(CohortStatus.NOT_REVIEWED)
+      .statusEnum(CohortStatus.NOT_REVIEWED)
       .participantKey(key1)
       .genderConceptId(TestDemo.MALE.getConceptId())
       .gender(TestDemo.MALE.getName())
@@ -188,7 +188,7 @@ public class CohortReviewControllerTest {
       .ethnicity(TestDemo.NOT_HISPANIC.getName())
       .birthDate(new java.sql.Date(today.getTime()));
     participantCohortStatus2 = new ParticipantCohortStatus()
-      .status(CohortStatus.NOT_REVIEWED)
+      .statusEnum(CohortStatus.NOT_REVIEWED)
       .participantKey(key2)
       .genderConceptId(TestDemo.FEMALE.getConceptId())
       .gender(TestDemo.FEMALE.getName())
@@ -293,7 +293,7 @@ public class CohortReviewControllerTest {
         .participantId(participantCohortStatus.getParticipantKey().getParticipantId())
         .raceConceptId(participantCohortStatus.getRaceConceptId())
         .race(participantCohortStatus.getRace())
-        .status(participantCohortStatus.getStatus()));
+        .status(participantCohortStatus.getStatusEnum()));
     }
     return new org.pmiops.workbench.model.CohortReview()
         .cohortReviewId(actualReview.getCohortReviewId())

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -178,7 +178,7 @@ public class AnnotationQueryBuilderTest {
   private CohortAnnotationDefinition makeAnnotationDefinition(long cohortId, String columnName,
       AnnotationType annotationType, String... enumValues) {
     CohortAnnotationDefinition cohortAnnotationDefinition = new CohortAnnotationDefinition();
-    cohortAnnotationDefinition.setAnnotationType(annotationType);
+    cohortAnnotationDefinition.setAnnotationTypeEnum(annotationType);
     cohortAnnotationDefinition.setCohortId(cohortId);
     cohortAnnotationDefinition.setColumnName(columnName);
     if (enumValues.length > 0) {
@@ -197,7 +197,7 @@ public class AnnotationQueryBuilderTest {
     key.setCohortReviewId(cohortReviewId);
     key.setParticipantId(participantId);
     ParticipantCohortStatus result = new ParticipantCohortStatus();
-    result.setStatus(status);
+    result.setStatusEnum(status);
     result.setParticipantKey(key);
     return result;
   }

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImplTest.java
@@ -606,7 +606,7 @@ public class CohortReviewServiceImplTest {
 
     private CohortAnnotationDefinition createCohortAnnotationDefinition(long cohortAnnotationDefinitionId, AnnotationType annotationType) {
         return new CohortAnnotationDefinition()
-                .annotationType(annotationType)
+                .annotationTypeEnum(annotationType)
                 .columnName("name")
                 .cohortAnnotationDefinitionId(cohortAnnotationDefinitionId)
                 .cohortId(1)
@@ -620,7 +620,7 @@ public class CohortReviewServiceImplTest {
             cohortReviewService.saveParticipantCohortAnnotation(participantCohortAnnotation.getCohortReviewId(), participantCohortAnnotation);
             fail("Should have thrown BadRequestExcpetion!");
         } catch (BadRequestException e) {
-            assertEquals("Invalid Request: Please provide a valid " + cohortAnnotationDefinition.getAnnotationType().name()
+            assertEquals("Invalid Request: Please provide a valid " + cohortAnnotationDefinition.getAnnotationTypeEnum().name()
                     + " value for annotation defintion id: " + cohortAnnotationDefinition.getCohortAnnotationDefinitionId(), e.getMessage());
         }
 
@@ -644,7 +644,7 @@ public class CohortReviewServiceImplTest {
             cohortReviewService.updateParticipantCohortAnnotation(annotationId, cohortReviewId, participantId, new ModifyParticipantCohortAnnotationRequest());
             fail("Should have thrown BadRequestExcpetion!");
         } catch (BadRequestException e) {
-            assertEquals("Invalid Request: Please provide a valid " + cohortAnnotationDefinition.getAnnotationType().name()
+            assertEquals("Invalid Request: Please provide a valid " + cohortAnnotationDefinition.getAnnotationTypeEnum().name()
                     + " value for annotation defintion id: " + cohortAnnotationDefinition.getCohortAnnotationDefinitionId(), e.getMessage());
         }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/CohortAnnotationDefinitionDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/CohortAnnotationDefinitionDaoTest.java
@@ -106,7 +106,7 @@ public class CohortAnnotationDefinitionDaoTest {
         return new CohortAnnotationDefinition()
                 .cohortId(COHORT_ID)
                 .columnName("annotation name")
-                .annotationType(AnnotationType.BOOLEAN);
+                .annotationTypeEnum(AnnotationType.BOOLEAN);
     }
 
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortAnnotationDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortAnnotationDaoTest.java
@@ -51,7 +51,7 @@ public class ParticipantCohortAnnotationDaoTest {
                 new CohortAnnotationDefinition()
                 .cohortId(COHORT_ID)
                 .columnName("enum")
-                .annotationType(AnnotationType.ENUM);
+                .annotationTypeEnum(AnnotationType.ENUM);
         CohortAnnotationEnumValue enumValue1 = new CohortAnnotationEnumValue().name("z").order(0).cohortAnnotationDefinition(cohortAnnotationDefinition);
         CohortAnnotationEnumValue enumValue2 = new CohortAnnotationEnumValue().name("r").order(1).cohortAnnotationDefinition(cohortAnnotationDefinition);
         CohortAnnotationEnumValue enumValue3 = new CohortAnnotationEnumValue().name("a").order(2).cohortAnnotationDefinition(cohortAnnotationDefinition);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -109,14 +109,14 @@ public class ParticipantCohortStatusDaoTest {
         ParticipantCohortStatusKey key2 = new ParticipantCohortStatusKey().cohortReviewId(2).participantId(4);
         ParticipantCohortStatus pcs1 = new ParticipantCohortStatus()
                 .participantKey(key1)
-                .status(CohortStatus.INCLUDED)
+                .statusEnum(CohortStatus.INCLUDED)
                 .birthDate(new Date(System.currentTimeMillis()))
                 .ethnicityConceptId(1L)
                 .genderConceptId(1L)
                 .raceConceptId(1L);
         ParticipantCohortStatus pcs2 = new ParticipantCohortStatus()
                 .participantKey(key2)
-                .status(CohortStatus.EXCLUDED)
+                .statusEnum(CohortStatus.EXCLUDED)
                 .birthDate(new Date(System.currentTimeMillis()))
                 .ethnicityConceptId(1L)
                 .genderConceptId(1L)
@@ -371,7 +371,7 @@ public class ParticipantCohortStatusDaoTest {
     private ParticipantCohortStatus createExpectedPCS(ParticipantCohortStatusKey key, CohortStatus status) {
         return new ParticipantCohortStatus()
                 .participantKey(key)
-                .status(status)
+                .statusEnum(status)
                 .ethnicityConceptId(38003564L)
                 .genderConceptId(8507L)
                 .raceConceptId(8515L);

--- a/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
@@ -9,10 +9,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.BillingProjectStatus;
+import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmailVerificationStatus;
+import org.pmiops.workbench.model.ReviewStatus;
 import org.pmiops.workbench.model.UnderservedPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
@@ -56,6 +59,24 @@ public class StorageEnumsTest {
         WorkspaceAccessLevel.values(),
         (Function<Short, WorkspaceAccessLevel>) StorageEnums::workspaceAccessLevelFromStorage,
         (Function<WorkspaceAccessLevel, Short>) StorageEnums::workspaceAccessLevelToStorage
+      },
+      {
+        ReviewStatus.class.getSimpleName(),
+        ReviewStatus.values(),
+        (Function<Short, ReviewStatus>) StorageEnums::reviewStatusFromStorage,
+        (Function<ReviewStatus, Short>) StorageEnums::reviewStatusToStorage
+      },
+      {
+        CohortStatus.class.getSimpleName(),
+        CohortStatus.values(),
+        (Function<Short, CohortStatus>) StorageEnums::cohortStatusFromStorage,
+        (Function<CohortStatus, Short>) StorageEnums::cohortStatusToStorage
+      },
+      {
+        AnnotationType.class.getSimpleName(),
+        AnnotationType.values(),
+        (Function<Short, AnnotationType>) StorageEnums::annotationTypeFromStorage,
+        (Function<AnnotationType, Short>) StorageEnums::annotationTypeToStorage
       },
     };
   }


### PR DESCRIPTION
PR 3/3 for converting workbench off enum ordinal value storage.