### PR TITLE
[risk=no] expose navigation for react components

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -28,6 +28,7 @@ import {ConceptSetResolver} from './resolvers/concept-set';
 import {WorkspaceResolver} from './resolvers/workspace';
 
 import {environment} from 'environments/environment';
+import {NavStore} from './utils/navigation';
 import {SignInComponent} from './views/sign-in/component';
 
 declare let gtag: Function;
@@ -265,6 +266,8 @@ const routes: Routes = [
 export class AppRoutingModule {
 
  constructor(public router: Router) {
+    NavStore.navigate = (commands, extras) => this.router.navigate(commands, extras);
+    NavStore.navigateByUrl = (url, extras) => this.router.navigateByUrl(url, extras);
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         gtag('config', environment.gaId, { 'page_path': event.urlAfterRedirects });

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -1,0 +1,14 @@
+export const NavStore = {
+  navigate: undefined,
+  navigateByUrl: undefined
+};
+
+// NOTE: Because these are wired up directly to the router component,
+// all navigation done from here will effectively use absolute paths.
+export const navigate = (...args) => {
+  return NavStore.navigate(...args);
+};
+
+export const navigateByUrl = (...args) => {
+  return NavStore.navigateByUrl(...args);
+};


### PR DESCRIPTION
This exposes the `navigate` and `navigateByUrl` methods via a module, so they can be used by React components without injecting.

Usage:
```
import {navigate} from 'app/utils/navigation';

<Button onClick={() => navigate(['somewhere'])}>
```

Note: Angular routing seems to be extremely fragile, which is why the code is formulated the way it is. Specifically, the actual call to `navigate` must originate from within a Component class, so we need to store callback functions to make that happen.