### PR TITLE
DB-190 [Wildcard* search causing issue on source vocabulary search]

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -19,7 +19,6 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptListResponse;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.SearchType;
 import org.pmiops.workbench.model.DomainCount;
 import org.pmiops.workbench.model.DomainInfoResponse;
 import org.pmiops.workbench.model.SearchConceptsRequest;
@@ -187,7 +186,7 @@ public class ConceptsController implements ConceptsApiDelegate {
       standardConceptFilter = StandardConceptFilter.ALL_CONCEPTS;
     }
 
-    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery(), SearchType.CONCEPT_SEARCH);
+    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery(), ConceptService.SearchType.CONCEPT_SEARCH);
     // TODO: consider doing these queries in parallel
     ConceptListResponse response = new ConceptListResponse();
     addDomainCounts(request, response, matchExp, standardConceptFilter);

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -186,7 +186,7 @@ public class ConceptsController implements ConceptsApiDelegate {
       standardConceptFilter = StandardConceptFilter.ALL_CONCEPTS;
     }
 
-    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery());
+    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery(), "concept_search");
     // TODO: consider doing these queries in parallel
     ConceptListResponse response = new ConceptListResponse();
     addDomainCounts(request, response, matchExp, standardConceptFilter);

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -19,6 +19,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptListResponse;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.SearchType;
 import org.pmiops.workbench.model.DomainCount;
 import org.pmiops.workbench.model.DomainInfoResponse;
 import org.pmiops.workbench.model.SearchConceptsRequest;
@@ -186,7 +187,7 @@ public class ConceptsController implements ConceptsApiDelegate {
       standardConceptFilter = StandardConceptFilter.ALL_CONCEPTS;
     }
 
-    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery(), "concept_search");
+    String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery(), SearchType.CONCEPT_SEARCH);
     // TODO: consider doing these queries in parallel
     ConceptListResponse response = new ConceptListResponse();
     addDomainCounts(request, response, matchExp, standardConceptFilter);

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -422,11 +422,6 @@ definitions:
     description: match column type on concept search
     enum: [CONCEPT_CODE, CONCEPT_ID, CONCEPT_NAME]
 
-  SearchType:
-    type: string
-    description: search type
-    enum: &SEARCH_TYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
-
   Concept:
     description: A concept describing a type of entity (e.g. measurement, observation, procedure.)
     type: object

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -424,7 +424,7 @@ definitions:
 
   SearchType:
     type: string
-    descrption: search type
+    description: search type
     enum: &SEARCH_TYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
 
   Concept:

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -422,6 +422,11 @@ definitions:
     description: match column type on concept search
     enum: [CONCEPT_CODE, CONCEPT_ID, CONCEPT_NAME]
 
+  SearchType:
+    type: string
+    descrption: search type
+    enum: &SEARCH_TYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
+
   Concept:
     description: A concept describing a type of entity (e.g. measurement, observation, procedure.)
     type: object

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -74,6 +74,7 @@ public class ConceptService {
         List<String> temp = new ArrayList<>();
         for (String key: keywords) {
             String tempKey;
+            // This is to exact match concept codes like 100.0, 507.01. Without this mysql was matching 100*, 507*.
             if (key.contains(".")) {
                 tempKey = "\"" + key + "\"";
             } else {
@@ -90,6 +91,11 @@ public class ConceptService {
                     if (key.length() < 3) {
                         temp.add(key);
                     } else {
+                        // Only in the case of calling this method from getDomainSearchResults to fetch survey counts add wildcard* search.
+                        // The survey view angular code fetches all the results of each survey module and then checks if the search text is present in the concept name / stratum4 of achilles results using regex test.
+                        // Without this the number of results for search smoke would be 6 while also the actual results would be 12 as smoking, smoked (smoke*) are considered.
+                        // Changing this would address the search count discrepancy for survey results. If * wildcard is added to all search types, source vocabulary code match on 507 fetches all the results matching 507*. (which is not desired to show the source / standard code mapping)
+                        // So added different search type for each purpose
                         if (searchType == SearchType.SURVEY_COUNTS) {
                             temp.add(new String("+" + key + "*"));
                         } else {
@@ -158,6 +164,7 @@ public class ConceptService {
                           try {
                             long conceptId = Long.parseLong(query);
                             standardOrCodeOrIdMatch.add(criteriaBuilder.equal(root.get("conceptId"),
+
                                 criteriaBuilder.literal(conceptId)));
                           } catch (NumberFormatException e) {
                             // Not a long, don't try to match it to a concept ID.

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -64,7 +64,7 @@ public class ConceptService {
         this.conceptDao = conceptDao;
     }
 
-    public static String modifyMultipleMatchKeyword(String query) {
+    public static String modifyMultipleMatchKeyword(String query, String purpose) {
         // This function modifies the keyword to match all the words if multiple words are present(by adding + before each word to indicate match that matching each word is essential)
         if (query == null || query.trim().isEmpty()) {
             return null;
@@ -82,7 +82,11 @@ public class ConceptService {
                     if (key.length() < 3) {
                         temp.add(key);
                     } else {
-                        temp.add(new String("+" + key + "*"));
+                        if (purpose.equalsIgnoreCase("survey_counts")) {
+                            temp.add(new String("+" + key + "*"));
+                        } else {
+                            temp.add(new String("+" + key));
+                        }
                     }
                 }
             }
@@ -118,7 +122,7 @@ public class ConceptService {
                     nonStandardConceptPredicates.add(criteriaBuilder.notEqual(root.get("standardConcept"),
                             criteriaBuilder.literal(CLASSIFICATION_CONCEPT_CODE)));
 
-                    final String keyword = modifyMultipleMatchKeyword(query);
+                    final String keyword = modifyMultipleMatchKeyword(query, "concept_search");
 
                     if (keyword != null) {
                       Expression<Double> matchExp = criteriaBuilder.function("matchConcept", Double.class,

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -18,10 +18,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import org.pmiops.workbench.model.SearchType;
 
 @Service
 public class ConceptService {
+
+    public static enum SearchType
+    {
+        CONCEPT_SEARCH, SURVEY_COUNTS, DOMAIN_COUNTS;
+    }
 
     public static class ConceptIds {
 

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -22,8 +22,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ConceptService {
 
-    public static enum SearchType
-    {
+    public static enum SearchType {
         CONCEPT_SEARCH, SURVEY_COUNTS, DOMAIN_COUNTS;
     }
 

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
@@ -16,7 +16,7 @@ public interface SurveyModuleDao extends CrudRepository<SurveyModule, Long> {
   @Query(nativeQuery=true,value="select m.name, m.description,\n" +
       "m.concept_id, COUNT(DISTINCT c.concept_id) as question_count,\n" +
       // We don't show participant counts when filtering by keyword, and don't have a way of computing them easily; return 0.
-      "0 participant_count\n" +
+      "0 participant_count, m.order_number \n" +
       "from survey_module m\n" +
       "join achilles_results r on m.concept_id = r.stratum_1\n" +
       "join concept c on r.stratum_2 = c.concept_id\n" +
@@ -26,7 +26,7 @@ public interface SurveyModuleDao extends CrudRepository<SurveyModule, Long> {
       "and (match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against (?1 in boolean mode) > 0 or\n" +
       "match(r.stratum_4) against(?1 in boolean mode) > 0)\n" +
       "group by m.name, m.description, m.concept_id\n" +
-      "order by m.name")
+      "order by m.order_number")
   List<SurveyModule> findSurveyModuleQuestionCounts(String matchExpression);
 
   SurveyModule findByConceptId(long conceptId);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
@@ -23,7 +23,7 @@ public interface SurveyModuleDao extends CrudRepository<SurveyModule, Long> {
       "where r.analysis_id = 3110\n" +
       // Because we're using a native query we use MySQL match() here directly instead of matchConcept()
       // TODO: add AchillesResults entity, replace this with JQL
-      "and (match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against (?1 in boolean mode) > 0 or\n" +
+      "and (match(c.concept_name) against (?1 in boolean mode) > 0 or\n" +
       "match(r.stratum_4) against(?1 in boolean mode) > 0)\n" +
       "group by m.name, m.description, m.concept_id\n" +
       "order by m.order_number")

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/SurveyModule.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/SurveyModule.java
@@ -19,7 +19,8 @@ public class SurveyModule {
               .name(surveyModule.getName())
               .description(surveyModule.getDescription())
               .questionCount(surveyModule.getQuestionCount())
-              .participantCount(surveyModule.getParticipantCount());
+              .participantCount(surveyModule.getParticipantCount())
+              .orderNumber(surveyModule.getOrderNumber());
 
   private long conceptId;
   private String name;

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -43,11 +43,6 @@ definitions:
     description: a domain for concepts corresponding to a table in the OMOP schema
     enum: &DOMAIN [OBSERVATION, PROCEDURE, DRUG, CONDITION, MEASUREMENT, DEVICE, DEATH, VISIT]
 
-  SearchType:
-    type: string
-    description: type of search
-    enum: &SEARCH_TYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
-
   CdrVersionListResponse:
     type: object
     required:

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -46,7 +46,7 @@ definitions:
   SearchType:
     type: string
     description: type of search
-    enum: &SEARCHTYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
+    enum: &SEARCH_TYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
 
   CdrVersionListResponse:
     type: object

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -43,6 +43,11 @@ definitions:
     description: a domain for concepts corresponding to a table in the OMOP schema
     enum: &DOMAIN [OBSERVATION, PROCEDURE, DRUG, CONDITION, MEASUREMENT, DEVICE, DEATH, VISIT]
 
+  SearchType:
+    type: string
+    description: type of search
+    enum: &SEARCHTYPE [SURVEY_COUNTS, DOMAIN_COUNTS, CONCEPT_SEARCH]
+
   CdrVersionListResponse:
     type: object
     required:

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -116,6 +116,7 @@ definitions:
       - description
       - questionCount
       - participantCount
+      - orderNumber
     properties:
       conceptId:
         description: the concept ID for the survey module
@@ -135,6 +136,10 @@ definitions:
         description: number of participants with data in the CDR for questions in this module
         type: integer
         format: int64
+      orderNumber:
+        description: survey release order number
+        type: integer
+        format: int32
 
   ErrorResponse:
     type: object

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -37,7 +37,6 @@ import org.pmiops.workbench.model.ConceptAnalysis;
 import org.pmiops.workbench.model.ConceptListResponse;
 import org.pmiops.workbench.model.SearchConceptsRequest;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.SearchType;
 import org.pmiops.workbench.model.MatchType;
 import org.pmiops.workbench.model.QuestionConceptListResponse;
 import org.pmiops.workbench.model.ConceptAnalysisListResponse;
@@ -307,8 +306,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     @Override
     public ResponseEntity<DomainInfosAndSurveyModulesResponse> getDomainSearchResults(String query){
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
-        String domainKeyword = ConceptService.modifyMultipleMatchKeyword(query, SearchType.DOMAIN_COUNTS);
-        String surveyKeyword = ConceptService.modifyMultipleMatchKeyword(query, SearchType.SURVEY_COUNTS);
+        String domainKeyword = ConceptService.modifyMultipleMatchKeyword(query, ConceptService.SearchType.DOMAIN_COUNTS);
+        String surveyKeyword = ConceptService.modifyMultipleMatchKeyword(query, ConceptService.SearchType.SURVEY_COUNTS);
         Long conceptId = 0L;
         try {
             conceptId = Long.parseLong(query);

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -37,6 +37,7 @@ import org.pmiops.workbench.model.ConceptAnalysis;
 import org.pmiops.workbench.model.ConceptListResponse;
 import org.pmiops.workbench.model.SearchConceptsRequest;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.SearchType;
 import org.pmiops.workbench.model.MatchType;
 import org.pmiops.workbench.model.QuestionConceptListResponse;
 import org.pmiops.workbench.model.ConceptAnalysisListResponse;
@@ -306,8 +307,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     @Override
     public ResponseEntity<DomainInfosAndSurveyModulesResponse> getDomainSearchResults(String query){
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
-        String domainKeyword = ConceptService.modifyMultipleMatchKeyword(query, "domain_counts");
-        String surveyKeyword = ConceptService.modifyMultipleMatchKeyword(query, "survey_counts");
+        String domainKeyword = ConceptService.modifyMultipleMatchKeyword(query, SearchType.DOMAIN_COUNTS);
+        String surveyKeyword = ConceptService.modifyMultipleMatchKeyword(query, SearchType.SURVEY_COUNTS);
         Long conceptId = 0L;
         try {
             conceptId = Long.parseLong(query);
@@ -380,6 +381,11 @@ public class DataBrowserController implements DataBrowserApiDelegate {
 
                 List<Concept> stdConcepts = conceptDao.findStandardConcepts(con.getConceptId());
                 response.setStandardConcepts(stdConcepts.stream().map(TO_CLIENT_CONCEPT).collect(Collectors.toList()));
+
+                List<Concept> tempSourceConcepts = new ArrayList<>();
+                tempSourceConcepts.add(con);
+                response.setItems(tempSourceConcepts.stream().map(TO_CLIENT_CONCEPT).collect(Collectors.toList()));
+                return ResponseEntity.ok(response);
             }
 
         }

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -306,7 +306,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     @Override
     public ResponseEntity<DomainInfosAndSurveyModulesResponse> getDomainSearchResults(String query){
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
-        String keyword = ConceptService.modifyMultipleMatchKeyword(query);
+        String domainKeyword = ConceptService.modifyMultipleMatchKeyword(query, "domain_counts");
+        String surveyKeyword = ConceptService.modifyMultipleMatchKeyword(query, "survey_counts");
         Long conceptId = 0L;
         try {
             conceptId = Long.parseLong(query);
@@ -321,8 +322,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             toMatchConceptIds.addAll(drugMatchedConcepts.stream().map(Concept::getConceptId).collect(Collectors.toList()));
         }
 
-        List<DomainInfo> domains = domainInfoDao.findStandardOrCodeMatchConceptCounts(keyword, query, toMatchConceptIds);
-        List<SurveyModule> surveyModules = surveyModuleDao.findSurveyModuleQuestionCounts(keyword);
+        List<DomainInfo> domains = domainInfoDao.findStandardOrCodeMatchConceptCounts(domainKeyword, query, toMatchConceptIds);
+        List<SurveyModule> surveyModules = surveyModuleDao.findSurveyModuleQuestionCounts(surveyKeyword);
         DomainInfosAndSurveyModulesResponse response = new DomainInfosAndSurveyModulesResponse();
         response.setDomainInfos(domains.stream()
             .map(DomainInfo.TO_CLIENT_DOMAIN_INFO)

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -171,14 +171,16 @@ public class DataBrowserControllerTest {
             .description("The Lifestyle module provides information on smoking, alcohol and recreational drug use")
             .conceptId(1585855L)
             .questionCount(568120L)
-            .participantCount(4L);
+            .participantCount(4L)
+            .orderNumber(0);
 
     private static final SurveyModule CLIENT_SURVEY_MODULE_2 = new SurveyModule()
             .name("The Basics")
             .description("The Basics module provides demographics and economic information for participants")
             .conceptId(1586134L)
             .questionCount(567437L)
-            .participantCount(5L);
+            .participantCount(5L)
+            .orderNumber(0);
 
     private static final AchillesAnalysis CLIENT_ANALYSIS_1 = new AchillesAnalysis()
             .analysisId(1900L)


### PR DESCRIPTION
1. Modified concept search to fetch counts by searching with wildcard* and to fetch actual concepts by the exact match.
2. Added order number ordering in survey results fetch.

Detail:
Bug: This line https://github.com/all-of-us/workbench/blob/master/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java#L85 for wildcard * search 
is causing DB-190 issue.

For Eg: Search on 507 code fetches all the concepts that have 507 in concept code along with the source concept that is exact match and the standard concept of the particular source concept.
Eg matched codes: 50792001, 50749006, 50799005, 507, 50711007.

So fixed this line to add wildcard* only in the case of fetching survey counts.

Reason to add this when fetching survey counts is the survey angular view fetches all the results before hand and filters the results that CONTAINS the search text (not the exact match with the words like mysql match).


