### PR TITLE
[risk=low] Increase FC billing account creation retries in prod

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -11,7 +11,7 @@
     "jupyterPlaygroundExtensionUri": "gs:\/\/all-of-us-rw-prod-cluster-resources/playground-extension.js",
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-prod",
-    "billingRetryCount": 2
+    "billingRetryCount": 4
   },
   "auth": {
     "serviceAccountApiUsers": [ "all-of-us-rw-prod@appspot.gserviceaccount.com" ]


### PR DESCRIPTION
At least one user has already hit this limit and is stuck. Adding more retries on billing account creation may allow their account to be restored.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
