### PR TITLE
[RW-1285][risk=no] Implement "remove concepts" from concept set support

### DIFF
--- a/ui/src/app/views/concept-set-details/component.html
+++ b/ui/src/app/views/concept-set-details/component.html
@@ -70,10 +70,20 @@
   <div *ngIf="conceptSet.concepts?.length" class="concept-table-wrap">
     <app-concept-table [concepts]="conceptSet.concepts"></app-concept-table>
   </div>
-  <app-sliding-fab *ngIf="canEdit" [expanded]="'Remove from set'" (submit)="openRemoveModal()">
+  <app-sliding-fab *ngIf="showRemoveFab" [expanded]="'Remove from set'" (submit)="removing=true">
     <clr-icon shape="trash" class="remove-icon"></clr-icon>
   </app-sliding-fab>
 </app-top-box>
 
 <app-confirm-delete-modal [resourceType]="'Concept Set'" [resource]=conceptSet (receiveDelete)=receiveDelete()>
 </app-confirm-delete-modal>
+
+<clr-modal [(clrModalOpen)]="removing" [clrModalSize]="'md'">
+  <div class="modal-title">
+    <div *ngIf="removing" class="modal-title-text">Are you sure you want to remove {{selectedConceptsCount}} concepts from this set?</div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline" (click)="removing=false">Cancel</button>
+    <button type="button" class="btn btn-primary confirm-remove-btn" (click)="removeConcepts()" [clrLoading]="removeSubmitting" [disabled]="removeSubmitting">Remove Concepts</button>
+  </div>
+</clr-modal>

--- a/ui/src/app/views/concept-set-details/component.html
+++ b/ui/src/app/views/concept-set-details/component.html
@@ -80,7 +80,9 @@
 
 <clr-modal [(clrModalOpen)]="removing" [clrModalSize]="'md'">
   <div class="modal-title">
-    <div *ngIf="removing" class="modal-title-text">Are you sure you want to remove {{selectedConceptsCount}} concepts from this set?</div>
+    <div *ngIf="removing" class="modal-title-text">
+      Are you sure you want to remove {{selectedConceptsCount}} {{selectedConceptsCount > 1 ? 'concepts' : 'concept'}} from this set?
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-outline" (click)="removing=false">Cancel</button>

--- a/ui/src/app/views/concept-set-details/component.spec.ts
+++ b/ui/src/app/views/concept-set-details/component.spec.ts
@@ -229,4 +229,27 @@ describe('ConceptSetDetailsComponent', () => {
     expect(router.navigate).toHaveBeenCalled();
     expect(conceptSetsStub.conceptSets).toEqual([]);
   }));
+
+  fit('should remove concepts', fakeAsync(() => {
+    // Start with 3 concepts, delete two.
+    const origConcepts = ConceptStubVariables.STUB_CONCEPTS.slice(0, 3);
+    setUpComponent({
+      ...newConceptSet(),
+      concepts: origConcepts.slice()
+    });
+
+    const de = fixture.debugElement;
+    const checkboxes = de.queryAll(
+      By.css('app-concept-table .datagrid-body input[type="checkbox"]'));
+    simulateClick(fixture, checkboxes[0]);
+    simulateClick(fixture, checkboxes[2]);
+    simulateClick(fixture, de.query(By.css('.sliding-button')));
+    simulateClick(fixture, de.query(By.css('.confirm-remove-btn')));
+    updateAndTick(fixture);
+
+    expect(de.queryAll(By.css('app-concept-table .datagrid-body .datagrid-row')).length).toEqual(1);
+    // Just the middle concept should remain.
+    const wantConcepts = [origConcepts[1]];
+    expect(conceptSetsStub.conceptSets[0].concepts).toEqual(wantConcepts);
+  }));
 });

--- a/ui/src/app/views/concept-set-details/component.spec.ts
+++ b/ui/src/app/views/concept-set-details/component.spec.ts
@@ -230,7 +230,7 @@ describe('ConceptSetDetailsComponent', () => {
     expect(conceptSetsStub.conceptSets).toEqual([]);
   }));
 
-  fit('should remove concepts', fakeAsync(() => {
+  it('should remove concepts', fakeAsync(() => {
     // Start with 3 concepts, delete two.
     const origConcepts = ConceptStubVariables.STUB_CONCEPTS.slice(0, 3);
     setUpComponent({

--- a/ui/src/app/views/concept-set-details/component.ts
+++ b/ui/src/app/views/concept-set-details/component.ts
@@ -25,6 +25,7 @@ import {
 })
 export class ConceptSetDetailsComponent {
   @ViewChild(ConfirmDeleteModalComponent) deleteModal;
+  @ViewChild(ConceptTableComponent) conceptTable;
 
   wsNamespace: string;
   wsId: string;
@@ -36,6 +37,9 @@ export class ConceptSetDetailsComponent {
   editSubmitting = false;
   editName: string;
   editDescription: string;
+
+  removing = false;
+  removeSubmitting = false;
 
   constructor(
     private conceptSetsService: ConceptSetsService,
@@ -81,12 +85,34 @@ export class ConceptSetDetailsComponent {
       });
   }
 
-  openRemoveModal() {
-    // TODO(calbach): Implement.
+  removeConcepts() {
+    this.conceptSetsService.updateConceptSetConcepts(
+      this.wsNamespace, this.wsId, this.conceptSet.id, {
+        etag: this.conceptSet.etag,
+        removedIds: this.conceptTable.selectedConcepts.map(c => c.conceptId)
+      }).subscribe((cs) => {
+        this.conceptSet = cs;
+        this.removing = false;
+        this.removeSubmitting = false;
+      }, () => {
+        // TODO(calbach): Handle errors.
+        this.removeSubmitting = false;
+      });
   }
 
   get canEdit(): boolean {
     return this.accessLevel === WorkspaceAccessLevel.OWNER
         || this.accessLevel === WorkspaceAccessLevel.WRITER;
+  }
+
+  get selectedConceptsCount(): number {
+    if (!this.conceptTable) {
+      return 0;
+    }
+    return this.conceptTable.selectedConcepts.length;
+  }
+
+  get showRemoveFab(): boolean {
+    return this.canEdit && this.selectedConceptsCount > 0;
   }
 }

--- a/ui/src/testing/stubs/concept-sets-service-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-service-stub.ts
@@ -1,12 +1,13 @@
 import {Response, ResponseOptions} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
-import {ConceptsServiceStub} from './concepts-service-stub.ts';
+import {ConceptsServiceStub} from './concepts-service-stub';
 
 import {
   ConceptSet,
   ConceptSetListResponse,
-  Domain
+  Domain,
+  UpdateConceptSetRequest
 } from 'generated';
 
 export class ConceptSetsServiceStub {
@@ -92,7 +93,7 @@ export class ConceptSetsServiceStub {
           }
         }
         for (const id of req.addedIds || []) {
-          const concept = conceptsStub.concepts.find(c => c.conceptId === id);
+          const concept = this.conceptsStub.concepts.find(c => c.conceptId === id);
           if (!concept) {
             throw Error(`concept ${id} not found`);
           }

--- a/ui/src/testing/stubs/concept-sets-service-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-service-stub.ts
@@ -1,6 +1,8 @@
 import {Response, ResponseOptions} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
+import {ConceptsServiceStub} from './concepts-service-stub.ts';
+
 import {
   ConceptSet,
   ConceptSetListResponse,
@@ -9,9 +11,15 @@ import {
 
 export class ConceptSetsServiceStub {
 
-  constructor(public conceptSets?: ConceptSet[]) {
+  constructor(
+    public conceptSets?: ConceptSet[],
+    public conceptsStub?: ConceptsServiceStub
+  ) {
     if (!this.conceptSets) {
       this.conceptSets = ConceptSetsServiceStub.stubConceptSets();
+    }
+    if (!conceptsStub) {
+      this.conceptsStub = new ConceptsServiceStub();
     }
   }
 
@@ -65,6 +73,34 @@ export class ConceptSetsServiceStub {
         observer.next(this.conceptSets[0]);
         observer.complete();
       });
+    });
+  }
+
+  public updateConceptSetConcepts(
+      workspaceNamespace: string, workspaceId: string, conceptSetId: number,
+      req: UpdateConceptSetRequest): Observable<ConceptSet> {
+    return new Observable<ConceptSet>(obs => {
+      setTimeout(() => {
+        const target = this.conceptSets.find(cs => cs.id === conceptSetId);
+        if (!target) {
+          throw Error(`concept set ${conceptSetId} not found`);
+        }
+        for (const id of req.removedIds || []) {
+          const index = target.concepts.findIndex(c => c.conceptId === id);
+          if (index >= 0) {
+            target.concepts.splice(index, 1);
+          }
+        }
+        for (const id of req.addedIds || []) {
+          const concept = conceptsStub.concepts.find(c => c.conceptId === id);
+          if (!concept) {
+            throw Error(`concept ${id} not found`);
+          }
+          target.concepts.push(concept);
+        }
+        obs.next(target);
+        obs.complete();
+      }, 0);
     });
   }
 

--- a/ui/src/testing/stubs/concepts-service-stub.ts
+++ b/ui/src/testing/stubs/concepts-service-stub.ts
@@ -94,7 +94,7 @@ export class DomainStubVariables {
 
 export class ConceptsServiceStub {
 
-  constructor(public concepts: Concept[]) {
+  constructor(public concepts?: Concept[]) {
     if (!this.concepts) {
       this.concepts = ConceptStubVariables.STUB_CONCEPTS;
     }

--- a/ui/src/testing/stubs/concepts-service-stub.ts
+++ b/ui/src/testing/stubs/concepts-service-stub.ts
@@ -94,7 +94,11 @@ export class DomainStubVariables {
 
 export class ConceptsServiceStub {
 
-  constructor() {}
+  constructor(public concepts: Concept[]) {
+    if (!this.concepts) {
+      this.concepts = ConceptStubVariables.STUB_CONCEPTS;
+    }
+  }
 
   public getDomainInfo(
     workspaceNamespace: string, workspaceId: string): Observable<DomainInfoResponse> {
@@ -131,7 +135,7 @@ export class ConceptsServiceStub {
           }
           const foundDomain =
             DomainStubVariables.STUB_DOMAINS.find(domain => domain.domain === request.domain);
-          ConceptStubVariables.STUB_CONCEPTS.forEach((concept) => {
+          this.concepts.forEach((concept) => {
             if (concept.domainId !== foundDomain.name) {
               return;
             }


### PR DESCRIPTION
Also adds support in the concept sets stub to optionally add a concept service stub dependency for cross-integration (e.g. adding concepts by ID).

Screenshot:
![image](https://user-images.githubusercontent.com/822298/46512495-253fd000-c809-11e8-8288-08f573d67afa.png)
