### PR TITLE
[RW-968][risk=no] Compile integration tests in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
           working_directory: ~/workbench/api
           command: ./project.rb validate-swagger --project-prop verboseTestLogging=yes
       - run:
+          name: Integration tests compile
+          working_directory: ~/workbench/api
+          command: ./project.rb gradle compileBigQuery compileIntegration
+      - run:
+          name: Unit tests
           working_directory: ~/workbench/api
           command: ./project.rb test
       - save_cache:


### PR DESCRIPTION
This turned out to be pretty easy, I was just very confused about what the "build" task was doing in gradle.

For posterity, here is what I was originally trying out:

```
gradle build integration -x test
```

i.e. "build the integration target but skip the tests".

This actually just tells gradle to run the "build" task, followed by the "integration" task, while excluding the "test" task. This caused compilation issues because "integration" depends on the "test" compilation target in order to get some of it's deps, like the "common-api". By not building that, I was getting failures importing those classes into test classes.

`build` is actually just a default task installed by the Java plugin as outlined here: https://docs.gradle.org/current/userguide/java_plugin.html#_lifecycle_tasks , it is associated with the main compile and test targets.

Instead I was able to just run a task to build everything that happens before the test target, which are the compile tasks.