### PR TITLE
[DB-51][risk=low] Reinstate public API/UI deploys in prod

### DIFF
--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -276,16 +276,9 @@ def deploy(cmd_name, args)
       #{op.opts.promote ? "--promote" : "--no-promote"}
   } + (op.opts.dry_run ? %W{--dry-run} : [])
 
-  if op.opts.project == PROD_PROJECT
-    maybe_log_jira.call "'#{op.opts.project}': Beginning deploy of api " +
-                        "(including DB updates), skipping public-api " +
-                        "(see DB-89)"
-    common.run_inline %W{../api/project.rb deploy --skip-public-api} + api_deploy_flags
-  else
-    maybe_log_jira.call "'#{op.opts.project}': Beginning deploy of api and " +
-                        "public-api services (including DB updates)"
-    common.run_inline %W{../api/project.rb deploy} + api_deploy_flags
-  end
+  maybe_log_jira.call "'#{op.opts.project}': Beginning deploy of api and " +
+                      "public-api services (including DB updates)"
+  common.run_inline %W{../api/project.rb deploy} + api_deploy_flags
 
   maybe_log_jira.call "'#{op.opts.project}': completed api service " +
                       "deployment; beginning deploy of UI service"
@@ -300,21 +293,16 @@ def deploy(cmd_name, args)
   } + (op.opts.dry_run ? %W{--dry-run} : [])
   maybe_log_jira.call "'#{op.opts.project}': completed UI service deployment"
 
-  if op.opts.project == PROD_PROJECT
-    maybe_log_jira.call "'#{op.opts.project}': Skipping Public-UI service " +
-                        "deployment (see DB-89)"
-  else
-    common.run_inline %W{
-      ../public-ui/project.rb deploy-ui
-        --project #{op.opts.project}
-        --account #{op.opts.account}
-        --key-file #{op.opts.key_file}
-        --version #{op.opts.app_version}
-        #{op.opts.promote ? "--promote" : "--no-promote"}
-        --quiet
-    } + (op.opts.dry_run ? %W{--dry-run} : [])
-    maybe_log_jira.call "'#{op.opts.project}': completed Public-UI service deployment"
-  end
+  common.run_inline %W{
+    ../public-ui/project.rb deploy-ui
+      --project #{op.opts.project}
+      --account #{op.opts.account}
+      --key-file #{op.opts.key_file}
+      --version #{op.opts.app_version}
+      #{op.opts.promote ? "--promote" : "--no-promote"}
+      --quiet
+  } + (op.opts.dry_run ? %W{--dry-run} : [])
+  maybe_log_jira.call "'#{op.opts.project}': completed Public-UI service deployment"
 
   if create_ticket
     jira_client.create_ticket(op.opts.project, from_version,


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/DB-51

Prod databrowser was temporarily disabled while we implemented a sign-in gate on the site. This work has been completed now by Bru: [DB-89](https://precisionmedicineinitiative.atlassian.net/browse/DB-89).

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
