### PR TITLE
[risk=no] Add instructions for manual backend queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,3 +432,31 @@ create and delete BigQuery datasets), run:
 ```
 
 By default, all tests will return just test pass / fail output and stack traces for exceptions. To get full logging, pass on the command line --project-prop verboseTestLogging=yes when running tests.
+
+## Manual Testing
+
+### Backend Swagger Portals
+
+These are easiest if you need to authenticate as one of your researcher accounts.
+
+Firecloud dev: https://firecloud-orchestration.dsde-dev.broadinstitute.org/
+Firecloud prod: https://api.firecloud.org
+
+Leo (notebook clusters) dev: https://leonardo.dsde-dev.broadinstitute.org
+Leo (notebook clusters) prod: https://notebooks.firecloud.org
+
+### Authenticated Backend Requests (CLI)
+
+This approach is required if you want to issue a request to a backend as a service account. This may be necessary in some cases as the Workbench service is an owner on all AoU billing projects.
+
+This approach requires [oauth2l](https://github.com/google/oauth2l) to be installed:
+```
+go get github.com/google/oauth2l
+go install github.com/google/oauth2l
+```
+
+The following shows how to make an authenticated backend request against Firecloud dev (assumes you have run dev-up at least once):
+
+```
+api$ curl -X GET -H "$(oauth2l header --json build/exploded-api/WEB-INF/sa-key.json userinfo.email userinfo.profile cloud-billing)" -H "Content-Type: application/json" https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/profile/billing
+```

--- a/README.md
+++ b/README.md
@@ -439,11 +439,12 @@ By default, all tests will return just test pass / fail output and stack traces 
 
 These are easiest if you need to authenticate as one of your researcher accounts.
 
-Firecloud dev: https://firecloud-orchestration.dsde-dev.broadinstitute.org/
-Firecloud prod: https://api.firecloud.org
-
-Leo (notebook clusters) dev: https://leonardo.dsde-dev.broadinstitute.org
-Leo (notebook clusters) prod: https://notebooks.firecloud.org
+- Firecloud
+  - dev: https://firecloud-orchestration.dsde-dev.broadinstitute.org/
+  - prod: https://api.firecloud.org
+- Leo (notebook clusters)
+  - dev: https://leonardo.dsde-dev.broadinstitute.org
+  - prod: https://notebooks.firecloud.org
 
 ### Authenticated Backend Requests (CLI)
 

--- a/README.md
+++ b/README.md
@@ -460,4 +460,7 @@ The following shows how to make an authenticated backend request against Fireclo
 
 ```
 api$ curl -X GET -H "$(oauth2l header --json build/exploded-api/WEB-INF/sa-key.json userinfo.email userinfo.profile cloud-billing)" -H "Content-Type: application/json" https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/profile/billing
+
+# If you get 401 errors, you may need to clear your token cache.
+oauth2l reset
 ```


### PR DESCRIPTION
I've used this a few times now to test Firecloud behaviors or act as the test service account to see various states.

Open to suggestions on:
- Better ways of doing this
- A better location for this documentation

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
