### PR TITLE
[risk=no] Use --runInBand to mitigate jest timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
           name: Run React tests (Jest)
           working_directory: ~/workbench/ui
           command: |
-            yarn test-react --detectOpenHandles --forceExit
+            yarn test-react --detectOpenHandles --forceExit --runInBand
       - run:
           name: Build with strict compilation
           working_directory: ~/workbench/ui


### PR DESCRIPTION
Stolen from @zarsky-broad and split out ahead of https://github.com/all-of-us/workbench/pull/1723 to mitigate high flakiness we're seeing.

https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
