### PR TITLE
[risk=no] Comment out PR template so it's only visible on creation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 Replace this this template with your PR description.
 Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
 include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title
@@ -11,3 +12,4 @@ Please also:
 
 * Get thumbs from reviewer(s)
 * Verify all tests go green, including CI tests
+-->


### PR DESCRIPTION
I'm tired of seeing this boilerplate, and when left undeleted it obfuscates any description the author might have written. With this change, you'll still see the template when you create a new PR, which I think is the only real purpose for it.

Alternatively, I might argue to remove this entirely since `CONTRIBUTING.md` is linked in the sidebar when you create a new PR. We can leave that idea for future discussion.