### PR TITLE
[RW-1702][Risk=no] Fix display of concept modal

### DIFF
--- a/ui/src/app/views/concept-add-modal/component.css
+++ b/ui/src/app/views/concept-add-modal/component.css
@@ -7,14 +7,19 @@
   width: 20rem;
 }
 
+:host::ng-deep .modal-header {
+  padding-bottom: 0.5rem;
+}
+
 :host::ng-deep .modal-title {
   height: 19px;
-  width: 357px;
+  width: 400px;
   color: #262262;
   font-family: Montserrat, sans-serif;
   font-size: 16px;
   font-weight: 600;
   line-height: 19px;
+  padding-bottom: 0.5rem;
 }
 
 .header {
@@ -23,15 +28,15 @@
   color: #000000;
   font-size: 14px;
   font-family: Montserrat, sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   line-height: 19px;
   background-color: transparent;
-  padding-bottom: 1.8rem;
   padding-left: 0.5rem;
+  display: inline-block;
 }
 
-.create-header {
-  padding-bottom: 1.5rem;
+.header.disabled {
+  color: #C3C3C3;
 }
 
 .inputName, .concept-select {
@@ -55,7 +60,6 @@
 
 .description {
   height: 168px;
-  width: 406px;
   border: 1px solid #979797;
   border-radius: 5px;
   background-color: #FFFFFF;

--- a/ui/src/app/views/concept-add-modal/component.html
+++ b/ui/src/app/views/concept-add-modal/component.html
@@ -2,14 +2,19 @@
   <h3 class="modal-title">Add {{selectConceptList?.length}} Concepts to {{selectDomain|titlecase}} Concept Set</h3>
   <div class="modal-body">
     <label *ngIf="errorSaving" class="error">{{errorMsg}}</label>
-    <div *ngIf="conceptSets?.length > 0" class="form-section">
-      <div style="display:flex; flex-direction: row;">
-        <input id="select-add" type="radio" [(ngModel)]="existingSetSelected" [value]="true"
-               [checked]="selectChange()"/>
-        <label class="header">Choose existing set</label>
-        <input id="select-create" type="radio" style="margin-left: 0.7rem;" [(ngModel)]="existingSetSelected" [value]="false"
-               [checked]="selectChange()"/>
-        <label class="header create-header">Create new set</label>
+    <div  class="form-section">
+      <div style="display:flex; flex-direction: row; padding-bottom: 1.5rem;">
+        <span role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-bottom-right">
+          <input id="select-add" type="radio" [(ngModel)]="existingSetSelected" [value]="true" [disabled]="conceptSets?.length === 0"
+                 [checked]="selectChange()"/>
+          <label class="header" [class.disabled]="conceptSets?.length === 0">Choose existing set</label>
+          <span *ngIf="conceptSets?.length === 0" class="tooltip-content">No Concept Sets in domain {{selectDomain|titlecase}}</span>
+        </span>
+        <span>
+          <input id="select-create" type="radio" style="margin-left: 0.7rem;" [(ngModel)]="existingSetSelected" [value]="false"
+                 [checked]="selectChange()"/>
+          <label class="header create-header">Create new set</label>
+        </span>
       </div>
       <select *ngIf="existingSetSelected" class="concept-select" [(ngModel)]="selectedConceptSet">
         <option *ngFor="let conceptSet of conceptSets" [ngValue]="conceptSet">{{conceptSet.name}}</option>
@@ -17,7 +22,6 @@
     </div>
     <div class="form-section">
       <label *ngIf="errorNameReq" class="error">{{errorMsg}}</label>
-      <label class="header" style="padding-left: 0rem;" *ngIf="conceptSets?.length === 0">Create a new Concept Set</label>
       <input *ngIf="!existingSetSelected || conceptSets?.length === 0" id="new-name" type="text" class="inputName" placeholder="Name"
              [(ngModel)]="name">
       <textarea *ngIf="!existingSetSelected || conceptSets?.length === 0" name="description" class="description" placeholder="Add a Description"

--- a/ui/src/app/views/concept-add-modal/component.html
+++ b/ui/src/app/views/concept-add-modal/component.html
@@ -4,13 +4,15 @@
     <label *ngIf="errorSaving" class="error">{{errorMsg}}</label>
     <div  class="form-section">
       <div style="display:flex; flex-direction: row; padding-bottom: 1.5rem;">
-        <span role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-bottom-right">
-          <input id="select-add" type="radio" [(ngModel)]="existingSetSelected" [value]="true" [disabled]="conceptSets?.length === 0"
-                 [checked]="selectChange()"/>
-          <label class="header" [class.disabled]="conceptSets?.length === 0">Choose existing set</label>
-          <span *ngIf="conceptSets?.length === 0" class="tooltip-content">No Concept Sets in domain {{selectDomain|titlecase}}</span>
-        </span>
-        <span>
+        <clr-tooltip>
+          <span clrTooltipTrigger>
+            <input id="select-add" type="radio" [(ngModel)]="existingSetSelected" [value]="true" [disabled]="conceptSets?.length === 0"
+                   [checked]="selectChange()"/>
+            <label class="header" [class.disabled]="conceptSets?.length === 0">Choose existing set</label>
+          </span>
+          <clr-tooltip-content clrPosition="top-right" clrSize="lg" *ngIf="conceptSets?.length === 0">No Concept Sets in domain {{selectDomain|titlecase}}</clr-tooltip-content>
+        </clr-tooltip>
+        <span style="display: flex; align-items: center;">
           <input id="select-create" type="radio" style="margin-left: 0.7rem;" [(ngModel)]="existingSetSelected" [value]="false"
                  [checked]="selectChange()"/>
           <label class="header create-header">Create new set</label>

--- a/ui/src/app/views/concept-add-modal/component.spec.ts
+++ b/ui/src/app/views/concept-add-modal/component.spec.ts
@@ -131,7 +131,7 @@ describe('ConceptSetAddComponent', () => {
     expect(conceptSetAddCreatePage.formSections.length).toBe(2);
   }));
 
-  it('does not display option to add to existing if concept set does not exist',
+  it('disables option to add to existing if concept set does not exist',
       fakeAsync(() => {
     conceptSetAddCreatePage.fixture.componentInstance.selectedDomain = Domain.DRUG;
     conceptSetAddCreatePage.fixture.componentInstance.selectedConcepts =
@@ -139,7 +139,9 @@ describe('ConceptSetAddComponent', () => {
     conceptSetAddCreatePage.fixture.componentInstance.open();
     conceptSetAddCreatePage.readPageData();
     tick();
-    expect(conceptSetAddCreatePage.formSections.length).toBe(1);
+    expect(conceptSetAddCreatePage.formSections.length).toBe(2);
+    expect(conceptSetAddCreatePage.fixture.debugElement
+      .query(By.css('#select-add')).properties['disabled']).toBeTruthy();
   }));
 
   it('selects Add to Existing option by default'

--- a/ui/src/app/views/concept-add-modal/component.ts
+++ b/ui/src/app/views/concept-add-modal/component.ts
@@ -45,8 +45,8 @@ export class ConceptAddModalComponent {
     private conceptSetsService: ConceptSetsService,
     private conceptService: ConceptsService,
     private route: ActivatedRoute) {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
+      this.wsNamespace = this.route.snapshot.params['ns'];
+      this.wsId = this.route.snapshot.params['wsid'];
   }
 
   open(): void {


### PR DESCRIPTION
This fixes the mismatch of display from text area and input on the create concept, and makes it so if there are no concept sets in the domain, we keep the UX consistent and display a tooltip to the user regarding the lack of concept sets.
<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
