### PR TITLE
[risk=low] Bump strict-transport-security max-age from 1d -> 1y

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/interceptors/SecurityHeadersInterceptor.java
+++ b/common-api/src/main/java/org/pmiops/workbench/interceptors/SecurityHeadersInterceptor.java
@@ -15,8 +15,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  */
 @Service
 public class SecurityHeadersInterceptor extends HandlerInterceptorAdapter {
-  // TODO(calbach): Bump this to 1y once we've verified this is working as expected.
-  private static final long HSTS_MAX_AGE = Duration.ofDays(1).getSeconds();
+  private static final long HSTS_MAX_AGE = Duration.ofDays(365).getSeconds();
 
   @Override
   public boolean preHandle(

--- a/public-ui/app.yaml
+++ b/public-ui/app.yaml
@@ -8,15 +8,14 @@ handlers:
   static_files: dist/\1
   upload: dist/(.*)
   secure: always
-  # TODO(calbach): Bump max-age to 1y once we've verified this is correct.
   http_headers:
-    Strict-Transport-Security: "max-age=86400; includeSubDomains; preload"
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html
   secure: always
   http_headers:
-    Strict-Transport-Security: "max-age=86400; includeSubDomains; preload"
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
 
 # If a file (relative path under public-ui/) matches this regex, do not upload it.
 # Skip everything not starting with "dist".

--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -8,15 +8,14 @@ handlers:
   static_files: dist/\1
   upload: dist/(.*)
   secure: always
-  # TODO(calbach): Bump max-age to 1y once we've verified this is correct.
   http_headers:
-    Strict-Transport-Security: "max-age=86400; includeSubDomains; preload"
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html
   secure: always
   http_headers:
-    Strict-Transport-Security: "max-age=86400; includeSubDomains; preload"
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
 
 # If a file (relative path under ui/) matches this regex, do not upload it.
 # Skip everything not starting with "dist".


### PR DESCRIPTION
... now that it's been working for a while.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
