### PR TITLE
[risk=no] Don't log null when converting notebook names

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -158,15 +158,18 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   }
 
   private FileDetail convertStringToFileDetail(String str) {
-    if (str != null && str.startsWith("gs://")) {
-      int pos = str.lastIndexOf('/') + 1;
-      String fileName = str.substring(pos);
-      String replacement = Matcher.quoteReplacement(fileName) + "$";
-      String filePath = str.replaceFirst(replacement, "");
-      return new FileDetail().name(fileName).path(filePath);
+    if (str == null) {
+      return null;
     }
-    log.log(Level.SEVERE, String.format("Invalid notebook file path found: %s", str));
-    return null;
+    if (!str.startsWith("gs://")) {
+      log.log(Level.SEVERE, String.format("Invalid notebook file path found: %s", str));
+      return null;
+    }
+    int pos = str.lastIndexOf('/') + 1;
+    String fileName = str.substring(pos);
+    String replacement = Matcher.quoteReplacement(fileName) + "$";
+    String filePath = str.replaceFirst(replacement, "");
+    return new FileDetail().name(fileName).path(filePath);
   }
 
 }


### PR DESCRIPTION
null is an expected input here, as a recent resource is a union of different types; cohorts and concept set resources will not have a notebook path.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
