### PR TITLE
[risk=no] Uglier but AoT friendly ReactWrapper approach

### DIFF
--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import ReactModal from 'react-modal';
-import {ReactComponent} from '../utils/index';
 
 const styles = {
   modal: {

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -1,5 +1,4 @@
-import {Component, DoCheck, ElementRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {Router} from '@angular/router';
+import {DoCheck, ElementRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {fromJS} from 'immutable';
 import {
   find,
@@ -164,7 +163,8 @@ export function cookiesEnabled(): boolean {
 export class ReactWrapperBase implements DoCheck, OnInit, OnDestroy {
   @ViewChild('root') rootElement: ElementRef;
 
-  constructor(private wrapped: any, private propNames: string[]) {}
+  constructor(private wrapped: new (...args: any[]) => React.Component,
+              private propNames: string[]) {}
 
   ngOnInit(): void {
     this.renderComponent();

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -152,39 +152,39 @@ export function cookiesEnabled(): boolean {
     }
 }
 
-export const ReactComponent = ({ propNames = [], ...options }) => WrappedComponent => {
-  class WrapperComponent implements DoCheck, OnInit, OnDestroy {
-    @ViewChild('root')
-    rootElement: ElementRef;
+/**
+ * Helper base class for defining an Angular-wrapped React component. This is a
+ * stop-gap for React migration.
+ *
+ * Requirements:
+ *  - Component template must contain a div labeled "#root".
+ *  - React propNames must exactly match instance property names on the subclass
+ *    (usually these are also annotated as Angular @Inputs)
+ */
+export class ReactWrapperBase implements DoCheck, OnInit, OnDestroy {
+  @ViewChild('root') rootElement: ElementRef;
 
-    ngOnInit(): void {
-      this.renderComponent();
-    }
+  constructor(private wrapped: any, private propNames: string[]) {}
 
-    ngDoCheck(): void {
-      this.renderComponent();
-    }
-
-    ngOnDestroy(): void {
-      ReactDOM.unmountComponentAtNode(this.rootElement.nativeElement);
-    }
-
-    renderComponent(): void {
-      ReactDOM.render(
-        React.createElement(
-          WrappedComponent,
-          fromPairs(propNames.map(name => [name, this[name]]))
-        ),
-        this.rootElement.nativeElement
-      );
-    }
+  ngOnInit(): void {
+    this.renderComponent();
   }
-  propNames.forEach(name => {
-    Input()(WrapperComponent.prototype, name, undefined);
-  });
 
-  return Component({
-    ...options,
-    template: '<div #root></div>'
-  })(WrapperComponent) as any;
-};
+  ngDoCheck(): void {
+    this.renderComponent();
+  }
+
+  ngOnDestroy(): void {
+    ReactDOM.unmountComponentAtNode(this.rootElement.nativeElement);
+  }
+
+  renderComponent(): void {
+    ReactDOM.render(
+      React.createElement(
+        this.wrapped,
+        fromPairs(this.propNames.map(name => [name, this[name]]))
+      ),
+      this.rootElement.nativeElement
+    );
+  }
+}

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -188,4 +188,3 @@ export class ReactWrapperBase implements DoCheck, OnInit, OnDestroy {
     );
   }
 }
-

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -163,7 +163,7 @@ export function cookiesEnabled(): boolean {
 export class ReactWrapperBase implements DoCheck, OnInit, OnDestroy {
   @ViewChild('root') rootElement: ElementRef;
 
-  constructor(private wrapped: new (...args: any[]) => React.Component,
+  constructor(private wrapped: (new (...args: any[]) => React.Component)|React.FunctionComponent,
               private propNames: string[]) {}
 
   ngOnInit(): void {
@@ -188,3 +188,4 @@ export class ReactWrapperBase implements DoCheck, OnInit, OnDestroy {
     );
   }
 }
+


### PR DESCRIPTION
## Issue
There are AoT [compilation issues](https://gist.github.com/chuckjaz/65dcc2fd5f4f5463e492ed0cb93bca60#ahead-of-time-aot-compile) with the current `@ReactComponent` decorator approach. The compile error isn't totally clear, but I suspect it's stemming from having a functional decorator that returns another decorator (at least, that's the first error we hit when using this approach):

```
./project.rb build --environment test
...
ERROR in app/views/rename-modal/component.tsx.ts(25,2): Error during template compile of 'RenameModalComponent'
  Function expressions are not supported in decorators in 'ReactComponent'
    'ReactComponent' contains the error at app/utils/index.ts(155,31)
      Consider changing the function expression into an exported function.
```

I also tried switching `ReactComponent` to be an exported function, and my new error was:

```
ERROR in : Unexpected value 'RenameModalComponent in /w/ui/src/app/views/rename-modal/component.tsx' declared by the module 'AppModule in /w/ui/src/app/app.module.ts'. Please add a @Pipe/@Directive/@Component annotation.
```

## Options
- Possibly there are other ways to satisfy the compiler; I tried a few obvious things without luck but there may be a way to fix the current approach
- Stop using --aot during the migration or indefinitely (especially makes sense if we decide to stop using Typescript)
- Switch to the uglier, but compiler-friendly approach outlined by this PR


Here's what the approaches look like...

Before:
```
@ReactComponent({
  selector: 'app-rename-modal',
  propNames: ['resource', 'onRename', 'onCancel']
})
export class RenameModalComponent extends React.Component {
  ...
}
```

After:
```
export class RenameModal extends React.Component {
  ...
}

@Component({
  selector: 'app-rename-modal',
  template: '<div #root></div>'
})
export class RenameModalComponent extends ReactWrapperBase {
  @Input('resource') resource: RenameModalProps['resource'];
  @Input('onRename') onRename: RenameModalProps['onRename'];
  @Input('onCancel') onCancel: RenameModalProps['onCancel'];

  constructor() {
    super(RenameModal, ['resource', 'onRename', 'onCancel']);
  }
}
```