### PR TITLE
[RW-1671][risk=no] Save Research Purpose Update Workspace 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -585,7 +585,15 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     if (workspace.getName() != null) {
       dbWorkspace.setName(workspace.getName());
     }
-    // TODO: handle research purpose
+    ResearchPurpose researchPurpose = request.getWorkspace().getResearchPurpose();
+    if (researchPurpose != null) {
+      setResearchPurposeDetails(dbWorkspace, researchPurpose);
+      if (researchPurpose.getReviewRequested()) {
+        Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+        dbWorkspace.setTimeRequested(now);
+      }
+      dbWorkspace.setReviewRequested(researchPurpose.getReviewRequested());
+    }
     // The version asserted on save is the same as the one we read via
     // getRequired() above, see RW-215 for details.
     dbWorkspace = workspaceService.saveWithLastModified(dbWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -379,8 +379,8 @@ public class WorkspacesControllerTest {
     researchPurpose.setPopulation(true);
     researchPurpose.setPopulationOfFocus("population");
     researchPurpose.setAdditionalNotes("additional notes");
-    researchPurpose.setTimeRequested(new Long(1000));
-    researchPurpose.setTimeReviewed(new Long(1500));
+    researchPurpose.setTimeRequested(1000L);
+    researchPurpose.setTimeReviewed(1500L);
     researchPurpose.setReviewRequested(true);
     researchPurpose.setApproved(false);
     Workspace workspace = new Workspace();
@@ -534,6 +534,44 @@ public class WorkspacesControllerTest {
     stubGetWorkspace(ws.getNamespace(), ws.getId(), ws.getCreator(), WorkspaceAccessLevel.OWNER);
     Workspace got = workspacesController.getWorkspace(ws.getNamespace(), ws.getId()).getBody().getWorkspace();
     assertThat(got).isEqualTo(ws);
+  }
+
+  @Test
+  public void testUpdateWorkspaceResearchPurpose() throws Exception {
+    Workspace ws = createDefaultWorkspace();
+    ws = workspacesController.createWorkspace(ws).getBody();
+
+    ResearchPurpose rp = new ResearchPurpose()
+            .diseaseFocusedResearch(false)
+            .diseaseOfFocus(null)
+            .methodsDevelopment(false)
+            .controlSet(false)
+            .aggregateAnalysis(false)
+            .ancestry(false)
+            .commercialPurpose(false)
+            .population(false)
+            .populationOfFocus(null)
+            .additionalNotes(null)
+            .reviewRequested(false);
+    ws.setResearchPurpose(rp);
+    UpdateWorkspaceRequest request = new UpdateWorkspaceRequest();
+    request.setWorkspace(ws);
+    ResearchPurpose updatedRp = workspacesController
+            .updateWorkspace(ws.getNamespace(), ws.getId(), request)
+            .getBody()
+            .getResearchPurpose();
+
+    assertThat(updatedRp.getDiseaseFocusedResearch()).isFalse();
+    assertThat(updatedRp.getDiseaseOfFocus()).isNull();
+    assertThat(updatedRp.getMethodsDevelopment()).isFalse();
+    assertThat(updatedRp.getControlSet()).isFalse();
+    assertThat(updatedRp.getAggregateAnalysis()).isFalse();
+    assertThat(updatedRp.getAncestry()).isFalse();
+    assertThat(updatedRp.getCommercialPurpose()).isFalse();
+    assertThat(updatedRp.getPopulation()).isFalse();
+    assertThat(updatedRp.getPopulationOfFocus()).isNull();
+    assertThat(updatedRp.getAdditionalNotes()).isNull();
+    assertThat(updatedRp.getReviewRequested()).isFalse();
   }
 
   @Test(expected = ForbiddenException.class)


### PR DESCRIPTION
## Addresses: 
https://precisionmedicineinitiative.atlassian.net/browse/RW-1671

## Changes
Previously, update workspace ignored any changes to the research purpose that were submitted from the UI, but handled it correctly on create and clone. This change adds the same save-research-purpose functionality back into update workspace.