### PR TITLE
[RW-1312][risk=no] Add checkbox for cloning collaborators

### DIFF
--- a/ui/src/app/views/workspace-edit/component.css
+++ b/ui/src/app/views/workspace-edit/component.css
@@ -34,8 +34,9 @@
   width: 100%;
 }
 
-.name-area {
+.name-area, .cdr-version-dropdown {
   margin-right: 20px;
+  margin-bottom: 5px;
 }
 
 .checkbox-group {

--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -43,6 +43,21 @@
         </ng-container>
       </clr-dropdown-menu>
     </clr-dropdown>
+    <div *ngIf="mode == Mode.Clone" class="clone-collab"
+         style="display: inline-block; vertical-align: middle;">
+      <clr-checkbox
+        name="clone-user-roles"
+        id="clone-user-roles"
+        style="display: inline-block; vertical-align: top;"
+        [(ngModel)]="cloneUserRoles">
+      </clr-checkbox>
+      <div style="display: inline-block;">
+        <label class="checkbox-label" for="clr-checkbox-clone-user-roles">
+          <h3 class="section-header">Copy original workspace collaborators</h3>
+          <span class="section-text">Share cloned workspace with same collaborators</span>
+        </label>
+      </div>
+    </div>
   </div>
   <div>
 

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -189,6 +189,7 @@ export class WorkspaceEditComponent implements OnInit {
   };
 
   researchPurposeItems = ResearchPurposeItems;
+  cloneUserRoles = false;
   fillDetailsLater = false;
   hideDetailsLaterOption = false;
   canEditResearchPurpose = true;
@@ -368,6 +369,7 @@ export class WorkspaceEditComponent implements OnInit {
     this.workspacesService.cloneWorkspace(
       this.oldWorkspaceNamespace,
       this.oldWorkspaceName, {
+        includeUserRoles: this.cloneUserRoles,
         workspace: this.workspace,
       }).subscribe(
         (r: CloneWorkspaceResponse) => {


### PR DESCRIPTION
Depends on https://github.com/all-of-us/workbench/pull/1234

Note: due to the 60% page-width consistency on the clone page, this will wrap to the next line on most screens. Not sure if that affects the UX and whether we want more spacing beneath

Screenshots:
![image](https://user-images.githubusercontent.com/822298/46115473-e3c97800-c1ab-11e8-819d-3db3775c9054.png)
![image](https://user-images.githubusercontent.com/822298/46115476-e6c46880-c1ab-11e8-8fe3-9efca52bbec5.png)
