### PR TITLE
[RW-1289][risk=no] Fix z-index loading screen rendering problems

### DIFF
--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -2,4 +2,3 @@
 <div *ngIf="overriddenUrl" style="position: absolute; top: 0; left: 1rem;">
   <span style="font-size: 80%; color: darkred;">API URL: {{this.overriddenUrl}}</span>
 </div>
-<app-routing-spinner></app-routing-spinner>

--- a/ui/src/app/views/routing-spinner/component.css
+++ b/ui/src/app/views/routing-spinner/component.css
@@ -1,12 +1,13 @@
 .page-spinner-container {
-  position: fixed;
+  display: none;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background: black;
-  opacity: 0;
-  z-index: -1;
+  opacity: 0.8;
+  z-index: 1;
 }
 
 .page-spinner-container > .spinner {

--- a/ui/src/app/views/routing-spinner/component.html
+++ b/ui/src/app/views/routing-spinner/component.html
@@ -1,5 +1,5 @@
 <div class="page-spinner-container">
-  <div #pageSpinner class="spinner spinner-inverse" [style.opacity]="0">
+  <div #pageSpinner class="spinner spinner-inverse">
     Loading...
   </div>
 </div>

--- a/ui/src/app/views/routing-spinner/component.ts
+++ b/ui/src/app/views/routing-spinner/component.ts
@@ -66,17 +66,13 @@ export class RoutingSpinnerComponent implements OnInit {
 
   private showSpinner() {
     this.zone.runOutsideAngular(() => {
-      this.renderer.setStyle(this.spinnerContainer, 'opacity', 0.8);
-      this.renderer.setStyle(this.spinnerContainer, 'z-index', 1);
-      this.renderer.setStyle(this.spinner, 'opacity', 1);
+      this.renderer.setStyle(this.spinnerContainer, 'display', 'block');
     });
   }
 
   private hideSpinner() {
     this.zone.runOutsideAngular(() => {
-      this.renderer.setStyle(this.spinnerContainer, 'opacity', 0);
-      this.renderer.setStyle(this.spinnerContainer, 'z-index', -1);
-      this.renderer.setStyle(this.spinner, 'opacity', 0);
+      this.renderer.setStyle(this.spinnerContainer, 'display', 'none');
     });
   }
 }

--- a/ui/src/app/views/signed-in/component.css
+++ b/ui/src/app/views/signed-in/component.css
@@ -107,6 +107,8 @@
   padding-right: 0.6rem;
   padding-left: 1rem;
   flex-grow: 1;
+  /* Needed for absolute positioned child elements, e.g. spinner. */
+  position: relative;
 }
 
 button.btn:focus {

--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -72,6 +72,7 @@
       based on clicking routerLink elements (above) or router.navigate calls.
     -->
     <router-outlet></router-outlet>
+    <app-routing-spinner></app-routing-spinner>
   </div>
 </div>
 <app-bug-report></app-bug-report>

--- a/ui/src/app/views/signed-in/component.spec.ts
+++ b/ui/src/app/views/signed-in/component.spec.ts
@@ -25,6 +25,7 @@ import {SignInService} from '../../services/sign-in.service';
 
 import {BreadcrumbComponent} from '../breadcrumb/component';
 import {BugReportComponent} from '../bug-report/component';
+import {RoutingSpinnerComponent} from '../routing-spinner/component';
 import {SignedInComponent} from '../signed-in/component';
 
 describe('SignedInComponent', () => {
@@ -40,6 +41,7 @@ describe('SignedInComponent', () => {
         BreadcrumbComponent,
         BugReportComponent,
         SignedInComponent,
+        RoutingSpinnerComponent
       ],
       providers: [
         {provide: BugReportService, useValue: new BugReportServiceStub()},


### PR DESCRIPTION
Ultimately I think this may have come down to a browser rendering issue, AFAICT the HTML/CSS stacking order defined did not match what was being rendered in the browser - my interpretation is that a correct rendering would have placed the spinner on top of everything (including the top-nav). Toggling various CSS properties on/off (and returning to the original CSS state) in chrome inspector resulted in things reaching the correct state. I remain perplexed as to why the browser rendered the top-nav on top of the loading screen at all, it seems by sheer coincidence this happened to also be the desired behavior.

Ultimately to solve this I made two changes:
- Switch from opacity-based visibility to "display", this seems to be more obvious signal for the browser to redraw (rather than scaling the opacity + z-index change).
- Move the spinner into the signed in page - shifting the spinner below the top-nav. AFAIK we didn't have a use case for this spinner in the signed out state.