### PR TITLE
[risk=no] improve notebook rename flow

### DIFF
--- a/ui/src/app/views/concept-set-list/component.html
+++ b/ui/src/app/views/concept-set-list/component.html
@@ -37,8 +37,7 @@
     <div style="display: flex; flex-wrap: wrap;">
       <div *ngFor="let conceptSet of resourceList">
         <app-resource-card [resourceCard]="conceptSet" [cssClass]="'for-list'"
-                           (onUpdate)="loadConceptSets()"
-                           (duplicateNameError)="duplicateNameError($event)">
+                           (onUpdate)="loadConceptSets()">
         </app-resource-card>
       </div>
     </div>
@@ -46,7 +45,3 @@
 </app-top-box>
 
 <app-create-concept-modal (onUpdate)="loadConceptSets()"></app-create-concept-modal>
-<clr-modal [(clrModalOpen)]="nameConflictError">
-  <h3 class="modal-title">Error:</h3>
-  <div class="modal-body">You already have a concept set named {{duplicateName}}. Please choose another name.</div>
-</clr-modal>

--- a/ui/src/app/views/concept-set-list/component.ts
+++ b/ui/src/app/views/concept-set-list/component.ts
@@ -31,8 +31,6 @@ export class ConceptSetListComponent implements OnInit {
   conceptSetsLoading = false;
   conceptSetsList: ConceptSet[];
   resourceList: RecentResource[];
-  duplicateName: string;
-  nameConflictError = false;
 
   @ViewChild(ToolTipComponent)
   toolTip: ToolTipComponent;
@@ -69,11 +67,6 @@ export class ConceptSetListComponent implements OnInit {
 
   newConceptSet(): void {
     this.conceptCreateModal.open();
-  }
-
-  duplicateNameError(dupName: string) {
-    this.duplicateName = dupName;
-    this.nameConflictError = true;
   }
 
   get writePermission(): boolean {

--- a/ui/src/app/views/notebook-list/component.html
+++ b/ui/src/app/views/notebook-list/component.html
@@ -23,9 +23,7 @@
     <div style="display: flex; flex-wrap: wrap; justify-content: flex-start;">
       <div *ngFor="let notebook of resourceList">
         <app-resource-card [resourceCard]="notebook" [cssClass]="'for-list'"
-                           (onUpdate)="updateList($event)"
-                           (duplicateNameError)="duplicateNameError($event)"
-                           (invalidNameError)="invalidNameError($event)">
+                           (onUpdate)="updateList($event)">
         </app-resource-card>
       </div>
     </div>
@@ -44,17 +42,6 @@
   <div class="modal-body">Could not load your notebook. Please <a (click)="submitNotebookLocalizeBugReport()">submit a bug report.</a></div>
   <div class="modal-footer">
     <button type="button" class="btn btn-primary" (click)="localizeNotebooksError = false">Ok</button>
-  </div>
-</clr-modal>
-<clr-modal [(clrModalOpen)]="notebookRenameConflictError">
-  <h3 class="modal-title">Error:</h3>
-  <div class="modal-body">You already have a notebook named {{duplicateName}}. Please choose another name.</div>
-</clr-modal>
-<clr-modal [(clrModalOpen)]="notebookRenameError">
-  <h3 class="modal-title">Error:</h3>
-  <div class="modal-body">The name you entered has a '/' in it. This is currently not allowed. Please choose another name.</div>
-  <div class="modal-footer">
-    <button type="button" class="btn btn-outline" (click)="notebookRenameError = false">Dismiss</button>
   </div>
 </clr-modal>
 <app-bug-report></app-bug-report>

--- a/ui/src/app/views/notebook-list/component.spec.ts
+++ b/ui/src/app/views/notebook-list/component.spec.ts
@@ -154,39 +154,6 @@ describe('NotebookListComponent', () => {
     expect(app.notebookList[0].path).toEqual('gs://bucket/notebooks/mockFile.ipynb');
   }));
 
-  it('displays correct information when notebook renamed', fakeAsync(() => {
-    const fixture = notebookListPage.fixture;
-    const de = fixture.debugElement;
-    simulateClickReact(fixture, '[data-test-id="resource-menu"]');
-    simulateClickReact(fixture, '[data-test-id="pencil"]');
-
-    simulateInputReact(fixture, '#new-name', 'testMockFile');
-    simulateClickReact(fixture, '[data-test-id="rename-button"]');
-    updateAndTick(fixture);
-
-    const notebooksOnPage = de.queryAll(By.css('.item-card'));
-    expect(notebooksOnPage.map((nb) => nb.nativeElement.innerText)).toMatch('testMockFile');
-    expect(fixture.componentInstance.resourceList[0].notebook.name)
-      .toEqual('testMockFile.ipynb');
-  }));
-
-  it('displays correct information when notebook renamed with duplicate name', fakeAsync(() => {
-    const fixture = notebookListPage.fixture;
-    const de = fixture.debugElement;
-    simulateClickReact(fixture, '[data-test-id="resource-menu"]');
-    simulateClickReact(fixture, '[data-test-id="pencil"]');
-
-    simulateInputReact(fixture, '#new-name', 'mockFile');
-    simulateClickReact(fixture, '[data-test-id="rename-button"]');
-    updateAndTick(fixture);
-
-    const errorMessage = de.queryAll(By.css('.modal-title'));
-    expect(errorMessage.map(com => com.nativeElement.innerText)[0]).toEqual('Error:');
-    simulateClick(fixture, de.query(By.css('.close')));
-    const notebooksOnPage = de.queryAll(By.css('.item-card'));
-    expect(notebooksOnPage.map((nb) => nb.nativeElement.innerText)).toMatch('mockFile');
-  }));
-
   it('displays correct information when notebook cloned', fakeAsync(() => {
     const fixture = notebookListPage.fixture;
     const de = fixture.debugElement;

--- a/ui/src/app/views/notebook-list/component.ts
+++ b/ui/src/app/views/notebook-list/component.ts
@@ -11,7 +11,6 @@ import {ToolTipComponent} from 'app/views/tooltip/component';
 import {
   Cluster,
   FileDetail,
-  NotebookRename,
   PageVisit,
   ProfileService,
   RecentResource,
@@ -43,9 +42,6 @@ export class NotebookListComponent implements OnInit, OnDestroy {
   showTip: boolean;
   newPageVisit: PageVisit = { page: NotebookListComponent.PAGE_ID};
   firstVisit = true;
-  notebookRenameConflictError = false;
-  notebookRenameError = false;
-  duplicateName = '';
   creatingNotebook = false;
 
 
@@ -115,24 +111,8 @@ export class NotebookListComponent implements OnInit, OnDestroy {
     this.creatingNotebook = false;
   }
 
-  updateList(rename?: NotebookRename): void {
-    if (rename === undefined) {
-      this.loadNotebookList();
-    } else {
-      const nb = this.resourceList.filter(resource => resource.notebook.name === rename.name)[0];
-      const newNb = Object.assign({}, nb);
-      newNb.notebook.name = rename.newName;
-      this.resourceList.splice(this.resourceList.indexOf(nb), 1, newNb);
-    }
-  }
-
-  duplicateNameError(dupName: string): void {
-    this.duplicateName = dupName;
-    this.notebookRenameConflictError = true;
-  }
-
-  invalidNameError(): void {
-    this.notebookRenameError = true;
+  updateList(): void {
+    this.loadNotebookList();
   }
 
   submitNotebooksLoadBugReport(): void {

--- a/ui/src/app/views/rename-modal/component.spec.tsx
+++ b/ui/src/app/views/rename-modal/component.spec.tsx
@@ -1,0 +1,24 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {RenameModal} from './component';
+import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
+
+import {WorkspacesApi} from 'generated/fetch';
+
+describe('RenameModal', () => {
+  beforeEach(() => {
+    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
+  });
+
+  it('should render', () => {
+    const wrapper = mount(<RenameModal
+      resource={{name: 'a'}}
+      onCancel={() => {}}
+      onRename={() => {}}
+      workspace={{namespace: 'a', name: 'b'}}
+    />);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+});

--- a/ui/src/app/views/rename-modal/component.spec.tsx
+++ b/ui/src/app/views/rename-modal/component.spec.tsx
@@ -14,7 +14,7 @@ describe('RenameModal', () => {
 
   it('should render', () => {
     const wrapper = mount(<RenameModal
-      resource={{name: 'a'}}
+      notebookName='a'
       onCancel={() => {}}
       onRename={() => {}}
       workspace={{namespace: 'a', name: 'b'}}

--- a/ui/src/app/views/rename-modal/component.tsx
+++ b/ui/src/app/views/rename-modal/component.tsx
@@ -25,7 +25,7 @@ const fullName = name => {
 };
 
 interface RenameModalProps {
-  resource: {name: string};
+  notebookName: string;
   workspace: {namespace: string, name: string};
   onRename: Function;
   onCancel: Function;
@@ -59,11 +59,11 @@ export class RenameModal extends React.Component<RenameModalProps, {
 
   private async rename() {
     try {
-      const {onRename, workspace, resource} = this.props;
+      const {onRename, workspace, notebookName} = this.props;
       const {newName} = this.state;
       this.setState({saving: true});
       await workspacesApi().renameNotebook(workspace.namespace, workspace.name, {
-        name: resource.name,
+        name: notebookName,
         newName: fullName(newName)
       });
       onRename();
@@ -75,7 +75,7 @@ export class RenameModal extends React.Component<RenameModalProps, {
   }
 
   render() {
-    const {resource, onCancel} = this.props;
+    const {notebookName, onCancel} = this.props;
     const {saving, newName, existingNames, nameTouched} = this.state;
     const errors = validate({newName: fullName(newName)}, {newName: {
       presence: {allowEmpty: false},
@@ -89,7 +89,7 @@ export class RenameModal extends React.Component<RenameModalProps, {
       }
     }});
     return <Modal>
-      <ModalTitle>Please enter the new name for {resource.name}</ModalTitle>
+      <ModalTitle>Please enter the new name for {notebookName}</ModalTitle>
       <ModalBody>
         <div style={headerStyles.formLabel}>New Name:</div>
         <TextInput autoFocus id='new-name'
@@ -120,12 +120,12 @@ export class RenameModal extends React.Component<RenameModalProps, {
   template: '<div #root></div>'
 })
 export class RenameModalComponent extends ReactWrapperBase {
-  @Input('resource') resource: RenameModalProps['resource'];
+  @Input('notebookName') notebookName: RenameModalProps['notebookName'];
   @Input('workspace') workspace: RenameModalProps['workspace'];
   @Input('onRename') onRename: RenameModalProps['onRename'];
   @Input('onCancel') onCancel: RenameModalProps['onCancel'];
 
   constructor() {
-    super(RenameModal, ['resource', 'workspace', 'onRename', 'onCancel']);
+    super(RenameModal, ['notebookName', 'workspace', 'onRename', 'onCancel']);
   }
 }

--- a/ui/src/app/views/rename-modal/component.tsx
+++ b/ui/src/app/views/rename-modal/component.tsx
@@ -1,72 +1,117 @@
 import {Component, Input} from '@angular/core';
+import {validate} from 'validate.js';
 
 import {
   Button
 } from 'app/components/buttons';
 import {styles as headerStyles} from 'app/components/headers';
-import {TextInput} from 'app/components/inputs';
+import {TextInput, ValidationError} from 'app/components/inputs';
 import {
   Modal,
   ModalBody,
   ModalFooter,
   ModalTitle,
 } from 'app/components/modals';
+import {TooltipTrigger} from 'app/components/popups';
+import {workspacesApi} from 'app/services/swagger-fetch-clients';
 
-import {ReactWrapperBase} from 'app/utils';
+import {ReactWrapperBase, summarizeErrors} from 'app/utils';
 
 import * as React from 'react';
 
 
+const fullName = name => {
+  return !name || /^.+\.ipynb$/.test(name) ? name : `${name}.ipynb`;
+};
+
 interface RenameModalProps {
-  resource: { name: string };
+  resource: {name: string};
+  workspace: {namespace: string, name: string};
   onRename: Function;
   onCancel: Function;
 }
 
-interface RenameModalState {
-  loading: boolean;
+export class RenameModal extends React.Component<RenameModalProps, {
+  saving: boolean;
   newName: string;
-}
-
-export class RenameModal extends React.Component<RenameModalProps, RenameModalState> {
+  existingNames: string[];
+  nameTouched: boolean;
+}> {
   constructor(props: RenameModalProps) {
     super(props);
     this.state = {
-      loading: false,
-      newName: ''
+      saving: false,
+      newName: '',
+      existingNames: [],
+      nameTouched: false
     };
   }
 
-  private rename(): void {
-    this.setState({
-      loading: true
-    });
-    this.props.onRename({
-      name: this.props.resource.name,
-      newName: this.state.newName
-    });
+  async componentDidMount() {
+    try {
+      const {workspace} = this.props;
+      const notebooks = await workspacesApi().getNoteBookList(workspace.namespace, workspace.name);
+      this.setState({existingNames: notebooks.map(n => n.name)});
+    } catch (error) {
+      console.error(error); // TODO: better error handling
+    }
+  }
+
+  private async rename() {
+    try {
+      const {onRename, workspace, resource} = this.props;
+      const {newName} = this.state;
+      this.setState({saving: true});
+      await workspacesApi().renameNotebook(workspace.namespace, workspace.name, {
+        name: resource.name,
+        newName: fullName(newName)
+      });
+      onRename();
+    } catch (error) {
+      console.error(error); // TODO: better error handling
+    } finally {
+      this.setState({saving: false});
+    }
   }
 
   render() {
-    return <React.Fragment>
-      <Modal>
-        <ModalTitle>Please enter the new name for {this.props.resource.name}</ModalTitle>
-        <ModalBody>
-          <div style={headerStyles.formLabel}>New Name:</div>
-          <TextInput id='new-name'
-             onChange={v => this.setState({newName: v})}
-          />
-        </ModalBody>
-        <ModalFooter>
-          <Button type='secondary' onClick={() => this.props.onCancel()}>Cancel</Button>
-          {/* TODO: Use a loading spinner here in addition to disabling. */}
-          <Button data-test-id='rename-button'
-                  disabled={this.state.loading}
-                  style={{marginLeft: '.5rem'}}
-                  onClick={() => this.rename()}>Rename Notebook</Button>
-        </ModalFooter>
-      </Modal>
-    </React.Fragment>;
+    const {resource, onCancel} = this.props;
+    const {saving, newName, existingNames, nameTouched} = this.state;
+    const errors = validate({newName: fullName(newName)}, {newName: {
+      presence: {allowEmpty: false},
+      format: {
+        pattern: /^[^\/]*$/,
+        message: 'can\'t contain a slash'
+      },
+      exclusion: {
+        within: existingNames,
+        message: 'already exists'
+      }
+    }});
+    return <Modal>
+      <ModalTitle>Please enter the new name for {resource.name}</ModalTitle>
+      <ModalBody>
+        <div style={headerStyles.formLabel}>New Name:</div>
+        <TextInput autoFocus id='new-name'
+           onChange={v => this.setState({newName: v, nameTouched: true})}
+        />
+        <ValidationError>
+          {summarizeErrors(nameTouched && errors && errors.newName)}
+        </ValidationError>
+      </ModalBody>
+      <ModalFooter>
+        <Button type='secondary' onClick={onCancel}>Cancel</Button>
+        {/* TODO: Use a loading spinner here in addition to disabling. */}
+        <TooltipTrigger content={summarizeErrors(errors)}>
+          <Button
+            data-test-id='rename-button'
+            disabled={!!errors || saving}
+            style={{marginLeft: '0.5rem'}}
+            onClick={() => this.rename()}
+          >Rename Notebook</Button>
+        </TooltipTrigger>
+      </ModalFooter>
+    </Modal>;
   }
 }
 
@@ -76,10 +121,11 @@ export class RenameModal extends React.Component<RenameModalProps, RenameModalSt
 })
 export class RenameModalComponent extends ReactWrapperBase {
   @Input('resource') resource: RenameModalProps['resource'];
+  @Input('workspace') workspace: RenameModalProps['workspace'];
   @Input('onRename') onRename: RenameModalProps['onRename'];
   @Input('onCancel') onCancel: RenameModalProps['onCancel'];
 
   constructor() {
-    super(RenameModal, ['resource', 'onRename', 'onCancel']);
+    super(RenameModal, ['resource', 'workspace', 'onRename', 'onCancel']);
   }
 }

--- a/ui/src/app/views/resource-card/component.html
+++ b/ui/src/app/views/resource-card/component.html
@@ -39,7 +39,7 @@
 
 
 <app-rename-modal *ngIf="renaming && resourceCard.notebook"
-                  [resource]="resourceCard.notebook"
+                  [notebookName]="resourceCard.notebook.name"
                   [workspace]="{namespace: this.wsNamespace, name: this.wsId}"
                   [onCancel]="cancelRename.bind(this)"
                   [onRename]="receiveNotebookRename.bind(this)"></app-rename-modal>

--- a/ui/src/app/views/resource-card/component.html
+++ b/ui/src/app/views/resource-card/component.html
@@ -40,6 +40,7 @@
 
 <app-rename-modal *ngIf="renaming && resourceCard.notebook"
                   [resource]="resourceCard.notebook"
+                  [workspace]="{namespace: this.wsNamespace, name: this.wsId}"
                   [onCancel]="cancelRename.bind(this)"
                   [onRename]="receiveNotebookRename.bind(this)"></app-rename-modal>
 

--- a/ui/src/app/views/resource-card/component.tsx
+++ b/ui/src/app/views/resource-card/component.tsx
@@ -112,8 +112,6 @@ export class ResourceCardComponent implements OnInit {
   @Input('cssClass')
   cssClass: string;
   @Output() onUpdate: EventEmitter<void | NotebookRename> = new EventEmitter();
-  @Output() duplicateNameError: EventEmitter<string> = new EventEmitter();
-  @Output() invalidNameError: EventEmitter<string> = new EventEmitter();
   wsNamespace: string;
   wsId: string;
   resource: any;
@@ -166,33 +164,9 @@ export class ResourceCardComponent implements OnInit {
     this.confirmDeleting = false;
   }
 
-  receiveNotebookRename(rename: NotebookRename): void {
-    let newName = rename.newName;
-    if (!(new RegExp('^.+\.ipynb$').test(newName))) {
-      newName = rename.newName + '.ipynb';
-      rename.newName = newName;
-    }
-    if (new RegExp('.*\/.*').test(newName)) {
-      this.renaming = false;
-      this.invalidNameError.emit(newName);
-      return;
-    }
-    this.workspacesService.getNoteBookList(this.wsNamespace, this.wsId)
-      .switchMap((fileList) => {
-        if (fileList.filter((nb) => nb.name === newName).length > 0) {
-          throw new Error(newName);
-        } else {
-          return this.workspacesService.renameNotebook(this.wsNamespace, this.wsId, rename);
-        }
-      })
-      .subscribe(() => {
-        this.renaming = false;
-        this.onUpdate.emit(rename);
-      },
-        (dupName) => {
-          this.duplicateNameError.emit(dupName);
-          this.renaming = false;
-        });
+  receiveNotebookRename(): void {
+    this.renaming = false;
+    this.onUpdate.emit();
   }
 
   receiveEdit(resource: RecentResource): void {

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -1,0 +1,13 @@
+import {
+  WorkspacesApi
+} from 'generated/fetch';
+
+export class WorkspacesApiStub extends WorkspacesApi {
+  constructor() {
+    super(undefined, undefined, (..._: any[]) => { throw Error('cannot fetch in tests'); });
+  }
+
+  getNoteBookList() {
+    return Promise.resolve([]);
+  }
+}


### PR DESCRIPTION
Cleans up the code and UX of the notebook rename modal. Notes:
* The modal now handles the rename itself, rather than delegating out to the parent container, so it should work properly and consistently in all locations.
* Performs inline validation to give the user feedback sooner. Pre-loads the notebook list when the modal mounts in order to provide duplicate name validation.
* Cleans up unused code in notebook list and concept set list.

Note: The two commented error paths should be entirely unexpected/unknown errors, so I think just logging is ok for the moment, but we should come up with a more robust solution for those kinds of error cases soon.