### PR TITLE
[RW-1286] Implementing getDataTableQuery [risk=no]

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -51,7 +51,6 @@ import org.pmiops.workbench.db.model.ParticipantCohortStatus;
 import org.pmiops.workbench.db.model.ParticipantCohortStatusKey;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.model.AnnotationQuery;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.ColumnFilter;
 import org.pmiops.workbench.model.DataAccessLevel;
@@ -77,7 +76,7 @@ import org.springframework.context.annotation.Import;
         TestJpaConfig.class, ConceptCacheConfiguration.class, TestBigQueryCdrSchemaConfig.class,
         AnnotationQueryBuilder.class, CdrBigQuerySchemaConfigService.class})
 @ComponentScan(basePackages = "org.pmiops.workbench.cohortbuilder.*")
-public class CohortMaterializationServiceTest extends BigQueryBaseTest {
+public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
 
   private CohortMaterializationService cohortMaterializationService;
   private CohortReview cohortReview;
@@ -1373,37 +1372,6 @@ public class CohortMaterializationServiceTest extends BigQueryBaseTest {
     assertThat(response.getNextPageToken()).isNull();
   }
 
-  @Test
-  public void testMaterializeAnnotationQueryNoPagination() {
-    FieldSet fieldSet = new FieldSet();
-    fieldSet.setAnnotationQuery(new AnnotationQuery());
-    MaterializeCohortResponse response =
-        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(),
-            null, 0, makeRequest(fieldSet, 1000));
-    ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
-    assertResults(response, p1Map);
-    assertThat(response.getNextPageToken()).isNull();
-  }
-
-  @Test
-  public void testMaterializeAnnotationQueryWithPagination() {
-    FieldSet fieldSet = new FieldSet();
-    fieldSet.setAnnotationQuery(new AnnotationQuery());
-    MaterializeCohortRequest request = makeRequest(fieldSet, 1);
-    request.setStatusFilter(ImmutableList.of(CohortStatus.INCLUDED, CohortStatus.EXCLUDED));
-    MaterializeCohortResponse response =
-        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), null, 0, request);
-    ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
-    assertResults(response, p1Map);
-    assertThat(response.getNextPageToken()).isNotNull();
-
-    request.setPageToken(response.getNextPageToken());
-    MaterializeCohortResponse response2 =
-        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), null, 0, request);
-    ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED");
-    assertResults(response2, p2Map);
-    assertThat(response2.getNextPageToken()).isNull();
-  }
 
   @Test(expected = BadRequestException.class)
   public void testMaterializeCohortConceptSetNoConcepts() {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -323,6 +323,7 @@ public class CohortsController implements CohortsApiDelegate {
   public ResponseEntity<CdrQuery> getDataTableQuery(String workspaceNamespace, String workspaceId,
       DataTableSpecification request) {
     // TODO: implement this
+
     return null;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -362,7 +362,7 @@ public class CohortsController implements CohortsApiDelegate {
     } else {
       throw new BadRequestException("Must specify either cohortName or cohortSpec");
     }
-    Set<Long> conceptIds = getConceptIds(workspace, request.getTableQuery());;
+    Set<Long> conceptIds = getConceptIds(workspace, request.getTableQuery());
     CdrQuery query = cohortMaterializationService.getCdrQuery(cohortReview, cohortSpec, conceptIds, request);
     return ResponseEntity.ok(query);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -2,6 +2,16 @@ package org.pmiops.workbench.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
+import javax.persistence.OptimisticLockException;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cohorts.CohortMaterializationService;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -34,17 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.inject.Provider;
-import javax.persistence.OptimisticLockException;
-import java.sql.Timestamp;
-import java.time.Clock;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 @RestController
 public class CohortsController implements CohortsApiDelegate {
@@ -363,7 +362,7 @@ public class CohortsController implements CohortsApiDelegate {
       throw new BadRequestException("Must specify either cohortName or cohortSpec");
     }
     Set<Long> conceptIds = getConceptIds(workspace, request.getTableQuery());
-    CdrQuery query = cohortMaterializationService.getCdrQuery(cohortReview, cohortSpec, conceptIds, request);
+    CdrQuery query = cohortMaterializationService.getCdrQuery(cohortSpec, request, cohortReview, conceptIds);
     return ResponseEntity.ok(query);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -2,11 +2,6 @@ package org.pmiops.workbench.cohortbuilder;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringJoiner;
 import org.pmiops.workbench.api.DomainLookupService;
 import org.pmiops.workbench.cohortbuilder.querybuilder.FactoryKey;
 import org.pmiops.workbench.cohortbuilder.querybuilder.QueryParameters;
@@ -16,6 +11,12 @@ import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
 
 @Service
 public class CohortQueryBuilder {
@@ -98,14 +99,13 @@ public class CohortQueryBuilder {
     List<String> queryParts = new ArrayList<>();
     for (SearchGroup includeGroup : groups) {
       for (SearchGroupItem includeItem : includeGroup.getItems()) {
-        QueryJobConfiguration queryRequest = QueryBuilderFactory
+        String query = QueryBuilderFactory
             .getQueryBuilder(FactoryKey.getType(includeItem.getType()))
-            .buildQueryJobConfig(new QueryParameters()
+            .buildQuery(params, new QueryParameters()
                 .type(includeItem.getType())
                 .parameters(includeItem.getSearchParameters())
                 .modifiers(includeItem.getModifiers()));
-        params.putAll(queryRequest.getNamedParameters());
-        queryParts.add(queryRequest.getQuery());
+        queryParts.add(query);
       }
       if (excludeSQL) {
         joiner.add(EXCLUDE_SQL_TEMPLATE.replace("${mainTable}", mainTable)

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -619,7 +619,14 @@ public class FieldSetQueryBuilder {
     return outerSql.toString();
   }
 
-  public QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
+  public QueryJobConfiguration getQueryJobConfiguration(ParticipantCriteria participantCriteria,
+      TableQueryAndConfig tableQueryAndConfig, Long resultSize) {
+    QueryConfiguration queryConfiguration = buildQuery(participantCriteria, tableQueryAndConfig,
+        resultSize, 0L);
+    return bigQueryService.filterBigQueryConfig(queryConfiguration.getQueryJobConfiguration());
+  }
+
+  private QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
       TableQueryAndConfig tableQueryAndConfig, Long resultSize, long offset) {
     QueryState queryState = new QueryState();
     queryState.schemaConfig = tableQueryAndConfig.getConfig();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -262,6 +262,9 @@ public class FieldSetQueryBuilder {
         SelectedColumn selectedColumn = new SelectedColumn();
         selectedColumn.columnInfo = new ColumnInfo(columnName, columnConfig);
         selectedColumn.tableAlias = tableNameAndAlias.alias;
+        // Separate table aliases from column aliases with "__" in the results. These can be
+        // replaced with "." to produce dot notation column names in the output. (BigQuery does not
+        // allow column aliases to contain dots, so we can't do that here directly.)
         selectedColumn.columnAlias = String.format("%s__%s", tableNameAndAlias.alias, columnEnd);
         selectColumns.add(selectedColumn);
       }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -688,7 +688,7 @@ public class FieldSetQueryBuilder {
    */
   public Iterable<Map<String, Object>> materializeTableQuery(TableQueryAndConfig tableQueryAndConfig,
       ParticipantCriteria criteria, int limit, long offset) {
-    QueryConfiguration queryConfiguration = buildQuery(criteria, tableQueryAndConfig, limit, offset);
+    QueryConfiguration queryConfiguration = buildQuery(criteria, tableQueryAndConfig, (long) limit, offset);
     QueryResult result;
     QueryJobConfiguration jobConfiguration = queryConfiguration.getQueryJobConfiguration();
     result = bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(jobConfiguration));

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -494,7 +494,7 @@ public class FieldSetQueryBuilder {
 
   private String buildSql(ParticipantCriteria participantCriteria, QueryState queryState,
       ImmutableList<SelectedColumn> selectColumns, String whereSql,
-      ImmutableList<OrderByColumn> orderByColumns, long resultSize, long offset) {
+      ImmutableList<OrderByColumn> orderByColumns, Long resultSize, long offset) {
 
     // Joining to tables after applying the LIMIT performs better in BigQuery than
     // joining to them before. Figure out if there are any tables that can be joined to after
@@ -567,8 +567,13 @@ public class FieldSetQueryBuilder {
         }
       }
     }
-    StringBuilder limitOffsetSql = new StringBuilder("\nlimit ");
-    limitOffsetSql.append(resultSize);
+    StringBuilder limitOffsetSql;
+    if (resultSize == null) {
+      limitOffsetSql = new StringBuilder("\n");
+    } else {
+      limitOffsetSql = new StringBuilder("\nlimit ");
+      limitOffsetSql.append(resultSize);
+    }
     if (offset > 0) {
       limitOffsetSql.append(" offset ");
       limitOffsetSql.append(offset);
@@ -614,8 +619,8 @@ public class FieldSetQueryBuilder {
     return outerSql.toString();
   }
 
-  private QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
-      TableQueryAndConfig tableQueryAndConfig, long resultSize, long offset) {
+  public QueryConfiguration buildQuery(ParticipantCriteria participantCriteria,
+      TableQueryAndConfig tableQueryAndConfig, Long resultSize, long offset) {
     QueryState queryState = new QueryState();
     queryState.schemaConfig = tableQueryAndConfig.getConfig();
     TableQuery tableQuery = tableQueryAndConfig.getTableQuery();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -262,7 +262,7 @@ public class FieldSetQueryBuilder {
         SelectedColumn selectedColumn = new SelectedColumn();
         selectedColumn.columnInfo = new ColumnInfo(columnName, columnConfig);
         selectedColumn.tableAlias = tableNameAndAlias.alias;
-        selectedColumn.columnAlias = String.format("%s_%s", tableNameAndAlias.alias, columnEnd);
+        selectedColumn.columnAlias = String.format("%s__%s", tableNameAndAlias.alias, columnEnd);
         selectColumns.add(selectedColumn);
       }
     }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/CodesQueryBuilder.java
@@ -12,15 +12,33 @@ import org.pmiops.workbench.model.SearchParameter;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.*;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.codeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.codeSubtypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.codeTypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.conceptIdNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.paramChild;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.paramParent;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.parametersEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.subtypeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.typeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.typeICD;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CODE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CONCEPT_ID;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.DOMAIN;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.EMPTY_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NOT_VALID_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETER;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETERS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.SUBTYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.from;
 
 /**
  * CodesQueryBuilder is an object that builds {@link QueryJobConfiguration}
@@ -63,11 +81,10 @@ public class CodesQueryBuilder extends AbstractQueryBuilder {
   private static final String UNION_TEMPLATE = " union all\n";
 
   @Override
-  public QueryJobConfiguration buildQueryJobConfig(QueryParameters params) {
+  public String buildQuery(Map<String, QueryParameterValue> queryParams, QueryParameters params) {
     from(parametersEmpty()).test(params.getParameters()).throwException(EMPTY_MESSAGE, PARAMETERS);
     ListMultimap<MultiKey, SearchParameter> paramMap = getMappedParameters(params.getParameters());
     List<String> queryParts = new ArrayList<String>();
-    Map<String, QueryParameterValue> queryParams = new HashMap<>();
 
     for (MultiKey key : paramMap.keySet()) {
         final List<SearchParameter> paramList = paramMap.get(key);
@@ -99,11 +116,7 @@ public class CodesQueryBuilder extends AbstractQueryBuilder {
     String codesSql = String.join(UNION_TEMPLATE, queryParts);
     String finalSql = buildModifierSql(codesSql, queryParams, params.getModifiers());
 
-    return QueryJobConfiguration
-      .newBuilder(finalSql)
-      .setNamedParameters(queryParams)
-      .setUseLegacySql(false)
-      .build();
+    return finalSql;
   }
 
   private void validateSearchParameter(SearchParameter param) {
@@ -120,31 +133,27 @@ public class CodesQueryBuilder extends AbstractQueryBuilder {
                                Map<String, QueryParameterValue> queryParams,
                                String domain, QueryParameterValue codes,
                                String groupOrChildSql) {
-    String uniqueName = getUniqueNamedParameterPostfix();
-    String typeNamedParameter = "type" + uniqueName;
-    String subtypeNamedParameter = "subtype" + uniqueName;
-    String codeNamedParameter = "code" + uniqueName;
-    String conceptIdsNamedParameter = "conceptIds" + uniqueName;
-
-    queryParams.put(typeNamedParameter, QueryParameterValue.string(type));
-    queryParams.put(subtypeNamedParameter, QueryParameterValue.string(subtype));
-    if (codes.getType().equals(StandardSQLTypeName.ARRAY)) {
-      queryParams.put(conceptIdsNamedParameter, codes);
-    } else {
-      queryParams.put(codeNamedParameter, codes);
-    }
-    ImmutableMap paramNames = new ImmutableMap.Builder<String, String>()
+    String typeNamedParameter = addQueryParameterValue(queryParams, QueryParameterValue.string(type));
+    String subtypeNamedParameter = addQueryParameterValue(queryParams, QueryParameterValue.string(subtype));
+    String codeNamedParameter = null;
+    String conceptIdsNamedParameter = null;
+    ImmutableMap.Builder<String, String> paramNames = ImmutableMap.<String, String>builder()
       .put("${tableName}", DomainTableEnum.getTableName(domain))
-      .put("${modifierColumns}", DomainTableEnum.getEntryDate(domain) +
-        " as entry_date, " + DomainTableEnum.getSourceConceptId(domain))
-      .put("${tableId}", DomainTableEnum.getSourceConceptId(domain))
-      .put("${type}", "@" + typeNamedParameter)
-      .put("${subtype}", "@" + subtypeNamedParameter)
-      .put("${code}", "@" + codeNamedParameter)
-      .put("${conceptIds}", "@" + conceptIdsNamedParameter)
-      .build();
+        .put("${modifierColumns}", DomainTableEnum.getEntryDate(domain) +
+            " as entry_date, " + DomainTableEnum.getSourceConceptId(domain))
+        .put("${tableId}", DomainTableEnum.getSourceConceptId(domain))
+        .put("${type}", "@" + typeNamedParameter)
+        .put("${subtype}", "@" + subtypeNamedParameter);
 
-    queryParts.add(filterSql(CODES_SQL_TEMPLATE + groupOrChildSql, paramNames));
+    if (codes.getType().equals(StandardSQLTypeName.ARRAY)) {
+      conceptIdsNamedParameter = addQueryParameterValue(queryParams, codes);
+      paramNames.put("${conceptIds}", "@" + conceptIdsNamedParameter);
+    } else {
+      codeNamedParameter = addQueryParameterValue(queryParams, codes);
+      paramNames.put("${code}", "@" + codeNamedParameter);
+    }
+
+    queryParts.add(filterSql(CODES_SQL_TEMPLATE + groupOrChildSql, paramNames.build()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/MeasurementQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/MeasurementQueryBuilder.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.cohortbuilder.querybuilder;
 
-import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.Operator;
@@ -9,14 +8,41 @@ import org.pmiops.workbench.utils.OperatorUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.*;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.betweenOperator;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.categoricalAndNotIn;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.nameBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsNotNumbers;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsNotTwo;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operatorNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.attributesEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.conceptIdNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.measTypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.parametersEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.typeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ANY;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ATTRIBUTE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ATTRIBUTES;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.BOTH;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CATEGORICAL;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CATEGORICAL_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CONCEPT_ID;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.EMPTY_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NAME;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NOT_VALID_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NUMERICAL;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERANDS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERANDS_NUMERIC_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERATOR;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETER;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETERS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TWO_OPERAND_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.operatorText;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.from;
 
 @Service
 public class MeasurementQueryBuilder extends AbstractQueryBuilder {
@@ -35,10 +61,9 @@ public class MeasurementQueryBuilder extends AbstractQueryBuilder {
     "value_as_concept_id ${operator} unnest(${values})\n";
 
   @Override
-  public QueryJobConfiguration buildQueryJobConfig(QueryParameters parameters) {
+  public String buildQuery(Map<String, QueryParameterValue> queryParams, QueryParameters parameters) {
     from(parametersEmpty()).test(parameters.getParameters()).throwException(EMPTY_MESSAGE, PARAMETERS);
     List<String> queryParts = new ArrayList<String>();
-    Map<String, QueryParameterValue> queryParams = new HashMap<>();
     for (SearchParameter parameter : parameters.getParameters()) {
       validateSearchParameter(parameter);
       String baseSql = MEASUREMENT_SQL_TEMPLATE.replace("${conceptId}", parameter.getConceptId().toString());
@@ -64,12 +89,7 @@ public class MeasurementQueryBuilder extends AbstractQueryBuilder {
       }
     }
     String measurementSql = String.join(UNION_ALL, queryParts);
-    String finalSql = buildModifierSql(measurementSql, queryParams, parameters.getModifiers());
-    return QueryJobConfiguration
-      .newBuilder(finalSql)
-      .setNamedParameters(queryParams)
-      .setUseLegacySql(false)
-      .build();
+    return buildModifierSql(measurementSql, queryParams, parameters.getModifiers());
   }
 
   @Override
@@ -100,28 +120,31 @@ public class MeasurementQueryBuilder extends AbstractQueryBuilder {
                                    Map<String, QueryParameterValue> queryParams,
                                    String baseSql,
                                    Attribute attribute) {
-    String namedParameter1 = LAB.toLowerCase() + getUniqueNamedParameterPostfix();
-    String namedParameter2 = LAB.toLowerCase() + getUniqueNamedParameterPostfix();
+    String namedParameter1 = addQueryParameterValue(queryParams,
+        QueryParameterValue.float64(new Double(attribute.getOperands().get(0))));
+    String valueExpression;
+    if (attribute.getOperator().equals(Operator.BETWEEN)) {
+      String namedParameter2 = addQueryParameterValue(queryParams,
+          QueryParameterValue.float64(new Double(attribute.getOperands().get(1))));
+      valueExpression =  "@" + namedParameter1 + " and " + "@" + namedParameter2;
+    } else {
+      valueExpression = "@" + namedParameter1;
+    }
+
     queryParts.add(baseSql
       .replace("${operator}", OperatorUtils.getSqlOperator(attribute.getOperator()))
-      .replace("${value}", attribute.getOperator().equals(Operator.BETWEEN)
-        ? "@" + namedParameter1 + " and " + "@" + namedParameter2 : "@" + namedParameter1));
-    queryParams.put(namedParameter1, QueryParameterValue.float64(new Double(attribute.getOperands().get(0))));
-    if (attribute.getOperator().equals(Operator.BETWEEN)) {
-      queryParams.put(namedParameter2, QueryParameterValue.float64(new Double(attribute.getOperands().get(1))));
-    }
+      .replace("${value}", valueExpression));
   }
 
   private void processCategoricalSql(List<String> queryParts,
                                      Map<String, QueryParameterValue> queryParams,
                                      String baseSql,
                                      Attribute attribute) {
-    String namedParameter1 = LAB.toLowerCase() + getUniqueNamedParameterPostfix();
+    String namedParameter1 = addQueryParameterValue(queryParams,
+        QueryParameterValue.array(attribute.getOperands().stream().map(s -> Long.parseLong(s)).toArray(Long[]::new),
+            Long.class));
     queryParts.add(baseSql
       .replace("${operator}", OperatorUtils.getSqlOperator(attribute.getOperator()))
       .replace("${values}", "@" + namedParameter1));
-    queryParams.put(namedParameter1,
-      QueryParameterValue.array(attribute.getOperands().stream().map(s -> Long.parseLong(s)).toArray(Long[]::new), Long.class)
-    );
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PMQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PMQueryBuilder.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.cohortbuilder.querybuilder;
 
-import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
 import org.pmiops.workbench.cdm.DomainTableEnum;
 import org.pmiops.workbench.model.Attribute;
@@ -11,14 +10,54 @@ import org.pmiops.workbench.utils.OperatorUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.*;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.attrConceptIdNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.betweenOperator;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.nameBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.notBetweenOperator;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsNotNumbers;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsNotOne;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operandsNotTwo;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.AttributePredicates.operatorNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.attributesEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.conceptIdNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainNotMeasurement;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.notAnyAttr;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.notSystolicAndDiastolic;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.notTwoAttributes;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.parametersEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.pmSubtypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.pmTypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.subtypeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.typeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.valueNotNumber;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.valueNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ANY;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ATTRIBUTE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ATTRIBUTES;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.BP_TWO_ATTRIBUTE_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CONCEPT_ID;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.DOMAIN;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.EMPTY_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NAME;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NOT_VALID_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.ONE_OPERAND_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERANDS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERANDS_NUMERIC_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.OPERATOR;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETER;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETERS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PM_TYPES_WITH_ATTR;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.SUBTYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TWO_OPERAND_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.VALUE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.operatorText;
 import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.from;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.*;
 
 @Service
 public class PMQueryBuilder extends AbstractQueryBuilder {
@@ -45,10 +84,9 @@ public class PMQueryBuilder extends AbstractQueryBuilder {
     BASE_SQL_TEMPLATE + "and value_as_concept_id = ${value}\n";
 
   @Override
-  public QueryJobConfiguration buildQueryJobConfig(QueryParameters parameters) {
+  public String buildQuery(Map<String, QueryParameterValue> queryParams, QueryParameters parameters) {
     from(parametersEmpty()).test(parameters.getParameters()).throwException(EMPTY_MESSAGE, PARAMETERS);
     List<String> queryParts = new ArrayList<String>();
-    Map<String, QueryParameterValue> queryParams = new HashMap<>();
     for (SearchParameter parameter : parameters.getParameters()) {
       validateSearchParameter(parameter);
       List<String> tempQueryParts = new ArrayList<String>();
@@ -56,34 +94,38 @@ public class PMQueryBuilder extends AbstractQueryBuilder {
       if (PM_TYPES_WITH_ATTR.contains(parameter.getSubtype())) {
         for (Attribute attribute : parameter.getAttributes()) {
           validateAttribute(attribute);
-          String namedParameterConceptId = CONCEPTID_PREFIX + getUniqueNamedParameterPostfix();
-          String namedParameter1 = getParameterPrefix(parameter.getSubtype()) + getUniqueNamedParameterPostfix();
-          String namedParameter2 = getParameterPrefix(parameter.getSubtype()) + getUniqueNamedParameterPostfix();
           String domain = parameter.getDomain().toLowerCase();
           if (attribute.getName().equals(ANY)) {
             String tempSql = isBP ? BP_INNER_SQL_TEMPLATE : BASE_SQL_TEMPLATE;
+            String namedParameterConceptId = addQueryParameterValue(queryParams,
+                QueryParameterValue.int64(attribute.getConceptId()));
             tempQueryParts.add(tempSql
               .replace("${conceptId}", "@" + namedParameterConceptId)
               .replace("${tableName}", DomainTableEnum.getTableName(domain))
               .replace("${tableConceptId}", DomainTableEnum.getSourceConceptId(domain))
               .replace("${tableDate}", DomainTableEnum.getEntryDate(domain)));
-            queryParams.put(namedParameterConceptId, QueryParameterValue.int64(attribute.getConceptId()));
           } else {
             boolean isBetween = attribute.getOperator().equals(Operator.BETWEEN);
             String tempSql = isBP ? BP_INNER_SQL_TEMPLATE + VALUE_AS_NUMBER : VALUE_AS_NUMBER_SQL_TEMPLATE;
+            String namedParameterConceptId = addQueryParameterValue(queryParams,
+                QueryParameterValue.int64(attribute.getConceptId()));
+            String namedParameter1 = addQueryParameterValue(queryParams,
+                QueryParameterValue.int64(new Long(attribute.getOperands().get(0))));
+            String valueExpression;
+            if (isBetween) {
+              String namedParameter2 = addQueryParameterValue(queryParams,
+                  QueryParameterValue.int64(new Long(attribute.getOperands().get(1))));
+              valueExpression = "@" + namedParameter1 + " and " + "@" + namedParameter2;
+            } else {
+              valueExpression = "@" + namedParameter1;
+            }
             tempQueryParts.add(tempSql
               .replace("${conceptId}", "@" + namedParameterConceptId)
               .replace("${operator}", OperatorUtils.getSqlOperator(attribute.getOperator()))
-              .replace("${value}", isBetween ? "@" + namedParameter1 + " and " + "@" + namedParameter2
-                : "@" + namedParameter1)
               .replace("${tableName}", DomainTableEnum.getTableName(domain))
               .replace("${tableConceptId}", DomainTableEnum.getSourceConceptId(domain))
-              .replace("${tableDate}", DomainTableEnum.getEntryDate(domain)));
-            queryParams.put(namedParameterConceptId, QueryParameterValue.int64(attribute.getConceptId()));
-            queryParams.put(namedParameter1, QueryParameterValue.int64(new Long(attribute.getOperands().get(0))));
-            if (isBetween) {
-              queryParams.put(namedParameter2, QueryParameterValue.int64(new Long(attribute.getOperands().get(1))));
-            }
+              .replace("${tableDate}", DomainTableEnum.getEntryDate(domain))
+              .replace("${value}", valueExpression));
           }
         }
         if (isBP) {
@@ -92,23 +134,18 @@ public class PMQueryBuilder extends AbstractQueryBuilder {
           queryParts.addAll(tempQueryParts);
         }
       } else {
-        String namedParameterConceptId = CONCEPTID_PREFIX + getUniqueNamedParameterPostfix();
-        String namedParameter = getParameterPrefix(parameter.getSubtype()) + getUniqueNamedParameterPostfix();
+        String namedParameterConceptId = addQueryParameterValue(queryParams,
+            QueryParameterValue.int64(parameter.getConceptId()));
+        String namedParameter = addQueryParameterValue(queryParams,
+            QueryParameterValue.int64(new Long(parameter.getValue())));
         String domain = parameter.getDomain().toLowerCase();
         queryParts.add(VALUE_AS_CONCEPT_ID_SQL_TEMPLATE.replace("${conceptId}", "@" + namedParameterConceptId)
           .replace("${value}","@" + namedParameter)
           .replace("${tableName}", DomainTableEnum.getTableName(domain))
           .replace("${tableConceptId}", DomainTableEnum.getSourceConceptId(domain)));
-        queryParams.put(namedParameterConceptId, QueryParameterValue.int64(parameter.getConceptId()));
-        queryParams.put(namedParameter, QueryParameterValue.int64(new Long(parameter.getValue())));
       }
     }
-    String finalSql = String.join(UNION_ALL, queryParts);
-    return QueryJobConfiguration
-      .newBuilder(finalSql)
-      .setNamedParameters(queryParams)
-      .setUseLegacySql(false)
-      .build();
+    return String.join(UNION_ALL, queryParts);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PPIQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PPIQueryBuilder.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.cohortbuilder.querybuilder;
 
-import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdm.DomainTableEnum;
@@ -8,12 +7,26 @@ import org.pmiops.workbench.model.SearchParameter;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.*;
-import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.*;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.conceptIdNull;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.domainNotObservation;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.nameNotNumber;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.parametersEmpty;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.ppiTypeInvalid;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.typeBlank;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.ParameterPredicates.valueNotNumber;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.CONCEPT_ID;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.DOMAIN;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.EMPTY_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NAME;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.NOT_VALID_MESSAGE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETER;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.PARAMETERS;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.TYPE;
+import static org.pmiops.workbench.cohortbuilder.querybuilder.util.QueryBuilderConstants.VALUE;
 import static org.pmiops.workbench.cohortbuilder.querybuilder.util.Validation.from;
 
 @Service
@@ -31,18 +44,18 @@ public class PPIQueryBuilder extends AbstractQueryBuilder {
     "and value_as_concept_id = ${value}\n";
 
   @Override
-  public QueryJobConfiguration buildQueryJobConfig(QueryParameters parameters) {
+  public String buildQuery(Map<String, QueryParameterValue> queryParams, QueryParameters parameters) {
     from(parametersEmpty()).test(parameters.getParameters()).throwException(EMPTY_MESSAGE, PARAMETERS);
     List<String> queryParts = new ArrayList<String>();
-    Map<String, QueryParameterValue> queryParams = new HashMap<>();
-
     for (SearchParameter parameter : parameters.getParameters()) {
       validateSearchParameter(parameter);
-      String namedParameterConceptId = CONCEPTID_PREFIX + getUniqueNamedParameterPostfix();
-      String namedParameter = VALUE_PREFIX + getUniqueNamedParameterPostfix();
-      String domain = parameter.getDomain().toLowerCase();
+      String namedParameterConceptId = addQueryParameterValue(queryParams,
+          QueryParameterValue.int64(parameter.getConceptId()));
       boolean isValueAsNum = StringUtils.isBlank(parameter.getValue());
       String value = isValueAsNum ? parameter.getName() : parameter.getValue();
+      String namedParameter = addQueryParameterValue(queryParams,
+          QueryParameterValue.int64(new Long(value)));
+      String domain = parameter.getDomain().toLowerCase();
       String sqlTemplate = isValueAsNum ?
         PPI_SQL_TEMPLATE + VALUE_AS_NUMBER_SQL_TEMPLATE :
         PPI_SQL_TEMPLATE + VALUE_AS_CONCEPT_ID_SQL_TEMPLATE;
@@ -52,16 +65,8 @@ public class PPIQueryBuilder extends AbstractQueryBuilder {
         .replace("${tableConceptId}", DomainTableEnum.getSourceConceptId(domain))
         .replace("${conceptId}", "@" + namedParameterConceptId)
         .replace("${value}","@" + namedParameter));
-      queryParams.put(namedParameterConceptId, QueryParameterValue.int64(parameter.getConceptId()));
-      queryParams.put(namedParameter, QueryParameterValue.int64(new Long(value)));
     }
-
-    String finalSql = String.join(UNION_ALL, queryParts);
-    return QueryJobConfiguration
-      .newBuilder(finalSql)
-      .setNamedParameters(queryParams)
-      .setUseLegacySql(false)
-      .build();
+    return String.join(UNION_ALL, queryParts);
   }
 
   private void validateSearchParameter(SearchParameter param) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/querybuilder/PhecodesQueryBuilder.java
@@ -37,11 +37,8 @@ public class PhecodesQueryBuilder extends AbstractQueryBuilder {
                     "where o.observation_source_concept_id in (${innerSql})\n";
 
     @Override
-    public QueryJobConfiguration buildQueryJobConfig(QueryParameters parameters) {
-        Map<String, QueryParameterValue> queryParams = new HashMap<>();
-
-        String namedParameter = "PheCodes" + getUniqueNamedParameterPostfix();
-        queryParams.put(namedParameter,
+    public String buildQuery(Map<String, QueryParameterValue> queryParams, QueryParameters parameters) {
+        String namedParameter = addQueryParameterValue(queryParams,
                 QueryParameterValue.array(
                         parameters
                                 .getParameters()
@@ -49,13 +46,7 @@ public class PhecodesQueryBuilder extends AbstractQueryBuilder {
                                 .map(SearchParameter::getValue)
                                 .toArray(String[]::new), String.class));
         String innerSql = INNER_SQL_TEMPLATE.replace("${pheCodes}", "@" + namedParameter);
-        String finalSql = OUTER_SQL_TEMPLATE.replace("${innerSql}", innerSql);
-
-        return QueryJobConfiguration
-                .newBuilder(finalSql)
-                .setNamedParameters(queryParams)
-                .setUseLegacySql(false)
-                .build();
+        return OUTER_SQL_TEMPLATE.replace("${innerSql}", innerSql);
     }
 
     @Override

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -10,12 +10,22 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.dao.ConceptService;
 import org.pmiops.workbench.cdr.dao.ConceptService.ConceptIds;
 import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.ParticipantCriteria;
-import org.pmiops.workbench.cohortbuilder.QueryConfiguration;
 import org.pmiops.workbench.cohortbuilder.TableQueryAndConfig;
 import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig;
@@ -45,18 +55,6 @@ import org.pmiops.workbench.utils.PaginationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nullable;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 @Service
 public class CohortMaterializationService {
 
@@ -81,7 +79,7 @@ public class CohortMaterializationService {
             valueMap.put("value", arrayValue.getValue());
             values.add(valueMap);
           }
-          parameterValueMap.put("arrayValues", values.toArray());
+          parameterValueMap.put("arrayValues", values.<Map<String, Object>>toArray());
         }
         result.put("parameterType", parameterTypeMap);
         result.put("parameterValue", parameterValueMap);
@@ -273,15 +271,15 @@ public class CohortMaterializationService {
     }
     TableQueryAndConfig tableQueryAndConfig = getTableQueryAndConfig(
         dataTableSpecification.getTableQuery(), conceptIds);
-    QueryConfiguration queryConfiguration = fieldSetQueryBuilder.buildQuery(criteria, tableQueryAndConfig,
-        dataTableSpecification.getMaxResults(),0L);
-    QueryJobConfiguration jobConfiguration = queryConfiguration.getQueryJobConfiguration();
+    QueryJobConfiguration jobConfiguration = fieldSetQueryBuilder.getQueryJobConfiguration(
+        criteria, tableQueryAndConfig,  dataTableSpecification.getMaxResults());
     cdrQuery.setSql(jobConfiguration.getQuery());
     Map<String, Object> configurationMap = new HashMap<>();
     Map<String, Object> queryConfigurationMap = new HashMap<>();
     configurationMap.put("query", queryConfigurationMap);
     queryConfigurationMap.put("queryParameters",
-        jobConfiguration.getNamedParameters().entrySet().stream().map(TO_QUERY_PARAMETER_MAP).toArray());
+        jobConfiguration.getNamedParameters().entrySet().stream().map(TO_QUERY_PARAMETER_MAP)
+            .<Map<String, Object>>toArray());
     cdrQuery.setConfiguration(configurationMap);
     return cdrQuery;
   }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -252,7 +252,8 @@ public class CohortMaterializationService {
     }
   }
 
-  public CdrQuery getCdrQuery(@Nullable CohortReview cohortReview, String cohortSpec,
+  @VisibleForTesting
+  CdrQuery getCdrQuery(@Nullable CohortReview cohortReview, SearchRequest searchRequest,
       @Nullable Set<Long> conceptIds, DataTableSpecification dataTableSpecification) {
     CdrVersion cdrVersion = CdrVersionContext.getCdrVersion();
     CdrQuery cdrQuery = new CdrQuery();
@@ -261,12 +262,6 @@ public class CohortMaterializationService {
     List<CohortStatus> statusFilter = dataTableSpecification.getStatusFilter();
     if (statusFilter == null) {
       statusFilter = NOT_EXCLUDED;
-    }
-    SearchRequest searchRequest;
-    try {
-      searchRequest = new Gson().fromJson(cohortSpec, SearchRequest.class);
-    } catch (JsonSyntaxException e) {
-      throw new BadRequestException("Invalid cohort spec");
     }
     ParticipantCriteria criteria = getParticipantCriteria(statusFilter, cohortReview,
         searchRequest);
@@ -289,6 +284,17 @@ public class CohortMaterializationService {
         jobConfiguration.getNamedParameters().entrySet().stream().map(TO_QUERY_PARAMETER_MAP).toArray());
     cdrQuery.setConfiguration(configurationMap);
     return cdrQuery;
+  }
+
+  public CdrQuery getCdrQuery(@Nullable CohortReview cohortReview, String cohortSpec,
+      @Nullable Set<Long> conceptIds, DataTableSpecification dataTableSpecification) {
+    SearchRequest searchRequest;
+    try {
+      searchRequest = new Gson().fromJson(cohortSpec, SearchRequest.class);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Invalid cohort spec");
+    }
+    return getCdrQuery(cohortReview, searchRequest, conceptIds, dataTableSpecification);
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -14,7 +14,6 @@ import com.google.gson.JsonSyntaxException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -67,9 +66,9 @@ public class CohortMaterializationService {
       (entry) -> {
         QueryParameterValue value = entry.getValue();
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
-            .put("name", entry.getKey())
-            .put("type", value.getType().toString());
+            .put("name", entry.getKey());
         ImmutableMap.Builder<String, Object> parameterTypeMap = ImmutableMap.builder();
+        parameterTypeMap.put("type", value.getType().toString());
         ImmutableMap.Builder<String, Object> parameterValueMap = ImmutableMap.builder();
         if (value.getArrayType() == null) {
           parameterValueMap.put("value", value.getValue());
@@ -255,12 +254,12 @@ public class CohortMaterializationService {
   }
 
   @VisibleForTesting
-  CdrQuery getCdrQuery(@Nullable CohortReview cohortReview, SearchRequest searchRequest,
-      @Nullable Set<Long> conceptIds, DataTableSpecification dataTableSpecification) {
+  CdrQuery getCdrQuery(SearchRequest searchRequest, DataTableSpecification dataTableSpecification,
+      @Nullable CohortReview cohortReview, @Nullable Set<Long> conceptIds) {
     CdrVersion cdrVersion = CdrVersionContext.getCdrVersion();
     CdrQuery cdrQuery = new CdrQuery()
-        .setBigqueryDataset(cdrVersion.getBigqueryDataset())
-        .setBigqueryProject(cdrVersion.getBigqueryProject());
+        .bigqueryDataset(cdrVersion.getBigqueryDataset())
+        .bigqueryProject(cdrVersion.getBigqueryProject());
     List<CohortStatus> statusFilter = dataTableSpecification.getStatusFilter();
     if (statusFilter == null) {
       statusFilter = NOT_EXCLUDED;
@@ -288,15 +287,15 @@ public class CohortMaterializationService {
     return cdrQuery;
   }
 
-  public CdrQuery getCdrQuery(@Nullable CohortReview cohortReview, String cohortSpec,
-      @Nullable Set<Long> conceptIds, DataTableSpecification dataTableSpecification) {
+  public CdrQuery getCdrQuery(String cohortSpec, DataTableSpecification dataTableSpecification,
+      @Nullable CohortReview cohortReview, @Nullable Set<Long> conceptIds) {
     SearchRequest searchRequest;
     try {
       searchRequest = new Gson().fromJson(cohortSpec, SearchRequest.class);
     } catch (JsonSyntaxException e) {
       throw new BadRequestException("Invalid cohort spec");
     }
-    return getCdrQuery(cohortReview, searchRequest, conceptIds, dataTableSpecification);
+    return getCdrQuery(searchRequest, dataTableSpecification, cohortReview, conceptIds);
   }
 
   /**

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -175,43 +175,15 @@ definitions:
           Google SQL to use when querying the CDR. If empty, it means no participants can possibly
           match the data table specification, and an empty data table should be returned.
         type: string
-      parameters:
-        description: named query parameters used when executing the above SQL
-        type: array
-        items:
-          $ref: "#/definitions/CdrQueryParameter"
+      configuration:
+        description: configuration for the BigQuery job (includes named parameters)
+        type: object
       bigqueryProject:
         description: name of the Google Cloud project containing the CDR dataset
         type: string
       bigqueryDataset:
         description: name of the CDR BigQuery dataset
         type: string
-
-  CdrQueryParameter:
-    type: object
-    required:
-      - name
-    description: A query parameter and value. One (and only one) of the value fields should be set.
-    properties:
-      name:
-        description: the name of the parameter
-        type: string
-      values:
-        description: An array of string values for this parameter. (It may contain just one value.)
-        type: array
-        items:
-          type: string
-      valueDate:
-        description: A date (yyyy-MM-dd) value for this parameter
-        type: string
-      valueDatetime:
-        description: A datetime (yyyy-MM-dd HH:mm:ss zzz) value for this parameter
-        type: string
-      valueNumbers:
-        description: An array of number values for this parameter. (It may contain just one value.)
-        type: array
-        items:
-          type: number
 
   CohortAnnotationsRequest:
     type: object

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -155,17 +155,25 @@ definitions:
             A query specifying how to pull data out of a single table. If tableQuery is not
             specified, just Person.person_id will be extracted.
         $ref: "#/definitions/TableQuery"
+      maxResults:
+        type: integer
+        format: int64
+        description: >
+          The maximum number of results returned in the data table. Defaults to no limit (all
+          matching results are returned.)
+
 
   CdrQuery:
     type: object
     required:
-      - sql
       - bigqueryProject
       - bigqueryDataset
 
     properties:
       sql:
-        description: Google SQL to use when querying the CDR
+        description: >
+          Google SQL to use when querying the CDR. If empty, it means no participants can possibly
+          match the data table specification, and an empty data table should be returned.
         type: string
       parameters:
         description: named query parameters used when executing the above SQL

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -176,7 +176,9 @@ definitions:
           match the data table specification, and an empty data table should be returned.
         type: string
       configuration:
-        description: configuration for the BigQuery job (includes named parameters)
+        description: >
+          configuration for the BigQuery job (includes named parameters); you can pass this JSON
+          dictionary in for the configuration when calling methods like pandas.read_gbq().
         type: object
       bigqueryProject:
         description: name of the Google Cloud project containing the CDR dataset

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -46,6 +46,7 @@ import org.pmiops.workbench.model.MaterializeCohortRequest;
 import org.pmiops.workbench.model.MaterializeCohortResponse;
 import org.pmiops.workbench.test.SearchRequests;
 import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
+import org.pmiops.workbench.testconfig.CdrJpaConfig;
 import org.pmiops.workbench.testconfig.TestJpaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
@@ -69,7 +70,7 @@ import org.springframework.transaction.annotation.Transactional;
     TestBigQueryCdrSchemaConfig.class, CohortQueryBuilder.class,
     CdrBigQuerySchemaConfigService.class, DomainLookupService.class,
     DemoQueryBuilder.class, QueryBuilderFactory.class, BigQueryService.class,
-    CohortMaterializationService.class, ConceptService.class, TestJpaConfig.class})
+    CohortMaterializationService.class, ConceptService.class, TestJpaConfig.class, CdrJpaConfig.class})
 @MockBean({BigQuery.class})
 public class CohortMaterializationServiceTest {
 

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -1,0 +1,225 @@
+package org.pmiops.workbench.cohorts;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.api.DomainLookupService;
+import org.pmiops.workbench.cdr.dao.ConceptDao;
+import org.pmiops.workbench.cdr.dao.ConceptService;
+import org.pmiops.workbench.cdr.dao.ConceptSynonymDao;
+import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
+import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
+import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
+import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.CohortReviewDao;
+import org.pmiops.workbench.db.dao.ParticipantCohortStatusDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.CdrVersion;
+import org.pmiops.workbench.db.model.Cohort;
+import org.pmiops.workbench.db.model.CohortReview;
+import org.pmiops.workbench.db.model.ParticipantCohortStatus;
+import org.pmiops.workbench.db.model.ParticipantCohortStatusKey;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.model.AnnotationQuery;
+import org.pmiops.workbench.model.CohortStatus;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.FieldSet;
+import org.pmiops.workbench.model.MaterializeCohortRequest;
+import org.pmiops.workbench.model.MaterializeCohortResponse;
+import org.pmiops.workbench.test.SearchRequests;
+import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class CohortMaterializationServiceTest {
+
+  @Autowired
+  private FieldSetQueryBuilder fieldSetQueryBuilder;
+
+  @Autowired
+  private AnnotationQueryBuilder annotationQueryBuilder;
+
+  @Autowired
+  private CdrBigQuerySchemaConfigService cdrBigQuerySchemaConfigService;
+
+  @Autowired
+  private ParticipantCohortStatusDao participantCohortStatusDao;
+
+  @Autowired
+  private CdrVersionDao cdrVersionDao;
+
+  @Autowired
+  private WorkspaceDao workspaceDao;
+
+  @Autowired
+  private CohortDao cohortDao;
+
+  @Autowired
+  private CohortReviewDao cohortReviewDao;
+
+  @Autowired
+  private ConceptDao conceptDao;
+
+  @Autowired
+  private ConceptSynonymDao conceptSynonymDao;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  private CohortReview cohortReview;
+  private CohortMaterializationService cohortMaterializationService;
+
+  @TestConfiguration
+  @Import({FieldSetQueryBuilder.class, AnnotationQueryBuilder.class,
+      TestBigQueryCdrSchemaConfig.class, CohortQueryBuilder.class,
+      CdrBigQuerySchemaConfigService.class, DomainLookupService.class})
+  @MockBean({BigQueryService.class})
+  static class Configuration {
+  }
+
+  @Before
+  public void setUp() {
+    CdrVersion cdrVersion = new CdrVersion();
+    cdrVersionDao.save(cdrVersion);
+
+    Workspace workspace = new Workspace();
+    workspace.setCdrVersion(cdrVersion);
+    workspace.setName("name");
+    workspace.setDataAccessLevelEnum(DataAccessLevel.PROTECTED);
+    workspaceDao.save(workspace);
+
+    Cohort cohort = new Cohort();
+    cohort.setWorkspaceId(workspace.getWorkspaceId());
+    cohort.setName("males");
+    cohort.setType("AOU");
+    Gson gson = new Gson();
+    cohort.setCriteria(gson.toJson(SearchRequests.males()));
+    cohortDao.save(cohort);
+
+    Cohort cohort2 = new Cohort();
+    cohort2.setWorkspaceId(workspace.getWorkspaceId());
+    cohort2.setName("all genders");
+    cohort2.setType("AOU");
+    cohort2.setCriteria(gson.toJson(SearchRequests.allGenders()));
+    cohortDao.save(cohort2);
+
+    cohortReview = new CohortReview();
+    cohortReview.setCdrVersionId(cdrVersion.getCdrVersionId());
+    cohortReview.setCohortId(cohort2.getCohortId());
+    cohortReview.setMatchedParticipantCount(3);
+    cohortReview.setReviewedCount(2);
+    cohortReview.setReviewSize(3);
+    cohortReviewDao.save(cohortReview);
+
+    participantCohortStatusDao.save(makeStatus(cohortReview.getCohortReviewId(), 1L, CohortStatus.INCLUDED));
+    participantCohortStatusDao.save(makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
+
+    ConceptService conceptService = new ConceptService(entityManager, conceptDao, conceptSynonymDao);
+
+    this.cohortMaterializationService = new CohortMaterializationService(fieldSetQueryBuilder,
+        annotationQueryBuilder, participantCohortStatusDao, cdrBigQuerySchemaConfigService, conceptService);
+
+  }
+
+  @Test
+  public void testMaterializeAnnotationQueryNoPagination() {
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setAnnotationQuery(new AnnotationQuery());
+    MaterializeCohortResponse response =
+        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(),
+            null, 0, makeRequest(fieldSet, 1000));
+    ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
+    assertResults(response, p1Map);
+    assertThat(response.getNextPageToken()).isNull();
+  }
+
+  @Test
+  public void testMaterializeAnnotationQueryWithPagination() {
+    FieldSet fieldSet = new FieldSet();
+    fieldSet.setAnnotationQuery(new AnnotationQuery());
+    MaterializeCohortRequest request = makeRequest(fieldSet, 1);
+    request.setStatusFilter(ImmutableList.of(CohortStatus.INCLUDED, CohortStatus.EXCLUDED));
+    MaterializeCohortResponse response =
+        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), null, 0, request);
+    ImmutableMap<String, Object> p1Map = ImmutableMap.of("person_id", 1L, "review_status", "INCLUDED");
+    assertResults(response, p1Map);
+    assertThat(response.getNextPageToken()).isNotNull();
+
+    request.setPageToken(response.getNextPageToken());
+    MaterializeCohortResponse response2 =
+        cohortMaterializationService.materializeCohort(cohortReview, SearchRequests.allGenders(), null, 0, request);
+    ImmutableMap<String, Object> p2Map = ImmutableMap.of("person_id", 2L, "review_status", "EXCLUDED");
+    assertResults(response2, p2Map);
+    assertThat(response2.getNextPageToken()).isNull();
+  }
+
+  private MaterializeCohortRequest makeRequest(int pageSize) {
+    MaterializeCohortRequest request = new MaterializeCohortRequest();
+    request.setPageSize(pageSize);
+    return request;
+  }
+
+  private MaterializeCohortRequest makeRequest(FieldSet fieldSet, int pageSize) {
+    MaterializeCohortRequest request = makeRequest(pageSize);
+    request.setFieldSet(fieldSet);
+    return request;
+  }
+
+  private ParticipantCohortStatus makeStatus(long cohortReviewId, long participantId, CohortStatus status) {
+    ParticipantCohortStatusKey key = new ParticipantCohortStatusKey();
+    key.setCohortReviewId(cohortReviewId);
+    key.setParticipantId(participantId);
+    ParticipantCohortStatus result = new ParticipantCohortStatus();
+    result.setStatusEnum(status);
+    result.setParticipantKey(key);
+    return result;
+  }
+
+  private void assertResults(MaterializeCohortResponse response, ImmutableMap<String, Object>... results) {
+    if (response.getResults().size() != results.length) {
+      fail("Expected " + results.length + ", got " + response.getResults().size() + "; actual results: " +
+          response.getResults());
+    }
+    for (int i = 0; i < response.getResults().size(); i++) {
+      MapDifference<String, Object> difference =
+          Maps.difference((Map<String, Object>) response.getResults().get(i), results[i]);
+      if (!difference.areEqual()) {
+        fail("Result " + i + " had difference: " + difference.entriesDiffering()
+            + "; unexpected entries: " + difference.entriesOnlyOnLeft()
+            + "; missing entries: " + difference.entriesOnlyOnRight());
+      }
+    }
+  }
+
+
+}

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -76,16 +76,7 @@ public class CohortMaterializationServiceTest {
 
   private static final String DATA_SET_ID = "data_set_id";
   private static final String PROJECT_ID = "project_id";
-
-  @Autowired
-  private FieldSetQueryBuilder fieldSetQueryBuilder;
-
-  @Autowired
-  private AnnotationQueryBuilder annotationQueryBuilder;
-
-  @Autowired
-  private CdrBigQuerySchemaConfigService cdrBigQuerySchemaConfigService;
-
+  
   @Autowired
   private ParticipantCohortStatusDao participantCohortStatusDao;
 

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -159,7 +159,6 @@ public class CohortMaterializationServiceTest {
         SearchRequests.allGenders(), new DataTableSpecification(), cohortReview, null);
     assertThat(cdrQuery.getBigqueryDataset()).isEqualTo(DATA_SET_ID);
     assertThat(cdrQuery.getBigqueryProject()).isEqualTo(PROJECT_ID);
-    // TODO: consider making parameter names deterministic, check the entire query
     assertThat(cdrQuery.getSql()).isEqualTo(
         "select person.person_id person_id\n"
         + "from `project_id.data_set_id.person` person\n"

--- a/api/src/test/java/org/pmiops/workbench/testconfig/CdrJpaConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/CdrJpaConfig.java
@@ -1,0 +1,16 @@
+package org.pmiops.workbench.testconfig;
+
+import javax.persistence.EntityManagerFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class CdrJpaConfig {
+
+  // This allows injection of @PersistenceContext(unitName="cdr") in the context of tests;
+  // it uses the same entity manager for both workbench and CDR dbs.
+  @Bean(name="cdr")
+  public EntityManagerFactory cdrEntityManager(EntityManagerFactory entityManagerFactory) {
+    return entityManagerFactory;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.testconfig;
 
+import javax.persistence.EntityManager;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -37,6 +38,13 @@ public class TestJpaConfig {
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
         em.setJpaProperties(additionalProperties());
         return em;
+    }
+
+    // This allows injection of @PersistenceContext(unitName="cdr") in the context of tests;
+    // it uses the same entity manager for both workbench and CDR dbs.
+    @Bean(name="cdr")
+    public EntityManagerFactory cdrEntityManager(EntityManagerFactory entityManagerFactory) {
+        return entityManagerFactory;
     }
 
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
@@ -1,6 +1,8 @@
 package org.pmiops.workbench.testconfig;
 
-import javax.persistence.EntityManager;
+import java.util.Properties;
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -9,10 +11,6 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
-import java.util.Properties;
 
 @TestConfiguration
 @EnableJpaRepositories(basePackages = { "org.pmiops.workbench.cdr", "org.pmiops.workbench.db" })
@@ -38,13 +36,6 @@ public class TestJpaConfig {
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
         em.setJpaProperties(additionalProperties());
         return em;
-    }
-
-    // This allows injection of @PersistenceContext(unitName="cdr") in the context of tests;
-    // it uses the same entity manager for both workbench and CDR dbs.
-    @Bean(name="cdr")
-    public EntityManagerFactory cdrEntityManager(EntityManagerFactory entityManagerFactory) {
-        return entityManagerFactory;
     }
 
     @Bean


### PR DESCRIPTION
Changing API to return a generic "configuration" dictionary, rather than a list of query parameter values. (This is what pandas.read_gbq is going to use, is a bit more flexible for changes in future, and it's simpler than converting QueryParameterValue to the previous parameter objects.)

Working on tests now.