### PR TITLE
[risk=no] Revert back to es5

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es6",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Revert ECMAScript version to es5 due to issue in cohort builder