### PR TITLE
[risk=no] Bring back the initial full-screen routing spinner

### DIFF
--- a/ui/src/app/views/app/component.html
+++ b/ui/src/app/views/app/component.html
@@ -1,4 +1,6 @@
 <router-outlet></router-outlet>
+<app-routing-spinner *ngIf="initialSpinner" [alwaysShow]="true">
+</app-routing-spinner>
 <div *ngIf="overriddenUrl" style="position: absolute; top: 0; left: 1rem;">
   <span style="font-size: 80%; color: darkred;">API URL: {{this.overriddenUrl}}</span>
 </div>

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -23,10 +23,10 @@ export const overriddenPublicUrlKey = 'publicApiUrlOverride';
 })
 export class AppComponent implements OnInit {
   isSignedIn = false;
+  initialSpinner = true;
   overriddenUrl: string = null;
   private baseTitle: string;
   private overriddenPublicUrl: string = null;
-
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -77,6 +77,9 @@ export class AppComponent implements OnInit {
 
     this.router.events.subscribe((event: RouterEvent) => {
       this.setTitleFromRoute(event);
+      if (event instanceof NavigationEnd) {
+        this.initialSpinner = false;
+      }
     });
   }
 

--- a/ui/src/app/views/routing-spinner/component.ts
+++ b/ui/src/app/views/routing-spinner/component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ElementRef,
+  Input,
   NgZone,
   OnInit,
   Renderer2,
@@ -25,6 +26,7 @@ import {Observable} from 'rxjs/Observable';
 })
 export class RoutingSpinnerComponent implements OnInit {
   @ViewChild('pageSpinner') pageSpinner: ElementRef;
+  @Input('alwaysShow') alwaysShow = false;
 
   constructor(
     private renderer: Renderer2,
@@ -33,6 +35,10 @@ export class RoutingSpinnerComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    if (this.alwaysShow) {
+      this.showSpinner();
+      return;
+    }
     /* TODO: The spinner should only show if the route is taking a certain
      * amount of time to load.  Also I'm not convinced that this is actually
      * activating for all the router start / end events we want it to.  But the


### PR DESCRIPTION
A side-effect of #1217 removed the initial loading screen. This seems useful to have e.g. when you initially sign into workbench (and your profile is super slow), so add back in an initial routing spinner (full-screen, not limited under the top-bar).