### PR TITLE
[RW-1972][risk=low] Add a swagger codegen fetch module

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -6,6 +6,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ClarityModule} from '@clr/angular';
 import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {environment} from 'environments/environment';
+import * as portableFetch from 'portable-fetch';
 import * as StackTrace from 'stacktrace-js';
 
 import {InterceptedHttp} from './factory/InterceptedHttp';
@@ -68,12 +69,17 @@ import {WorkspaceComponent} from './views/workspace/component';
 import {AppRoutingModule} from './app-routing.module';
 import {CohortCommonModule} from './cohort-common/module';
 import {IconsModule} from './icons/icons.module';
+import {FETCH_API_REF, FetchModule} from './services/fetch.module';
 
 import {
   ApiModule,
   ConfigService,
   Configuration,
 } from 'generated';
+
+import {
+  Configuration as FetchConfiguration,
+} from 'generated/fetch';
 
 import {
   ApiModule as LeoApiModule,
@@ -127,6 +133,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     ReactiveFormsModule,
 
     CohortCommonModule,
+    FetchModule,
     IconsModule,
     NgxChartsModule,
     ClarityModule,
@@ -193,6 +200,18 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
       provide: LeoConfiguration,
       deps: [SignInService],
       useFactory: getLeoConfiguration
+    },
+    {
+      provide: FetchConfiguration,
+      deps: [Configuration],
+      useFactory: (c: Configuration) => new FetchConfiguration({
+        accessToken: c.accessToken,
+        basePath: c.basePath
+      })
+    },
+    {
+      provide: FETCH_API_REF,
+      useValue: portableFetch
     },
     ErrorHandlingService,
     ServerConfigService,

--- a/ui/src/app/services/fetch.module.ts
+++ b/ui/src/app/services/fetch.module.ts
@@ -1,0 +1,169 @@
+import { Inject, NgModule } from '@angular/core';
+
+import {
+  AuditApi,
+  AuditApiFactory,
+  AuthDomainApi,
+  AuthDomainApiFactory,
+  BugReportApi,
+  BugReportApiFactory,
+  CdrVersionsApi,
+  CdrVersionsApiFactory,
+  ClusterApi,
+  ClusterApiFactory,
+  CohortAnnotationDefinitionApi,
+  CohortAnnotationDefinitionApiFactory,
+  CohortBuilderApi,
+  CohortBuilderApiFactory,
+  CohortReviewApi,
+  CohortReviewApiFactory,
+  CohortsApi,
+  CohortsApiFactory,
+  ConceptsApi,
+  ConceptsApiFactory,
+  ConceptSetsApi,
+  ConceptSetsApiFactory,
+  ConfigApi,
+  ConfigApiFactory,
+  Configuration as FetchConfiguration,
+  CronApi,
+  CronApiFactory,
+  OfflineClusterApi,
+  OfflineClusterApiFactory,
+  ProfileApi,
+  ProfileApiFactory,
+  StatusApi,
+  StatusApiFactory,
+  UserApi,
+  UserApiFactory,
+  UserMetricsApi,
+  UserMetricsApiFactory,
+  WorkspacesApi,
+  WorkspacesApiFactory,
+} from 'generated/fetch';
+
+
+export const FETCH_API_REF = 'fetchApi';
+
+const BASE_PATH_REF = 'basePath';
+const tsFetchDeps: any[] = [
+  FetchConfiguration, [new Inject(FETCH_API_REF)], [new Inject(BASE_PATH_REF)]
+];
+
+/**
+ * This module requires a FETCH_API_REF and FetchConfiguration instance to be
+ * provided. Unfortunately typescript-fetch does not provide this module by
+ * default, so a new entry will need to be added below for each new API service
+ * added to the Swagger interfaces.
+ *
+ * This module is transitional for the Angular -> React conversion. Once routing
+ * switches off Angular, we should generate these API stubs dynamically.
+ */
+@NgModule({
+  imports:      [],
+  declarations: [],
+  exports:      [],
+  providers: [
+    {
+      provide: BASE_PATH_REF,
+      deps: [FetchConfiguration],
+      useFactory: (c: FetchConfiguration) => c.basePath
+    },
+    {
+      provide: AuditApi,
+      deps: tsFetchDeps,
+      useFactory: AuditApiFactory
+    },
+    {
+      provide: AuthDomainApi,
+      deps: tsFetchDeps,
+      useFactory: AuthDomainApiFactory
+    },
+    {
+      provide: BugReportApi,
+      deps: tsFetchDeps,
+      useFactory: BugReportApiFactory
+    },
+    {
+      provide: CdrVersionsApi,
+      deps: tsFetchDeps,
+      useFactory: CdrVersionsApiFactory
+    },
+    {
+      provide: ClusterApi,
+      deps: tsFetchDeps,
+      useFactory: ClusterApiFactory
+    },
+    {
+      provide: CohortAnnotationDefinitionApi,
+      deps: tsFetchDeps,
+      useFactory: CohortAnnotationDefinitionApiFactory
+    },
+    {
+      provide: CohortBuilderApi,
+      deps: tsFetchDeps,
+      useFactory: CohortBuilderApiFactory
+    },
+    {
+      provide: CohortReviewApi,
+      deps: tsFetchDeps,
+      useFactory: CohortReviewApiFactory
+    },
+    {
+      provide: CohortsApi,
+      deps: tsFetchDeps,
+      useFactory: CohortsApiFactory
+    },
+    {
+      provide: ConceptSetsApi,
+      deps: tsFetchDeps,
+      useFactory: ConceptSetsApiFactory
+    },
+    {
+      provide: ConceptsApi,
+      deps: tsFetchDeps,
+      useFactory: ConceptsApiFactory
+    },
+    {
+      provide: ConfigApi,
+      deps: tsFetchDeps,
+      useFactory: ConfigApiFactory
+    },
+    {
+      provide: CronApi,
+      deps: tsFetchDeps,
+      useFactory: CronApiFactory
+    },
+    {
+      provide: OfflineClusterApi,
+      deps: tsFetchDeps,
+      useFactory: OfflineClusterApiFactory
+    },
+    {
+      provide: ProfileApi,
+      deps: tsFetchDeps,
+      useFactory: ProfileApiFactory
+    },
+    {
+      provide: StatusApi,
+      deps: tsFetchDeps,
+      useFactory: StatusApiFactory
+    },
+    {
+      provide: UserApi,
+      deps: tsFetchDeps,
+      useFactory: UserApiFactory
+    },
+    {
+      provide: UserMetricsApi,
+      deps: tsFetchDeps,
+      useFactory: UserMetricsApiFactory
+    },
+    {
+      provide: WorkspacesApi,
+      deps: tsFetchDeps,
+      useFactory: WorkspacesApiFactory
+    }
+  ]
+})
+export class FetchModule {}


### PR DESCRIPTION
This will allow for injection of fetch-based API stubs with proper credential plumbing and without explicit inclusion of the base URL. See the module comment for details.

I believe we'll likely want these kinds of services available via `props` once we're fully on React. @panentheos to sanity check that assertion.

CC: @UrsaStutsman 

Example usage:
- https://github.com/all-of-us/workbench/pull/1663
- https://github.com/all-of-us/workbench/compare/srubenst/settings-page...ch/fetch-fix?expand=1

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
