### PR TITLE
[RW-1373][risk=no] Upgrade bootstrap

### DIFF
--- a/public-ui/package.json
+++ b/public-ui/package.json
@@ -34,7 +34,7 @@
     "@webcomponents/custom-elements": "^1.0.0",
     "angular-2-local-storage": "^1.0.1",
     "angular2-highcharts": "^0.5.5",
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.2",
     "core-js": "^2.5.3",
     "enhanced-resolve": "3.3.0",
     "highcharts": "^6.0.4",

--- a/public-ui/yarn.lock
+++ b/public-ui/yarn.lock
@@ -816,9 +816,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
+bootstrap@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.2.tgz#aee2a93472e61c471fc79fb475531dcbc87de326"
 
 brace-expansion@^1.1.7:
   version "1.1.8"

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
     "@webcomponents/custom-elements": "^1.0.0",
     "angular-2-local-storage": "^1.0.1",
     "angular2-highcharts": "^0.5.5",
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.2",
     "core-js": "^2.5.3",
     "d3": "^4.12.2",
     "dom-to-image": "^2.6.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -840,9 +840,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
+bootstrap@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.2.tgz#aee2a93472e61c471fc79fb475531dcbc87de326"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Even in the latest version of `@clr/ui`, they still depend on an older version of bootstrap which we'd already upgraded off of. I ran the UI locally - compilation worked and I didn't notice any obvious issues clicking around.