### PR TITLE
[RW-1416][RW-1355][risk=low] Rename CDRs, fix prod CDR config

### DIFF
--- a/api/config/cdr_versions_local.json
+++ b/api/config/cdr_versions_local.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Test Registered CDR",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",

--- a/api/config/cdr_versions_local.json
+++ b/api/config/cdr_versions_local.json
@@ -1,5 +1,6 @@
 [
   {
+    "cdrVersionId": 1,
     "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Test Registered CDR",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -7,7 +7,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "cdr20180831",
-    "publicDbName": "public20180831"
+    "cdrDbName": "cdr20180817",
+    "publicDbName": "public20180817"
   }
 ]

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -1,5 +1,6 @@
 [
   {
+    "cdrVersionId": 1,
     "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -1,5 +1,6 @@
 [
   {
+    "cdrVersionId": 1,
     "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
@@ -11,6 +12,7 @@
     "publicDbName": "public20180831"
   },
   {
+    "cdrVersionId": 2,
     "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Test Registered CDR",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",
@@ -11,7 +11,7 @@
     "publicDbName": "public20180831"
   },
   {
-    "name": "Test Registered CDR 20180920",
+    "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -1,5 +1,6 @@
 [
   {
+    "cdrVersionId": 1,
     "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
@@ -11,6 +12,7 @@
     "publicDbName": "public20180831"
   },
   {
+    "cdrVersionId": 2,
     "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Test Registered CDR",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",
@@ -11,7 +11,7 @@
     "publicDbName": "public20180831"
   },
   {
-    "name": "Test Registered CDR 20180920",
+    "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Test Registered CDR",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",
@@ -11,7 +11,7 @@
     "publicDbName": "public20180920"
   },
   {
-    "name": "New Test Registered CDR",
+    "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "test_merge_dec26",

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -1,5 +1,6 @@
 [
   {
+    "cdrVersionId": 1,
     "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
@@ -11,6 +12,7 @@
     "publicDbName": "public20180920"
   },
   {
+    "cdrVersionId": 2,
     "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -17,7 +17,7 @@
     "serviceAccountApiUsers": [ "all-of-us-workbench-test@appspot.gserviceaccount.com" ]
   },
   "cdr": {
-    "defaultCdrVersion": "Test Registered CDR",
+    "defaultCdrVersion": "Synthetic Dataset v1",
     "debugQueries": false
   },
   "googleCloudStorageService": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -16,7 +16,7 @@
     "serviceAccountApiUsers": [ "all-of-us-rw-prod@appspot.gserviceaccount.com" ]
   },
   "cdr": {
-    "defaultCdrVersion": "Test Registered CDR",
+    "defaultCdrVersion": "Synthetic Dataset v1",
     "debugQueries": false
   },
   "googleCloudStorageService": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -16,7 +16,7 @@
     "serviceAccountApiUsers": [ "all-of-us-rw-stable@appspot.gserviceaccount.com" ]
   },
   "cdr": {
-    "defaultCdrVersion": "Test Registered CDR 20180920",
+    "defaultCdrVersion": "Synthetic Dataset v2",
     "debugQueries": true
   },
   "googleCloudStorageService": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -16,7 +16,7 @@
     "serviceAccountApiUsers": [ "all-of-us-rw-staging@appspot.gserviceaccount.com" ]
   },
   "cdr": {
-    "defaultCdrVersion": "Test Registered CDR 20180920",
+    "defaultCdrVersion": "Synthetic Dataset v2",
     "debugQueries": true
   },
   "googleCloudStorageService": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -17,7 +17,7 @@
     "serviceAccountApiUsers": [ "all-of-us-workbench-test@appspot.gserviceaccount.com" ]
   },
   "cdr": {
-    "defaultCdrVersion": "New Test Registered CDR",
+    "defaultCdrVersion": "Synthetic Dataset v2",
     "debugQueries": true
   },
   "googleCloudStorageService": {


### PR DESCRIPTION
- Fix prod CDR configs to point to an actual CDR that's available in prod (it's currently broken)
- Rename to "Dataset" to avoid the opaque "CDR" acronym
- Require an "id" in CDR JSONs; use this as the primary key
-> I prefer this to introducing a new ID type