### PR TITLE
Biopete/build w sa [risk=low]

### DIFF
--- a/api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -17,7 +17,6 @@ FILE=
 # get options
 USAGE="./generate-clousql-cdr/cloudsql-import.sh --project <PROJECT> --instance <INSTANCE> --bucket <BUCKET> \
 --database <database> [--create-db-sql-file <filename.sql>] [--file <just_import_me_filename>]"
-# example account for test : all-of-us-workbench-test@appspot.gserviceaccount.com
 while [ $# -gt 0 ]; do
   case "$1" in
     --project) PROJECT=$2; shift 2;;
@@ -99,7 +98,7 @@ function grant_access_to_files () {
 # if [ $(db_exists($DATABASE)) == 1 ]; then echo "database exists"; fi
 function db_exists () {
   local db_name=$1
-  local db=$(gcloud sql databases list -i workbenchmaindb --project all-of-us-workbench-test --filter="NAME = $db_name" \
+  local db=$(gcloud sql databases list -i workbenchmaindb --project $PROJECT --filter="NAME = $db_name" \
 --format="csv [no-heading] (NAME)")
   if [ "$db" == "$db_name" ]
   then

--- a/api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -98,7 +98,7 @@ function grant_access_to_files () {
 # if [ $(db_exists($DATABASE)) == 1 ]; then echo "database exists"; fi
 function db_exists () {
   local db_name=$1
-  local db=$(gcloud sql databases list -i workbenchmaindb --project $PROJECT --filter="NAME = $db_name" \
+  local db=$(gcloud sql databases list -i $INSTANCE --project $PROJECT --filter="NAME = $db_name" \
 --format="csv [no-heading] (NAME)")
   if [ "$db" == "$db_name" ]
   then

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -672,8 +672,13 @@ Generates databases in bigquery with data from a cdr that will be imported to my
 })
 
 def generate_cloudsql_db(cmd_name, *args)
-  ensure_docker cmd_name, args
+  #ensure_docker cmd_name, args
   op = WbOptionsParser.new(cmd_name, args)
+  op.add_option(
+    "--project [project]",
+    ->(opts, v) { opts.project = v},
+    "Project for Cloud Sql instancer"
+  )
   op.add_option(
     "--instance [instance]",
     ->(opts, v) { opts.instance = v},
@@ -689,11 +694,11 @@ def generate_cloudsql_db(cmd_name, *args)
     ->(opts, v) { opts.bucket = v},
     "Name of the GCS bucket containing the SQL dump"
   )
-  gcc = GcloudContextV2.new(op)
+  #gcc = GcloudContextV2.new(op)
   op.parse.validate
-  gcc.validate
+  #gcc.validate
 
-  ServiceAccountContext.new(gcc.project).run do
+  ServiceAccountContext.new(op.opts.project).run do
     common = Common.new
     common.run_inline %W{docker-compose run db-generate-cloudsql-db
           --project #{op.opts.project} --instance #{op.opts.instance} --database #{op.opts.database}

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -671,17 +671,41 @@ Generates databases in bigquery with data from a cdr that will be imported to my
   :fn => ->(*args) { generate_cdr_counts(*args) }
 })
 
-def generate_cloudsql_db(*args)
-  common = Common.new
-  common.run_inline %W{docker-compose run db-generate-cloudsql-db} + args
-end
+def generate_cloudsql_db(cmd_name, *args)
+  ensure_docker cmd_name, args
+  op = WbOptionsParser.new(cmd_name, args)
+  op.add_option(
+    "--instance [instance]",
+    ->(opts, v) { opts.instance = v},
+    "Cloud SQL instance"
+  )
+  op.add_option(
+      "--database [database]",
+      ->(opts, v) { opts.database = v},
+      "Database name"
+  )
+  op.add_option(
+    "--bucket [bucket]",
+    ->(opts, v) { opts.bucket = v},
+    "Name of the GCS bucket containing the SQL dump"
+  )
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate
 
+  ServiceAccountContext.new(gcc.project).run do
+    common = Common.new
+    common.run_inline %W{docker-compose run db-generate-cloudsql-db
+          --project #{op.opts.project} --instance #{op.opts.instance} --database #{op.opts.database}
+          --bucket #{op.opts.bucket}}
+  end
+end
 Common.register_command({
   :invocation => "generate-cloudsql-db",
-  :description => "./generate-cdr/generate-cloudsql-db.sh --project <PROJECT> --instance <INSTANCE> \
+  :description => "generate-cloudsql-db  --project <PROJECT> --instance <INSTANCE> \
 --database <cdrYYYYMMDD> --bucket <BUCKET>
 Generates a cloudsql database from data in a bucket. Used to make cdr and public count databases.",
-  :fn => ->(*args) { generate_cloudsql_db(*args) }
+  :fn => ->(*args) { generate_cloudsql_db("generate-cloudsql-db", *args) }
 })
 
 def generate_local_cdr_db(*args)


### PR DESCRIPTION
generate-cloudsql-db runs in service account context now for the project specified in the argument so it works in all projects. 


 
