### PR TITLE
[RW-1113][Risk=no] Fix font for sign in button

### DIFF
--- a/ui/src/app/views/login/component.css
+++ b/ui/src/app/views/login/component.css
@@ -11,11 +11,17 @@
 .google-icon {
   height: 54px;
   width: 54px;
-  margin-right: 24px;
+  /*The image file comes with about 5 pixels of padding around it, which we want to trim off*/
+  margin: -3px 19px -3px -3px;
 }
 
 .btn.btn-lg.btn-primary {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  height: auto;
   font-family: 'Roboto', sans-serif;
+  padding-left: 0;
   font-size: 18px;
   font-weight: 500;
   font-style: normal;

--- a/ui/src/app/views/login/component.css
+++ b/ui/src/app/views/login/component.css
@@ -15,7 +15,7 @@
 }
 
 .btn.btn-lg.btn-primary {
-  font-family: Roboto;
+  font-family: 'Roboto', sans-serif;
   font-size: 18px;
   font-weight: 500;
   font-style: normal;

--- a/ui/src/app/views/login/component.html
+++ b/ui/src/app/views/login/component.html
@@ -5,7 +5,7 @@
       <div style="display: flex;">
         <button (click)="signIn()" class="btn btn-lg btn-primary">
           <img class="google-icon" [src]="googleIcon">
-          Sign In with Google
+          <div>Sign In with Google</div>
         </button>
       </div>
       <div style="padding-top: 1rem;">

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -24,6 +24,7 @@
       gtag('config', ga_tracking_id);
     </script>
     <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7761236/6749992/css/fonts.css" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   </head>
 
   <!-- Push state routing -->


### PR DESCRIPTION
We could not actually use the font we used elsewhere for sign in, per [google's branding guidelines](https://developers.google.com/identity/branding-guidelines), but we weren't actually loading the font correctly. This loads in the font and displays it properly.

Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
