### PR TITLE
[risk=no] add spinners

### DIFF
--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -1,0 +1,29 @@
+import {reactStyles} from 'app/utils/index';
+import * as React from 'react';
+
+const styles = reactStyles({
+  overlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+    position: 'absolute', top: 0, left: 0, bottom: 0, right: 0,
+    display: 'flex', justifyContent: 'center', alignItems: 'center'
+  },
+  square: {
+    display: 'flex', backgroundColor: '#fff', borderRadius: 4, padding: '0.5rem'
+  }
+});
+
+export const Spinner = ({style = {}, ...props}) => {
+  return <svg
+    xmlns='http://www.w3.org/2000/svg' viewBox='0 0 72 72' width={72} height={72}
+    style={{animation: '1s linear infinite spin', ...style}} {...props}
+  >
+    <circle cx='36' cy='36' r='33' stroke='#000' strokeOpacity='.1' fill='none' strokeWidth='5' />
+    <path d='M14.3 60.9A33 33 0 0 1 36 3' stroke='#0079b8' fill='none' strokeWidth='5' />
+  </svg>;
+};
+
+export const SpinnerOverlay = () => {
+  return <div style={styles.overlay}>
+    <div style={styles.square}><Spinner /></div>
+  </div>;
+};

--- a/ui/src/app/views/rename-modal/component.tsx
+++ b/ui/src/app/views/rename-modal/component.tsx
@@ -13,6 +13,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import {TooltipTrigger} from 'app/components/popups';
+import {SpinnerOverlay} from 'app/components/spinners';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 
 import {ReactWrapperBase, summarizeErrors} from 'app/utils';
@@ -101,7 +102,6 @@ export class RenameModal extends React.Component<RenameModalProps, {
       </ModalBody>
       <ModalFooter>
         <Button type='secondary' onClick={onCancel}>Cancel</Button>
-        {/* TODO: Use a loading spinner here in addition to disabling. */}
         <TooltipTrigger content={summarizeErrors(errors)}>
           <Button
             data-test-id='rename-button'
@@ -111,6 +111,7 @@ export class RenameModal extends React.Component<RenameModalProps, {
           >Rename Notebook</Button>
         </TooltipTrigger>
       </ModalFooter>
+      {saving && <SpinnerOverlay />}
     </Modal>;
   }
 }


### PR DESCRIPTION
Adds a standard spinner overlay component. Can be used to provide feedback that an action is in progress, as well as block the underlying UI.

Typical usage is to set `position: relative` on the container you want to overlay, then conditionally render the `SpinnerOverlay` inside that container (at the end, to make sure it's on top of other elements).

See the included example (note that modals already `position: relative` on them)