### PR TITLE
[RW-1939][risk=no] Do not delete workspaces when keeping FC/AoU in sync

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -52,6 +53,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class WorkspacesController implements WorkspacesApiDelegate {
+  private static final Logger log = Logger.getLogger(WorkspacesController.class.getName());
+
   private static final String RANDOM_CHARS = "abcdefghijklmnopqrstuvwxyz";
   private static final int NUM_RANDOM_CHARS = 20;
   private static final int MAX_FC_CREATION_ATTEMPT_VALUES = 6;
@@ -531,8 +534,9 @@ public class WorkspacesController implements WorkspacesApiDelegate {
           fcWorkspace = filteredFcWorkspaces.get(0);
         }
         if (fcWorkspace == null) {
-          //  remove from our database
-          workspaceService.getDao().delete(dbWorkspace);
+          log.warning(String.format(
+              "workspace '%s' workbench ACLs are out of sync with Firecloud, " +
+              "omitting this workspace for current user", dbWorkspace.getFirecloudName()));
         } else {
           if (dbWorkspace.getFirecloudUuid() == null) {
             // populate UUID


### PR DESCRIPTION
Full details: https://precisionmedicineinitiative.atlassian.net/browse/RW-1939

This line was deleting data it shouldn't have. My understanding is that this deletion was an optimization and not a functional requirement, so just log it for now. In the future, we should reassess our technical design in this area - i.e. what the expected behaviors are and how we want AoU+FC workspaces to interact.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
