### PR TITLE
[RW-1147][risk=no] Display loading text on unregistered page

### DIFF
--- a/ui/src/app/views/unregistered/component.html
+++ b/ui/src/app/views/unregistered/component.html
@@ -1,4 +1,7 @@
 <div [ngSwitch]="idvStatus">
+  <p *ngSwitchCase="null">
+    Loading...
+  </p>
   <p *ngSwitchCase="IdVerificationStatus.REJECTED">
     Identity verification rejected, please create an account with an approved contact email or contact the DRC PI for your institution.
   </p>

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -136,6 +136,8 @@ describe('UnregisteredComponent', () => {
     loadProfileWithRegistrationSettings({
       dataAccessLevel: DataAccessLevel.Unregistered
     });
+    tick();
+    fixture.detectChanges();
 
     expect(de.nativeElement.textContent).toContain('Awaiting identity verification');
   }));
@@ -163,6 +165,7 @@ describe('UnregisteredComponent', () => {
     // Tick the retry delays.
     tick(1000);
     tick(1000);
+    fixture.detectChanges();
 
     expect(de.nativeElement.textContent).toContain('Awaiting identity verification');
     expectAllRegistrationSubmitted(profileStub.profile);

--- a/ui/src/app/views/unregistered/component.spec.ts
+++ b/ui/src/app/views/unregistered/component.spec.ts
@@ -115,7 +115,7 @@ describe('UnregisteredComponent', () => {
     const profile = {
       ...ProfileStubVariables.PROFILE_STUB,
       dataAccessLevel: p.dataAccessLevel,
-      idVerificationStatus: p.idVerificationStatus,
+      idVerificationStatus: p.idVerificationStatus || IdVerificationStatus.UNVERIFIED,
       requestedIdVerification: !!p.requestedIdVerification,
       termsOfServiceCompletionTime: p.termsOfServiceCompletionTime,
       ethicsTrainingCompletionTime: p.ethicsTrainingCompletionTime,

--- a/ui/src/app/views/unregistered/component.ts
+++ b/ui/src/app/views/unregistered/component.ts
@@ -20,7 +20,7 @@ import {
 })
 export class UnregisteredComponent implements OnInit, OnDestroy {
   IdVerificationStatus = IdVerificationStatus;
-  idvStatus: IdVerificationStatus;
+  idvStatus: IdVerificationStatus = null;
   private profileSub: Subscription;
 
   constructor(


### PR DESCRIPTION
This should only display if you do an initial load of the unregistered page. A loading spinner would be better here, but this page is a stop-gap anyways.