### PR TITLE
[risk=low] Update paths for notebook extensions

### DIFF
--- a/api/demos/Get Started in R Notebooks.ipynb
+++ b/api/demos/Get Started in R Notebooks.ipynb
@@ -137,7 +137,7 @@
     "\n",
     "**Important** The current AllofUs client library is written in Python, so to do analysis in R you will have to:\n",
     "1. Install the reticulate package, which provides a comprehensive set of tools for interoperability between Python and R (details here: https://github.com/rstudio/reticulate)\n",
-    "2. Install additional R data analysis packages reccomended in this notebook\n"
+    "2. Install additional R data analysis packages recommended in this notebook\n"
    ]
   },
   {
@@ -221,7 +221,9 @@
    "source": [
     "# A collection of helpful functions for summarizing data and formatting results (details here: https://github.com/dewittpe/qwraps2)\n",
     "install.packages('qwraps2')\n",
-    "library(qwraps2)"
+    "library(qwraps2)\n",
+    "\n",
+    "# If this fails to install, you can work around it by creating the symlink in https://github.com/DataBiosphere/leonardo/issues/710"
    ]
   },
   {
@@ -247,7 +249,7 @@
     }
    ],
    "source": [
-    "# An \"opnionated\" collection of R packages designed for Data Science \n",
+    "# An \"opinionated\" collection of R packages designed for Data Science \n",
     "install.packages('tidyverse') \n",
     "library(tidyverse)"
    ]
@@ -616,7 +618,7 @@
    "source": [
     "# 2. Run this cell to install an extension that allows you to collapse headings\n",
     "\n",
-    "system('jupyter nbextension install ~/.local/lib/python3.4/site-packages/jupyter_contrib_nbextensions/nbextensions/collapsible_headings --user',\n",
+    "system('jupyter nbextension install ~/.local/lib/python3.6/site-packages/jupyter_contrib_nbextensions/nbextensions/collapsible_headings --user',\n",
     "       intern = TRUE)\n",
     "system('jupyter nbextension enable collapsible_headings/main', intern=TRUE)"
    ]
@@ -642,7 +644,7 @@
    "source": [
     "# 3. Run this cell to enable the collapsible heading extension installed above\n",
     "\n",
-    "system('jupyter nbextension enable python-markdown/main', intern = TRUE)"
+    "system('jupyter nbextension enable collapsible_headings/main', intern = TRUE)"
    ]
   },
   {
@@ -666,7 +668,7 @@
    "source": [
     "# 4. Run this cell to disable the collapsible heading extension enabled above\n",
     "\n",
-    "system('jupyter nbextension disable python-markdown/main', intern = TRUE)"
+    "system('jupyter nbextension disable collapsible_headings/main', intern = TRUE)"
    ]
   },
   {


### PR DESCRIPTION
Typo fixes and also two changes per the recent update to the leonardo image:
* Python is now version 3.6
* the qwraps2 package is failing to install due to a missing system dependency.


