### PR TITLE
[risk=no] Update the AoU support email address

### DIFF
--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -38,7 +38,7 @@
     [clrAlertClosable]="true">
   <div clr-alert-item class="alert-item">
     An error occurred loading the help desk submission form. Please reload the page, or email
-    &nbsp;<a href="mailto:support@aousupporthelp.zendesk.com">support@aousupporthelp.zendesk.com</a>
+    &nbsp;<a href="mailto:support@researchallofus.org">support@researchallofus.org</a>
     &nbsp;directly with your support request.
   </div>
 </clr-alert>


### PR DESCRIPTION
Per guidance from Roxana, the AoU support email will actually be "support@researchallofus.org". This isn't (yet) attached to the Zendesk application, but it will go live once Zendesk is security approved.