### PR TITLE
[RW-1286] Adding getDataTableQuery and getCohortAnnotations methods [risk=no]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -29,8 +29,12 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.model.CdrQuery;
 import org.pmiops.workbench.model.Cohort;
+import org.pmiops.workbench.model.CohortAnnotationsRequest;
+import org.pmiops.workbench.model.CohortAnnotationsResponse;
 import org.pmiops.workbench.model.CohortListResponse;
+import org.pmiops.workbench.model.DataTableSpecification;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.MaterializeCohortRequest;
 import org.pmiops.workbench.model.MaterializeCohortResponse;
@@ -313,6 +317,20 @@ public class CohortsController implements CohortsApiDelegate {
     MaterializeCohortResponse response = cohortMaterializationService.materializeCohort(
         cohortReview, cohortSpec, conceptIds, request);
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  public ResponseEntity<CdrQuery> getDataTableQuery(String workspaceNamespace, String workspaceId,
+      DataTableSpecification request) {
+    // TODO: implement this
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<CohortAnnotationsResponse> getCohortAnnotations(String workspaceNamespace,
+      String workspaceId, CohortAnnotationsRequest request) {
+    // TODO: implement this
+    return null;
   }
 
   private org.pmiops.workbench.db.model.Cohort getDbCohort(String workspaceNamespace,

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -188,11 +188,8 @@ definitions:
       name:
         description: the name of the parameter
         type: string
-      value:
-        description: A string value for this parameter.
-        type: string
       values:
-        description: An array of string values for this parameter.
+        description: An array of string values for this parameter. (It may contain just one value.)
         type: array
         items:
           type: string
@@ -202,11 +199,8 @@ definitions:
       valueDatetime:
         description: A datetime (yyyy-MM-dd HH:mm:ss zzz) value for this parameter
         type: string
-      valueNumber:
-        description: A number value for this parameter.
-        type: number
       valueNumbers:
-        description: An array of number values for this parameter
+        description: An array of number values for this parameter. (It may contain just one value.)
         type: array
         items:
           type: number
@@ -222,7 +216,7 @@ definitions:
         type: string
       statusFilter:
         description: >
-          An array of status values; participants with these statuses will be have their annotations
+          An array of status values; participants with these statuses will have their annotations
           retrieved. Defaults to [NOT_REVIEWED, INCLUDED, NEEDS_FURTHER_REVIEW] --
           everything but EXCLUDED.
         type: array

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -53,28 +53,6 @@ parameters:
 
 paths:
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/materializeCohort:
-    parameters:
-      - $ref: '#/parameters/workspaceNamespace'
-      - $ref: '#/parameters/workspaceId'
-    post:
-      tags:
-        - cohorts
-      description: >
-        Materializes a cohort for a given CDR version to specified output.
-      operationId: "materializeCohort"
-      parameters:
-       - in: body
-         name: request
-         description: cohort materialization request
-         schema:
-           $ref: "#/definitions/MaterializeCohortRequest"
-      responses:
-        200:
-          description: The results of materializing the cohort
-          schema:
-            $ref: "#/definitions/MaterializeCohortResponse"
-
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/getDataTableQuery:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
@@ -143,72 +121,6 @@ paths:
               $ref: "#/definitions/ConceptListResponse"
 
 definitions:
-
-  MaterializeCohortRequest:
-    type: object
-    properties:
-      cohortName:
-        description: >
-         The name of a cohort that is to be evaluated. Either this or cohortSpec should be specified
-        type: string
-      cohortSpec:
-        description: >
-          JSON representation of a cohort to be evaluated (using the same format used for saved
-          cohorts). Either this or cohortName should be specified
-        type: string
-      statusFilter:
-        description: >
-          An array of status values; participants with these statuses will be included.
-          Defaults to [NOT_REVIEWED, INCLUDED, NEEDS_FURTHER_REVIEW] -- everything but EXCLUDED.
-          Only valid for use with cohortName (cohorts saved in the database.)
-        type: array
-        items:
-          $ref: "#/definitions/CohortStatus"
-      cdrVersionName:
-        description: >
-          The name of a CDR version to use when evaluating the cohort; if none is specified,
-          the CDR version currently associated with the workspace will be used
-        type: string
-      pageToken:
-        description: >
-          Pagination token retrieved from a previous call to materializeCohort; used for
-          retrieving additional pages of results. If this is specified, all other fields on
-          MaterializeCohortRequest apart from pageSize must match the values specified
-          on the request that generated this token.
-        type: string
-      pageSize:
-        description: >
-          Maximum number of results to return in a response. Defaults to 1000.
-        type: integer
-        format: int32
-      fieldSet:
-        description: >
-          Specification defining what data to return for participants in the cohort. Defaults to
-          just participant IDs.
-        $ref: "#/definitions/FieldSet"
-      # TODO: add output information
-
-  MaterializeCohortResponse:
-    type: object
-    required:
-      - results
-    properties:
-      results:
-        description: >
-          An array of JSON dictionaries representing results to the cohort materialization.
-          (In Java, this is represented as Map<String, Object>[]. In Python clients, this is a
-          list[object] where each object is a dictionary. In Typescript clients, this is an
-          Array<any> where each object is a dictionary.) Keys in the dictionaries will be the
-          columns selected in the field set provided in the request, and the values will
-          be the values of those columns.
-        type: array
-        items:
-          type: object
-      nextPageToken:
-        description: >
-          Pagination token that can be used in a subsequent call to MaterializeCohortRequest to
-          retrieve more results. If not set, there are no more results to retrieve.
-        type: string
 
   DataTableSpecification:
     type: object
@@ -342,23 +254,6 @@ definitions:
         type: array
         items:
           type: object
-
-  FieldSet:
-    type: object
-    description: >
-      A specification for fields to retrieve about participants in a cohort.
-      Exactly one of the properties below should be specified.
-    properties:
-      tableQuery:
-        description: >
-          A query specifying how to pull data out of a single table. Either this or annotationQuery
-          should be set (not both.)
-        $ref: "#/definitions/TableQuery"
-      annotationQuery:
-        description: >
-          A query specifying how to retrieve annotation values created about participants in a
-          cohort during cohort review. Either this or tableQuery should be set (not both.)
-        $ref: "#/definitions/AnnotationQuery"
 
   TableQuery:
     type: object

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -60,7 +60,8 @@ paths:
     post:
       tags:
         - cohorts
-      description: Materializes a cohort for a given CDR version to specified output
+      description: >
+        Materializes a cohort for a given CDR version to specified output.
       operationId: "materializeCohort"
       parameters:
        - in: body
@@ -73,6 +74,50 @@ paths:
           description: The results of materializing the cohort
           schema:
             $ref: "#/definitions/MaterializeCohortResponse"
+
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/getDataTableQuery:
+    parameters:
+      - $ref: '#/parameters/workspaceNamespace'
+      - $ref: '#/parameters/workspaceId'
+    post:
+      tags:
+        - cohorts
+      description: >
+        Translates a data table specification into a SQL query to run against the CDR.
+      operationId: "getDataTableQuery"
+      parameters:
+        - in: body
+          name: request
+          description: a query specification for a data table
+          schema:
+            $ref: "#/definitions/DataTableSpecification"
+      responses:
+        200:
+          description: the query to run against the CDR to retrieve the data
+          schema:
+            $ref: "#/definitions/CdrQuery"
+
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/getCohortAnnotations:
+    parameters:
+      - $ref: '#/parameters/workspaceNamespace'
+      - $ref: '#/parameters/workspaceId'
+    post:
+      tags:
+        - cohorts
+      description: >
+        Retrieves annotations for a cohort in the workspace
+      operationId: "getCohortAnnotations"
+      parameters:
+        - in: body
+          name: request
+          description: a request indicating what annotations to retrieve
+          schema:
+            $ref: "#/definitions/CohortAnnotationsRequest"
+      responses:
+        200:
+          description: the requested annotations
+          schema:
+            $ref: "#/definitions/CohortAnnotationsResponse"
 
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/searchConcepts:
       post:
@@ -164,6 +209,139 @@ definitions:
           Pagination token that can be used in a subsequent call to MaterializeCohortRequest to
           retrieve more results. If not set, there are no more results to retrieve.
         type: string
+
+  DataTableSpecification:
+    type: object
+    properties:
+      cohortName:
+        description: >
+         The name of a cohort that data should be retrieved for. This and cohortSpec should not
+         be used at the same time. If neither cohortName nor cohortSpec are specified, data will
+         be extracted for everyone in the CDR.
+        type: string
+      cohortSpec:
+        description: >
+          JSON representation of a cohort to be evaluated (using the same format used for saved
+          cohorts). This and cohortName should not be used at the same time. If neither cohortName
+          nor cohortSpec are specified, data will be extracted for everyone in the CDR.
+        type: string
+      statusFilter:
+        description: >
+          An array of status values; participants with these statuses will be included.
+          Defaults to [NOT_REVIEWED, INCLUDED, NEEDS_FURTHER_REVIEW] -- everything but EXCLUDED.
+          Only valid for use with cohortName (cohorts saved in the database.)
+        type: array
+        items:
+          $ref: "#/definitions/CohortStatus"
+      cdrVersionName:
+        description: >
+          The name of a CDR version to use when evaluating the cohort; if none is specified,
+          the CDR version currently associated with the workspace will be used
+        type: string
+      tableQuery:
+        description: >
+            A query specifying how to pull data out of a single table. If tableQuery is not
+            specified, just Person.person_id will be extracted.
+        $ref: "#/definitions/TableQuery"
+
+  CdrQuery:
+    type: object
+    required:
+      - sql
+      - bigqueryProject
+      - bigqueryDataset
+
+    properties:
+      sql:
+        description: Google SQL to use when querying the CDR
+        type: string
+      parameters:
+        description: named query parameters used when executing the above SQL
+        type: array
+        items:
+          $ref: "#/definitions/CdrQueryParameter"
+      bigqueryProject:
+        description: name of the Google Cloud project containing the CDR dataset
+        type: string
+      bigqueryDataset:
+        description: name of the CDR BigQuery dataset
+        type: string
+
+  CdrQueryParameter:
+    type: object
+    required:
+      - name
+    description: A query parameter and value. One (and only one) of the value fields should be set.
+    properties:
+      name:
+        description: the name of the parameter
+        type: string
+      value:
+        description: A string value for this parameter.
+        type: string
+      values:
+        description: An array of string values for this parameter.
+        type: array
+        items:
+          type: string
+      valueDate:
+        description: A date (yyyy-MM-dd) value for this parameter
+        type: string
+      valueDatetime:
+        description: A datetime (yyyy-MM-dd HH:mm:ss zzz) value for this parameter
+        type: string
+      valueNumber:
+        description: A number value for this parameter.
+        type: number
+      valueNumbers:
+        description: An array of number values for this parameter
+        type: array
+        items:
+          type: number
+
+  CohortAnnotationsRequest:
+    type: object
+    required:
+      - cohortName
+    properties:
+      cohortName:
+        description: >
+         The name of a cohort that annotations should be retrieved for.
+        type: string
+      statusFilter:
+        description: >
+          An array of status values; participants with these statuses will be have their annotations
+          retrieved. Defaults to [NOT_REVIEWED, INCLUDED, NEEDS_FURTHER_REVIEW] --
+          everything but EXCLUDED.
+        type: array
+        items:
+          $ref: "#/definitions/CohortStatus"
+      cdrVersionName:
+        description: >
+          The name of a CDR version to use when retrieving annotations; if none is specified,
+          the CDR version currently associated with the workspace will be used
+        type: string
+      annotationQuery:
+        description: >
+          Specification defining what annotations to retrieve.
+        $ref: "#/definitions/AnnotationQuery"
+
+  CohortAnnotationsResponse:
+    type: object
+    required:
+      - results
+    properties:
+      results:
+        description: >
+          An array of JSON dictionaries, with each dictionary representing the requested
+          annotations and/or review status for a single person.
+          (In Java, this is represented as Map<String, Object>[]. In Python clients, this is a
+          list[object] where each object is a dictionary. In Typescript clients, this is an
+          Array<any> where each object is a dictionary.) Keys in the dictionaries will be
+          "person_id", "review_status", or the name of an annotation.
+        type: array
+        items:
+          type: object
 
   FieldSet:
     type: object

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -983,6 +983,29 @@ paths:
           description: ACCEPTED
           schema:
             $ref: '#/definitions/EmptyResponse'
+
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/materializeCohort:
+    parameters:
+      - $ref: '#/parameters/workspaceNamespace'
+      - $ref: '#/parameters/workspaceId'
+    post:
+      tags:
+        - cohorts
+      description: >
+        Materializes a cohort for a given CDR version to specified output.
+      operationId: "materializeCohort"
+      parameters:
+       - in: body
+         name: request
+         description: cohort materialization request
+         schema:
+           $ref: "#/definitions/MaterializeCohortRequest"
+      responses:
+        200:
+          description: The results of materializing the cohort
+          schema:
+            $ref: "#/definitions/MaterializeCohortResponse"
+
 ######### USER RECENT RESOURCES ########################################
   /v1/workspaces/user-recent-resources:
     get:
@@ -1562,6 +1585,88 @@ definitions:
         type: integer
         format: int64
         description: Milliseconds since the UNIX epoch.
+
+  MaterializeCohortRequest:
+    type: object
+    properties:
+      cohortName:
+        description: >
+         The name of a cohort that is to be evaluated. Either this or cohortSpec should be specified
+        type: string
+      cohortSpec:
+        description: >
+          JSON representation of a cohort to be evaluated (using the same format used for saved
+          cohorts). Either this or cohortName should be specified
+        type: string
+      statusFilter:
+        description: >
+          An array of status values; participants with these statuses will be included.
+          Defaults to [NOT_REVIEWED, INCLUDED, NEEDS_FURTHER_REVIEW] -- everything but EXCLUDED.
+          Only valid for use with cohortName (cohorts saved in the database.)
+        type: array
+        items:
+          $ref: "#/definitions/CohortStatus"
+      cdrVersionName:
+        description: >
+          The name of a CDR version to use when evaluating the cohort; if none is specified,
+          the CDR version currently associated with the workspace will be used
+        type: string
+      pageToken:
+        description: >
+          Pagination token retrieved from a previous call to materializeCohort; used for
+          retrieving additional pages of results. If this is specified, all other fields on
+          MaterializeCohortRequest apart from pageSize must match the values specified
+          on the request that generated this token.
+        type: string
+      pageSize:
+        description: >
+          Maximum number of results to return in a response. Defaults to 1000.
+        type: integer
+        format: int32
+      fieldSet:
+        description: >
+          Specification defining what data to return for participants in the cohort. Defaults to
+          just participant IDs.
+        $ref: "#/definitions/FieldSet"
+
+  FieldSet:
+    type: object
+    description: >
+      A specification for fields to retrieve about participants in a cohort.
+      Exactly one of the properties below should be specified.
+    properties:
+      tableQuery:
+        description: >
+          A query specifying how to pull data out of a single table. Either this or annotationQuery
+          should be set (not both.)
+        $ref: "#/definitions/TableQuery"
+      annotationQuery:
+        description: >
+          A query specifying how to retrieve annotation values created about participants in a
+          cohort during cohort review. Either this or tableQuery should be set (not both.)
+        $ref: "#/definitions/AnnotationQuery"
+
+  MaterializeCohortResponse:
+    type: object
+    required:
+      - results
+    properties:
+      results:
+        description: >
+          An array of JSON dictionaries representing results to the cohort materialization.
+          (In Java, this is represented as Map<String, Object>[]. In Python clients, this is a
+          list[object] where each object is a dictionary. In Typescript clients, this is an
+          Array<any> where each object is a dictionary.) Keys in the dictionaries will be the
+          columns selected in the field set provided in the request, and the values will
+          be the values of those columns.
+        type: array
+        items:
+          type: object
+      nextPageToken:
+        description: >
+          Pagination token that can be used in a subsequent call to MaterializeCohortRequest to
+          retrieve more results. If not set, there are no more results to retrieve.
+        type: string
 
   ConceptSetListResponse:
     type: object


### PR DESCRIPTION
Implementation of each will come later.

For the moment, I'm not proposing we deprecate materializeCohort... there may be clients that can't easily query BigQuery themselves, and could still use it. But we won't use it anymore in our pyclient library once this gets implemented.