### PR TITLE
[risk=no] add table components

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -95,6 +95,7 @@
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.6.3",
     "react-onclickoutside": "^6.7.1",
+    "react-paginating": "^1.0.3-react16.0",
     "redux": "^3.7.2",
     "redux-observable": "^0.16.0",
     "rxjs": "^5.5.6",

--- a/ui/src/app/components/icons.tsx
+++ b/ui/src/app/components/icons.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const ClrIcon = props => {
+  return React.createElement('clr-icon', props);
+};

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -4,7 +4,7 @@ import Pagination from 'react-paginating';
 import { nextSort } from '../utils/index';
 import { ClrIcon } from './icons';
 
-const rowHeight = 36;
+const rowHeight = '1.5rem';
 
 const styles = {
   flexCell: ({ basis = 0, grow = 1, shrink = 1, min: minWidth = 0, max } = {} as any) => ({
@@ -24,10 +24,10 @@ const styles = {
   },
   cell: {
     display: 'flex', alignItems: 'center',
-    paddingLeft: 12, paddingRight: 12
+    paddingLeft: '0.5rem', paddingRight: '0.5rem'
   },
   paginationRow: {
-    display: 'flex', alignItems: 'center', height: 36,
+    display: 'flex', alignItems: 'center', height: rowHeight,
     border: '1px solid #ccc', backgroundColor: '#fafafa', fontSize: 13
   }
 };

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -57,7 +57,7 @@ export const SimpleTable = ({ columns, rowCount, rowProps }) => {
 const PageButton = ({ active = false, onClick, children }) => {
   return <div
     style={{
-      cursor: 'pointer', padding: 4,
+      cursor: 'pointer', padding: '0.1666rem',
       fontWeight: active ? 'bold' : undefined,
       textDecoration: active ? 'underline' : undefined
     }}
@@ -69,7 +69,7 @@ export const SimplePagination = ({ total, limit, currentPage, onPageChange }) =>
   return <Pagination {...{ total, limit, currentPage }} pageCount={5}>
     {({ pages, hasPreviousPage, previousPage, hasNextPage, nextPage, totalPages }) => {
       return <div style={styles.paginationRow}>
-        <div style={{ marginLeft: 'auto', marginRight: 24 }}>
+        <div style={{ marginLeft: 'auto', marginRight: '1rem' }}>
           {(currentPage - 1) * limit + 1} - {min([total, currentPage * limit])} of {total}
         </div>
         <PageButton onClick={hasPreviousPage ? (() => onPageChange(1)) : undefined}>

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -1,0 +1,116 @@
+import { map, min, range, toPairs } from 'lodash/fp';
+import * as React from 'react';
+import Pagination from 'react-paginating';
+import { nextSort } from '../utils/index';
+import { ClrIcon } from './icons';
+
+const rowHeight = 36;
+
+const styles = {
+  flexCell: ({ basis = 0, grow = 1, shrink = 1, min: minWidth = 0, max } = {} as any) => ({
+    flexGrow: grow,
+    flexShrink: shrink,
+    flexBasis: basis,
+    minWidth,
+    maxWidth: max
+  }),
+  headerRow: {
+    display: 'flex', height: rowHeight,
+    borderBottom: '1px solid #ccc', backgroundColor: '#fafafa'
+  },
+  bodyRow: {
+    display: 'flex', height: rowHeight,
+    borderTop: '1px solid #ddd', backgroundColor: 'white'
+  },
+  cell: {
+    display: 'flex', alignItems: 'center',
+    paddingLeft: 12, paddingRight: 12
+  },
+  paginationRow: {
+    display: 'flex', alignItems: 'center', height: 36,
+    border: '1px solid #ccc', backgroundColor: '#fafafa', fontSize: 13
+  }
+};
+
+export const SimpleTable = ({ columns, rowCount, rowProps }) => {
+  return <div style={{ border: '1px solid #ccc' }}>
+    <div style={styles.headerRow}>
+      {map(([i, { headerRenderer, size }]: any) => {
+        return <div key={i} style={{ ...styles.cell, ...styles.flexCell(size) }}>
+          {headerRenderer()}
+        </div>;
+      }, toPairs(columns))}
+    </div>
+    {map(rowIndex => {
+      const { style = {}, ...props } = rowProps ? rowProps({ rowIndex }) : {};
+      return <div key={rowIndex} style={{ ...styles.bodyRow, ...style }} {...props}>
+        {map(([i, { cellRenderer, size }]: any) => {
+          return <div key={i} style={{ ...styles.cell, ...styles.flexCell(size) }}>
+            {cellRenderer({ rowIndex })}
+          </div>;
+        }, toPairs(columns))}
+      </div>;
+    }, range(0, rowCount))}
+  </div>;
+};
+
+const PageButton = ({ active = false, onClick, children }) => {
+  return <div
+    style={{
+      cursor: 'pointer', padding: 4,
+      fontWeight: active ? 'bold' : undefined,
+      textDecoration: active ? 'underline' : undefined
+    }}
+    {...{ onClick, children }}
+  />;
+};
+
+export const SimplePagination = ({ total, limit, currentPage, onPageChange }) => {
+  return <Pagination {...{ total, limit, currentPage }} pageCount={5}>
+    {({ pages, hasPreviousPage, previousPage, hasNextPage, nextPage, totalPages }) => {
+      return <div style={styles.paginationRow}>
+        <div style={{ marginLeft: 'auto', marginRight: 24 }}>
+          {(currentPage - 1) * limit + 1} - {min([total, currentPage * limit])} of {total}
+        </div>
+        <PageButton onClick={hasPreviousPage ? (() => onPageChange(1)) : undefined}>
+          <ClrIcon shape='angle-double left' />
+        </PageButton>
+        <PageButton onClick={hasPreviousPage ? (() => onPageChange(previousPage)) : undefined}>
+          <ClrIcon shape='angle left' />
+        </PageButton>
+        {map(page => {
+          return <PageButton
+            key={page}
+            active={page === currentPage}
+            onClick={() => onPageChange(page)}
+          >{page}</PageButton>;
+        }, pages)}
+        <PageButton onClick={hasNextPage ? (() => onPageChange(nextPage)) : undefined}>
+          <ClrIcon shape='angle right' />
+        </PageButton>
+        <PageButton onClick={hasNextPage ? (() => onPageChange(totalPages)) : undefined}>
+          <ClrIcon shape='angle-double right' />
+        </PageButton>
+      </div>;
+    }}
+  </Pagination>;
+};
+
+export const SortableHeader = ({ sort, field, onSort, children }) => {
+  return <div
+    style={{ flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', minWidth: 0 }}
+    onClick={() => onSort(nextSort(sort, field))}
+  >
+    {children}
+    {sort.field === field && <div style={{ color: '#0079b8', marginLeft: 'auto' }}>
+      <ClrIcon shape={sort.direction === 'asc' ? 'arrow down' : 'arrow'} />
+    </div>}
+  </div>;
+};
+
+export const TextCell = ({ style = {}, ...props }) => {
+  return <div
+    style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', ...style }}
+    {...props}
+  />;
+};

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -116,3 +116,9 @@ export const withWindowSize = () => WrappedComponent => {
   }
   return Wrapper as any;
 };
+
+export const nextSort = ({ field, direction }, newField) => {
+  return newField === field ?
+    { field, direction: direction === 'asc' ? 'desc' : 'asc' } :
+    { field: newField, direction: 'asc' };
+};

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6677,6 +6677,11 @@ react-onclickoutside@^6.7.1:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
   integrity sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
 
+react-paginating@^1.0.3-react16.0:
+  version "1.0.3-react16.0"
+  resolved "https://registry.yarnpkg.com/react-paginating/-/react-paginating-1.0.3-react16.0.tgz#a49579e6963e8ec1f307da46dd3929c480837762"
+  integrity sha512-Kr/IBfTdAyudzRAOBrKcmhpdKMD4C5nHaJFCU/nz3k9AJhsHI1KWEpm/DweDgZp1j9g5ig9dmqCEkkSelHe+iA==
+
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"


### PR DESCRIPTION
This adds some basic components for tables, pagination, and sortable headers. The style is currently modeled on the Clarity table, but that can be changed later. The current implementation does a basic flex layout, which works best for small tables with limited rows and columns, but it could be replaced with a "virtual scroll" implementation later, if desired.