### PR TITLE
[risk=no] Fix concept set details routing and loading

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -181,34 +181,34 @@ const routes: Routes = [
               }
             },
             {
-                path: 'concepts/sets',
+              path: 'concepts/sets',
+              data: {
+                breadcrumb: {
+                  value: 'Concept Sets',
+                  intermediate: true
+                }
+              },
+              children: [{
+                path: '',
                 component: ConceptSetListComponent,
                 data: {
-                    title: 'View Concept Sets',
-                    breadcrumb: {
-                      value: 'Concept Sets',
-                      intermediate: true
-                    }
+                  title: 'View Concept Sets',
+                }
+              }, {
+                path: ':csid',
+                component: ConceptSetDetailsComponent,
+                data: {
+                  title: 'Concept Set',
+                  breadcrumb: {
+                    value: 'Param: Concept Set Name',
+                  }
                 },
-                children: [
-                    {
-                        path: ':csid',
-                        component: ConceptSetDetailsComponent,
-                        data: {
-                            title: 'Concept Set',
-                            breadcrumb: {
-                              value: 'Param: Concept Set Name',
-                            }
-                        },
-                        resolve: {
-                            conceptSet: ConceptSetResolver,
-                        }
-                    }
-                ]
-            },
-            ]
-        }
-        ]
+                resolve: {
+                  conceptSet: ConceptSetResolver,
+                }
+              }]
+            }]
+        }]
       },
       {
         path: 'admin/review-workspace',

--- a/ui/src/app/views/concept-set-details/component.html
+++ b/ui/src/app/views/concept-set-details/component.html
@@ -86,6 +86,7 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-outline" (click)="removing=false">Cancel</button>
-    <button type="button" class="btn btn-primary confirm-remove-btn" (click)="removeConcepts()" [clrLoading]="removeSubmitting" [disabled]="removeSubmitting">Remove Concepts</button>
+    <button type="button" class="btn btn-primary confirm-remove-btn" (click)="removeConcepts()"
+            [clrLoading]="removeSubmitting" [disabled]="removeSubmitting">Remove Concepts</button>
   </div>
 </clr-modal>

--- a/ui/src/app/views/concept-set-details/component.ts
+++ b/ui/src/app/views/concept-set-details/component.ts
@@ -86,6 +86,7 @@ export class ConceptSetDetailsComponent {
   }
 
   removeConcepts() {
+    this.removeSubmitting = true;
     this.conceptSetsService.updateConceptSetConcepts(
       this.wsNamespace, this.wsId, this.conceptSet.id, {
         etag: this.conceptSet.etag,


### PR DESCRIPTION
Because we don't want the components to be simultaneously rendered on the page, we actually just need a component-less router entry above "concept sets" in the route hierarchy to place the breadcrumb. I forgot about these component actions so I misadvised here.

Separately I forgot to set the loading property on my modal.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
