### PR TITLE
[risk=no] DB-15 [6-7] Filtering achilles results by domain and rounding source counts only > 0 and not = 0

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-public-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-public-data.sh
@@ -86,12 +86,12 @@ set count_value =
         cast(CEIL(count_value / ${BIN_SIZE}) * ${BIN_SIZE} as int64)
     end,
     source_count_value =
-    case when source_count_value < ${BIN_SIZE}
+    case when source_count_value < ${BIN_SIZE} and source_count_value > 0
         then ${BIN_SIZE}
     else
         cast(CEIL(source_count_value / ${BIN_SIZE}) * ${BIN_SIZE} as int64)
     end
-where count_value >= 0"
+where count_value > 0"
 
 
 #delete concepts with 0 count / source count value
@@ -117,7 +117,7 @@ set count_value =
         cast(CEIL(count_value / ${BIN_SIZE}) * ${BIN_SIZE} as int64)
     end,
     source_count_value =
-    case when source_count_value < ${BIN_SIZE}
+    case when source_count_value < ${BIN_SIZE} and source_count_value > 0
         then ${BIN_SIZE}
     else
         cast(CEIL(source_count_value / ${BIN_SIZE}) * ${BIN_SIZE} as int64)

--- a/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
+++ b/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
@@ -54,7 +54,7 @@ public class QuestionConcept {
         genderStratumNameMap.put("8570", "Ambiguous");
         genderStratumNameMap.put("1585849", "None of these describe me");
         genderStratumNameMap.put("1585848", "Intersex");
-        genderIdentityStratumNameMap.put("0", "Other");
+        genderStratumNameMap.put("0", "Other");
     }
 
     public static void setGenderIdentityStratumNameMap() {

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -534,7 +534,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
                 Long analysisId = (Long)pair.getKey();
                 AchillesAnalysis aa = (AchillesAnalysis)pair.getValue();
                 //aa.setUnitName(unitName);
-                if(analysisId != MEASUREMENT_GENDER_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_ANALYSIS_ID && analysisId != MEASUREMENT_DIST_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_DIST_ANALYSIS_ID) {
+                if(analysisId != MEASUREMENT_GENDER_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_ANALYSIS_ID && analysisId != MEASUREMENT_DIST_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_DIST_ANALYSIS_ID && !domainId.isEmpty()) {
                     aa.setResults(aa.getResults().stream().filter(ar -> ar.getStratum3().equalsIgnoreCase(domainId)).collect(Collectors.toList()));
                 }
                 if(analysisId == GENDER_ANALYSIS_ID){

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -389,8 +389,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
         }
 
         List<Concept> conceptList = new ArrayList(concepts.getContent());
-
-        if(searchConceptsRequest.getDomain() != null && searchConceptsRequest.getDomain().equals(Domain.DRUG)) {
+        if(searchConceptsRequest.getDomain() != null && searchConceptsRequest.getDomain().equals(Domain.DRUG) && !searchConceptsRequest.getQuery().isEmpty()) {
             List<Concept> drugMatchedConcepts = conceptDao.findDrugIngredientsByBrand(searchConceptsRequest.getQuery());
 
             if(drugMatchedConcepts.size() > 0) {
@@ -476,7 +475,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     }
 
     @Override
-    public ResponseEntity<ConceptAnalysisListResponse> getConceptAnalysisResults(List<String> conceptIds){
+    public ResponseEntity<ConceptAnalysisListResponse> getConceptAnalysisResults(List<String> conceptIds, String domainId){
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
         ConceptAnalysisListResponse resp=new ConceptAnalysisListResponse();
         List<ConceptAnalysis> conceptAnalysisList=new ArrayList<>();
@@ -535,6 +534,9 @@ public class DataBrowserController implements DataBrowserApiDelegate {
                 Long analysisId = (Long)pair.getKey();
                 AchillesAnalysis aa = (AchillesAnalysis)pair.getValue();
                 //aa.setUnitName(unitName);
+                if(analysisId != MEASUREMENT_GENDER_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_ANALYSIS_ID && analysisId != MEASUREMENT_DIST_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_DIST_ANALYSIS_ID) {
+                    aa.setResults(aa.getResults().stream().filter(ar -> ar.getStratum3().equalsIgnoreCase(domainId)).collect(Collectors.toList()));
+                }
                 if(analysisId == GENDER_ANALYSIS_ID){
                     addGenderStratum(aa);
                     conceptAnalysis.setGenderAnalysis(TO_CLIENT_ANALYSIS.apply(aa));

--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -90,6 +90,11 @@ paths:
             type: string
           required: true
           description: concept id
+        - in: query
+          name: domain-id
+          type: string
+          required: false
+          description: domain id
       responses:
         200:
           description: A collection of analysis for concept

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -514,7 +514,7 @@ public class DataBrowserControllerTest {
     public void testGetMeasurementAnalysisNoMatch() throws Exception{
         ArrayList<String> queryConceptIds = new ArrayList<String>();
         queryConceptIds.add("137990");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(queryConceptIds);
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(queryConceptIds,"Drug");
         List<ConceptAnalysis> conceptAnalysisList = response.getBody().getItems();
         assertThat(conceptAnalysisList.get(0).getAgeAnalysis()).isEqualTo(null);
     }
@@ -523,7 +523,7 @@ public class DataBrowserControllerTest {
     public void testGetSurveyDemographicAnalysesMatch() throws Exception{
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1586134");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds);
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds,"survey");
         List<ConceptAnalysis> conceptAnalysis = response.getBody().getItems();
         Analysis ageAnalysis = conceptAnalysis.get(0).getAgeAnalysis();
         Analysis genderAnalysis = conceptAnalysis.get(0).getGenderAnalysis();
@@ -536,7 +536,7 @@ public class DataBrowserControllerTest {
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1586134");
         conceptsIds.add("1585855");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds);
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "survey");
         List<ConceptAnalysis> conceptAnalysis = response.getBody().getItems();
         assertThat(conceptAnalysis.get(0).getGenderAnalysis().getResults().size()).isEqualTo(2);
         assertThat(conceptAnalysis.get(1).getGenderAnalysis()).isEqualTo(null);
@@ -546,7 +546,7 @@ public class DataBrowserControllerTest {
     public void testGetSurveyDemographicAnalysesNoMatch() throws Exception{
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1585855");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds);
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "survey");
         List<ConceptAnalysis> conceptAnalysisList = response.getBody().getItems();
         assertThat(conceptAnalysisList.get(0).getAgeAnalysis()).isEqualTo(null);
     }

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -514,7 +514,7 @@ public class DataBrowserControllerTest {
     public void testGetMeasurementAnalysisNoMatch() throws Exception{
         ArrayList<String> queryConceptIds = new ArrayList<String>();
         queryConceptIds.add("137990");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(queryConceptIds,"Drug");
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(queryConceptIds,"");
         List<ConceptAnalysis> conceptAnalysisList = response.getBody().getItems();
         assertThat(conceptAnalysisList.get(0).getAgeAnalysis()).isEqualTo(null);
     }
@@ -523,7 +523,7 @@ public class DataBrowserControllerTest {
     public void testGetSurveyDemographicAnalysesMatch() throws Exception{
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1586134");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds,"survey");
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds,"");
         List<ConceptAnalysis> conceptAnalysis = response.getBody().getItems();
         Analysis ageAnalysis = conceptAnalysis.get(0).getAgeAnalysis();
         Analysis genderAnalysis = conceptAnalysis.get(0).getGenderAnalysis();
@@ -536,7 +536,7 @@ public class DataBrowserControllerTest {
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1586134");
         conceptsIds.add("1585855");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "survey");
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "");
         List<ConceptAnalysis> conceptAnalysis = response.getBody().getItems();
         assertThat(conceptAnalysis.get(0).getGenderAnalysis().getResults().size()).isEqualTo(2);
         assertThat(conceptAnalysis.get(1).getGenderAnalysis()).isEqualTo(null);
@@ -546,7 +546,7 @@ public class DataBrowserControllerTest {
     public void testGetSurveyDemographicAnalysesNoMatch() throws Exception{
         List<String> conceptsIds = new ArrayList<>();
         conceptsIds.add("1585855");
-        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "survey");
+        ResponseEntity<ConceptAnalysisListResponse> response = dataBrowserController.getConceptAnalysisResults(conceptsIds, "");
         List<ConceptAnalysis> conceptAnalysisList = response.getBody().getItems();
         assertThat(conceptAnalysisList.get(0).getAgeAnalysis()).isEqualTo(null);
     }

--- a/public-ui/src/app/data-browser/chart/chart.component.ts
+++ b/public-ui/src/app/data-browser/chart/chart.component.ts
@@ -330,7 +330,6 @@ export class ChartComponent implements OnChanges {
         color = this.dbc.GENDER_COLORS[a.stratum5];
       }
       if (this.analysis.analysisId === this.dbc.SURVEY_GENDER_IDENTITY_ANALYSIS_ID) {
-        console.log(this.analysis.results);
         color = this.dbc.GENDER_IDENTITY_COLORS[a.stratum5];
       }
       if (this.analysis.analysisId === this.dbc.GENDER_IDENTITY_ANALYSIS_ID) {

--- a/public-ui/src/app/data-browser/chart/chart.component.ts
+++ b/public-ui/src/app/data-browser/chart/chart.component.ts
@@ -329,6 +329,10 @@ export class ChartComponent implements OnChanges {
       if (this.analysis.analysisId === this.dbc.SURVEY_GENDER_ANALYSIS_ID) {
         color = this.dbc.GENDER_COLORS[a.stratum5];
       }
+      if (this.analysis.analysisId === this.dbc.SURVEY_GENDER_IDENTITY_ANALYSIS_ID) {
+        console.log(this.analysis.results);
+        color = this.dbc.GENDER_IDENTITY_COLORS[a.stratum5];
+      }
       if (this.analysis.analysisId === this.dbc.GENDER_IDENTITY_ANALYSIS_ID) {
         color = this.dbc.GENDER_IDENTITY_COLORS[a.stratum2];
       }

--- a/public-ui/src/app/data-browser/concept-charts/concept-charts.component.ts
+++ b/public-ui/src/app/data-browser/concept-charts/concept-charts.component.ts
@@ -56,7 +56,8 @@ export class ConceptChartsComponent implements OnInit, OnDestroy {
     // Get chart results for concept
     this.loadingStack.push(true);
     const conceptIdStr = '' + this.concept.conceptId.toString();
-    this.subscriptions.push( this.api.getConceptAnalysisResults([conceptIdStr]).subscribe(
+    this.subscriptions.push( this.api.getConceptAnalysisResults([conceptIdStr],
+      this.concept.domainId).subscribe(
     results =>  {
       this.results = results.items;
       this.analyses = results.items[0];
@@ -80,6 +81,9 @@ export class ConceptChartsComponent implements OnInit, OnDestroy {
     this.subscriptions.push( this.api.getSourceConcepts(this.concept.conceptId).subscribe(
     results => {
       this.sourceConcepts = results.items;
+      if (this.sourceConcepts.length > 10) {
+        this.sourceConcepts = this.sourceConcepts.slice(0, 10);
+      }
       this.loadingStack.pop();
       }));
   }

--- a/public-ui/src/app/views/survey-view/survey-view.component.ts
+++ b/public-ui/src/app/views/survey-view/survey-view.component.ts
@@ -138,7 +138,6 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
     if (!countValue || countValue <= 0) { return 0; }
     let percent: number = countValue / this.survey.participantCount ;
     percent = parseFloat(percent.toFixed(4));
-
     return percent * 100;
   }
 


### PR DESCRIPTION
1. Some drug concepts also seem to be in procedure occurrence table causing two sets of achilles results of different domain, so filtering the results in any domain page to display only of that domain.
2. Not rounding the source count value of concepts from 0 to 20.
3. Displaying only top ten source concepts.