### PR TITLE
[RW-1233][risk=low] Implement an account creation nonce to secure resend/updateContactEmail

### DIFF
--- a/api/db/changelog/db.changelog-52-user-nonce.xml
+++ b/api/db/changelog/db.changelog-52-user-nonce.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet author="calbach" id="changelog-52">
+    <addColumn tableName="user">
+      <column name="creation_nonce" type="bigint"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -59,4 +59,5 @@
   <include file="changelog/db.changelog-49-add-concept-set-to-user-recent-resource.xml"/>
   <include file="changelog/db.changelog-50.xml"/>
   <include file="changelog/db.changelog-51-user-profile-updates.xml"/>
+  <include file="changelog/db.changelog-52-user-nonce.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -1,6 +1,8 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -12,10 +14,12 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
 import javax.inject.Provider;
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.auth.ProfileService;
 import org.pmiops.workbench.auth.UserAuthentication;
@@ -31,6 +35,7 @@ import org.pmiops.workbench.exceptions.EmailException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.GatewayTimeoutException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.UnauthorizedException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership.CreationStatusEnum;
@@ -396,7 +401,7 @@ public class ProfileController implements ProfileApiDelegate {
     // profile, since it can be edited in our UI as well as the Google UI,  and we're fine with
     // that; the expectation is their profile in AofU will be managed in AofU, not in Google.
 
-    userService.createUser(
+    User user = userService.createUser(
         request.getProfile().getGivenName(),
         request.getProfile().getFamilyName(),
         googleUser.getPrimaryEmail(),
@@ -412,9 +417,7 @@ public class ProfileController implements ProfileApiDelegate {
       throw new WorkbenchException(e);
     }
 
-    // TODO(dmohs): This should be 201 Created with no body, but the UI's swagger-generated code
-    // doesn't allow this. Fix.
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return getProfileResponse(user);
   }
 
   @Override
@@ -467,6 +470,15 @@ public class ProfileController implements ProfileApiDelegate {
     }
   }
 
+  private void checkUserCreationNonce(User user, String nonce) {
+    if (Strings.isNullOrEmpty(nonce)) {
+      throw new BadRequestException("missing required creationNonce");
+    }
+    if (user.getCreationNonce() == null || !nonce.equals(user.getCreationNonce().toString())) {
+      throw new UnauthorizedException("invalid creationNonce provided");
+    }
+  }
+
   /*
    * This un-authed API method is limited such that we only allow contact email updates before the user has signed in
    * with the newly created gsuite account. Once the user has logged in, they can change their contact email through
@@ -478,10 +490,11 @@ public class ProfileController implements ProfileApiDelegate {
     com.google.api.services.admin.directory.model.User googleUser =
       directoryService.getUser(username);
     User user = userDao.findUserByEmail(username);
-    String newEmail = updateContactEmailRequest.getContactEmail();
+    checkUserCreationNonce(user, updateContactEmailRequest.getCreationNonce());
     if (!userNeverLoggedIn(googleUser, user)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
+    String newEmail = updateContactEmailRequest.getContactEmail();
     try {
       new InternetAddress(newEmail).validate();
     } catch (AddressException e) {
@@ -498,6 +511,7 @@ public class ProfileController implements ProfileApiDelegate {
     com.google.api.services.admin.directory.model.User googleUser =
       directoryService.getUser(username);
     User user = userDao.findUserByEmail(username);
+    checkUserCreationNonce(user, resendRequest.getCreationNonce());
     if (!userNeverLoggedIn(googleUser, user)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -5,7 +5,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.IdVerificationStatus;
 import org.pmiops.workbench.model.InstitutionalAffiliation;
 import org.pmiops.workbench.model.PageVisit;
@@ -40,12 +39,10 @@ public class ProfileService {
       }
     };
 
-  private final FireCloudService fireCloudService;
   private final UserDao userDao;
 
   @Autowired
-  public ProfileService(FireCloudService fireCloudService, UserDao userDao) {
-    this.fireCloudService = fireCloudService;
+  public ProfileService(UserDao userDao) {
     this.userDao = userDao;
   }
 
@@ -60,6 +57,9 @@ public class ProfileService {
     Profile profile = new Profile();
     profile.setUserId(user.getUserId());
     profile.setUsername(user.getEmail());
+    if (user.getCreationNonce() != null) {
+      profile.setCreationNonce(user.getCreationNonce().toString());
+    }
     profile.setFamilyName(user.getFamilyName());
     profile.setGivenName(user.getGivenName());
     profile.setOrganization(user.getOrganization());

--- a/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
@@ -4,7 +4,9 @@ import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import java.security.SecureRandom;
 import java.time.Clock;
+import java.util.Random;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,4 +25,7 @@ public class CommonConfig {
 
   @Bean
   Clock clock() { return Clock.systemUTC(); }
+
+  @Bean
+  Random random() { return new SecureRandom(); }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.db.dao;
 
-import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
@@ -38,21 +37,23 @@ public class UserService {
   private final UserDao userDao;
   private final AdminActionHistoryDao adminActionHistoryDao;
   private final Clock clock;
+  private final Random random;
   private final FireCloudService fireCloudService;
   private final Provider<WorkbenchConfig> configProvider;
-  private Random random = new SecureRandom();
 
   @Autowired
   public UserService(Provider<User> userProvider,
       UserDao userDao,
       AdminActionHistoryDao adminActionHistoryDao,
       Clock clock,
+      Random random,
       FireCloudService fireCloudService,
       Provider<WorkbenchConfig> configProvider) {
     this.userProvider = userProvider;
     this.userDao = userDao;
     this.adminActionHistoryDao = adminActionHistoryDao;
     this.clock = clock;
+    this.random = random;
     this.fireCloudService = fireCloudService;
     this.configProvider = configProvider;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,12 +1,16 @@
 package org.pmiops.workbench.db.dao;
 
+import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.inject.Provider;
+
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.AdminActionHistory;
 import org.pmiops.workbench.db.model.CommonStorageEnums;
@@ -36,6 +40,7 @@ public class UserService {
   private final Clock clock;
   private final FireCloudService fireCloudService;
   private final Provider<WorkbenchConfig> configProvider;
+  private Random random = new SecureRandom();
 
   @Autowired
   public UserService(Provider<User> userProvider,
@@ -124,6 +129,7 @@ public class UserService {
       String organization,
       String areaOfResearch) {
     User user = new User();
+    user.setCreationNonce(Math.abs(random.nextLong()));
     user.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
     user.setEmail(email);
     user.setContactEmail(contactEmail);

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -31,6 +31,9 @@ import org.pmiops.workbench.model.EmailVerificationStatus;
 public class User {
   private long userId;
   private int version;
+  // A nonce which can be used during the account creation flow to verify
+  // unauthenticated API calls after account creation, but before initial login.
+  private Long creationNonce;
   // The Google email address that the user signs in with.
   private String email;
   // The email address that can be used to contact the user.
@@ -80,6 +83,11 @@ public class User {
   public int getVersion() { return version; }
 
   public void setVersion(int version) { this.version = version; }
+
+  @Column(name = "creation_nonce")
+  public Long getCreationNonce() { return creationNonce; }
+
+  public void setCreationNonce(Long creationNonce) { this.creationNonce = creationNonce; }
 
   @Column(name = "email")
   public String getEmail() {

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -243,7 +243,7 @@ paths:
           schema:
             $ref: "#/definitions/CreateAccountRequest"
       responses:
-        201:
+        200:
           description: Account created successfully.
           schema:
             $ref: "#/definitions/Profile"
@@ -1830,16 +1830,21 @@ definitions:
     type: object
     required:
       - username
+      - creationNonce
     properties:
       username:
         type: string
         description: Username of account to resend welcome email to
+      creationNonce:
+        type: string
+        description: The nonce returned from the account creation API.
 
   UpdateContactEmailRequest:
     type: object
     required:
       - contactEmail
       - username
+      - creationNonce
     properties:
       contactEmail:
         type: string
@@ -1847,6 +1852,9 @@ definitions:
       username:
         type: string
         description: Username for account.
+      creationNonce:
+        type: string
+        description: The nonce returned from the account creation API.
 
   BugReport:
     type: object
@@ -1888,6 +1896,11 @@ definitions:
         format: int64
       username:
         description: researchallofus username
+        type: string
+      creationNonce:
+        description: >
+          A value which can be used to secure API calls during the account
+          creation flow, prior to account login.
         type: string
       contactEmail:
         description: email address that can be used to contact the user

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -11,13 +12,16 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
+
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Map;
+
 import javax.inject.Provider;
+
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +49,7 @@ import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.test.FakeLongRandom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
@@ -147,7 +152,9 @@ public class ClusterControllerTest {
     when(userProvider.get()).thenReturn(user);
     clusterController.setUserProvider(userProvider);
 
-    UserService userService = new UserService(userProvider, userDao, adminActionHistoryDao, CLOCK, fireCloudService, configProvider);
+    UserService userService = new UserService(
+        userProvider, userDao, adminActionHistoryDao, CLOCK, new FakeLongRandom(123),
+        fireCloudService, configProvider);
     clusterController.setUserService(userService);
 
     cdrVersion = new CdrVersion();

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -1,7 +1,9 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static junit.framework.TestCase.fail;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -10,13 +12,17 @@ import static org.pmiops.workbench.api.ConceptsControllerTest.makeConcept;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+
 import javax.inject.Provider;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -65,6 +71,7 @@ import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.test.SearchRequests;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
@@ -175,6 +182,11 @@ public class CohortsControllerTest {
     @Bean
     Clock clock() {
       return CLOCK;
+    }
+
+    @Bean
+    Random random() {
+      return new FakeLongRandom(123);
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -1,17 +1,22 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.api.ConceptsControllerTest.makeConcept;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Random;
+
 import javax.inject.Provider;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +52,7 @@ import org.pmiops.workbench.model.UpdateConceptSetRequest;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.test.FakeLongRandom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -184,6 +190,11 @@ public class ConceptSetsControllerTest {
     @Bean
     Clock clock() {
       return CLOCK;
+    }
+
+    @Bean
+    Random random() {
+      return new FakeLongRandom(123);
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -3,11 +3,15 @@ package org.pmiops.workbench.api;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Lists;
+
 import java.time.Clock;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
+
 import javax.inject.Provider;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +67,7 @@ public class UserControllerTest {
     config.firecloud = new WorkbenchConfig.FireCloudConfig();
     config.firecloud.enforceRegistered = false;
     configProvider = Providers.of(config);
-    this.userService = new UserService(userProvider, userDao, adminActionHistoryDao, clock, fireCloudService, configProvider);
+    this.userService = new UserService(userProvider, userDao, adminActionHistoryDao, clock, new Random(), fireCloudService, configProvider);
     this.userController = new UserController(userService);
     saveFamily();
   }
@@ -76,7 +80,7 @@ public class UserControllerTest {
   @Test
   public void testEnforceRegistered() {
     configProvider.get().firecloud.enforceRegistered = true;
-    this.userService = new UserService(userProvider, userDao, adminActionHistoryDao, clock, fireCloudService, configProvider);
+    this.userService = new UserService(userProvider, userDao, adminActionHistoryDao, clock, new Random(), fireCloudService, configProvider);
     this.userController = new UserController(userService);
     User john = userDao.findUserByEmail("john@lis.org");
 

--- a/api/src/test/java/org/pmiops/workbench/test/FakeLongRandom.java
+++ b/api/src/test/java/org/pmiops/workbench/test/FakeLongRandom.java
@@ -1,0 +1,19 @@
+package org.pmiops.workbench.test;
+
+import java.util.Random;
+
+/**
+ * Stubbed Random implementation for testing.
+ */
+public class FakeLongRandom extends Random {
+  private final long value;
+
+  public FakeLongRandom(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public long nextLong() {
+    return value;
+  }
+}

--- a/ui/src/app/views/account-creation-modals/component.spec.ts
+++ b/ui/src/app/views/account-creation-modals/component.spec.ts
@@ -6,12 +6,10 @@ import {ClarityModule} from '@clr/angular';
 import {ProfileService} from 'generated';
 
 import {ProfileServiceStub} from 'testing/stubs/profile-service-stub';
-import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 
 import {
   updateAndTick
 } from '../../../testing/test-helpers';
-import {ServerConfigService} from '../../services/server-config.service';
 
 import {AccountCreationModalsComponent} from '../account-creation-modals/component';
 
@@ -28,12 +26,7 @@ describe('AccountCreationModalsComponent', () => {
       ],
       providers: [
         { provide: ProfileService, useValue: new ProfileServiceStub() },
-        {
-          provide: ServerConfigService,
-          useValue: new ServerConfigServiceStub({
-            gsuiteDomain: 'fake-research-aou.org'
-          })
-        }]
+      ]
     }).compileComponents().then(() => {
       fixture = TestBed.createComponent(AccountCreationModalsComponent);
       tick();

--- a/ui/src/app/views/account-creation-modals/component.ts
+++ b/ui/src/app/views/account-creation-modals/component.ts
@@ -2,7 +2,6 @@ import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 
 import {ProfileService} from 'generated';
 import {ResendWelcomeEmailRequest, UpdateContactEmailRequest} from 'generated';
-import {ServerConfigService} from '../../services/server-config.service';
 
 function isBlank(s: string) {
   return (!s || /^\s*$/.test(s));
@@ -21,17 +20,13 @@ export class AccountCreationModalsComponent {
   emailOffFocus = true;
   waiting = false;
   @Input('username') username: string;
-  @Input('gsuiteDomain') gsuiteDomain: string;
+  @Input('creationNonce') creationNonce: string;
 
   @Output() updateEmail = new EventEmitter<string>();
 
   constructor(
-    private profileService: ProfileService,
-    serverConfigService: ServerConfigService
+    private profileService: ProfileService
   ) {
-    serverConfigService.getConfig().subscribe((config) => {
-      this.gsuiteDomain = config.gsuiteDomain;
-    });
     this.contactEmail = '';
     this.emailOffFocus = false;
   }
@@ -50,12 +45,12 @@ export class AccountCreationModalsComponent {
     if (this.contactEmailInvalidError) {
       return;
     }
-    const request: UpdateContactEmailRequest = {
-      username: this.username + '@' + this.gsuiteDomain,
-      contactEmail: this.contactEmail
-    };
     this.updateEmail.emit(this.contactEmail);
-    this.profileService.updateContactEmail(request).subscribe(() => {
+    this.profileService.updateContactEmail({
+      username: this.username,
+      contactEmail: this.contactEmail,
+      creationNonce: this.creationNonce
+    }).subscribe(() => {
       this.resendingEmail = false;
       this.waiting = false;
       this.changingEmail = false;
@@ -64,10 +59,10 @@ export class AccountCreationModalsComponent {
 
   send() {
     this.waiting = true;
-    const request: ResendWelcomeEmailRequest = {
-      username: this.username + '@' + this.gsuiteDomain
-    };
-    this.profileService.resendWelcomeEmail(request).subscribe(() => {
+    this.profileService.resendWelcomeEmail({
+      username: this.username,
+      creationNonce: this.creationNonce
+    }).subscribe(() => {
       this.resendingEmail = false;
       this.waiting = false;
     });

--- a/ui/src/app/views/account-creation-success/component.html
+++ b/ui/src/app/views/account-creation-success/component.html
@@ -7,7 +7,7 @@
     <h3 style="font-weight: 400">Your new account</h3>
   </div>
   <div class="row" style="white-space: nowrap">
-    <h3 style="font-weight: 400">{{username}}@{{gsuiteDomain}}</h3>
+    <h3 style="font-weight: 400">{{username}}</h3>
   </div>
   <div class="row">
     <h3 style="margin-top:.5rem; font-weight: 400">is hosted by Google.</h3>
@@ -24,6 +24,6 @@
   </div>
 </div>
 <app-account-creation-modals [username]="username"
-                             [gsuiteDomain]="gsuiteDomain"
+                             [creationNonce]="creationNonce"
                              (updateEmail)="receiveMessage($event)">
 </app-account-creation-modals>

--- a/ui/src/app/views/account-creation-success/component.spec.ts
+++ b/ui/src/app/views/account-creation-success/component.spec.ts
@@ -9,13 +9,11 @@ import {
 } from 'generated';
 
 import {ProfileServiceStub, ProfileStubVariables} from 'testing/stubs/profile-service-stub';
-import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 import {SignInServiceStub} from 'testing/stubs/sign-in-service-stub';
 
 import {
   updateAndTick
 } from '../../../testing/test-helpers';
-import {ServerConfigService} from '../../services/server-config.service';
 import {SignInService} from '../../services/sign-in.service';
 
 import {AccountCreationModalsComponent} from '../account-creation-modals/component';
@@ -43,12 +41,6 @@ describe('AccountCreationSuccessComponent', () => {
         },
         { provide: LoginComponent, useValue: {}},
         { provide: ProfileService, useValue: new ProfileServiceStub },
-        {
-          provide: ServerConfigService,
-          useValue: new ServerConfigServiceStub({
-            gsuiteDomain: 'fake-research-aou.org'
-          })
-        },
         { provide: SignInService, useValue: new SignInServiceStub()}
       ]
     }).compileComponents().then(() => {

--- a/ui/src/app/views/account-creation-success/component.ts
+++ b/ui/src/app/views/account-creation-success/component.ts
@@ -1,14 +1,11 @@
 import {Component, Input, OnInit, ViewChild} from '@angular/core';
 import {Router} from '@angular/router';
 
-import {ServerConfigService} from '../../services/server-config.service';
 import {SignInService} from '../../services/sign-in.service';
 import {AccountCreationModalsComponent} from '../account-creation-modals/component';
 import {AccountCreationComponent} from '../account-creation/component';
 
 import {LoginComponent} from '../login/component';
-
-import {Subscription} from 'rxjs/Subscription';
 
 @Component({
   selector : 'app-account-creation-success',
@@ -19,8 +16,7 @@ import {Subscription} from 'rxjs/Subscription';
 export class AccountCreationSuccessComponent {
   username: string;
   @Input('contactEmail') contactEmail: string;
-  gsuiteDomain: string;
-  subscription: Subscription;
+  creationNonce: string
 
   @ViewChild(AccountCreationModalsComponent)
   accountCreationModalsComponent: AccountCreationModalsComponent;
@@ -29,18 +25,15 @@ export class AccountCreationSuccessComponent {
     private loginComponent: LoginComponent,
     private account: AccountCreationComponent,
     private router: Router,
-    private signInService: SignInService,
-    serverConfigService: ServerConfigService
+    private signInService: SignInService
   ) {
-    serverConfigService.getConfig().subscribe((config) => {
-      this.gsuiteDomain = config.gsuiteDomain;
-    });
     // This is a workaround for ExpressionChangedAfterItHasBeenCheckedError from angular
     setTimeout(() => {
       loginComponent.smallerBackgroundImgSrc = '/assets/images/congrats-female-standing.png';
       loginComponent.backgroundImgSrc = '/assets/images/congrats-female.png';
     }, 0);
     this.username = account.profile.username;
+    this.creationNonce = account.profile.creationNonce;
   }
 
   signIn(): void {

--- a/ui/src/app/views/account-creation-success/component.ts
+++ b/ui/src/app/views/account-creation-success/component.ts
@@ -16,7 +16,7 @@ import {LoginComponent} from '../login/component';
 export class AccountCreationSuccessComponent {
   username: string;
   @Input('contactEmail') contactEmail: string;
-  creationNonce: string
+  creationNonce: string;
 
   @ViewChild(AccountCreationModalsComponent)
   accountCreationModalsComponent: AccountCreationModalsComponent;

--- a/ui/src/app/views/account-creation/component.spec.ts
+++ b/ui/src/app/views/account-creation/component.spec.ts
@@ -7,14 +7,12 @@ import {ClarityModule} from '@clr/angular';
 import {randomString} from 'app/utils/index';
 import {ProfileService} from 'generated';
 import {ProfileServiceStub} from 'testing/stubs/profile-service-stub';
-import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 
 import {
   simulateEvent,
   simulateInput,
   updateAndTick
 } from '../../../testing/test-helpers';
-import {ServerConfigService} from '../../services/server-config.service';
 
 import {AccountCreationModalsComponent} from '../account-creation-modals/component';
 import {AccountCreationSuccessComponent} from '../account-creation-success/component';
@@ -43,12 +41,7 @@ describe('AccountCreationComponent', () => {
         { provide: LoginComponent, useValue: {}},
         { provide: InvitationKeyComponent, useValue: {}},
         { provide: ProfileService, useValue: new ProfileServiceStub() },
-        {
-          provide: ServerConfigService,
-          useValue: new ServerConfigServiceStub({
-            gsuiteDomain: 'fake-research-aou.org'
-          })
-        }]
+      ]
     }).compileComponents().then(() => {
       fixture = TestBed.createComponent(AccountCreationComponent);
       tick();


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-1233

- Store a random int64 on account creation and return it
- Require that unauthenticated "resendWelcomeEmail" and "updateContactEmail" calls provide this value, effectively limiting those calls to the same account creation client session.
- Implement a `FakeLongRandom` class for testing purposes, faking out the whole Random implementation was too onerous.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
