### PR TITLE
[RW-1042][risk=low] URI encode notebook names during redirection

### DIFF
--- a/ui/src/app/views/notebook-redirect/component.spec.ts
+++ b/ui/src/app/views/notebook-redirect/component.spec.ts
@@ -220,4 +220,16 @@ describe('NotebookRedirectComponent', () => {
     fixture.detectChanges();
     expect(spinnerText()).toContain('Redirecting');
   }));
+
+
+  it('should escape notebooks names', fakeAsync(() => {
+    updateAndTick(fixture);
+
+    fixture.componentInstance.notebookName = '1%2B1.ipynb';
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+    tick(10000);
+    fixture.detectChanges();
+
+    expect(fakeWindow.location.href).toContain('/1%252B1.ipynb');
+  }));
 });

--- a/ui/src/app/views/notebook-redirect/component.ts
+++ b/ui/src/app/views/notebook-redirect/component.ts
@@ -130,9 +130,10 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
   }
 
   private notebookUrl(cluster: Cluster, nbName: string): string {
-    return environment.leoApiUrl + '/notebooks/'
-      + cluster.clusterNamespace + '/'
-      + cluster.clusterName + '/notebooks/' + nbName;
+    return encodeURI(
+      environment.leoApiUrl + '/notebooks/'
+        + cluster.clusterNamespace + '/'
+        + cluster.clusterName + '/notebooks/' + nbName);
   }
 
   private initializeNotebookCookies(c: Cluster): Observable<Cluster> {


### PR DESCRIPTION
Setting an unescaped URL to the window location escapes only as needed, which is why notebooks with spaces in the name currently work fine.

However, strings that are already URI escaped will not be re-escaped here, we therefore need to explicitly escape before redirecting. Else for example a notebook containing `%2B` (+), gets unescaped as `+`, which causes downstream failures on redirection.