### PR TITLE
[RW-1530][RW-1533][risk=no] Concept set bug fixes

### DIFF
--- a/ui/src/app/views/concept-add-modal/component.html
+++ b/ui/src/app/views/concept-add-modal/component.html
@@ -1,5 +1,5 @@
 <clr-modal [(clrModalOpen)]="modalOpen" [clrModalSize]="'md'" *ngIf="!loading">
-  <h3 class="modal-title">Add {{selectConceptList?.length}} to {{selectDomain|titlecase}} Concept Set</h3>
+  <h3 class="modal-title">Add {{selectConceptList?.length}} Concepts to {{selectDomain|titlecase}} Concept Set</h3>
   <div class="modal-body">
     <label *ngIf="errorSaving" class="error">{{errorMsg}}</label>
     <div *ngIf="conceptSets?.length > 0" class="form-section">

--- a/ui/src/app/views/concept-homepage/component.html
+++ b/ui/src/app/views/concept-homepage/component.html
@@ -96,7 +96,7 @@
                          [placeholderValue]="placeholderValue"
                          (getSelectedConcepts)="selectConcept($event)">
       </app-concept-table>
-      <app-sliding-fab [expanded]=addToSetText (submit)="openAddModal()" [disable]="!isConceptSelected">
+      <app-sliding-fab [expanded]=addToSetText (submit)="openAddModal()" [disable]="activeSelectedConceptCount === 0">
         <clr-icon class="add-icon" shape="plus"></clr-icon>
       </app-sliding-fab>
     </div>

--- a/ui/src/app/views/concept-homepage/component.spec.ts
+++ b/ui/src/app/views/concept-homepage/component.spec.ts
@@ -220,7 +220,7 @@ describe('ConceptHomepageComponent', () => {
     expect(buttonText).toBe('Add (1) to set');
   }));
 
-  fit('should clear selected count after adding', fakeAsync(() => {
+  it('should clear selected count after adding', fakeAsync(() => {
     const de = fixture.debugElement;
 
     simulateClick(fixture, de.query(By.css('.standard-concepts-checkbox')).children[0]);

--- a/ui/src/app/views/concept-homepage/component.spec.ts
+++ b/ui/src/app/views/concept-homepage/component.spec.ts
@@ -96,11 +96,6 @@ describe('ConceptHomepageComponent', () => {
       });
   }));
 
-
-  it('should render.', fakeAsync(() => {
-    expect(fixture).toBeTruthy();
-  }));
-
   it('should have one card per domain.', fakeAsync(() => {
     expect(fixture.debugElement.queryAll(By.css('.card.item-card')).length)
       .toBe(DomainStubVariables.STUB_DOMAINS.length);
@@ -180,7 +175,7 @@ describe('ConceptHomepageComponent', () => {
     expect(fixture.debugElement.queryAll(By.css('.concept-row')).length).toBe(2);
   }));
 
-  it( 'should display the selected concepts on header', fakeAsync(() => {
+  it('should display the selected concepts on header', fakeAsync(() => {
     const spy = spyOn(TestBed.get(ConceptsService), 'searchConcepts')
         .and.callThrough();
     const searchTerm = 'test';
@@ -199,7 +194,7 @@ describe('ConceptHomepageComponent', () => {
     expect(pillValue).toBe('1');
   }));
 
-  it( 'should display the selected concepts on sliding button', fakeAsync(() => {
+  it('should display the selected concepts on sliding button', fakeAsync(() => {
     const spy = spyOn(TestBed.get(ConceptsService), 'searchConcepts')
         .and.callThrough();
 
@@ -223,5 +218,31 @@ describe('ConceptHomepageComponent', () => {
 
     // After select add the number of selected concepts
     expect(buttonText).toBe('Add (1) to set');
+  }));
+
+  fit('should clear selected count after adding', fakeAsync(() => {
+    const de = fixture.debugElement;
+
+    simulateClick(fixture, de.query(By.css('.standard-concepts-checkbox')).children[0]);
+    simulateInput(fixture, de.query(By.css('#concept-search-input')), 'test');
+    simulateClick(fixture, de.query(By.css('.btn-search')));
+    updateAndTick(fixture);
+    const dataRow = de.queryAll(By.css('.concept-row'));
+    const checkBox = dataRow[0].queryAll(By.css('.datagrid-select'))[0]
+        .query(By.css('.checkbox')).children;
+    simulateClick(fixture, checkBox[0]);
+    updateAndTick(fixture);
+
+    simulateClick(fixture, de.query(By.css('.sliding-button')));
+    updateAndTick(fixture);
+
+    simulateClick(fixture, de.query(By.css('.btn-primary')));
+    updateAndTick(fixture);
+
+    const addButton = de.query(By.css('.sliding-button'));
+    expect(addButton.classes['disable']).toBeTruthy();
+
+    // Run out the "added" notification timer.
+    tick(10000);
   }));
 });

--- a/ui/src/app/views/concept-homepage/component.spec.ts
+++ b/ui/src/app/views/concept-homepage/component.spec.ts
@@ -236,6 +236,11 @@ describe('ConceptHomepageComponent', () => {
     simulateClick(fixture, de.query(By.css('.sliding-button')));
     updateAndTick(fixture);
 
+    // Create a new concept set to avoid any dependency on existing stub data.
+    de.query(By.css('#select-create')).nativeElement.click();
+    updateAndTick(fixture);
+    simulateInput(fixture, de.query(By.css('#new-name')), 'foo');
+    updateAndTick(fixture);
     simulateClick(fixture, de.query(By.css('.btn-primary')));
     updateAndTick(fixture);
 

--- a/ui/src/app/views/concept-homepage/component.ts
+++ b/ui/src/app/views/concept-homepage/component.ts
@@ -52,7 +52,6 @@ export class ConceptHomepageComponent implements OnInit {
     domain: undefined,
     conceptCount: 0
   };
-  isConceptSelected = false;
   selectedConcept: Concept[] = [];
 
   @ViewChild(ConceptTableComponent)
@@ -73,7 +72,6 @@ export class ConceptHomepageComponent implements OnInit {
   conceptsCache: Array<ConceptCacheSet> = [];
   completedDomainSearches: Array<Domain> = [];
   placeholderValue = '';
-  addToSetText = 'Add to set';
   vocabularies: Array<VocabularyCountSelected> = [];
   wsNamespace: string;
   wsId: string;
@@ -122,7 +120,6 @@ export class ConceptHomepageComponent implements OnInit {
     if (!this.selectedConceptDomainMap[domainCount.domain]) {
       this.selectedConceptDomainMap[domainCount.domain] = 0;
     }
-    this.addToSetText = this.getAddToSetText(this.selectedConceptDomainMap[domainCount.domain]);
     this.selectedDomain = domainCount;
     this.placeholderValue = this.noConceptsConstant;
     this.setConceptsAndVocabularies();
@@ -138,8 +135,6 @@ export class ConceptHomepageComponent implements OnInit {
     this.selectedConcept = [];
     this.selectedConceptDomainMap = new Map<string, number>();
     this.conceptDomainCounts = [];
-    this.addToSetText = 'Add to set';
-    this.isConceptSelected = false;
 
   }
   browseDomain(domain: DomainInfo) {
@@ -266,19 +261,15 @@ export class ConceptHomepageComponent implements OnInit {
           })
           .length;
       this.selectedConceptDomainMap[domainName] = filterConceptsCount;
-      this.isConceptSelected = filterConceptsCount > 0 ;
     } else {
-      this.isConceptSelected = false;
       this.selectedConceptDomainMap[domainName] = 0;
     }
-    this.addToSetText = this.getAddToSetText(this.selectedConceptDomainMap[domainName]);
   }
 
   afterConceptsSaved() {
     this.setConceptsSaveText();
 
     // Once concepts are saved clear the selection from concept homepage for active Domain
-
     this.conceptTable.selectedConcepts.length = 0;
     this.selectedConceptDomainMap[this.selectedDomain.domain] = 0;
     this.cloneCacheConcepts();
@@ -302,11 +293,19 @@ export class ConceptHomepageComponent implements OnInit {
     cacheItem.items = cloneConcepts;
   }
 
+  get activeSelectedConceptCount(): number {
+    if (!this.selectedDomain || !this.selectedDomain.domain) {
+      return 0;
+    }
+    return this.selectedConceptDomainMap[this.selectedDomain.domain];
+  }
+
   get noConceptsConstant() {
     return 'No concepts found for domain \'' + this.selectedDomain.name + '\' this search.';
   }
 
-  getAddToSetText(conceptsCount): string {
-    return conceptsCount === 0 ? 'Add to set' : 'Add (' + conceptsCount + ') to set';
+  get addToSetText(): string {
+    const count = this.activeSelectedConceptCount;
+    return count === 0 ? 'Add to set' : 'Add (' + count + ') to set';
   }
 }

--- a/ui/src/app/views/concept-set-details/component.html
+++ b/ui/src/app/views/concept-set-details/component.html
@@ -70,7 +70,7 @@
   <div *ngIf="conceptSet.concepts?.length" class="concept-table-wrap">
     <app-concept-table [concepts]="conceptSet.concepts" [placeholderValue]="'No Concepts Found'"></app-concept-table>
   </div>
-  <app-sliding-fab *ngIf="showRemoveFab" [expanded]="'Remove from set'" (submit)="removing=true">
+  <app-sliding-fab [disable]="disableRemoveFab" [expanded]="'Remove from set'" (submit)="removing=true">
     <clr-icon shape="trash" class="remove-icon"></clr-icon>
   </app-sliding-fab>
 </app-top-box>

--- a/ui/src/app/views/concept-set-details/component.ts
+++ b/ui/src/app/views/concept-set-details/component.ts
@@ -80,7 +80,7 @@ export class ConceptSetDetailsComponent {
   receiveDelete() {
     this.conceptSetsService.deleteConceptSet(this.wsNamespace, this.wsId, this.conceptSet.id)
       .subscribe(() => {
-        this.router.navigate(['workspaces', this.wsNamespace, this.wsId, 'concepts']);
+        this.router.navigate(['workspaces', this.wsNamespace, this.wsId, 'concepts', 'sets']);
         this.deleteModal.close();
       });
   }
@@ -113,7 +113,7 @@ export class ConceptSetDetailsComponent {
     return this.conceptTable.selectedConcepts.length;
   }
 
-  get showRemoveFab(): boolean {
-    return this.canEdit && this.selectedConceptsCount > 0;
+  get disableRemoveFab(): boolean {
+    return !this.canEdit || this.selectedConceptsCount === 0;
   }
 }

--- a/ui/src/testing/stubs/concept-sets-service-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-service-stub.ts
@@ -96,6 +96,9 @@ export class ConceptSetsServiceStub {
         if (!target) {
           throw Error(`concept set ${conceptSetId} not found`);
         }
+        if (!target.concepts) {
+          target.concepts = [];
+        }
         for (const id of req.removedIds || []) {
           const index = target.concepts.findIndex(c => c.conceptId === id);
           if (index >= 0) {


### PR DESCRIPTION
- Concept set deletion now redirects to concept sets list page
- Concept removal uses disabled FAB UX
- Fix disablement of "add to set" FAB and selected count (+some refactoring)
- Minor wording tweak on "add to set" modal

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
