### PR TITLE
[risk=no] convert utils to tsx

### DIFF
--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -109,7 +109,7 @@ export const withWindowSize = () => WrappedComponent => {
 
     render() {
       const { windowSize } = this.state;
-      return React.createElement(WrappedComponent, { windowSize, ...this.props });
+      return <WrappedComponent windowSize={windowSize} {...this.props} />;
     }
   }
   return Wrapper as any;
@@ -188,7 +188,7 @@ export function reactStyles<T extends {[key: string]: React.CSSProperties}>(t: T
 export class ReactWrapperBase implements OnChanges, OnInit, OnDestroy {
   @ViewChild('root') rootElement: ElementRef;
 
-  constructor(private wrapped: React.ComponentType, private propNames: string[]) {}
+  constructor(private WrappedComponent: React.ComponentType, private propNames: string[]) {}
 
   ngOnInit(): void {
     this.renderComponent();
@@ -203,11 +203,9 @@ export class ReactWrapperBase implements OnChanges, OnInit, OnDestroy {
   }
 
   renderComponent(): void {
+    const {WrappedComponent, propNames} = this;
     ReactDOM.render(
-      React.createElement(
-        this.wrapped,
-        fp.fromPairs(this.propNames.map(name => [name, this[name]]))
-      ),
+      <WrappedComponent {...fp.fromPairs(propNames.map(name => [name, this[name]]))} />,
       this.rootElement.nativeElement
     );
   }
@@ -221,4 +219,3 @@ export function decamelize(str: string, separator: string) {
       .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + separator + '$2')
       .toLowerCase();
 }
-


### PR DESCRIPTION
Converts the main utils file to tsx, so we don't have to keep using `createElement`. This is its own PR to make sure git parses it as a rename, to make merges and rebases easier.