### PR TITLE
[No Ticket][Risk=no] Move menu options to top of card, to align with …

### DIFF
--- a/ui/src/app/views/cohort-list/component.css
+++ b/ui/src/app/views/cohort-list/component.css
@@ -29,7 +29,7 @@
 
 .header-area {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 }
 
 clr-dropdown-menu {

--- a/ui/src/app/views/notebook-list/component.css
+++ b/ui/src/app/views/notebook-list/component.css
@@ -69,7 +69,7 @@
 
 .header-area {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .header-area .name {

--- a/ui/src/app/views/workspace-list/component.css
+++ b/ui/src/app/views/workspace-list/component.css
@@ -110,12 +110,11 @@
 
 .header-area {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .workspace-name {
   color: #216FB4;
-  padding-top: 0.5rem;
   margin-bottom: 0.5rem;
   font-weight: 500;
   font-size: 18px;


### PR DESCRIPTION
…name

This has bothered me for a bit. Our menu dropdowns should align with the top of the name, not the center. This is true of the mocks as well. I just fixed it to align more to that.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
