### PR TITLE
[RW-1318][risk=no] Adjust the layout of the cohort builder modal

### DIFF
--- a/ui/src/app/cohort-search/modal/modal.component.css
+++ b/ui/src/app/cohort-search/modal/modal.component.css
@@ -23,11 +23,13 @@
   left: 50%;
   transform: translate(-50%, -50%);
   width: calc(100vw - calc(19rem + 60px));
+  height:   calc(100vh - 60px);
   background-color: white;
   border-radius: 4px;
   display: flex;
   flex-flow: column nowrap;
   justify-content: space-between;
+  overflow: hidden;
 }
 
 .title-bar {
@@ -157,6 +159,7 @@ button.tab.active {
 }
 .panel-right-container{
   width: 100%;
+  min-height: calc(100vh - 60px);
   padding-left: 1rem;
   padding-top: 0.5rem;
   background-color: rgb(241, 242, 242) ;
@@ -169,9 +172,8 @@ button.tab.active {
   border-radius: 5px;
   overflow-y: auto;
   overflow-x: hidden;
-  min-height: 27.5rem;
+  min-height: calc(70vh - 60px);
   max-height: 27.5rem;
-  overflow-y: auto;
   background-color: white;
 }
 


### PR DESCRIPTION
## Addresses:
Partially: https://precisionmedicineinitiative.atlassian.net/browse/RW-1318

This PR allows the cohort builder modal to flex with a resized window. It works down to our standard 1280x800 resolution and even smaller, but breaks down at very small screen sizes. In theory, this should address the minimum requirement. 

## 1280x800 resolution: 
<img width="1392" alt="screen shot 2018-10-04 at 8 49 36 am" src="https://user-images.githubusercontent.com/116679/46475106-9f913580-c7b2-11e8-84fe-8796c0b180fe.png">

## 1440x900 resolution:
<img width="1517" alt="screen shot 2018-10-04 at 8 52 24 am" src="https://user-images.githubusercontent.com/116679/46475184-d7987880-c7b2-11e8-8bcb-74c06812b4ad.png">

## 1024x640 resolution:
It breaks down a little bit here.
<img width="1136" alt="screen shot 2018-10-04 at 8 49 54 am" src="https://user-images.githubusercontent.com/116679/46475229-f39c1a00-c7b2-11e8-82f5-78ac286d5caa.png">

