### PR TITLE
[risk=no] fixing bug with multiple cdr datasources.

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -93,15 +93,16 @@ public class CdrDbConfig {
           // explicitly initialize the pool parameters here. We override the primary connection
           // info, as the autowired PoolConfiguration is initialized from the same set of properties
           // as the workbench DB.
-          basePoolConfig.setUsername(dbUser);
-          basePoolConfig.setPassword(dbPassword);
-          basePoolConfig.setUrl(dbUrl);
-          tomcatSource.setPoolProperties(basePoolConfig);
+          PoolConfiguration cdrPool = new PoolProperties();
+          cdrPool.setUsername(dbUser);
+          cdrPool.setPassword(dbPassword);
+          cdrPool.setUrl(dbUrl);
+          tomcatSource.setPoolProperties(cdrPool);
 
           // The Spring autowiring is a bit of a maze here, log something concrete which will allow
           // verification that the DB settings in application.properties are actually being loaded.
           log.info("using Tomcat pool for CDR data source, with minIdle: " +
-              basePoolConfig.getMinIdle());
+            cdrPool.getMinIdle());
         } else {
           log.warn("not using Tomcat pool or initializing pool configuration; " +
               "this should only happen within tests");


### PR DESCRIPTION
Using the same PoolConfiguration for datasources with different db urls was overriding the db urls to the last cdr db name. Seems that all datasources in the same PoolConfiguration must have the same db url.
