### PR TITLE
[No ticket][Risk=low] update aou-utils

### DIFF
--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -79,6 +79,8 @@ paths:
     post:
       tags:
         - cohortReview
+      consumes:
+        - application/json
       description:  >
         This endpoint will create an cohort review which is a participant cohort sample
         specified by the review size parameter.
@@ -105,6 +107,8 @@ paths:
     post:
       tags:
           - cohortReview
+      consumes:
+        - application/json
       description:  >
         Returns a collection of participants for the specified cohortId and cdrVersionId. This endpoint
         does pagination based on page, limit, order and column.
@@ -142,6 +146,8 @@ paths:
     put:
       tags:
         - cohortReview
+      consumes:
+        - application/json
       description: Modifies the ParticipantCohortStatus status
       operationId: updateParticipantCohortStatus
       parameters:
@@ -223,6 +229,8 @@ paths:
     post:
       tags:
         - cohortReview
+      consumes:
+        - application/json
       description: This endpoint will create a ParticipantCohortAnnotation.
       operationId: "createParticipantCohortAnnotation"
       parameters:
@@ -258,6 +266,8 @@ paths:
     post:
       tags:
         - cohortReview
+      consumes:
+        - application/json
       description:  >
             Returns a collection of participant data for the specified params based off the PageFilterRequest. This endpoint
             does pagination based on page, limit, order and column.
@@ -291,6 +301,8 @@ paths:
     put:
       tags:
         - cohortReview
+      consumes:
+        - application/json
       description: This endpoint will modify a ParticipantCohortAnnotation.
       operationId: "updateParticipantCohortAnnotation"
       parameters:
@@ -325,6 +337,8 @@ paths:
     post:
       tags:
         - cohortAnnotationDefinition
+      consumes:
+        - application/json
       description: This endpoint will create a CohortAnnotationDefinition.
       operationId: "createCohortAnnotationDefinition"
       parameters:
@@ -374,6 +388,8 @@ paths:
     put:
       tags:
         - cohortAnnotationDefinition
+      consumes:
+        - application/json
       description: modify the CohortAnnotationDefinition.
       operationId: updateCohortAnnotationDefinition
       parameters:

--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -214,6 +214,8 @@ paths:
     post:
       tags:
         - cohortBuilder
+      consumes:
+        - application/json
       description: Searches for participants based on criteria, criteria specific parameters, and modifiers.
       operationId: "countParticipants"
       parameters:
@@ -236,6 +238,8 @@ paths:
     post:
       tags:
         - cohortBuilder
+      consumes:
+        - application/json
       description: Searches for demographic info about subjects.
       operationId: "getDemoChartInfo"
       parameters:

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -60,6 +60,8 @@ paths:
     post:
       tags:
         - cohorts
+      consumes:
+        - application/json
       description: >
         Translates a data table specification into a SQL query to run against the CDR.
       operationId: "getDataTableQuery"
@@ -82,6 +84,8 @@ paths:
     post:
       tags:
         - cohorts
+      consumes:
+        - application/json
       description: >
         Retrieves annotations for a cohort in the workspace
       operationId: "getCohortAnnotations"
@@ -101,6 +105,8 @@ paths:
       post:
         tags:
           - concepts
+        consumes:
+          - application/json
         description: >
           Searches for concepts in concept table by name, and optionally filter on
           domain, vocabulary IDs, or standard concept status. Uses the CDR version affiliated

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -93,6 +93,8 @@ paths:
             $ref: '#/definitions/CreateRawlsBillingProjectFullRequest'
       tags:
         - Billing
+      consumes:
+        - application/json
       summary: create billing project in FireCloud and google
       operationId: createBillingProjectFull
       security:
@@ -270,6 +272,8 @@ paths:
     post:
       tags:
         - Workspaces
+      consumes:
+        - application/json
       operationId: createWorkspace
       summary: Create workspace
       parameters:
@@ -334,6 +338,8 @@ paths:
     patch:
       tags:
         - Workspaces
+      consumes:
+        - application/json
       operationId: updateWorkspaceACL
       summary: Update workspace ACL
       parameters:
@@ -369,6 +375,8 @@ paths:
     post:
       tags:
         - Workspaces
+      consumes:
+        - application/json
       operationId: cloneWorkspace
       summary: Clone Workspace
       parameters:
@@ -418,6 +426,8 @@ paths:
       post:
         tags:
           - Profile
+        consumes:
+          - application/json
         operationId: setProfile
         summary: Sets a profile object in the user profile service for the currently logged-in user.
         parameters:

--- a/api/src/main/resources/jira.yaml
+++ b/api/src/main/resources/jira.yaml
@@ -33,6 +33,8 @@ paths:
       description: "Creates issue in JIRA and return IssueResponse"
       tags:
         - Jira
+      consumes:
+        - application/json
       operationId: createIssue
       parameters:
         - name: fields

--- a/api/src/main/resources/mandrill_api.yaml
+++ b/api/src/main/resources/mandrill_api.yaml
@@ -20,6 +20,8 @@ paths:
     post:
       tags:
         - mandrill
+      consumes:
+        - application/json
       operationId: send
       summary: Send an email via mandrill
       responses:

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -194,6 +194,8 @@ paths:
       operationId: createClusterV2
       tags:
         - cluster
+      consumes:
+        - application/json
       parameters:
         - in: path
           name: googleProject
@@ -360,6 +362,8 @@ paths:
       operationId: proxyLocalize
       tags:
         - notebooks
+      consumes:
+        - application/json
       parameters:
         - in: path
           name: googleProject
@@ -577,6 +581,8 @@ paths:
       description: "A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {'copy_from': '/path/to/OtherNotebook.ipynb'} creates a new copy of OtherNotebook in path."
       tags:
         - jupyter
+      consumes:
+        - application/json
       operationId: postContents
       parameters:
         - name: model
@@ -639,6 +645,8 @@ paths:
       description: "Saves the file in the location specified by name and path.  PUT is very similar to POST, but the requester specifies the name, whereas with POST, the server picks the name."
       tags:
         - jupyter
+      consumes:
+        - application/json
       operationId: putContents
       parameters:
         - name: model

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -113,6 +113,8 @@ paths:
     post:
       tags:
         - bugReport
+      consumes:
+        - application/json
       description: Sends an email to developers about a user reported bug
       operationId: sendBugReport
       parameters:
@@ -172,6 +174,8 @@ paths:
     post:
       tags:
         - profile
+      consumes:
+        - application/json
       description: Only for accounts that have not logged in yet, update contact email.
       operationId: updateContactEmail
       security: []
@@ -214,6 +218,8 @@ paths:
     post:
       tags:
         - profile
+      consumes:
+        - application/json
       description: Verifies invitation key.
       operationId: invitationKeyVerification
       security: []
@@ -234,6 +240,8 @@ paths:
     post:
       tags:
         - profile
+      consumes:
+        - application/json
       description: Creates an account in the researchallofus.org domain.
       operationId: createAccount
       security: []
@@ -268,6 +276,8 @@ paths:
     post:
       tags:
         - profile
+      consumes:
+        - application/json
       description: Updates a users profile
       operationId: updateProfile
       parameters:
@@ -288,6 +298,8 @@ paths:
     post:
       tags:
       - profile
+      consumes:
+        - application/json
       description: Updates a users page visits
       operationId: updatePageVisits
       parameters:
@@ -367,6 +379,8 @@ paths:
     post:
       tags:
         - authDomain
+      consumes:
+        - application/json
       responses:
         204:
           description: Successfully Added User To Group
@@ -520,6 +534,8 @@ paths:
       operationId: localize
       tags:
         - cluster
+      consumes:
+        - application/json
       parameters:
       - in: path
         name: clusterNamespace
@@ -586,6 +602,8 @@ paths:
     post:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: Creates a workspace
       operationId: createWorkspace
       parameters:
@@ -617,6 +635,8 @@ paths:
     patch:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: >
         Modifies the workspace definition with the specified ID and namespace;
         fields that are omitted will not be modified
@@ -717,6 +737,8 @@ paths:
     post:
       tags:
         - profile
+      consumes:
+        - application/json
       description: >
           Manually sets the ID verfication status for a user. Requires
           REVIEW_ID_VERIFICATION authority.
@@ -739,6 +761,8 @@ paths:
     post:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: Sets a research purpose review result.
       operationId: reviewWorkspace
       parameters:
@@ -797,6 +821,8 @@ paths:
     post:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: Shares a workspace with users
       operationId: shareWorkspace
       parameters:
@@ -818,6 +844,8 @@ paths:
     post:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: >
         Clone an existing workspace, with given modifications to workspace metadata. Caller will own
         the newly cloned workspace, and must have read access to the source workspace. In
@@ -846,6 +874,8 @@ paths:
     post:
       tags:
         - workspaces
+      consumes:
+        - application/json
       description: Renames specified notebook
       operationId: "renameNotebook"
       parameters:
@@ -926,6 +956,8 @@ paths:
     post:
       tags:
         - cohorts
+      consumes:
+        - application/json
       description: Creates a cohort definition in a workspace.
       operationId: "createCohort"
       parameters:
@@ -958,6 +990,8 @@ paths:
     patch:
       tags:
         - cohorts
+      consumes:
+        - application/json
       description: >
         Modifies the cohort definition with the specified ID; fields that are omitted
         will not be modified
@@ -991,6 +1025,8 @@ paths:
     post:
       tags:
         - cohorts
+      consumes:
+        - application/json
       description: >
         Materializes a cohort for a given CDR version to specified output.
       operationId: "materializeCohort"
@@ -1026,6 +1062,8 @@ paths:
     post:
       tags:
         - userMetrics
+      consumes:
+        - application/json
       description: Add/update user recent resource
       operationId: updateRecentResource
       parameters:
@@ -1086,6 +1124,8 @@ paths:
     post:
       tags:
         - conceptSets
+      consumes:
+        - application/json
       description: Creates a concept set in a workspace.
       operationId: "createConceptSet"
       parameters:
@@ -1118,6 +1158,8 @@ paths:
     patch:
       tags:
         - conceptSets
+      consumes:
+        - application/json
       description: >
         Modifies the name or description of the concept set with the specified ID;
         fields that are omitted will not be modified
@@ -1152,6 +1194,8 @@ paths:
     post:
       tags:
         - conceptSets
+      consumes:
+        - application/json
       description: >
         Adds or removes concepts from the concept set.
       operationId: "updateConceptSetConcepts"

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
@@ -373,7 +373,7 @@ export class ModifierPageComponent implements OnInit, OnDestroy, AfterContentChe
   }
 
   get addEncounters() {
-    return [TreeType[TreeType.PM], TreeType[TreeType.VISIT]].indexOf(this.ctype) === -1
+    return [TreeType[TreeType.PM], TreeType[TreeType.VISIT]].indexOf(TreeType[this.ctype]) === -1
       && !this.modifiers.find(modifier => modifier.modType === ModifierType.ENCOUNTERS);
   }
 


### PR DESCRIPTION
With the new Swagger (2.4). We need to make sure to add the parameter consumes - application/json to post/put/patch endpoints that have params in their bodies. If the endpoint has no params, or only params in their path, do NOT add this parameter!