### PR TITLE
[RW-1451] Implementing getCohortAnnotations [risk=low]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -170,9 +170,14 @@ public class AnnotationQueryBuilder {
     return orderByBuilder.toString();
   }
 
-  private String getLimitAndOffsetSql(int limit, long offset, ImmutableMap.Builder<String, Object> params) {
-    StringBuilder endSqlBuilder = new StringBuilder("\nLIMIT :limit");
-    params.put("limit", limit);
+  private String getLimitAndOffsetSql(Integer limit, long offset, ImmutableMap.Builder<String, Object> params) {
+    StringBuilder endSqlBuilder;
+    if (limit == null) {
+      endSqlBuilder = new StringBuilder("\n");
+    } else {
+      endSqlBuilder = new StringBuilder("\nLIMIT :limit");
+      params.put("limit", limit);
+    }
     if (offset != 0L) {
       // TODO: consider pagination based on values rather than offsets
       endSqlBuilder.append(" OFFSET :offset");
@@ -182,7 +187,7 @@ public class AnnotationQueryBuilder {
   }
 
   private String getSql(CohortReview cohortReview, List<CohortStatus> statusFilter,
-      AnnotationQuery annotationQuery, int limit, long offset,
+      AnnotationQuery annotationQuery, Integer limit, long offset,
       Map<String, CohortAnnotationDefinition> annotationDefinitions,
       ImmutableMap.Builder<String, Object> parameters) {
     Map<String, String> columnAliasMap = Maps.newHashMap();
@@ -200,7 +205,7 @@ public class AnnotationQueryBuilder {
 
   public Iterable<Map<String, Object>> materializeAnnotationQuery(CohortReview cohortReview,
       List<CohortStatus> statusFilter,
-      AnnotationQuery annotationQuery, int limit, long offset) {
+      AnnotationQuery annotationQuery, Integer limit, long offset) {
     if (statusFilter == null || statusFilter.isEmpty()) {
       throw new BadRequestException("statusFilter cannot be empty");
     }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMaterializationService.java
@@ -41,6 +41,8 @@ import org.pmiops.workbench.db.model.ParticipantIdAndCohortStatus.Key;
 import org.pmiops.workbench.db.model.StorageEnums;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CdrQuery;
+import org.pmiops.workbench.model.CohortAnnotationsRequest;
+import org.pmiops.workbench.model.CohortAnnotationsResponse;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.ColumnFilter;
 import org.pmiops.workbench.model.DataTableSpecification;
@@ -404,5 +406,17 @@ public class CohortMaterializationService {
       response.setNextPageToken(nextToken);
     }
     return response;
+  }
+
+  public CohortAnnotationsResponse getAnnotations(CohortReview cohortReview,
+      CohortAnnotationsRequest request) {
+    List<CohortStatus> statusFilter = request.getStatusFilter();
+    if (statusFilter == null) {
+      statusFilter = NOT_EXCLUDED;
+    }
+    Iterable<Map<String, Object>> results =
+        annotationQueryBuilder.materializeAnnotationQuery(cohortReview, statusFilter,
+            request.getAnnotationQuery(), null, 0L);
+    return new CohortAnnotationsResponse().results(ImmutableList.copyOf(results));
   }
 }


### PR DESCRIPTION
This replaces materialize cohort, and allows us to remove the materialize_cohort functions from the python client (and replace them with API calls specifically for getting annotations.)