### PR TITLE
[risk=no] Fix auth on account creation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -368,6 +368,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   private ResponseEntity<Profile> getProfileResponse(User user) {
     Profile profile = profileService.getProfile(user);
+    // Note: The following requires that the current request is authenticated.
     NihStatus nihStatus = fireCloudService.getNihStatus();
     if (nihStatus != null) {
       profile.setLinkedNihUsername(nihStatus.getLinkedNihUsername());
@@ -437,7 +438,8 @@ public class ProfileController implements ProfileApiDelegate {
       throw new WorkbenchException(e);
     }
 
-    return getProfileResponse(user);
+    // Note: Avoid getProfileResponse() here as this is not an authenticated request.
+    return ResponseEntity.ok(profileService.getProfile(user));
   }
 
   @Override


### PR DESCRIPTION
Checking NIH status requires an authenticated request. When creating a new account, the request is not authenticated.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
