### PR TITLE
[RW-2016][risk=no] Drop https requirement on SSL verification file

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -8,7 +8,6 @@ handlers:
 - url: /.well-known/pki-validation/gsdv.txt
   static_files: dist/assets/gsdv.txt
   upload: dist/assets/gsdv.txt
-  secure: always
 - url: /(.*\.(css|eot|gz|html|ico|jpg|jpeg|js|map|png|svg|ttf|woff|woff2))
   static_files: dist/\1
   upload: dist/(.*)


### PR DESCRIPTION
This is a bit of a catch-22 if the purpose of serving this file is to setup SSL.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
