### PR TITLE
[RW-1341][risk=no] Implement selected tab styling

### DIFF
--- a/ui/src/app/views/workspace-nav-bar/component.css
+++ b/ui/src/app/views/workspace-nav-bar/component.css
@@ -6,11 +6,9 @@
   height: 100%;
   width: 8rem;
   background-color: transparent;
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
-  border-right: 1px solid rgba(255, 255, 255, 0.15);
+  border: none;
   border-radius: 0;
-  border-top: none;
-  border-bottom: none;
+  padding: 0;
 }
 
 ::ng-deep #workspace-top-nav-bar .btn.btn-primary.btn-top:hover {
@@ -95,6 +93,18 @@
   top: 55px !important;
 }
 
+.tab-inner {
+  height: 100%;
+  line-height: 55px;
+  width: 100%;
+}
+
+.selected-tab-inner {
+  background-color: rgba(255,255,255,0.15);
+  border-bottom: 8px solid #2691D0;
+  font-weight: bold;
+}
+
 label.dropdown-header {
   font-size: 14px;
   color: #262262;
@@ -119,4 +129,3 @@ label.dropdown-header {
   display: inline-grid;
   margin-left: -0.4rem;
 }
-

--- a/ui/src/app/views/workspace-nav-bar/component.html
+++ b/ui/src/app/views/workspace-nav-bar/component.html
@@ -1,19 +1,29 @@
 <clr-button-group id="workspace-top-nav-bar" class="btn-group" [clrMenuPosition]="'bottom-right'">
   <clr-button class="btn btn-primary btn-top" [routerLink]="['/workspaces', wsNamespace, wsId]" routerLinkActive="active"
-          [routerLinkActiveOptions]="{exact: true}">
-    About
+        [routerLinkActiveOptions]="{exact: true}">
+    <div class="tab-inner" [class.selected-tab-inner]="tabPath == ''">
+      About
+    </div>
   </clr-button>
-  <!--<clr-button class="btn btn-primary btn-top" [routerLink]="['/workspaces', wsNamespace, wsId, 'concepts']" routerLinkActive="active"-->
-          <!--[routerLinkActiveOptions]="{exact: true}">-->
-    <!--Concepts-->
-  <!--</clr-button>-->
+  <!--
+  <clr-button class="btn btn-primary btn-top" [routerLink]="['/workspaces', wsNamespace, wsId, 'concepts']" routerLinkActive="active"
+          [routerLinkActiveOptions]="{exact: true}">
+    <div class="tab-inner" [class.selected-tab-inner]="tabPath == 'concepts'">
+      Concepts
+    </div>
+  </clr-button>
+  -->
   <clr-button class="btn btn-primary btn-top" [routerLink]="['/workspaces', wsNamespace, wsId, 'notebooks']" routerLinkActive="active"
               [routerLinkActiveOptions]="{exact: true}">
-    Notebooks
+    <div class="tab-inner" [class.selected-tab-inner]="tabPath == 'notebooks'">
+      Notebooks
+    </div>
   </clr-button>
   <clr-button class="btn btn-primary btn-top" [routerLink]="['/workspaces', wsNamespace, wsId, 'cohorts']" routerLinkActive="active"
               [routerLinkActiveOptions]="{exact: true}">
-    Cohorts
+    <div class="tab-inner" [class.selected-tab-inner]="tabPath == 'cohorts'">
+      Cohorts
+    </div>
   </clr-button>
   <clr-button class="btn btn-primary btn-top btn-dropdown">
     <clr-dropdown class="nav-bar-dropdown">

--- a/ui/src/app/views/workspace-nav-bar/component.spec.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.spec.ts
@@ -63,14 +63,14 @@ class FakeNotebooksComponent {}
 class FakeCohortsComponent {}
 
 describe('WorkspaceNavBarComponent', () => {
-  let fixture: ComponentFixture<WorkspaceNavBarComponent>;
+  let fixture: ComponentFixture<FakeAppComponent>;
   let router: Router;
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
         ClarityModule.forRoot(),
-        RouterTestingModule.withRoutes({
+        RouterTestingModule.withRoutes([{
           path: 'workspaces/:ns/:wsid',
           component: WorkspaceNavBarComponent,
           data: {
@@ -97,7 +97,7 @@ describe('WorkspaceNavBarComponent', () => {
               component: FakeCohortsComponent,
             },
           ]
-        })
+        }])
       ],
       declarations: [
         BugReportComponent,
@@ -140,7 +140,7 @@ describe('WorkspaceNavBarComponent', () => {
     expect(fixture).toBeTruthy();
   }));
 
-  fit('should highlight the active tab', fakeAsync(() => {
+  it('should highlight the active tab', fakeAsync(() => {
     const de = fixture.debugElement;
     const cohortsBtn = de.queryAll(By.css('.btn-top'))
       .find(btn => btn.nativeElement.textContent.includes('Cohorts'));
@@ -152,7 +152,7 @@ describe('WorkspaceNavBarComponent', () => {
     expect(cohortsBtn.query(By.css('.selected-tab-inner'))).toBeTruthy();
   }));
 
-  fit('should navigate on tab click', fakeAsync(() => {
+  it('should navigate on tab click', fakeAsync(() => {
     const de = fixture.debugElement;
     expect(de.query(By.css('app-fake-notebooks'))).toBeFalsy();
 

--- a/ui/src/app/views/workspace-nav-bar/component.spec.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.spec.ts
@@ -1,6 +1,8 @@
+import {Component} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
+import {By} from '@angular/platform-browser';
+import {ActivatedRoute, Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {ClarityModule} from '@clr/angular';
@@ -17,6 +19,7 @@ import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub'
 import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
 
 import {
+  simulateClick,
   updateAndTick
 } from '../../../testing/test-helpers';
 
@@ -28,43 +31,86 @@ import {ConfirmDeleteModalComponent} from '../confirm-delete-modal/component';
 import {WorkspaceNavBarComponent} from '../workspace-nav-bar/component';
 import {WorkspaceShareComponent} from '../workspace-share/component';
 
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-      {path: 'workspaces'},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID}
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    },
-    data: {
-      workspace: {
-        ...WorkspacesServiceStub.stubWorkspace(),
-        accessLevel: WorkspaceAccessLevel.OWNER,
-      }
-    }
-  }
-};
+@Component({
+  selector: 'app-test',
+  template: '<router-outlet></router-outlet>'
+})
+class FakeAppComponent {}
+
+@Component({
+  selector: 'app-fake-about',
+  template: 'about'
+})
+class FakeAboutComponent {}
+
+@Component({
+  selector: 'app-fake-concepts',
+  template: 'concepts'
+})
+class FakeConceptsComponent {}
+
+
+@Component({
+  selector: 'app-fake-notebooks',
+  template: 'notebooks'
+})
+class FakeNotebooksComponent {}
+
+@Component({
+  selector: 'app-fake-cohorts',
+  template: 'cohorts'
+})
+class FakeCohortsComponent {}
 
 describe('WorkspaceNavBarComponent', () => {
   let fixture: ComponentFixture<WorkspaceNavBarComponent>;
+  let router: Router;
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
-        RouterTestingModule,
-        ClarityModule.forRoot()
+        ClarityModule.forRoot(),
+        RouterTestingModule.withRoutes({
+          path: 'workspaces/:ns/:wsid',
+          component: WorkspaceNavBarComponent,
+          data: {
+            workspace: {
+              ...WorkspacesServiceStub.stubWorkspace(),
+              accessLevel: WorkspaceAccessLevel.OWNER,
+            }
+          },
+          children: [
+            {
+              path: '',
+              component: FakeAboutComponent,
+            },
+            {
+              path: 'concepts',
+              component: FakeConceptsComponent,
+            },
+            {
+              path: 'notebooks',
+              component: FakeNotebooksComponent,
+            },
+            {
+              path: 'cohorts',
+              component: FakeCohortsComponent,
+            },
+          ]
+        })
       ],
       declarations: [
         BugReportComponent,
         ConfirmDeleteModalComponent,
+        FakeAboutComponent,
+        FakeAppComponent,
+        FakeConceptsComponent,
+        FakeNotebooksComponent,
+        FakeCohortsComponent,
         WorkspaceNavBarComponent,
         WorkspaceShareComponent,
       ],
       providers: [
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
         {provide: BugReportService, useValue: new BugReportServiceStub()},
         {provide: ProfileStorageService, useValue: new ProfileStorageServiceStub()},
         {
@@ -76,13 +122,45 @@ describe('WorkspaceNavBarComponent', () => {
         {provide: WorkspacesService, useValue: new WorkspacesServiceStub()},
       ]
     }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(WorkspaceNavBarComponent);
+      fixture = TestBed.createComponent(FakeAppComponent);
+      router = TestBed.get(Router);
+
+      router.navigateByUrl(
+          `/workspaces/${WorkspaceStubVariables.DEFAULT_WORKSPACE_NS}/` +
+          WorkspaceStubVariables.DEFAULT_WORKSPACE_ID);
+      // Clarity needs several ticks/redraw cycles to render its button group.
       tick();
+      updateAndTick(fixture);
+      updateAndTick(fixture);
     });
   }));
 
   it('should render', fakeAsync(() => {
     updateAndTick(fixture);
     expect(fixture).toBeTruthy();
+  }));
+
+  fit('should highlight the active tab', fakeAsync(() => {
+    const de = fixture.debugElement;
+    const cohortsBtn = de.queryAll(By.css('.btn-top'))
+      .find(btn => btn.nativeElement.textContent.includes('Cohorts'));
+    expect(cohortsBtn).toBeTruthy();
+    expect(cohortsBtn.query(By.css('.selected-tab-inner'))).toBeFalsy();
+    simulateClick(fixture, cohortsBtn);
+
+    updateAndTick(fixture);
+    expect(cohortsBtn.query(By.css('.selected-tab-inner'))).toBeTruthy();
+  }));
+
+  fit('should navigate on tab click', fakeAsync(() => {
+    const de = fixture.debugElement;
+    expect(de.query(By.css('app-fake-notebooks'))).toBeFalsy();
+
+    const notebooksBtn = de.queryAll(By.css('.btn-top'))
+      .find(btn => btn.nativeElement.textContent.includes('Notebooks'));
+    simulateClick(fixture, notebooksBtn);
+
+    updateAndTick(fixture);
+    expect(de.query(By.css('app-fake-notebooks'))).toBeTruthy();
   }));
 });

--- a/ui/src/app/views/workspace-nav-bar/component.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
+import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -21,7 +21,7 @@ import {
               './component.css'],
   templateUrl: './component.html',
 })
-export class WorkspaceNavBarComponent implements OnInit {
+export class WorkspaceNavBarComponent implements OnInit, OnDestroy {
   @ViewChild(WorkspaceShareComponent)
   shareModal: WorkspaceShareComponent;
 

--- a/ui/src/app/views/workspace-nav-bar/component.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
+import {Subscription} from 'rxjs/Subscription';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
 
@@ -24,7 +25,6 @@ export class WorkspaceNavBarComponent implements OnInit {
   @ViewChild(WorkspaceShareComponent)
   shareModal: WorkspaceShareComponent;
 
-
   @ViewChild(ConfirmDeleteModalComponent)
   deleteModal: ConfirmDeleteModalComponent;
 
@@ -34,9 +34,12 @@ export class WorkspaceNavBarComponent implements OnInit {
   accessLevel: WorkspaceAccessLevel;
   deleting = false;
   workspaceDeletionError = false;
+  tabPath: string;
 
   @ViewChild(BugReportComponent)
   bugReportComponent: BugReportComponent;
+
+  private subscription: Subscription;
 
   constructor(
     private route: ActivatedRoute,
@@ -51,6 +54,27 @@ export class WorkspaceNavBarComponent implements OnInit {
     const {approved, reviewRequested} = this.workspace.researchPurpose;
     this.wsNamespace = this.route.snapshot.params['ns'];
     this.wsId = this.route.snapshot.params['wsid'];
+    this.tabPath = this.getTabPath();
+    this.subscription = this.router.events.filter(event => event instanceof NavigationEnd)
+      .subscribe(event => {
+        this.tabPath = this.getTabPath();
+      });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  private getTabPath(): string {
+    const child = this.route.firstChild;
+    if (!child) {
+      return '';
+    }
+    const path = child.routeConfig.path;
+    if (!path.includes('/')) {
+      return path;
+    }
+    return path.slice(0, path.indexOf('/'));
   }
 
   delete(workspace: Workspace): void {


### PR DESCRIPTION
Notes:
- Put activated contents inside the button, required dropping the borders/padding 
- Required removing the intermediate button borders for now; implementing them with the clarity button group is tricky - possibly a follow-up (note: the mocks show the dividers spanning only about 75% of the button heights, whereas the current implementation spans 100%)

 Demo: https://calbach-dot-all-of-us-workbench-test.appspot.com/ 