### PR TITLE
[No Ticket][Risk=no] Rip angular out of account creation modals

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -20,7 +20,6 @@ import {StatusCheckService} from './services/status-check.service';
 import {WorkspaceStorageService} from './services/workspace-storage.service';
 import {cookiesEnabled, WINDOW_REF} from './utils';
 
-import {AccountCreationModalsComponent} from './views/account-creation-modals/component';
 import {AccountCreationSuccessComponent} from './views/account-creation-success/component';
 import {AccountCreationComponent} from './views/account-creation/component';
 import {AdminReviewIdVerificationComponent} from './views/admin-review-id-verification/component';
@@ -133,7 +132,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
   ],
   declarations: [
     AccountCreationComponent,
-    AccountCreationModalsComponent,
     AccountCreationSuccessComponent,
     AdminReviewWorkspaceComponent,
     AdminReviewIdVerificationComponent,

--- a/ui/src/app/views/account-creation-modals/component.tsx
+++ b/ui/src/app/views/account-creation-modals/component.tsx
@@ -38,11 +38,6 @@ interface AccountCreationResendModalProps {
 
 export class AccountCreationResendModalReact extends
     React.Component<AccountCreationResendModalProps, {}> {
-  constructor(props: AccountCreationResendModalProps) {
-    super(props);
-    this.state = {};
-  }
-
   send() {
     const request: ResendWelcomeEmailRequest = {
       username: this.props.username,
@@ -185,53 +180,5 @@ export class AccountCreationUpdateModalReact extends
         </ModalFooter>
       </Modal>}
     </React.Fragment>;
-  }
-
-}
-
-@Component({
-  selector: 'app-account-creation-modals',
-  templateUrl: './component.html',
-})
-
-export class AccountCreationModalsComponent implements OnInit, DoCheck {
-  @Input('updateEmail')
-  public updateEmail: Function;
-  @Input('close')
-  public close: Function;
-  @Input('username')
-  public userName: string;
-  @Input('creationNonce')
-  public creationNonce: string;
-  @Input('update')
-  public update: boolean;
-  @Input('resend')
-  public resend: boolean;
-
-  constructor(
-  ) {}
-
-  renderModal(): void {
-    let component;
-    const props = {username: this.userName, creationNonce: this.creationNonce,
-                   closeFunction: this.close};
-    if (this.resend) {
-      component = AccountCreationResendModalReact;
-      props['resend'] = this.resend;
-    } else {
-      component = AccountCreationUpdateModalReact;
-      props['passNewEmail'] = this.updateEmail;
-      props['update'] = this.update;
-    }
-    ReactDOM.render(React.createElement(component, props),
-      document.getElementById('account-creation-modal'));
-  }
-
-  ngOnInit(): void {
-    this.renderModal();
-  }
-
-  ngDoCheck(): void {
-    this.renderModal();
   }
 }


### PR DESCRIPTION
Now that the modals are only called from react components, we should be able to rip out all the angular cruft.
<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
