### PR TITLE
[RW-1503] Fixing SQL when max_results is null and outer SQL is generated. [risk=no]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -616,8 +616,10 @@ public class FieldSetQueryBuilder {
       outerOrderByExpressions.add(column.descending ? columnAlias + " DESC" : columnAlias);
     }
     outerSql.append(commaJoiner.join(outerOrderByExpressions));
-    outerSql.append("\nlimit ");
-    outerSql.append(resultSize);
+    if (resultSize != null) {
+      outerSql.append("\nlimit ");
+      outerSql.append(resultSize);
+    }
 
     return outerSql.toString();
   }


### PR DESCRIPTION
(It used to say "limit null"... now it doesn't have a limit.)