### PR TITLE
Fixing annotation DB reading of enum values. [risk=no]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -389,7 +389,7 @@ public class CohortsController implements CohortsApiDelegate {
     CohortReview cohortReview = cohortReviewDao.findCohortReviewByCohortIdAndCdrVersionId(cohort.getCohortId(),
           cdrVersion.getCdrVersionId());
     if (cohortReview == null) {
-      return ResponseEntity.ok(new CohortAnnotationsResponse());
+      return ResponseEntity.ok(new CohortAnnotationsResponse().columns(request.getAnnotationQuery().getColumns()));
     }
     return ResponseEntity.ok(cohortMaterializationService.getAnnotations(cohortReview, request));
   }

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilder.java
@@ -4,14 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
 import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
 import org.pmiops.workbench.db.model.CohortAnnotationDefinition;
 import org.pmiops.workbench.db.model.CohortReview;
@@ -25,6 +17,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 @Service
 // TODO(RW-499): use a library to construct the SQL below, rather than concatenating strings
@@ -239,7 +240,7 @@ public class AnnotationQueryBuilder {
           if (obj != null) {
             String column = columns.get(i);
             if (column.equals(REVIEW_STATUS_COLUMN)) {
-              result.put(column, StorageEnums.cohortStatusFromStorage((Short) obj).name());
+              result.put(column, StorageEnums.cohortStatusFromStorage(((Number) obj).shortValue()).name());
             } else if (obj instanceof java.sql.Date) {
               result.put(column, DATE_FORMAT.format((java.sql.Date) obj));
             } else {

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -226,7 +226,6 @@ definitions:
   CohortAnnotationsResponse:
     type: object
     required:
-      - columns
       - results
     properties:
       columns:

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -168,6 +168,7 @@ definitions:
     required:
       - bigqueryProject
       - bigqueryDataset
+      - columns
 
     properties:
       sql:
@@ -175,6 +176,14 @@ definitions:
           Google SQL to use when querying the CDR. If empty, it means no participants can possibly
           match the data table specification, and an empty data table should be returned.
         type: string
+      columns:
+        description: >
+          An array of names to be used for the columns being returned by the query.
+          (Note that related table aliases will be returned with '.' as a separator, whereas '__' is used in the SQL.)
+          This will be populated even if sql is empty (i.e. there are no results.)
+        type: array
+        items:
+          type: string
       configuration:
         description: >
           configuration for the BigQuery job (includes named parameters); you can pass this JSON
@@ -217,8 +226,15 @@ definitions:
   CohortAnnotationsResponse:
     type: object
     required:
+      - columns
       - results
     properties:
+      columns:
+        description: >
+            An array of columns for the annotations being returned.
+        type: array
+        items:
+          type: string
       results:
         description: >
           An array of JSON dictionaries, with each dictionary representing the requested

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -161,6 +161,7 @@ public class CohortMaterializationServiceTest {
         SearchRequests.allGenders(), new DataTableSpecification(), cohortReview, null);
     assertThat(cdrQuery.getBigqueryDataset()).isEqualTo(DATA_SET_ID);
     assertThat(cdrQuery.getBigqueryProject()).isEqualTo(PROJECT_ID);
+    assertThat(cdrQuery.getColumns()).isEqualTo(ImmutableList.of("person_id"));
     assertThat(cdrQuery.getSql()).isEqualTo(
         "select person.person_id person_id\n"
         + "from `project_id.data_set_id.person` person\n"


### PR DESCRIPTION
Adding columns to CdrQuery, CohortAnnotationsResponse; these will be used to give the names of columns in resulting data frames (whether or not there are any results.)
