### PR TITLE
[risk=low] Exclude guava5 everywhere

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -137,6 +137,9 @@ task generate_local_appengine_web_xml(type: Exec) {
 
 configurations {
   generatedCompile
+  all {
+    exclude group: 'com.google.guava', module:'guava-jdk5'
+  }
 }
 
 project.ext.GAE_VERSION = '1.9.64'
@@ -263,9 +266,7 @@ dependencies {
   compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0'
   compile 'com.google.apis:google-api-services-oauth2:v2-rev139-1.23.0'
   compile 'com.google.cloud:google-cloud-bigquery:0.30.0-beta'
-  compile ('com.google.cloud:google-cloud-storage:1.8.0') {
-    exclude group: 'com.google.guava', module:'guava-jdk5'
-  }
+  compile 'com.google.cloud:google-cloud-storage:1.8.0'
   compile 'com.google.code.gson:gson:2.8.5'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
   compile 'com.squareup.okhttp:okhttp:2.7.4'


### PR DESCRIPTION
After a docker-clean, I was getting the following exception upon trying to read the invite key from GCS:

```
api_1                          | Caused by: java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;
api_1                          | 	at com.google.api.gax.retrying.BasicRetryingFuture.<init>(BasicRetryingFuture.java:77)
api_1                          | 	at com.google.api.gax.retrying.DirectRetryingExecutor.createFuture(DirectRetryingExecutor.java:73)
api_1                          | 	at com.google.cloud.RetryHelper.run(RetryHelper.java:73)
api_1                          | 	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:51)
api_1                          | 	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:194)
api_1                          | 	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:186)
```

# Before

I used gradle dependency insight to see what versions we were pointing at.

```
./gradlew dependencyInsight --dependency "com.google.guava" --configuration compile

> Task :dependencyInsight
com.google.guava:guava:26.0-jre (selected by rule)
+--- compile
\--- project :common-api
     \--- compile

com.google.guava:guava:19.0 -> 26.0-jre
+--- com.google.api:api-common:1.2.0
|    +--- com.google.cloud:google-cloud-core:1.12.0
|    |    +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta
|    |    |    \--- compile
|    |    +--- com.google.cloud:google-cloud-storage:1.8.0
|    |    |    \--- compile
|    |    \--- com.google.cloud:google-cloud-core-http:1.12.0
|    |         +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta (*)
|    |         \--- com.google.cloud:google-cloud-storage:1.8.0 (*)
|    +--- com.google.api:gax:1.15.0
|    |    \--- com.google.cloud:google-cloud-core:1.12.0 (*)
|    \--- com.google.api.grpc:proto-google-iam-v1:0.1.25
|         \--- com.google.cloud:google-cloud-core:1.12.0 (*)
+--- com.google.auth:google-auth-library-oauth2-http:0.9.0
|    +--- com.google.cloud:google-cloud-core-http:1.12.0 (*)
|    \--- com.google.api:gax:1.15.0 (*)
\--- com.google.protobuf:protobuf-java-util:3.4.0
     \--- com.google.cloud:google-cloud-core:1.12.0 (*)

com.google.guava:guava:20.0 -> 26.0-jre
+--- com.google.api:gax:1.15.0
|    \--- com.google.cloud:google-cloud-core:1.12.0
|         +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta
|         |    \--- compile
|         +--- com.google.cloud:google-cloud-storage:1.8.0
|         |    \--- compile
|         \--- com.google.cloud:google-cloud-core-http:1.12.0
|              +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta (*)
|              \--- com.google.cloud:google-cloud-storage:1.8.0 (*)
+--- com.google.cloud:google-cloud-core:1.12.0 (*)
+--- com.google.cloud:google-cloud-core-http:1.12.0 (*)
\--- com.google.cloud.sql:jdbc-socket-factory-core:1.0.10
     \--- com.google.cloud.sql:mysql-socket-factory:1.0.10
          \--- compile

com.google.guava:guava-jdk5:17.0
\--- com.google.api-client:google-api-client:1.23.0
     +--- com.google.api-client:google-api-client-appengine:1.23.0
     |    \--- compile
     +--- com.google.cloud:google-cloud-core-http:1.12.0
     |    +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta
     |    |    \--- compile
     |    \--- com.google.cloud:google-cloud-storage:1.8.0
     |         \--- compile
     +--- com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0
     |    \--- compile
     +--- com.google.apis:google-api-services-oauth2:v2-rev139-1.23.0
     |    \--- compile
     +--- com.google.api-client:google-api-client-servlet:1.23.0
     |    \--- com.google.api-client:google-api-client-appengine:1.23.0 (*)
     +--- com.google.apis:google-api-services-bigquery:v2-rev347-1.22.0
     |    \--- com.google.cloud:google-cloud-bigquery:0.30.0-beta (*)
     \--- com.google.apis:google-api-services-sqladmin:v1beta4-rev56-1.23.0
          \--- com.google.cloud.sql:jdbc-socket-factory-core:1.0.10
               \--- com.google.cloud.sql:mysql-socket-factory:1.0.10
                    \--- compile

(*) - dependencies omitted (listed previously)
```

# After

As it seemed guava-jdk5 was the only outlier, I removed this everywhere which seems to have resolved the issue.

```
./gradlew dependencyInsight --dependency "com.google.guava" --configuration compile
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :dependencyInsight
com.google.guava:guava:26.0-jre (selected by rule)
+--- compile
\--- project :common-api
     \--- compile

com.google.guava:guava:19.0 -> 26.0-jre
+--- com.google.api:api-common:1.2.0
|    +--- com.google.cloud:google-cloud-core:1.12.0
|    |    +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta
|    |    |    \--- compile
|    |    +--- com.google.cloud:google-cloud-storage:1.8.0
|    |    |    \--- compile
|    |    \--- com.google.cloud:google-cloud-core-http:1.12.0
|    |         +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta (*)
|    |         \--- com.google.cloud:google-cloud-storage:1.8.0 (*)
|    +--- com.google.api:gax:1.15.0
|    |    \--- com.google.cloud:google-cloud-core:1.12.0 (*)
|    \--- com.google.api.grpc:proto-google-iam-v1:0.1.25
|         \--- com.google.cloud:google-cloud-core:1.12.0 (*)
+--- com.google.auth:google-auth-library-oauth2-http:0.9.0
|    +--- com.google.cloud:google-cloud-core-http:1.12.0 (*)
|    \--- com.google.api:gax:1.15.0 (*)
\--- com.google.protobuf:protobuf-java-util:3.4.0
     \--- com.google.cloud:google-cloud-core:1.12.0 (*)

com.google.guava:guava:20.0 -> 26.0-jre
+--- com.google.api:gax:1.15.0
|    \--- com.google.cloud:google-cloud-core:1.12.0
|         +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta
|         |    \--- compile
|         +--- com.google.cloud:google-cloud-storage:1.8.0
|         |    \--- compile
|         \--- com.google.cloud:google-cloud-core-http:1.12.0
|              +--- com.google.cloud:google-cloud-bigquery:0.30.0-beta (*)
|              \--- com.google.cloud:google-cloud-storage:1.8.0 (*)
+--- com.google.cloud:google-cloud-core:1.12.0 (*)
+--- com.google.cloud:google-cloud-core-http:1.12.0 (*)
\--- com.google.cloud.sql:jdbc-socket-factory-core:1.0.10
     \--- com.google.cloud.sql:mysql-socket-factory:1.0.10
          \--- compile

(*) - dependencies omitted (listed previously)
```