### PR TITLE
[risk=no] add withCurrentWorkspace

### DIFF
--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -1,7 +1,12 @@
+import {WorkspaceData} from 'app/resolvers/workspace';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 export const NavStore = {
   navigate: undefined,
   navigateByUrl: undefined
 };
+
+export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
 
 // NOTE: Because these are wired up directly to the router component,
 // all navigation done from here will effectively use absolute paths.

--- a/ui/src/app/views/workspace-nav-bar/component.ts
+++ b/ui/src/app/views/workspace-nav-bar/component.ts
@@ -3,6 +3,7 @@ import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
 
+import {currentWorkspaceStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 
@@ -47,6 +48,7 @@ export class WorkspaceNavBarComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const handleData = (data) => {
       const workspace = <WorkspaceData> data.workspace;
+      currentWorkspaceStore.next(workspace);
       this.workspace = workspace;
       this.accessLevel = workspace.accessLevel;
     };
@@ -71,6 +73,7 @@ export class WorkspaceNavBarComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    currentWorkspaceStore.next(undefined);
     for (const s of this.subscriptions) {
       s.unsubscribe();
     }


### PR DESCRIPTION
This adds an HOC to enable components to access the current workspace from the route. It injects a prop `workspace` of type `WorkspaceData`. Usage is similar to other HOCs:

```const MyComponent = withCurrentWorkspace()(BaseComponent)```