### PR TITLE
[risk=no] standardize text inputs

### DIFF
--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -23,6 +23,12 @@ export const styles = {
   h4: {
     fontWeight: 300,
     color: '#000',
+  },
+  formLabel: {
+    color: '#262262',
+    fontWeight: 600,
+    marginTop: '0.5rem',
+    marginBottom: '0.125rem'
   }
 };
 

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -3,11 +3,6 @@ import * as React from 'react';
 import {withStyle} from 'app/utils/index';
 
 export const styles = {
-  input: {
-    marginLeft: '.5rem',
-    width: '90%'
-  },
-
   unsuccessfulInput: {
     backgroundColor: '#FCEFEC',
     borderColor: '#F68D76'
@@ -17,24 +12,12 @@ export const styles = {
     borderColor: '#7AC79B'
   },
 
-  longInput: {
-    width: '16rem'
-  },
-
   error: {
     padding: '0 0.5rem',
     fontWeight: 600,
     color: '#2F2E7E',
     marginTop: '0.2rem',
     width: '90%'
-  },
-
-  formInput: {
-    borderRadius: '5px',
-    backgroundColor: 'white',
-    lineHeight: '1.5rem',
-    height: '1.5rem',
-    width: '16rem'
   },
 
   errorMessage: {
@@ -58,8 +41,48 @@ export const styles = {
 };
 
 
-export const FieldInput = withStyle(styles.input)('input');
-export const FormInput = withStyle(styles.formInput)('input');
-export const LongInput = withStyle({...styles.formInput, ...styles.longInput})('input');
 export const Error = withStyle(styles.error)('div');
 export const ErrorMessage = withStyle(styles.errorMessage)('div');
+
+export const ValidationError = ({children}) => {
+  if (!children) {
+    return null;
+  }
+  return <div
+    style={{
+      color: '#c72314',
+      fontSize: 10, fontWeight: 500, textTransform: 'uppercase',
+      marginLeft: '0.5rem', marginTop: '0.25rem'
+    }}
+  >{children}</div>;
+};
+
+export const TextInput = ({style = {}, onChange, invalid = false, ...props}) => {
+  return <input
+    {...props}
+    onChange={onChange ? (e => onChange(e.target.value)) : undefined}
+    style={{
+      width: '100%', height: '1.5rem',
+      border: '1px solid #9a9a9a', borderRadius: 4,
+      padding: '0 0.5rem',
+      backgroundColor: '#fff',
+      ...(invalid ? styles.unsuccessfulInput : {}),
+      ...style
+    }}
+  />;
+};
+
+export const TextArea = ({style = {}, onChange, invalid = false, ...props}) => {
+  return <textarea
+    {...props}
+    onChange={onChange ? (e => onChange(e.target.value)) : undefined}
+    style={{
+      width: '100%',
+      border: '1px solid #9a9a9a', borderRadius: 4,
+      padding: '0.25rem 0.5rem',
+      backgroundColor: '#fff',
+      ...(invalid ? styles.unsuccessfulInput : {}),
+      ...style
+    }}
+  />;
+};

--- a/ui/src/app/views/account-creation-modals/component.tsx
+++ b/ui/src/app/views/account-creation-modals/component.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
-import {Error, FieldInput, styles as inputStyles} from 'app/components/inputs';
+import {styles as headerStyles} from 'app/components/headers';
+import {TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 
@@ -73,27 +74,16 @@ export class AccountCreationUpdateModal extends React.Component<
     return <Modal onRequestClose={onClose}>
       <ModalTitle>Change contact email</ModalTitle>
       <ModalBody>
-        <table style={{width: '100%'}}>
-          <tbody>
-          <tr>
-            <td><label>Contact Email:</label></td>
-            <td style={{width: '70%'}}><FieldInput
-              value={contactEmail}
-              style={showEmailError ? inputStyles.unsuccessfulInput : {}}
-              onChange={(e) => this.setState({contactEmail: e.target.value})}
-              onBlur={() => this.setState({emailOffFocus: true})}
-              onFocus={() => this.setState({emailOffFocus: false})}
-            />
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td style={{width: '70%'}}>
-              {showEmailError && <Error>Email is not valid.</Error>}
-            </td>
-          </tr>
-          </tbody>
-        </table>
+        <div style={headerStyles.formLabel}>Contact Email:</div>
+        <TextInput
+          autoFocus
+          value={contactEmail}
+          invalid={showEmailError}
+          onChange={v => this.setState({contactEmail: v})}
+          onBlur={() => this.setState({emailOffFocus: true})}
+          onFocus={() => this.setState({emailOffFocus: false})}
+        />
+        {showEmailError && <ValidationError>Email is not valid.</ValidationError>}
       </ModalBody>
       <ModalFooter>
         <Button type='secondary' onClick={onClose}>Cancel</Button>

--- a/ui/src/app/views/account-creation/component.spec.tsx
+++ b/ui/src/app/views/account-creation/component.spec.tsx
@@ -1,4 +1,4 @@
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
@@ -10,7 +10,7 @@ import {
 
 let props: AccountCreationProps;
 const component = () => {
-  return shallow<AccountCreation,
+  return mount<AccountCreation,
     AccountCreationProps,
     AccountCreationState>(<AccountCreation {...props}/>);
 };
@@ -27,7 +27,7 @@ it('should handle given name validity', () => {
   const testInput = fp.repeat(101, 'a');
   expect(wrapper.exists('#givenName')).toBeTruthy();
   expect(wrapper.exists('#givenNameError')).toBeFalsy();
-  wrapper.find('#givenName')
+  wrapper.find('input#givenName')
     .simulate('change', {target: {value: testInput}});
   wrapper.update();
   expect(wrapper.exists('#givenNameError')).toBeTruthy();
@@ -38,7 +38,7 @@ it ('should handle family name validity', () => {
   const testInput = fp.repeat(101, 'a');
   expect(wrapper.exists('#familyName')).toBeTruthy();
   expect(wrapper.exists('#familyNameError')).toBeFalsy();
-  wrapper.find('#familyName').simulate('change', {target: {value: testInput}});
+  wrapper.find('input#familyName').simulate('change', {target: {value: testInput}});
   expect(wrapper.exists('#familyNameError')).toBeTruthy();
 });
 
@@ -47,7 +47,7 @@ it ('should handle organization validity', () => {
   const testInput = fp.repeat(300, 'a');
   expect(wrapper.exists('#organization')).toBeTruthy();
   expect(wrapper.exists('#organizationError')).toBeFalsy();
-  wrapper.find('#organization').simulate('change', {target: {value: testInput}});
+  wrapper.find('input#organization').simulate('change', {target: {value: testInput}});
   expect(wrapper.exists('#organizationError')).toBeTruthy();
 });
 
@@ -56,7 +56,7 @@ it ('should handle current position validity', () => {
   const testInput = fp.repeat(300, 'a');
   expect(wrapper.exists('#currentPosition')).toBeTruthy();
   expect(wrapper.exists('#currentPositionError')).toBeFalsy();
-  wrapper.find('#currentPosition').simulate('change', {target: {value: testInput}});
+  wrapper.find('input#currentPosition').simulate('change', {target: {value: testInput}});
   expect(wrapper.exists('#currentPositionError')).toBeTruthy();
 });
 
@@ -65,7 +65,7 @@ it ('should handle username validity starts with .', () => {
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
   expect(wrapper.exists('#usernameConflictError')).toBeFalsy();
-  wrapper.find('#username').simulate('change', {target: {value: '.startswith'}});
+  wrapper.find('input#username').simulate('change', {target: {value: '.startswith'}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
@@ -73,7 +73,7 @@ it('should handle username validity ends with .', () => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
-  wrapper.find('#username').simulate('change', {target: {value: 'endswith.'}});
+  wrapper.find('input#username').simulate('change', {target: {value: 'endswith.'}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
@@ -81,7 +81,7 @@ it('should handle username validity contains special chars', () => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
-  wrapper.find('#username').simulate('change', {target: {value: 'user@name'}});
+  wrapper.find('input#username').simulate('change', {target: {value: 'user@name'}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
@@ -92,7 +92,7 @@ it('should handle username validity long but has mismatch at end', () => {
   // if username is long (not too long) but has a mismatch at end
   let testInput = fp.repeat(50, 'a');
   testInput = testInput + ' a';
-  wrapper.find('#username').simulate('change', {target: {value: testInput}});
+  wrapper.find('input#username').simulate('change', {target: {value: testInput}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
@@ -100,6 +100,6 @@ it('should handle username validity if name is valid', () => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
-  wrapper.find('#username').simulate('change', {target: {value: 'username'}});
+  wrapper.find('input#username').simulate('change', {target: {value: 'username'}});
   expect(wrapper.exists('#usernameError')).toBeFalsy();
 });

--- a/ui/src/app/views/account-creation/component.tsx
+++ b/ui/src/app/views/account-creation/component.tsx
@@ -8,12 +8,7 @@ import {
   Profile,
 } from 'generated/fetch/api';
 
-import {
-  Error,
-  ErrorMessage,
-  LongInput,
-  styles as inputStyles
-} from 'app/components/inputs';
+import { Error, ErrorMessage, styles as inputStyles, TextArea, TextInput } from 'app/components/inputs';
 
 import {
   InfoIcon,
@@ -157,75 +152,77 @@ export class AccountCreation extends
   }
 
   render() {
-    const {givenName, familyName, currentPosition, organization} = this.state.profile;
+    const {
+      profile: {
+        givenName, familyName, currentPosition, organization,
+        contactEmail, username, areaOfResearch
+      }
+    } = this.state;
     return <div id='account-creation'
                 style={{'paddingTop': '3rem', 'paddingRight': '3rem', 'paddingLeft': '3rem'}}>
         <BoldHeader>Create your account</BoldHeader>
         <div>
           <FormSection>
-            <LongInput type='text' id='givenName' name='givenName' autoFocus
+            <TextInput id='givenName' name='givenName' autoFocus
                        placeholder='First Name'
                        value={givenName}
-                       style={(givenName.length > 80) ?
-                         inputStyles.unsuccessfulInput : inputStyles.successfulInput}
-                       onChange={e => this.updateProfile('givenName', e.target.value)}/>
+                       invalid={givenName.length > 80}
+                       style={{width: '16rem'}}
+                       onChange={v => this.updateProfile('givenName', v)}/>
             {givenName.length > 80 &&
             <ErrorMessage id='givenNameError'>
               First Name must be 80 characters or less.
             </ErrorMessage>}
           </FormSection>
           <FormSection>
-            <LongInput type='text' id='familyName' name='familyName' placeholder='Last Name'
+            <TextInput id='familyName' name='familyName' placeholder='Last Name'
                        value={familyName}
-                       style={(familyName.length > 80) ?
-                         inputStyles.unsuccessfulInput : inputStyles.successfulInput}
-                       onChange={e => this.updateProfile('familyName', e.target.value)}/>
+                       invalid={familyName.length > 80}
+                       style={{width: '16rem'}}
+                       onChange={v => this.updateProfile('familyName', v)}/>
             {familyName.length > 80 &&
             <ErrorMessage id='familyNameError'>
               Last Name must be 80 character or less.
             </ErrorMessage>}
           </FormSection>
           <FormSection>
-            <LongInput type='text' id='contactEmail' name='contactEmail'
+            <TextInput id='contactEmail' name='contactEmail'
                        placeholder='Email Address'
-                       onChange={e => this.updateProfile('contactEmail', e.target.value)}/>
+                       value={contactEmail}
+                       style={{width: '16rem'}}
+                       onChange={v => this.updateProfile('contactEmail', v)}/>
           </FormSection>
           <FormSection>
-            <LongInput type='text' id='currentPosition' name='currentPosition'
-                       placeholder='You Current Position'
+            <TextInput id='currentPosition' name='currentPosition'
+                       placeholder='Your Current Position'
                        value={currentPosition}
-                       style={(currentPosition.length > 255) ?
-                         inputStyles.unsuccessfulInput : inputStyles.successfulInput}
-                       onChange={e => this.updateProfile('currentPosition', e.target.value)}/>
+                       invalid={currentPosition.length > 255}
+                       style={{width: '16rem'}}
+                       onChange={v => this.updateProfile('currentPosition', v)}/>
             {currentPosition.length > 255 &&
             <ErrorMessage id='currentPositionError'>
               Current Position must be 255 characters or less.
             </ErrorMessage>}
           </FormSection>
           <FormSection>
-            <LongInput type='text' id='organization' name='organization'
+            <TextInput id='organization' name='organization'
                        placeholder='Your Organization'
                        value={organization}
-                       style={(organization.length > 255) ?
-                         inputStyles.unsuccessfulInput : inputStyles.successfulInput}
-                       onChange={e => this.updateProfile('organization', e.target.value)}/>
+                       invalid={organization.length > 255}
+                       style={{width: '16rem'}}
+                       onChange={v => this.updateProfile('organization', v)}/>
             {organization.length > 255 &&
             <ErrorMessage id='organizationError'>
               Organization must be 255 characters of less.
             </ErrorMessage>}
           </FormSection>
           <FormSection style={{display: 'flex'}}>
-              <textarea style={{
-                ...inputStyles.formInput,
-                ...inputStyles.longInput,
-                'height': '10em',
-                'resize': 'none',
-                'width': '16rem'
-              }}
+              <TextArea style={{height: '10em', resize: 'none', width: '16rem'}}
                         id='areaOfResearch'
                         name='areaOfResearch'
                         placeholder='Describe Your Current Research'
-                        onChange={e => this.updateProfile('areaOfResearch', e.target.value)}/>
+                        value={areaOfResearch}
+                        onChange={v => this.updateProfile('areaOfResearch', v)}/>
             <TooltipTrigger content='You are required to describe your current research in
                       order to help All of Us improve the Researcher Workbench.'>
               <InfoIcon style={{
@@ -236,10 +233,12 @@ export class AccountCreation extends
             </TooltipTrigger>
           </FormSection>
           <FormSection>
-            <LongInput type='text' id='username' name='username' placeholder='New Username'
-                       onChange={e => this.usernameChanged(e.target.value)}
-                       style={(this.state.usernameConflictError || this.usernameInvalidError()) ?
-                         inputStyles.unsuccessfulInput : inputStyles.successfulInput}/>
+            <TextInput id='username' name='username' placeholder='New Username'
+                       value={username}
+                       onChange={v => this.usernameChanged(v)}
+                       invalid={this.state.usernameConflictError || this.usernameInvalidError()}
+                       style={{width: '16rem'}}
+            />
             <div style={inputStyles.iconArea}>
               <ValidationIcon validSuccess={this.usernameValid()}/>
             </div>

--- a/ui/src/app/views/invitation-key/component.tsx
+++ b/ui/src/app/views/invitation-key/component.tsx
@@ -1,7 +1,7 @@
 import {AlertDanger} from 'app/components/alert';
 import {Button} from 'app/components/buttons';
 import {BoldHeader} from 'app/components/headers';
-import {FormInput} from 'app/components/inputs';
+import {TextInput} from 'app/components/inputs';
 
 import {profileApi} from 'app/services/swagger-fetch-clients';
 
@@ -73,9 +73,10 @@ export class InvitationKey extends React.Component<InvitationKeyProps, Invitatio
         <BoldHeader>
           Enter your Invitation Key:
         </BoldHeader>
-        <FormInput type='text' id='invitationKey' value={this.state.invitationKey}
-                   placeholder='Invitation Key' onChange={input =>
-                                                 this.setState({invitationKey: input.target.value})}
+        <TextInput id='invitationKey' value={this.state.invitationKey}
+                   style={{width: '16rem'}}
+                   placeholder='Invitation Key'
+                   onChange={v => this.setState({invitationKey: v})}
                    ref={this.inputElement} autoFocus/>
         {this.state.invitationKeyReq &&
          <AlertDanger>

--- a/ui/src/app/views/rename-modal/component.tsx
+++ b/ui/src/app/views/rename-modal/component.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import {
   Button
 } from 'app/components/buttons';
+import {styles as headerStyles} from 'app/components/headers';
+import {TextInput} from 'app/components/inputs';
 import {
   Modal,
   ModalBody,
@@ -48,10 +50,10 @@ export class RenameModal extends React.Component<RenameModalProps, RenameModalSt
       <Modal>
         <ModalTitle>Please enter the new name for {this.props.resource.name}</ModalTitle>
         <ModalBody>
-          <label>New Name: </label>
-          <input id='new-name' type='text'
-                 onChange={(e) => this.setState({newName: e.target.value})}>
-          </input>
+          <div style={headerStyles.formLabel}>New Name:</div>
+          <TextInput id='new-name'
+             onChange={v => this.setState({newName: v})}
+          />
         </ModalBody>
         <ModalFooter>
           <Button type='secondary' onClick={() => this.props.onCancel()}>Cancel</Button>


### PR DESCRIPTION
Introduces `TextInput` and `TextArea` components to standardize the basic text input appearance. The exact design may be tweaked with e.g. nicer focus outlines and success/error states, but I wanted to get the abstraction in place so people can start using it.

n.b. Width defaults to `100%`, but can be overridden via `style`