### PR TITLE
[risk=no] Cache the yarn cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ jobs:
       - save_cache:
           paths:
             - ~/.cache/yarn
-            - ~/workbench/ui/node_modules
           key: ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
       - run:
           name: Lint Angular app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.cache/yarn
+            - ~/workbench/ui/node_modules
           key: ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
       - run:
           name: Lint Angular app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,10 @@ jobs:
       # Use the ui-build-test workspace here to avoid redoing the setup.
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+          - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
+          - ui-cache-
       - deploy:
           name: Deploy to App Engine
           working_directory: ~/workbench/ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,15 +204,15 @@ jobs:
             ruby -r ./aou-utils/swagger.rb -e Workbench::Swagger.download_swagger_codegen_cli
       - restore_cache:
           keys:
-          - ui-cache-{{ checksum "~/workbench/ui/package.json" }}
+          - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
           - ui-cache-
       - run:
           working_directory: ~/workbench/ui
-          command: yarn install && yarn codegen
+          command: yarn install --frozen-lockfile && yarn codegen
       - save_cache:
           paths:
-            - ~/workbench/ui/node_modules
-          key: ui-cache-{{ checksum "~/workbench/ui/package.json" }}
+            - ~/.cache/yarn
+          key: ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
       - run:
           name: Lint Angular app
           working_directory: ~/workbench/ui

--- a/common-ui/common-ui-devstart.rb
+++ b/common-ui/common-ui-devstart.rb
@@ -41,7 +41,7 @@ def build(cmd_name, ui_name, args)
   options = BuildOptions.new.parse(cmd_name, args)
 
   common = Common.new
-  common.run_inline %W{yarn install}
+  common.run_inline %W{yarn install --frozen-lockfile}
 
   # Just use --aot for "test", which catches many compilation issues. Go full
   # --prod (includes --aot) for other environments. Don't use full --prod in the


### PR DESCRIPTION
https://yarnpkg.com/lang/en/docs/cli/cache/
https://circleci.com/docs/2.0/caching/#yarn-node

Also freeze yarn.lock generation on Circle + deploys for improved determinism.

On a sample run, this reduced `yarn install` runtime from ~30 -> ~18s. Not great, but at least it's following the standard docs.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
