### PR TITLE
[risk=no] Refactor Hotswap class

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,7 @@
 import io.swagger.codegen.config.CodegenConfigurator
 import io.swagger.codegen.DefaultGenerator
 import org.pmiops.workbench.tooling.GenerateAPIListingTask
+import org.pmiops.workbench.tooling.IncrementalHotSwapTask
 
 def swaggerTemplateDir = 'src/main/resources'
 def mergedApiSourceFile = 'src/main/resources/merged.yaml'
@@ -404,37 +405,6 @@ version = '0.1.0'          // Version in generated output
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-
-
-// Custom task based on https://docs.gradle.org/2.5/userguide/custom_tasks.html#incremental_tasks
-class IncrementalHotSwapTask extends DefaultTask {
-    @InputDirectory
-    def File inputDir
-
-    @TaskAction
-    void execute(IncrementalTaskInputs inputs) {
-      // Only handle incremental builds---don't hot-swap on initial compile.
-      if (inputs.incremental) {
-
-        inputs.outOfDate { change ->
-          String prefix = inputDir.path + "/"
-          String relativePath = change.file.path.substring(prefix.length())
-          String fqClassName = relativePath[0..-(".class".length() + 1)].replaceAll("/", ".")
-          printf "Hot swapping $fqClassName from $change.file.path..."
-          def proc = "echo redefine $fqClassName $change.file.path".execute() \
-            | "/usr/lib/jvm/default-jvm/bin/jdb -attach 8001".execute()
-          proc.waitFor()
-          println "done."
-        }
-
-        inputs.removed { change ->
-          println "Class removed (may require restart): ${change.file.path}"
-        }
-      } else {
-        println "Watching ${inputDir}"
-      }
-    }
-}
 
 task incrementalHotSwap(type: IncrementalHotSwapTask) {
     inputDir = sourceSets.main.java.outputDir

--- a/api/buildSrc/src/main/groovy/org/pmiops/workbench/tooling/IncrementalHotSwapTask.groovy
+++ b/api/buildSrc/src/main/groovy/org/pmiops/workbench/tooling/IncrementalHotSwapTask.groovy
@@ -1,0 +1,37 @@
+package org.pmiops.workbench.tooling
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+
+// Custom task based on https://docs.gradle.org/2.5/userguide/custom_tasks.html#incremental_tasks
+class IncrementalHotSwapTask extends DefaultTask {
+    @InputDirectory
+    File inputDir
+
+    @TaskAction
+    void execute(IncrementalTaskInputs inputs) {
+        // Only handle incremental builds---don't hot-swap on initial compile.
+        if (inputs.incremental) {
+
+            inputs.outOfDate { change ->
+                String prefix = inputDir.path + "/"
+                String relativePath = change.file.path.substring(prefix.length())
+                String fqClassName = relativePath[0..-(".class".length() + 1)].replaceAll("/", ".")
+                printf "Hot swapping $fqClassName from $change.file.path..."
+                def proc = "echo redefine $fqClassName $change.file.path".execute() \
+            | "/usr/lib/jvm/default-jvm/bin/jdb -attach 8001".execute()
+                proc.waitFor()
+                println "done."
+            }
+
+            inputs.removed { change ->
+                println "Class removed (may require restart): ${change.file.path}"
+            }
+        } else {
+            println "Watching ${inputDir}"
+        }
+    }
+
+}


### PR DESCRIPTION
Simple refactor - move the `IncrementalHotSwapTask` class to `buildSrc` for a cleaner build file.

Tested locally by spinning up a local instance, making some minor code changes, and watching the console rebuild.