### PR TITLE
[RW-474][risk=no] Tear down inter-tab communication code

### DIFF
--- a/ui/src/app/views/new-notebook-modal/component.ts
+++ b/ui/src/app/views/new-notebook-modal/component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnDestroy} from '@angular/core';
+import {Component, Input} from '@angular/core';
 
 import {SignInService} from 'app/services/sign-in.service';
 import {isBlank} from 'app/utils/index';
@@ -16,7 +16,7 @@ import {FileDetail, UserMetricsService, Workspace} from 'generated';
     '../../styles/errors.css'],
   templateUrl: './component.html',
 })
-export class NewNotebookModalComponent implements OnDestroy {
+export class NewNotebookModalComponent {
   public creatingNotebook = false;
   public newName = '';
   @Input() workspace: Workspace;
@@ -24,7 +24,6 @@ export class NewNotebookModalComponent implements OnDestroy {
   Kernels = Kernels;
   kernelType: number = Kernels.Python3;
   nameConflict = false;
-  notebookAuthListeners: EventListenerOrEventListenerObject[] = [];
 
   loading = false;
 
@@ -32,10 +31,6 @@ export class NewNotebookModalComponent implements OnDestroy {
     private signInService: SignInService,
     private userMetricsService: UserMetricsService,
   ) {}
-
-  ngOnDestroy(): void {
-    this.notebookAuthListeners.forEach(f => window.removeEventListener('message', f));
-  }
 
   open(): void {
     this.creatingNotebook = true;
@@ -60,34 +55,7 @@ export class NewNotebookModalComponent implements OnDestroy {
         `notebooks/create/?notebook-name=` + encodeURIComponent(this.newName) +
         `&kernel-type=${this.kernelType}`;
 
-    const notebook = window.open(nbUrl, '_blank');
-
-    // TODO(RW-474): Remove the authHandler integration. This is messy,
-    // non-standard, and currently will break in the following situation:
-    // - User opens a new notebook tab.
-    // - While that tab is loading, user immediately navigates away from this
-    //   page.
-    // This is not easily fixed without leaking listeners outside the lifespan
-    // of the workspace component.
-    const authHandler = (e: MessageEvent) => {
-      if (e.source !== notebook) {
-        return;
-      }
-      if (e.origin !== environment.leoApiUrl) {
-        return;
-      }
-      if (e.data.type !== 'bootstrap-auth.request') {
-        return;
-      }
-      notebook.postMessage({
-        'type': 'bootstrap-auth.response',
-        'body': {
-          'googleClientId': this.signInService.clientId
-        }
-      }, environment.leoApiUrl);
-    };
-    window.addEventListener('message', authHandler);
-    this.notebookAuthListeners.push(authHandler);
+    window.open(nbUrl, '_blank');
     this.close();
   }
 


### PR DESCRIPTION
This actually wasn't working anyways on account of a Leo regression. We now set a default client ID server side as of #1385 .

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
