### PR TITLE
[risk=no] Split out karma/jest tsconfigs - only compile one or the other

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -42,13 +42,7 @@
     ],
     "globals": {
       "ts-jest": {
-        "diagnostics": {
-          "warnOnly": true
-        },
-        "tsConfig": {
-          "module": "commonjs",
-          "jsx": "react"
-        }
+        "tsConfig": "src/tsconfig.jest.json"
       }
     }
   },

--- a/ui/src/tsconfig.jest.json
+++ b/ui/src/tsconfig.jest.json
@@ -1,22 +1,21 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../out-tsc/spec",
+    "outDir": "../out-tsc/jest",
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
     "types": [
-      "jasmine",
+      "jest",
       "node"
     ],
     "jsx": "react"
   },
   "files": [
-    "test.ts",
     "polyfills.ts"
   ],
   "include": [
-    "**/*.spec.ts",
+    "**/*.spec.tsx",
     "**/*.d.ts",
   ]
 }


### PR DESCRIPTION
- Allows tsx tests to reference "jest" without compilation failure.
- `yarn test` doesn't compile tsx tests
- `npx jest` now complains on compile failure, to match previous behavior of `yarn test`

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
