### PR TITLE
[risk=no] Display only valid age deciles in graph

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
+++ b/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
@@ -169,7 +169,7 @@ public class QuestionConcept {
                     if (validAgeDeciles.contains(r.getStratum5())) {
                         questionAnalysis.addResult(r);
                     }
-                } else{
+                } else {
                     questionAnalysis.addResult(r);
                 }
                 String rStratum5Name = r.getAnalysisStratumName();

--- a/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
+++ b/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
@@ -165,7 +165,13 @@ public class QuestionConcept {
                     q.setAnalysis(new AchillesAnalysis(analysis));
                 }
                 AchillesAnalysis questionAnalysis = q.getAnalysis(analysis.getAnalysisId());
-                questionAnalysis.addResult(r);
+                if (analysis.getAnalysisId() == SURVEY_AGE_ANALYSIS_ID) {
+                    if (validAgeDeciles.contains(r.getStratum5())) {
+                        questionAnalysis.addResult(r);
+                    }
+                } else{
+                    questionAnalysis.addResult(r);
+                }
                 String rStratum5Name = r.getAnalysisStratumName();
                 if (rStratum5Name == null || rStratum5Name.equals("")) {
                     if (analysis.getAnalysisId() == SURVEY_AGE_ANALYSIS_ID) {

--- a/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
+++ b/public-api/src/main/java/org/pmiops/workbench/cdr/model/QuestionConcept.java
@@ -187,7 +187,6 @@ public class QuestionConcept {
                     }
                 }
             }
-            analysis.setResults(analysis.getResults().stream().filter(ar -> ar.getAnalysisStratumName() != null).collect(Collectors.toList()));
         }
     }
 

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -468,6 +468,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             List<AchillesAnalysis> analyses = achillesAnalysisDao.findSurveyAnalysisResults(surveyConceptId, qlist);
             QuestionConcept.mapAnalysesToQuestions(questions, analyses);
         }
+
         resp.setItems(questions.stream().map(TO_CLIENT_QUESTION_CONCEPT).collect(Collectors.toList()));
         return ResponseEntity.ok(resp);
     }
@@ -532,7 +533,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
                 Long analysisId = (Long)pair.getKey();
                 AchillesAnalysis aa = (AchillesAnalysis)pair.getValue();
                 //aa.setUnitName(unitName);
-                if(analysisId != MEASUREMENT_GENDER_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_ANALYSIS_ID && analysisId != MEASUREMENT_DIST_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_DIST_ANALYSIS_ID && !Strings.isNullOrEmpty(domainId)){
+                if(analysisId != MEASUREMENT_GENDER_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_ANALYSIS_ID && analysisId != MEASUREMENT_DIST_ANALYSIS_ID && analysisId != MEASUREMENT_AGE_DIST_ANALYSIS_ID && !domainId.isEmpty()) {
                     aa.setResults(aa.getResults().stream().filter(ar -> ar.getStratum3().equalsIgnoreCase(domainId)).collect(Collectors.toList()));
                 }
                 if(analysisId == GENDER_ANALYSIS_ID){

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -468,7 +468,6 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             List<AchillesAnalysis> analyses = achillesAnalysisDao.findSurveyAnalysisResults(surveyConceptId, qlist);
             QuestionConcept.mapAnalysesToQuestions(questions, analyses);
         }
-
         resp.setItems(questions.stream().map(TO_CLIENT_QUESTION_CONCEPT).collect(Collectors.toList()));
         return ResponseEntity.ok(resp);
     }


### PR DESCRIPTION
The prod data has weird age deciles like 11 (110-120), 98 and such. 
Filtering away those results to make the bar graph look clean.
