### PR TITLE
[RW-578][risk=low] Fix GCS link for multilogin users

### DIFF
--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -159,7 +159,10 @@
         </div>
       </div>
     </div>
-    <a href="https://console.cloud.google.com/storage/browser/{{workspace.googleBucketName}}">Google Bucket</a>
+    <a href="https://console.cloud.google.com/storage/browser/{{workspace.googleBucketName}}?authuser={{username}}"
+        target="_blank">
+      Google Bucket
+    </a>
   </div>
 </div>
 <app-workspace-share [workspace]="workspace" [accessLevel]="accessLevel"></app-workspace-share>

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -105,6 +105,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   rightResearchPurposes: String[];
   newPageVisit: PageVisit = { page: WorkspaceComponent.PAGE_ID};
   firstVisit = true;
+  username = '';
 
   @ViewChild(BugReportComponent)
   bugReportComponent: BugReportComponent;
@@ -148,6 +149,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     // TODO: RW-1057
     this.profileService.getMe().subscribe(
       profile => {
+        this.username = profile.username;
         if (profile.pageVisits) {
           this.firstVisit = !profile.pageVisits.some(v =>
             v.page === WorkspaceComponent.PAGE_ID);


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-578

- Include authuser in cloud console link, it's typical for users to be multilogged in (especially with the research account as secondary) since we require creation of a second google account to use workbench.
- Open in a new tab by default

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
