### PR TITLE
[RW-474][risk=low] Set a default cluster oauth client ID on all Leo clusters

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -31,7 +31,8 @@
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
     "publicApiKeyForErrorReports": "",
     "projectId": "all-of-us-workbench-test",
-    "shortName": "Local"
+    "shortName": "Local",
+    "oauthClientId": "602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com"
   },
   "admin": {
     "loginUrl": "http:\/\/localhost:4200/login",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -30,7 +30,8 @@
     "apiBaseUrl": "https:\/\/api.workbench.researchallofus.org",
     "publicApiKeyForErrorReports": "AIzaSyBSPcQ0FcR99GLXaqX4Ujpoj3JUDSP689g",
     "projectId": "all-of-us-rw-prod",
-    "shortName": "Prod"
+    "shortName": "Prod",
+    "oauthClientId": "684273740878-d7i68in5d9hqr6n9mfvrdh53snekp79f.apps.googleusercontent.com"
   },
   "admin": {
     "adminIdVerification": "support@researchallofus.org",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -30,7 +30,8 @@
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-stable.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyA4gOEvyJRkhIbW0x0Y7PkIowOSIK_Tous",
     "projectId": "all-of-us-rw-stable",
-    "shortName": "Stable"
+    "shortName": "Stable",
+    "oauthClientId": "56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-stable.appspot.com/login",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -30,7 +30,8 @@
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-staging.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyAkMIMIzUwv02RBK-A7cE1PbPpDJ2MTNtk",
     "projectId": "all-of-us-rw-staging",
-    "shortName": "Staging"
+    "shortName": "Staging",
+    "oauthClientId": "657299777109-kvb5qafr70bl01i6bnpgsiq5nt6v1o8u.apps.googleusercontent.com"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-staging.appspot.com/login",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -31,7 +31,8 @@
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyDPoX4Eg7-_FVKi7JFzEKaJpZ4IMRLaER4",
     "projectId": "all-of-us-workbench-test",
-    "shortName": "Test"
+    "shortName": "Test",
+    "oauthClientId": "602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-workbench-test.appspot.com/login",

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -44,12 +44,13 @@ public class NotebooksServiceImpl implements NotebooksService {
   }
 
   private ClusterRequest createFirecloudClusterRequest(String userEmail) {
-    Map<String, String> labels = new HashMap<String, String>();
-    labels.put(CLUSTER_LABEL_AOU, "true");
-    labels.put(CLUSTER_LABEL_CREATED_BY, userEmail);
+    WorkbenchConfig config = workbenchConfigProvider.get();
     return new ClusterRequest()
-        .labels(labels)
-        .jupyterUserScriptUri(workbenchConfigProvider.get().firecloud.jupyterUserScriptUri)
+        .labels(ImmutableMap.of(
+            CLUSTER_LABEL_AOU, "true",
+            CLUSTER_LABEL_CREATED_BY, userEmail))
+        .defaultClientId(config.server.oauthClientId)
+        .jupyterUserScriptUri(config.firecloud.jupyterUserScriptUri)
         .userJupyterExtensionConfig(new UserJupyterExtensionConfig()
             .nbExtensions(ImmutableMap.<String, String>of())
             .serverExtensions(ImmutableMap.of("jupyterlab", "jupyterlab"))

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -57,6 +57,7 @@ public class WorkbenchConfig {
     public String publicApiKeyForErrorReports;
     public String projectId;
     public String shortName;
+    public String oauthClientId;
   }
 
   public static class AdminConfig {


### PR DESCRIPTION
Previously we depended on inter-window communication between Workbench and Leo to communicate the Oauth client ID to use for credential refreshes. This was brittle and would fail in particular basic modes, e.g. copy-paste a link or closing the original parent tab.

This inter-tab communication also somehow broken within the past few releases so currently we don't seems to plumb through a client ID at all, i.e. tabs die after 1h.

I've confirmed locally that this properly plumbs down the client id.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
