### PR TITLE
[risk=no] CSS typing proposal

### DIFF
--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -154,7 +154,7 @@ export function cookiesEnabled(): boolean {
 
 type ReactStyles<T> = {
   readonly [P in keyof T]: React.CSSProperties;
-}
+};
 
 /**
  * Helper to assert the React.CSSProperties type for all properties in a tuple,

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -152,6 +152,35 @@ export function cookiesEnabled(): boolean {
     }
 }
 
+type ReactStyles<T> = {
+  readonly [P in keyof T]: React.CSSProperties;
+}
+
+/**
+ * Helper to assert the React.CSSProperties type for all properties in a tuple,
+ * while maintaining property names. This will fail compilation if input CSS
+ * properties are invalid and will avoid the need for a type assertion on the
+ * output. Also makes the properties readonly.
+ *
+ * This is a workaround to an issue in the Typescript compiler which should
+ * eventually be fixed: https://github.com/Microsoft/TypeScript/issues/11152.
+ *
+ * This approach works only with a single-level nested tuples currently:
+ * const styles = reactStyles({
+ *   style1: {color: 'red'},
+ *   style2: {color: 'blue', position: 'relative'}
+ * });
+ *
+ * Alternatively, style tuples can be cast individually (with arbitrary nesting):
+ * const styles = {
+ *   style1: {color: 'red'} as React.CssProperties,
+ *   style2: {color: 'blue', position: 'relative'} as React.CssProperties
+ * };
+ */
+export function reactStyles<T extends {[key: string]: React.CSSProperties}>(t: T): ReactStyles<T> {
+  return t;
+}
+
 export const ReactComponent = ({ propNames = [], ...options }) => WrappedComponent => {
   class WrapperComponent implements DoCheck, OnInit, OnDestroy {
     @ViewChild('root')

--- a/ui/src/app/views/quick-tour-modal/component.tsx
+++ b/ui/src/app/views/quick-tour-modal/component.tsx
@@ -1,4 +1,7 @@
 import {Component, DoCheck, Input, OnInit} from '@angular/core';
+
+import {reactStyles} from 'app/utils';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -89,9 +92,7 @@ export const panels = [
       image: '/assets/images/notebooks.png'
     }];
 
-
-/** @type {{search: React.CSSProperties}} */
-const styles = {
+const styles = reactStyles({
   modalBackdrop: {
     position: 'fixed',
     top: 0,
@@ -101,7 +102,7 @@ const styles = {
     backgroundColor: '#313131',
     opacity: .8,
     zIndex: 1040,
-  } as React.CSSProperties,
+  },
   mainStyling: {
     height: '79.23%',
     width: '80%',
@@ -112,7 +113,7 @@ const styles = {
     left: '10%',
     top: '1%',
     zIndex: 1050,
-  } as React.CSSProperties,
+  },
   title: {
     color: '#FFFFFF',
     marginTop: '2%',
@@ -120,7 +121,7 @@ const styles = {
     fontSize: '21px',
     width: '100%',
     fontWeight: 500
-  } as React.CSSProperties,
+  },
   mainTitle: {
     color: '#FFFFFF',
     fontSize: '48px',
@@ -128,27 +129,27 @@ const styles = {
     marginTop: '3%',
     marginLeft: '3%',
     fontWeight: 'bold'
-  } as React.CSSProperties,
+  },
   breadcrumbs: {
     width: '100%',
     marginTop: '5%',
     justifyContent: 'center',
     display: 'flex',
     flexDirection: 'row'
-  } as React.CSSProperties,
+  },
   circle: {
     border: '2px solid #8C9BA5',
     borderRadius: '50%',
     height: '21.92px',
     width: '21.92px',
     left: '21.92px'
-  } as React.CSSProperties,
+  },
   check: {
     minHeight: '10px',
     minWidth: '10px',
     marginLeft: '2px',
     marginTop: '-3px'
-  } as React.CSSProperties,
+  },
   current: {
     minHeight: '12px',
     minWidth: '12px',
@@ -157,7 +158,7 @@ const styles = {
     backgroundColor: '#2691D0',
     borderRadius: '50%',
     display: 'inline-block'
-  } as React.CSSProperties,
+  },
   connector: {
     border: '2px solid #8C9BA5',
     boxSizing: 'border-box',
@@ -166,12 +167,12 @@ const styles = {
     position: 'relative',
     left: '21.92px',
     top: '-36px'
-  } as React.CSSProperties,
+  },
   breadcrumbTitle: {
     transform: 'translate(-40%)',
     textAlign: 'center',
     color: '#2691D0'
-  } as React.CSSProperties,
+  },
 
   divider: {
     boxSizing: 'border-box',
@@ -180,27 +181,27 @@ const styles = {
     border: '0.5px solid #FFFFFF',
     boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
     margin: 'auto'
-  } as React.CSSProperties,
+  },
   panel: {
     marginTop: '5%',
     width: '100%',
     height: '30%',
     display: 'flex'
-  } as React.CSSProperties,
+  },
   panelTitle: {
     width: '100%',
     marginLeft: '5%',
     color: '#FFFFFF',
     fontSize: '28px',
     fontWeight: 'bold'
-  } as React.CSSProperties,
+  },
   panelContents: {
     paddingLeft: '5%',
     marginTop: '1%',
     color: '#FFFFFF',
     fontSize: '14px',
     textAlign: 'left'
-  } as React.CSSProperties,
+  },
   panelText: {
     marginRight: '2%',
     paddingTop: '.5%',
@@ -208,7 +209,7 @@ const styles = {
     lineHeight: '24px',
     whiteSpace: 'pre-line',
     textAlign: 'left'
-  } as React.CSSProperties,
+  },
   panelRight: {
     marginRight: '5%',
     marginBottom: '5%',
@@ -217,7 +218,7 @@ const styles = {
     position: 'relative',
     display: 'flex',
     justifyContent: 'flex-end'
-  } as React.CSSProperties,
+  },
   panelImage: {
     width: '78%',
     height: '95%',
@@ -226,29 +227,30 @@ const styles = {
     position: 'relative',
     zIndex: 1,
     display: 'inline'
-  } as React.CSSProperties,
+  },
   controls: {
     width: '100%',
     position: 'absolute',
     bottom: '8%',
     display: 'flex',
     justifyContent: 'space-between'
-  } as React.CSSProperties
-};
+  }
+});
+
 
 const completedStyles = {
   circleCompleted: Object.assign(
-      styles.circle,
-      {
-        left: '0px',
-        border: '2px solid #2691D0',
-      }
+    styles.circle,
+    {
+      left: '0px',
+      border: '2px solid #2691D0',
+    }
   ),
   connectorCompleted: Object.assign(
-      styles.connector,
-      {
-        border: '2px solid #2691D0'
-      }
+    styles.connector,
+    {
+      border: '2px solid #2691D0'
+    }
   )
 };
 


### PR DESCRIPTION
I went down a bit of a rabbit hole here... but ultimately the behavior is pretty close to what we want with minimal boilerplate. Only real limitation is incompatibility with arbitrary levels of style tuple nesting.

Also, eventually the TS compiler should just handle this for us: https://github.com/Microsoft/TypeScript/issues/11152

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
