### PR TITLE
Adding synonyms column to concept, domain_vocabulary_info table

### DIFF
--- a/api/db-cdr/changelog-schema/db.changelog-18.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-18.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet author="danrodney" id="changelog-18">
+
+    <addColumn tableName="concept">
+      <!-- Contains the concept ID, concept code, concept name, and all concept_synonym_name values
+           from concept_synonym -->
+      <column name="synonyms" type="clob"/>
+    </addColumn>
+
+    <createTable tableName="domain_vocabulary_info">
+      <column name="concept_id" type="INTEGER">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="vocabulary_id" type="VARCHAR(20)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="all_concept_count" defaultValue="0" type="INTEGER">
+        <constraints nullable="false"/>
+      </column>
+      <column name="standard_concept_count" defaultValue="0" type="INTEGER">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -24,4 +24,5 @@
   <include file="changelog-schema/db.changelog-15.xml"/>
   <include file="changelog-schema/db.changelog-16.xml"/>
   <include file="changelog-schema/db.changelog-17.xml"/>
+  <include file="changelog-schema/db.changelog-18.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Shows the schema changes I'm hoping to have to our Cloud SQL metadata... the synonyms column will allow for faster concept searching, and the domain_vocabulary_info table for faster vocab count retrieval when the user hasn't entered a search term yet.