### PR TITLE
[RW-436][risk=no] Add env-specific GA ids

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -28,8 +28,9 @@ import {CohortResolver} from './resolvers/cohort';
 import {ConceptSetResolver} from './resolvers/concept-set';
 import {WorkspaceResolver} from './resolvers/workspace';
 
+import {environment} from 'environments/environment';
+
 declare let gtag: Function;
-declare let ga_tracking_id: string;
 
 const routes: Routes = [
   {
@@ -239,7 +240,7 @@ export class AppRoutingModule {
  constructor(public router: Router) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
-        gtag('config', ga_tracking_id, { 'page_path': event.urlAfterRedirects });
+        gtag('config', environment.gaId, { 'page_path': event.urlAfterRedirects });
       }
     });
   }

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -107,7 +107,8 @@ export class AppComponent implements OnInit {
 
   /**
    * Setting the Google Analytics ID here.
-   * This first injects Google's gtag script via iife, then secondarily defines the global gtag function.
+   * This first injects Google's gtag script via iife, then secondarily defines
+   * the global gtag function.
    */
   private setGTagManager() {
     const s = this.doc.createElement('script');

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -1,5 +1,5 @@
-import {Location} from '@angular/common';
-import {Component, OnInit} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {Component, Inject, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {
   ActivatedRoute,
@@ -30,6 +30,7 @@ export class AppComponent implements OnInit {
   private overriddenPublicUrl: string = null;
 
   constructor(
+    @Inject(DOCUMENT) private doc: any,
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private titleService: Title
@@ -83,6 +84,8 @@ export class AppComponent implements OnInit {
         this.initialSpinner = false;
       }
     });
+
+    this.setGTagManager();
   }
 
   /**
@@ -102,4 +105,29 @@ export class AppComponent implements OnInit {
     }
   }
 
+  /**
+   * Setting the Google Analytics ID here.
+   * This first injects Google's gtag script via iife, then secondarily defines the global gtag function.
+   */
+  private setGTagManager() {
+    const s = this.doc.createElement('script');
+    s.type = 'text/javascript';
+    s.innerHTML =
+      '(function(w,d,s,l,i){' +
+        'w[l]=w[l]||[];' +
+        'var f=d.getElementsByTagName(s)[0];' +
+        'var j=d.createElement(s);' +
+        'var dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';' +
+        'j.async=true;' +
+        'j.src=\'https://www.googletagmanager.com/gtag/js?id=\'+i+dl;' +
+        'f.parentNode.insertBefore(j,f);' +
+      '})' +
+      '(window, document, \'script\', \'dataLayer\', \'' + environment.gaId + '\');' +
+      'window.dataLayer = window.dataLayer || [];' +
+      'function gtag(){dataLayer.push(arguments);}' +
+      'gtag(\'js\', new Date());' +
+      'gtag(\'config\', \'' + environment.gaId + '\');';
+    const head = this.doc.getElementsByTagName('head')[0];
+    head.appendChild(s);
+  }
 }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -7,5 +7,6 @@ export const environment = {
   leoApiUrl: 'https://leonardo.dsde-dev.broadinstitute.org',
   publicApiUrl: 'http://localhost:8083',
   publicUiUrl: 'http://localhost:4201',
-  debug: true
+  debug: true,
+  gaId: 'UA-112406425-1'
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -8,5 +8,5 @@ export const environment = {
   publicApiUrl: 'http://localhost:8083',
   publicUiUrl: 'http://localhost:4201',
   debug: true,
-  gaId: 'UA-112406425-1'
+  gaId: 'UA-112406425-5'
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -5,5 +5,6 @@ export const environment = {
   leoApiUrl: 'https://notebooks.firecloud.org',
   publicApiUrl: 'https://public.api.researchallofus.org',
   publicUiUrl: 'https://databrowser.researchallofus.org',
-  debug: false
+  debug: false,
+  gaId: 'UA-112406425-4'
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -5,5 +5,6 @@ export const environment = {
   leoApiUrl: 'https://notebooks.firecloud.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-stable.appspot.com',
   publicUiUrl: 'https://public-ui-dot-all-of-us-rw-stable.appspot.com',
-  debug: false
+  debug: false,
+  gaId: 'UA-112406425-3'
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -5,5 +5,6 @@ export const environment = {
   leoApiUrl: 'https://notebooks.firecloud.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-rw-staging.appspot.com',
   publicUiUrl: 'https://public-ui-dot-all-of-us-rw-staging.appspot.com',
-  debug: false
+  debug: false,
+  gaId: 'UA-112406425-2'
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -3,5 +3,6 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 export const environment = {
   ...testEnvironmentBase,
   displayTag: 'Local->Test',
-  debug: true
+  debug: true,
+  gaId: 'UA-112406425-1'
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -3,6 +3,5 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 export const environment = {
   ...testEnvironmentBase,
   displayTag: 'Local->Test',
-  debug: true,
-  gaId: 'UA-112406425-1'
+  debug: true
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -7,4 +7,5 @@ export const testEnvironmentBase = {
   leoApiUrl: 'https://leonardo.dsde-dev.broadinstitute.org',
   publicApiUrl: 'https://public-api-dot-all-of-us-workbench-test.appspot.com',
   publicUiUrl: 'https://public-ui-dot-all-of-us-workbench-test.appspot.com',
+  gaId: 'UA-112406425-1'
 };

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -11,18 +11,6 @@
       This puts `gapi` into the global namespace
     -->
     <script src="https://apis.google.com/js/platform.js"></script>
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112406425-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      // TODO: make this configurable per environment
-      ga_tracking_id = 'UA-112406425-1';
-      gtag('config', ga_tracking_id);
-    </script>
     <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   </head>


### PR DESCRIPTION
## Addresses 
https://precisionmedicineinitiative.atlassian.net/browse/RW-436

## Changes
Moves the GA tracking id from the index page into the app so we can make use of different IDs per environment. The ids provided have been created in GA.

## Notes
I copied from two places for the bulk of the code here: 
* https://developers.google.com/analytics/devguides/collection/gtagjs/
* https://github.com/angular/angular-cli/issues/4451#issuecomment-384992203
