### PR TITLE
[RW-1598][risk=no] null recent resource regression test (slightly contrived)

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -185,18 +185,18 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     // TODO: Dispatch these requests in batch or in parallel.
     // TODO: If we find a non-existent notebook, expunge from the cache.
     Set<BlobId> foundNotebooks = workspaceFilteredResources.stream()
-          .map(r -> parseBlobId(r.getNotebookName()))
-          .filter(Objects::nonNull)
-          .limit(MAX_RECENT_NOTEBOOKS)
-          .filter(id -> {
-            try {
-              return cloudStorageService.blobExists(id);
-            } catch (StorageException e) {
-              log.log(Level.WARNING, "failed to check blob existence, assuming it exists", e);
-              return true;
-            }
-          })
-          .collect(Collectors.toSet());
+        .map(r -> parseBlobId(r.getNotebookName()))
+        .filter(Objects::nonNull)
+        .limit(MAX_RECENT_NOTEBOOKS)
+        .filter(id -> {
+          try {
+            return cloudStorageService.blobExists(id);
+          } catch (StorageException e) {
+            log.log(Level.WARNING, "failed to check blob existence, assuming it exists", e);
+            return true;
+          }
+        })
+        .collect(Collectors.toSet());
 
     RecentResourceResponse recentResponse = new RecentResourceResponse();
     recentResponse.addAll(

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -139,7 +139,6 @@ public class CloudStorageServiceImpl implements CloudStorageService {
 
   @Override
   public boolean blobExists(BlobId id) throws StorageException {
-    if (null == id) { return false; }
     return StorageOptions.getDefaultInstance().getService().get(id) != null;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -9,14 +9,11 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableList;
-
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-
 import javax.inject.Provider;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -144,6 +141,7 @@ public class UserMetricsControllerTest {
         .thenReturn(workspaceResponse2);
 
     when(cloudStorageService.blobExists(any())).thenReturn(true);
+    when(cloudStorageService.blobExists(null)).thenThrow(new NullPointerException());
 
     userMetricsController = new UserMetricsController(
         userProvider,


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-1598

I'd consider null to be an invalid input to this method, and I'd rather not mask any bugs that might arise from this returning false.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
