### PR TITLE
[RW-2076][risk=low] Fix BigQuery integration tests

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -425,7 +425,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     ppiParam.type(TreeType.PPI.name());
     searchRequest = createSearchRequests(TreeType.PPI.name(), Arrays.asList(ppiParam), new ArrayList<>());
     assertMessageException(searchRequest, NOT_VALID_MESSAGE,
-      PARAMETER, CONCEPT_ID, ppiParam.getConceptId());
+      PARAMETER, NAME, ppiParam.getName());
 
     //ppi no value as number
     ppiParam.conceptId(1L);

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/ReviewQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/ReviewQueryBuilder.java
@@ -115,7 +115,6 @@ public class ReviewQueryBuilder {
       "left join (select standard_code, RANK() OVER(ORDER BY COUNT(*) DESC) as rnk\n" +
       "from `${projectId}.${dataSetId}.%s`\n" +
       "where person_id = @" + NAMED_PARTICIPANTID_PARAM + "\n" +
-      "and standard_concept_id != 0 \n" +
       "group by standard_code\n" +
       "LIMIT @" + NAMED_LIMIT_PARAM + ") b on a.standard_code = b.standard_code\n" +
       "where person_id = @" + NAMED_PARTICIPANTID_PARAM + "\n" +


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-2076

- Reverts https://github.com/all-of-us/workbench/pull/1728 temporarily, tried fixing the tests here but I don't understand the original issue fully and I'm not sure about expected behavior so should wait on @freemabd1 . Per discussion with @dolbeew , sounds like this is an existing issue which is probably not critical to the next release.
- Fixes error message testing to match updated behavior from #1727 .

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
