### PR TITLE
[risk=no] add buttons

### DIFF
--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+const styles = {
+  base: ({ disabled }) => ({
+    display: 'inline-flex', justifyContent: 'space-around', alignItems: 'center',
+    height: '1.5rem', minWidth: '3rem', maxWidth: '15rem',
+    fontWeight: 500, fontSize: 12, letterSpacing: '0.02rem', textTransform: 'uppercase',
+    overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis',
+    cursor: disabled ? undefined : 'pointer', userSelect: 'none',
+    margin: 0, padding: '0rem 0.77rem',
+  }),
+  primary: ({ hover, disabled }) => ({
+    border: 'none',
+    backgroundColor: disabled ? '#c3c3c3' : (hover ? '#4356A7' : '#262262'),
+    borderRadius: '0.3rem',
+    color: '#fff',
+  }),
+  secondary: ({ hover, disabled }) => ({
+    border: '2px solid',
+    borderColor: disabled ? '#c3c3c3' : '#262262',
+    backgroundColor: disabled ? '#f1f2f2' : (hover ? '#262262' : '#ffffff'),
+    borderRadius: '0.2rem',
+    color: disabled ? '#c3c3c3' : (hover ? '#ffffff' : '#262262'),
+  })
+};
+
+class HoverContainer extends React.Component<
+  { children: ({ hover: boolean, trackHover: Function }) => React.ReactNode },
+  { hover: boolean }
+> {
+  constructor(props) {
+    super(props);
+    this.state = { hover: false };
+  }
+
+  trackHover = el => {
+    return React.cloneElement(el, {
+      onMouseEnter: (...args) => {
+        if (el.props.onMouseEnter) {
+          el.props.onMouseEnter(...args);
+        }
+        this.setState({ hover: true });
+      },
+      onMouseLeave: (...args) => {
+        if (el.props.onMouseLeave) {
+          el.props.onMouseLeave(...args);
+        }
+        this.setState({ hover: false });
+      }
+    });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { hover } = this.state;
+    return children({ hover, trackHover: this.trackHover });
+  }
+}
+
+export const Clickable = ({ disabled = false, onClick = null, ...props }) => {
+  return <div
+    {...props}
+    onClick={(...args) => onClick && !disabled && onClick(...args)}
+  />;
+};
+
+export const Button = ({ type = 'primary', style = {}, disabled = false, ...props }) => {
+  return <HoverContainer>
+    {({ hover, trackHover }) => {
+      return trackHover(<Clickable
+        {...{ disabled, ...props }}
+        style={{ ...styles.base({ disabled }), ...styles[type]({ hover, disabled }), ...style }}
+      />);
+    }}
+  </HoverContainer>;
+};

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -24,6 +24,11 @@ const styles = {
   })
 };
 
+/*
+ * Uses the function-as-child technique. The children function is called with:
+ *   hover: the current hover state
+ *   trackHover: transforms an element, adds hooks to track hover state
+ */
 class HoverContainer extends React.Component<
   { children: ({ hover: boolean, trackHover: Function }) => React.ReactNode },
   { hover: boolean }


### PR DESCRIPTION
This adds a basic button component with the existing style variants. Usage is like this:
`<Button onClick={...}>Save</Button>`
`<Button type='secondary' onClick={...}>Cancel</Button>`

There's a lightweight wrapper for tracking hover state. We can decide later whether it's worth bringing in a heavier library like `react-interactive` later.

The lower level `Clickable` component can serve as a useful abstraction of basic button-like behavior (specifically disabled state), without any styling baked in. It can be used as a base for one-off icon buttons, menu items, etc.

Note: This is currently using a div element without any accessibility attributes, due to some unfortunate browser behavior around disabled buttons. So it does not score well from a screen reader or keyboard perspective. Looking at the existing code, it didn't seem like this was a priority, so I left it alone for now, but this could be improved later if desired.