### PR TITLE
[RW-1149] Moving parsing of cohort spec into CohortMaterializationService. [risk=no]

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -187,10 +187,24 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     return request;
   }
 
+  @Test(expected = BadRequestException.class)
+  public void testMaterializeCohortBadSpec() {
+    cohortMaterializationService.materializeCohort(null,
+        "badSpec", makeRequest(1000));
+  }
+
+  @Test
+  public void testMaterializeCohortOneMaleSpec() {
+    MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
+        new Gson().toJson(SearchRequests.males()),makeRequest(1000));
+    assertPersonIds(response, 1L);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
   @Test
   public void testMaterializeCohortOneMale() {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(1000));
+        SearchRequests.males(), 0, makeRequest(1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -198,7 +212,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
   @Test
   public void testMaterializeCohortICD9Group() {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-            SearchRequests.icd9Codes(), makeRequest(1000));
+            SearchRequests.icd9Codes(), 0, makeRequest(1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -206,7 +220,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
   @Test
   public void testMaterializeCohortWithReviewNullStatusFilter() {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), makeRequest(2));
+        SearchRequests.allGenders(), 0, makeRequest(2));
     // With a null status filter, everyone but excluded participants are returned.
     assertPersonIds(response, 1L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
@@ -218,7 +232,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     request.setStatusFilter(ImmutableList
             .of(CohortStatus.NOT_REVIEWED, CohortStatus.INCLUDED, CohortStatus.NEEDS_FURTHER_REVIEW));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     // With a not excluded status filter, ID 2 is not returned.
     assertPersonIds(response, 1L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
@@ -229,7 +243,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.EXCLUDED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -239,7 +253,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.INCLUDED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -249,7 +263,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.EXCLUDED, CohortStatus.INCLUDED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -259,7 +273,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.NOT_REVIEWED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -269,7 +283,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.INCLUDED, CohortStatus.NOT_REVIEWED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 1L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -279,7 +293,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.NEEDS_FURTHER_REVIEW, CohortStatus.NOT_REVIEWED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -289,7 +303,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(2);
     request.setStatusFilter(ImmutableList.of(CohortStatus.EXCLUDED, CohortStatus.NOT_REVIEWED));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -300,12 +314,12 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     request.setStatusFilter(ImmutableList.of(CohortStatus.EXCLUDED, CohortStatus.NOT_REVIEWED,
         CohortStatus.INCLUDED, CohortStatus.NEEDS_FURTHER_REVIEW));
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNotNull();
     request.setPageToken(response.getNextPageToken());
     MaterializeCohortResponse response2 = cohortMaterializationService.materializeCohort(cohortReview,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response2, 102246L);
     assertThat(response2.getNextPageToken()).isNull();
   }
@@ -314,19 +328,19 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
   public void testMaterializeCohortPaging() {
     MaterializeCohortRequest request = makeRequest(2);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNotNull();
     request.setPageToken(response.getNextPageToken());
     MaterializeCohortResponse response2 = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), request);
+        SearchRequests.allGenders(), 0, request);
     assertPersonIds(response2, 102246L);
     assertThat(response2.getNextPageToken()).isNull();
 
     try {
       // Pagination token doesn't match, this should fail.
       cohortMaterializationService.materializeCohort(null, SearchRequests.males(),
-          request);
+          1, request);
       fail("Exception expected");
     } catch (BadRequestException e) {
       // expected
@@ -336,9 +350,9 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     PaginationToken invalidToken = new PaginationToken(-1L, token.getParameterHash());
     request.setPageToken(invalidToken.toBase64());
     try {
-      // Pagination token doesn't match, this should fail.
+      // Invalid offset, this should fail.
       cohortMaterializationService.materializeCohort(null, SearchRequests.males(),
-          request);
+          0, request);
       fail("Exception expected");
     } catch (BadRequestException e) {
       // expected
@@ -353,7 +367,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -370,7 +384,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -389,7 +403,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -407,7 +421,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -425,7 +439,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -443,7 +457,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -461,7 +475,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -479,7 +493,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -497,7 +511,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -514,7 +528,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -531,7 +545,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -549,7 +563,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -567,7 +581,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -585,7 +599,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -603,7 +617,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -621,7 +635,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -635,7 +649,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L,
         "gender_concept_id", 8507L);
     ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L,
@@ -655,7 +669,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L,
         "gender_concept_id", 8507L);
     ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L,
@@ -679,7 +693,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -697,7 +711,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -715,7 +729,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -732,7 +746,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -752,7 +766,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -772,7 +786,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -800,7 +814,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -812,7 +826,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
        .put("person_id", 1L)
        .put("gender_source_value", "1")
@@ -843,7 +857,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("observation_id", 5L)
         .put("person_id", 1L)
@@ -874,7 +888,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.females(), makeRequest(fieldSet, 1000));
+        SearchRequests.females(), 0, makeRequest(fieldSet, 1000));
     assertResults(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -891,7 +905,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -908,7 +922,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -926,7 +940,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -944,7 +958,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -962,7 +976,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -980,7 +994,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -997,7 +1011,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1014,7 +1028,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1032,7 +1046,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1050,7 +1064,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1068,7 +1082,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1086,7 +1100,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.males(), makeRequest(fieldSet, 1000));
+        SearchRequests.males(), 0, makeRequest(fieldSet, 1000));
     assertResults(response, ImmutableMap.of("observation_id", 5L));
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1110,7 +1124,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("person_id", 1L)
         .put("gender_concept.concept_name", "MALE")
@@ -1151,7 +1165,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("person_id", 1L)
         .put("gender_concept.concept_name", "MALE")
@@ -1192,7 +1206,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("person_id", 1L)
         .put("gender_concept.concept_name", "MALE")
@@ -1231,7 +1245,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("person_id", 1L)
         .put("gender_concept.concept_name", "MALE")
@@ -1270,7 +1284,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.<String, Object>builder()
         .put("person_id", 1L)
         .put("gender_concept.concept_name", "MALE")
@@ -1303,7 +1317,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 102246L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1317,7 +1331,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     FieldSet fieldSet = new FieldSet();
     fieldSet.setTableQuery(tableQuery);
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(null,
-        SearchRequests.allGenders(), makeRequest(fieldSet, 1000));
+        SearchRequests.allGenders(), 0, makeRequest(fieldSet, 1000));
     assertPersonIds(response, 102246L, 1L, 2L);
     assertThat(response.getNextPageToken()).isNull();
   }
@@ -1328,7 +1342,7 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     fieldSet.setAnnotationQuery(new AnnotationQuery());
     MaterializeCohortResponse response =
         cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(),
-            makeRequest(fieldSet, 1000));
+            0, makeRequest(fieldSet, 1000));
     ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
     assertResults(response, p1Map);
     assertThat(response.getNextPageToken()).isNull();
@@ -1341,14 +1355,14 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     MaterializeCohortRequest request = makeRequest(fieldSet, 1);
     request.setStatusFilter(ImmutableList.of(CohortStatus.INCLUDED, CohortStatus.EXCLUDED));
     MaterializeCohortResponse response =
-        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), request);
+        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), 0, request);
     ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
     assertResults(response, p1Map);
     assertThat(response.getNextPageToken()).isNotNull();
 
     request.setPageToken(response.getNextPageToken());
     MaterializeCohortResponse response2 =
-        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), request);
+        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), 0, request);
     ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED");
     assertResults(response2, p2Map);
     assertThat(response2.getNextPageToken()).isNull();

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -272,15 +272,8 @@ public class CohortsController implements CohortsApiDelegate {
       request.setPageSize(MAX_PAGE_SIZE);
     }
 
-    SearchRequest searchRequest;
-    try {
-      searchRequest = new Gson().fromJson(cohortSpec, SearchRequest.class);
-    } catch (JsonSyntaxException e) {
-      throw new BadRequestException("Invalid cohort spec");
-    }
-
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(
-        cohortReview, searchRequest, request);
+        cohortReview, cohortSpec, request);
     return ResponseEntity.ok(response);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -166,7 +167,6 @@ public class CohortMaterializationService {
    * @param request {@link MaterializeCohortRequest} representing the request options
    * @return {@link MaterializeCohortResponse} containing the results of cohort materialization
    */
-
   public MaterializeCohortResponse materializeCohort(@Nullable CohortReview cohortReview,
       String cohortSpec, MaterializeCohortRequest request) {
     SearchRequest searchRequest;
@@ -196,10 +196,11 @@ public class CohortMaterializationService {
     String paginationToken = request.getPageToken();
     int pageSize = request.getPageSize();
     // TODO: add CDR version ID here
-    // We require the client to specify requestHash here instead of hashing searchRequest itself;
-    // searchRequest.hashCode() includes hashing of Enum values and is thus not stable across
+    // We require the client to specify requestHash here instead of hashing searchRequest itself,
+    // and use Objects.toString(statusFilter) instead of just statusFilter;
+    // both searchRequest and statusFilter contain enums, which do not have stable has codes across
     // JVMs (see [RW-1149]).
-    Object[] paginationParameters = new Object[] { requestHash, statusFilter };
+    Object[] paginationParameters = new Object[] { requestHash, String.valueOf(statusFilter) };
 
     if (paginationToken != null) {
       PaginationToken token = PaginationToken.fromBase64(paginationToken);

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -197,7 +197,7 @@ public class CohortMaterializationService {
     int pageSize = request.getPageSize();
     // TODO: add CDR version ID here
     // We require the client to specify requestHash here instead of hashing searchRequest itself,
-    // and use Objects.toString(statusFilter) instead of just statusFilter;
+    // and use String.valueOf(statusFilter) instead of just statusFilter;
     // both searchRequest and statusFilter contain enums, which do not have stable has codes across
     // JVMs (see [RW-1149]).
     Object[] paginationParameters = new Object[] { requestHash, String.valueOf(statusFilter) };

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -301,16 +301,6 @@ public class CohortsControllerTest {
   }
 
   @Test(expected = BadRequestException.class)
-  public void testMaterializeCohortBadCohortSpec() throws Exception {
-    Cohort cohort = createDefaultCohort();
-    cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
-
-    MaterializeCohortRequest request = new MaterializeCohortRequest();
-    request.setCohortSpec("badSpec");
-    cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME, request);
-  }
-
-  @Test(expected = BadRequestException.class)
   public void testMaterializeCohortNoSpecOrCohortName() throws Exception {
     Cohort cohort = createDefaultCohort();
     cohort = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), cohort).getBody();
@@ -341,7 +331,7 @@ public class CohortsControllerTest {
     request.setCohortName(cohort.getName());
     request.setPageSize(CohortsController.DEFAULT_PAGE_SIZE);
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(null, searchRequest, adjustedRequest))
+    when(cohortMaterializationService.materializeCohort(null, cohortCriteria, adjustedRequest))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);
@@ -358,7 +348,7 @@ public class CohortsControllerTest {
     request.setCohortName(cohort.getName());
     request.setPageSize(CohortsController.MAX_PAGE_SIZE);
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(null, searchRequest, adjustedRequest))
+    when(cohortMaterializationService.materializeCohort(null, cohortCriteria, adjustedRequest))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);
@@ -371,7 +361,7 @@ public class CohortsControllerTest {
     MaterializeCohortRequest request = new MaterializeCohortRequest();
     request.setCohortName(cohort.getName());
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(null, searchRequest, request))
+    when(cohortMaterializationService.materializeCohort(null, cohortCriteria, request))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);
@@ -391,7 +381,7 @@ public class CohortsControllerTest {
     MaterializeCohortRequest request = new MaterializeCohortRequest();
     request.setCohortName(cohort.getName());
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(cohortReview, searchRequest, request))
+    when(cohortMaterializationService.materializeCohort(cohortReview, cohortCriteria, request))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);
@@ -405,7 +395,7 @@ public class CohortsControllerTest {
     MaterializeCohortRequest request = new MaterializeCohortRequest();
     request.setCohortSpec(cohort.getCriteria());
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(null, searchRequest, request))
+    when(cohortMaterializationService.materializeCohort(null, cohortCriteria, request))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);
@@ -424,7 +414,7 @@ public class CohortsControllerTest {
     List<CohortStatus> statuses = ImmutableList.of(CohortStatus.INCLUDED, CohortStatus.NOT_REVIEWED);
     request.setStatusFilter(statuses);
     MaterializeCohortResponse response = new MaterializeCohortResponse();
-    when(cohortMaterializationService.materializeCohort(null, searchRequest, request))
+    when(cohortMaterializationService.materializeCohort(null, cohortCriteria, request))
         .thenReturn(response);
     assertThat(cohortsController.materializeCohort(WORKSPACE_NAMESPACE, WORKSPACE_NAME,
         request).getBody()).isEqualTo(response);


### PR DESCRIPTION
Hashing the spec string instead of the SearchRequest object in order to
avoid issues with non-stable hashing of enums.

(It's a little simpler to keep pagination handling logic in CohortMaterializationService from a testing perspective.)