### PR TITLE
[RW-1559][RISK=NO]Bad formatting for concept set tooltip

### DIFF
--- a/ui/src/app/views/concept-set-list/component.ts
+++ b/ui/src/app/views/concept-set-list/component.ts
@@ -19,6 +19,7 @@ import {ToolTipComponent} from '../tooltip/component';
 @Component({
   styleUrls: ['../../styles/buttons.css',
     '../../styles/cards.css',
+    '../../styles/tooltip.css',
     './component.css'],
   templateUrl: './component.html',
 })


### PR DESCRIPTION
It was : 
<img width="672" alt="screen shot 2018-10-29 at 1 13 15 pm" src="https://user-images.githubusercontent.com/34481816/47936331-b4491200-deb3-11e8-9f3f-79fdf3807f41.png">

Now it is 
<img width="630" alt="screen shot 2018-11-02 at 3 26 22 pm" src="https://user-images.githubusercontent.com/34481816/47936340-bad78980-deb3-11e8-84dc-5da09ef5df7c.png">

