### PR TITLE
[RW-1217][risk=no] Bump machine size to n1-standard-2

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -56,7 +56,7 @@ public class NotebooksServiceImpl implements NotebooksService {
             .combinedExtensions(ImmutableMap.<String, String>of()))
         .machineConfig(new MachineConfig()
             .masterDiskSize(20 /* GB */)
-            .masterMachineType("n1-standard-1"));
+            .masterMachineType("n1-standard-2"));
   }
 
   @Override


### PR DESCRIPTION
Nicole is frequently wedging her cluster due to running too much intensive processing (likely RAM-limited). Since autopause is now in effect, we should be able to justify using a slightly better machine (1vcpu, 4GB) -> (2vcpu, 8GB)