### PR TITLE
[risk=no] add react-modal

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -95,6 +95,7 @@
     "react": "^16.6.3",
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.6.3",
+    "react-modal": "^3.8.1",
     "react-onclickoutside": "^6.7.1",
     "react-paginating": "^1.0.3-react16.0",
     "redux": "^3.7.2",

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -1,57 +1,48 @@
 import * as React from 'react';
-export const styles = {
-  modalMain: {
-    // tricky little bit required to get certain CSSProperties
-    // to work properly in this setup
-    position: 'fixed' as 'fixed',
-    background: 'white',
-    borderRadius: '8px',
-    width: '30%',
-    height: 'auto',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%,-50%)',
-    zIndex: 1050
+import ReactModal from 'react-modal';
+import {ReactComponent} from '../utils/index';
+
+const styles = {
+  modal: {
+    borderRadius: 8, position: 'relative',
+    padding: '1rem', outline: 'none',
+    backgroundColor: 'white', boxShadow: '0 1px 2px 2px rgba(0,0,0,.2)'
   },
 
-  modalBackdrop: {
-    position: 'fixed' as 'fixed',
-    top: 0,
-    bottom: 0,
-    right: 0,
-    left: 0,
-    backgroundColor: '#313131',
-    opacity: .85,
-    zIndex: 1040
+  overlay: {
+    backgroundColor: 'rgba(49, 49, 49, 0.85)', padding: '2rem 1rem',
+    display: 'flex', justifyContent: 'center', alignItems: 'flex-start',
+    position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
   },
 
   modalTitle: {
-    marginTop: '4%',
-    marginLeft: '5%',
     fontSize: '20px',
-    color: '#302973'
+    color: '#302973',
+    marginBottom: '1rem'
   },
 
   modalBody: {
     fontSize: '14px',
     lineHeight: '.8rem',
-    marginLeft: '5%',
-    marginTop: '3%'
   },
 
   modalFooter: {
     display: 'flex' as 'flex',
     justifyContent: 'flex-end' as 'flex-end',
-    marginBottom: '.4rem',
-    marginRight: '.4rem',
-    marginTop: '.4rem'
+    marginTop: '1rem'
   }
 };
 
-export const Modal = ({style = {}, ...props}) => {
-  return <div><div style={{...styles.modalBackdrop}} />
-    <div {...props} style={{...styles.modalMain, ...style}} /></div>;
+export const Modal = ({width = 450, ...props}) => {
+  return <ReactModal
+    parentSelector={() => document.getElementById('popup-root')}
+    isOpen
+    style={{overlay: styles.overlay, content: {...styles.modal, width}}}
+    ariaHideApp={false}
+    {...props}
+  />;
 };
+
 export const ModalTitle = ({style = {}, ...props}) =>
   <div {...props} style={{...styles.modalTitle, ...style}} />;
 export const ModalBody = ({style = {}, ...props}) =>

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -5,13 +5,12 @@ import {ReactComponent} from '../utils/index';
 const styles = {
   modal: {
     borderRadius: 8, position: 'relative',
-    padding: '1rem', outline: 'none',
+    padding: '1rem', margin: 'auto', outline: 'none',
     backgroundColor: 'white', boxShadow: '0 1px 2px 2px rgba(0,0,0,.2)'
   },
 
   overlay: {
-    backgroundColor: 'rgba(49, 49, 49, 0.85)', padding: '2rem 1rem',
-    display: 'flex', justifyContent: 'center', alignItems: 'flex-start',
+    backgroundColor: 'rgba(49, 49, 49, 0.85)', padding: '1rem', display: 'flex',
     position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
   },
 

--- a/ui/src/app/views/account-creation-modals/component.tsx
+++ b/ui/src/app/views/account-creation-modals/component.tsx
@@ -60,9 +60,10 @@ export class AccountCreationResendModalReact extends
   }
 
   render() {
+    const { closeFunction } = this.props;
     return <React.Fragment>
       {this.props.resend &&
-      <Modal id='resend-instructions'>
+      <Modal onRequestClose={closeFunction}>
         <ModalTitle>Resend Instructions</ModalTitle>
         <ModalFooter>
           <button type='button' className='btn btn-outline'
@@ -145,9 +146,10 @@ export class AccountCreationUpdateModalReact extends
   }
 
   render() {
+    const { closeFunction } = this.props;
     return <React.Fragment>
       {this.props.update &&
-      <Modal>
+      <Modal onRequestClose={closeFunction}>
         <ModalTitle>Change contact email</ModalTitle>
         <ModalBody>
           <table style={{width: '100%'}}>
@@ -165,7 +167,7 @@ export class AccountCreationUpdateModalReact extends
             </tr>
             <tr>
               <td></td>
-              <td style={{width: '76%'}}>
+              <td style={{width: '70%'}}>
                 {this.showEmailValidationError() &&
                 <Error>Email is not valid.</Error>
                 }

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,7 +1,9 @@
 // The main file is boilerplate; AppModule configures our app.
 
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import ReactModal from 'react-modal';
 
 import {AppModule} from 'app/app.module';
 
+ReactModal.defaultStyles = { overlay: {}, content: {} };
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2989,6 +2989,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -6357,7 +6362,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6562,6 +6567,21 @@ react-dom@^16.6.3:
 react-is@^16.6.1, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-modal@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.8.1.tgz#7300f94a6f92a2e17994de0be6ccb61734464c9e"
+  integrity sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
 
 react-onclickoutside@^6.7.1:
   version "6.7.1"
@@ -8177,6 +8197,13 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
This introduces the `react-modal` library for backing our modal implementation. Main benefits:
* The modal is rendered in a 'portal', meaning the markup appears at the end of the body element. This ensures that it always appears over the main content without worrying about z-index.
* It does focus management, ensuring that a user cannot tab out and interact with the underlying page while the modal is open.

It also has hooks for doing animations, if we want to wire that up at some point.