### PR TITLE
[RW-2080][risk=no] proxy route data for react conversion

### DIFF
--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -7,6 +7,8 @@ export const NavStore = {
 };
 
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
+export const urlParamsStore = new BehaviorSubject<any>({});
+export const routeConfigDataStore = new BehaviorSubject<any>(undefined);
 
 // NOTE: Because these are wired up directly to the router component,
 // all navigation done from here will effectively use absolute paths.

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -11,6 +11,7 @@ import {
 
 
 import {cookiesEnabled} from 'app/utils';
+import {routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 
 export const overriddenUrlKey = 'allOfUsApiUrlOverride';
@@ -93,6 +94,11 @@ export class AppComponent implements OnInit {
         // Terminal navigation events.
         this.initialSpinner = false;
       }
+      if (e instanceof NavigationEnd) {
+        const leafRoute = this.getLeafRoute();
+        urlParamsStore.next(leafRoute.snapshot.params);
+        routeConfigDataStore.next(leafRoute.snapshot.routeConfig.data);
+      }
     });
 
     this.setGTagManager();
@@ -100,6 +106,10 @@ export class AppComponent implements OnInit {
     if (this.cookiesEnabled) {
       this.setTCellAgent();
     }
+  }
+
+  getLeafRoute(route = this.activatedRoute) {
+    return route.firstChild ? this.getLeafRoute(route.firstChild) : route;
   }
 
   /**

--- a/ui/src/app/views/cohort-list/component.spec.ts
+++ b/ui/src/app/views/cohort-list/component.spec.ts
@@ -2,8 +2,6 @@ import {DebugElement} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, UrlSegment} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
 
 import {ClarityModule} from '@clr/angular';
 
@@ -26,6 +24,7 @@ import {ToolTipComponent} from 'app/views/tooltip/component';
 import {TopBoxComponent} from 'app/views/top-box/component';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import {currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 import {CohortsApi} from 'generated/fetch';
 import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
 
@@ -38,29 +37,8 @@ import {
 } from 'generated';
 
 
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-      {path: 'workspaces'},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID}
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    },
-    data: {
-      workspace: {
-        ...WorkspacesServiceStub.stubWorkspace(),
-        accessLevel: WorkspaceAccessLevel.OWNER,
-      }
-    }
-  }
-};
-
 class CohortListPage {
   fixture: ComponentFixture<CohortListComponent>;
-  route: UrlSegment[];
   form: DebugElement;
 
   constructor(testBed: typeof TestBed) {
@@ -81,7 +59,6 @@ describe('CohortListComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
-        RouterTestingModule,
         FormsModule,
         ReactiveFormsModule,
         ClarityModule.forRoot()
@@ -95,7 +72,6 @@ describe('CohortListComponent', () => {
         TopBoxComponent
       ],
       providers: [
-        { provide: ActivatedRoute, useValue: activatedRouteStub},
         { provide: CohortsService, useValue: new CohortsServiceStub()},
         { provide: ConceptSetsService },
         { provide: SignInService, useValue: new SignInServiceStub()},
@@ -103,6 +79,14 @@ describe('CohortListComponent', () => {
       ] }).compileComponents().then(() => {
         cohortListPage = new CohortListPage(TestBed);
       });
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+    });
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
     registerApiClient(CohortsApi, new CohortsApiStub());
     tick();
   }));

--- a/ui/src/app/views/cohort-list/component.ts
+++ b/ui/src/app/views/cohort-list/component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
+import {currentWorkspaceStore, navigate} from 'app/utils/navigation';
 import {ConfirmDeleteModalComponent} from 'app/views/confirm-delete-modal/component';
 
 import {
@@ -32,17 +32,14 @@ export class CohortListComponent implements OnInit {
   deleteModal: ConfirmDeleteModalComponent;
 
   constructor(
-    private route: ActivatedRoute,
     private cohortsService: CohortsService,
-    private router: Router,
-  ) {
-    const wsData: WorkspaceData = this.route.snapshot.data.workspace;
-    this.accessLevel = wsData.accessLevel;
-  }
+  ) {}
 
   ngOnInit(): void {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
+    const ws = currentWorkspaceStore.getValue();
+    this.accessLevel = ws.accessLevel;
+    this.wsNamespace = ws.namespace;
+    this.wsId = ws.id;
     this.reloadCohorts();
   }
 
@@ -62,7 +59,7 @@ export class CohortListComponent implements OnInit {
   }
 
   buildCohort(): void {
-    this.router.navigate(['build'], {relativeTo: this.route});
+    navigate(['/workspaces', this.wsNamespace, this.wsId, 'cohorts', 'build']);
   }
 
   get writePermission(): boolean {

--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -1,7 +1,7 @@
 import {Component, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
+import {navigate} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {environment} from 'environments/environment';
 
@@ -265,8 +265,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
     private profileService: ProfileService,
     private profileStorageService: ProfileStorageService,
     private serverConfigService: ServerConfigService,
-    private route: ActivatedRoute,
-    private router: Router,
   ) {
     // create bound methods to use as callbacks
     this.closeQuickTour = this.closeQuickTour.bind(this);
@@ -380,15 +378,15 @@ export class HomepageComponent implements OnInit, OnDestroy {
   }
 
   addWorkspace(): void {
-    this.router.navigate(['workspaces/build'], {relativeTo : this.route});
+    navigate(['workspaces/build']);
   }
 
   navigateToProfile(): void {
-    this.router.navigate(['profile']);
+    navigate(['profile']);
   }
 
   listWorkspaces(): void {
-    this.router.navigate(['workspaces']);
+    navigate(['workspaces']);
   }
 
   get twoFactorBannerEnabled() {

--- a/ui/src/app/views/workspace-edit/component.html
+++ b/ui/src/app/views/workspace-edit/component.html
@@ -396,7 +396,7 @@
 <!-- TODO: Factor out to component -->
 <ng-template #notFoundMessage>
   <h3>
-    Workspace {{route.snapshot.params['ns']}}/{{route.snapshot.params['wsid']}} could not be found.
+    Workspace {{oldWorkspaceNamespace}}/{{oldWorkspaceName}} could not be found.
   </h3>
 </ng-template>
 <clr-modal [(clrModalOpen)]="workspaceCreationError">

--- a/ui/src/app/views/workspace-edit/component.spec.ts
+++ b/ui/src/app/views/workspace-edit/component.spec.ts
@@ -2,7 +2,6 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
@@ -10,6 +9,7 @@ import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {WorkspaceStorageService} from 'app/services/workspace-storage.service';
+import {currentWorkspaceStore, NavStore, routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {ConfirmDeleteModalComponent} from 'app/views/confirm-delete-modal/component';
 import {WorkspaceEditComponent, WorkspaceEditMode} from 'app/views/workspace-edit/component';
@@ -34,14 +34,12 @@ import {
 
 
 describe('WorkspaceEditComponent', () => {
-  let activatedRouteStub: any;
-  let router: Router;
   let testComponent: WorkspaceEditComponent;
   let fixture: ComponentFixture<WorkspaceEditComponent>;
   let workspacesService: WorkspacesServiceStub;
 
   function setupComponent(mode: WorkspaceEditMode) {
-    activatedRouteStub.routeConfig.data.mode = mode;
+    routeConfigDataStore.next({mode});
     fixture = TestBed.createComponent(WorkspaceEditComponent);
     testComponent = fixture.componentInstance;
     fixture.detectChanges();
@@ -50,27 +48,14 @@ describe('WorkspaceEditComponent', () => {
   }
 
   beforeEach(fakeAsync(() => {
-    activatedRouteStub = {
-      snapshot: {
-        url: [
-          {path: 'workspaces'},
-          {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-          {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID},
-          {path: 'clone'}
-        ],
-        params: {
-          'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-          'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-        },
-        data: {
-          workspace: {
-            ...WorkspacesServiceStub.stubWorkspace(),
-            accessLevel: WorkspaceAccessLevel.OWNER,
-          }
-        }
-      },
-      routeConfig: {data: {}}
-    };
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+    });
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
     workspacesService = new WorkspacesServiceStub();
     TestBed.configureTestingModule({
       declarations: [
@@ -93,7 +78,6 @@ describe('WorkspaceEditComponent', () => {
         { provide: WorkspaceStorageService, useClass: WorkspaceStorageService },
         // Wrap in a factory function so we can later mutate the value if needed
         // for testing.
-        { provide: ActivatedRoute, useFactory: () => activatedRouteStub },
         { provide: ProfileStorageService, useValue: new ProfileStorageServiceStub() },
         {
           provide: CdrVersionStorageService,
@@ -118,9 +102,7 @@ describe('WorkspaceEditComponent', () => {
             gsuiteDomain: 'fake-research-aou.org'
           })
         }
-      ]}).compileComponents().then(() => {
-        router = TestBed.get(Router);
-      });
+      ]});
   }));
 
   it('should show a conflict-specific error when creating a name conflict workspace',
@@ -180,7 +162,7 @@ describe('WorkspaceEditComponent', () => {
   }));
 
   it('should support creating a workspace', fakeAsync(() => {
-    spyOn(TestBed.get(Router), 'navigate');
+    NavStore.navigate = jasmine.createSpy('navigate');
     workspacesService.workspaces = [];
     setupComponent(WorkspaceEditMode.Create);
 
@@ -196,7 +178,7 @@ describe('WorkspaceEditComponent', () => {
     tick();
     expect(workspacesService.workspaces.length).toBe(1);
     expect(workspacesService.workspaces[0].name).toBe('created');
-    expect(TestBed.get(Router).navigate)
+    expect(NavStore.navigate)
       .toHaveBeenCalledWith(['workspaces', 'foo', 'created']);
   }));
 
@@ -211,7 +193,7 @@ describe('WorkspaceEditComponent', () => {
     expect(testComponent.hasPermission).toBeTruthy(
       'cloner should be able to edit cloned workspace');
 
-    const spy = spyOn(router, 'navigate');
+    NavStore.navigate = jasmine.createSpy('navigate');
     fixture.debugElement.query(By.css('.add-button'))
       .triggerEventHandler('click', null);
     fixture.detectChanges();
@@ -221,7 +203,7 @@ describe('WorkspaceEditComponent', () => {
     expect(got).not.toBeNull();
     expect(got.namespace).toBe(
       ProfileStubVariables.PROFILE_STUB.freeTierBillingProjectName);
-    expect(spy).toHaveBeenCalled();
+    expect(NavStore.navigate).toHaveBeenCalled();
   }));
 
   it('should support cloning a workspace with cdr version change', fakeAsync(() => {
@@ -236,7 +218,7 @@ describe('WorkspaceEditComponent', () => {
       .find(d => d.nativeElement.textContent.includes('cdr1'));
     simulateClick(fixture, cdr1Option);
 
-    const spy = spyOn(router, 'navigate');
+    NavStore.navigate = jasmine.createSpy('navigate');
     fixture.debugElement.query(By.css('.add-button'))
       .triggerEventHandler('click', null);
     fixture.detectChanges();
@@ -245,7 +227,7 @@ describe('WorkspaceEditComponent', () => {
     const got = workspacesService.workspaces.find(w => w.name === testComponent.workspace.name);
     expect(got).not.toBeNull();
     expect(got.cdrVersionId).toBe('1');
-    expect(spy).toHaveBeenCalled();
+    expect(NavStore.navigate).toHaveBeenCalled();
   }));
 
   it('should use default CDR version for workspace creation', fakeAsync(() => {
@@ -261,7 +243,7 @@ describe('WorkspaceEditComponent', () => {
 
   it('should not create a workspace without description and fill later checkbox not selected',
     fakeAsync(() => {
-      spyOn(TestBed.get(Router), 'navigate');
+      NavStore.navigate = jasmine.createSpy('navigate');
       workspacesService.workspaces = [];
       setupComponent(WorkspaceEditMode.Create);
 
@@ -281,7 +263,7 @@ describe('WorkspaceEditComponent', () => {
 
   it('should create a workspace without description and fill later checkbox selected',
     fakeAsync(() => {
-      spyOn(TestBed.get(Router), 'navigate');
+      NavStore.navigate = jasmine.createSpy('navigate');
       workspacesService.workspaces = [];
       setupComponent(WorkspaceEditMode.Create);
 
@@ -302,7 +284,7 @@ describe('WorkspaceEditComponent', () => {
     }));
 
   it('should not create a workspace with name greater than 80 characters', fakeAsync(() => {
-    spyOn(TestBed.get(Router), 'navigate');
+    NavStore.navigate = jasmine.createSpy('navigate');
     workspacesService.workspaces = [];
     setupComponent(WorkspaceEditMode.Create);
     simulateInput(fixture, fixture.debugElement.query(By.css('.input.name')),
@@ -317,7 +299,7 @@ describe('WorkspaceEditComponent', () => {
   }));
 
   it('should allow editing unset underserved population on clone', fakeAsync(() => {
-    spyOn(TestBed.get(Router), 'navigate');
+    NavStore.navigate = jasmine.createSpy('navigate');
     setupComponent(WorkspaceEditMode.Clone);
     const de = fixture.debugElement;
     simulateClick(fixture, de.query(By.css('.underserved-icon')));

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -1,12 +1,12 @@
 import {Location} from '@angular/common';
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {WorkspaceData, WorkspaceStorageService} from 'app/services/workspace-storage.service';
 
 import {deepCopy, isBlank} from 'app/utils';
+import {currentWorkspaceStore, navigate, routeConfigDataStore} from 'app/utils/navigation';
 
 import {ToolTipComponent} from 'app/views/tooltip/component';
 import {
@@ -201,12 +201,10 @@ export class WorkspaceEditComponent implements OnInit {
 
   constructor(
     private locationService: Location,
-    private route: ActivatedRoute,
     private workspacesService: WorkspacesService,
     private workspaceStorageService: WorkspaceStorageService,
     private cdrVersionStorageService: CdrVersionStorageService,
     public profileStorageService: ProfileStorageService,
-    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -228,8 +226,9 @@ export class WorkspaceEditComponent implements OnInit {
         underservedPopulationDetails: []
       }};
     this.mode = WorkspaceEditMode.Edit;
-    if (this.route.routeConfig.data.mode) {
-      this.mode = this.route.routeConfig.data.mode;
+    const configData = routeConfigDataStore.getValue();
+    if (configData.mode) {
+      this.mode = configData.mode;
     }
 
     this.cdrVersionStorageService.cdrVersions$.subscribe(resp => {
@@ -247,14 +246,15 @@ export class WorkspaceEditComponent implements OnInit {
     }
     if (this.mode === WorkspaceEditMode.Edit || this.mode === WorkspaceEditMode.Clone) {
       // There is an existing workspace referenced in this flow.
-      this.oldWorkspaceNamespace = this.route.snapshot.params['ns'];
-      this.oldWorkspaceName = this.route.snapshot.params['wsid'];
+      const ws = currentWorkspaceStore.getValue();
+      this.oldWorkspaceNamespace = ws.namespace;
+      this.oldWorkspaceName = ws.id;
       this.loadWorkspace();
     }
   }
 
   loadWorkspace(): void {
-    const wsData: WorkspaceData = deepCopy(this.route.snapshot.data.workspace) as WorkspaceData;
+    const wsData: WorkspaceData = deepCopy(currentWorkspaceStore.getValue()) as WorkspaceData;
     if (this.mode === WorkspaceEditMode.Edit) {
       this.workspace = wsData;
       this.accessLevel = wsData.accessLevel;
@@ -328,7 +328,7 @@ export class WorkspaceEditComponent implements OnInit {
     this.savingWorkspace = true;
     this.workspacesService.createWorkspace(this.workspace).subscribe(
       (workspace) => {
-        this.router.navigate(['workspaces', workspace.namespace, workspace.id]);
+        navigate(['workspaces', workspace.namespace, workspace.id]);
       },
       (error) => {
         if (error.status === 409) {
@@ -377,7 +377,7 @@ export class WorkspaceEditComponent implements OnInit {
         workspace: this.workspace,
       }).subscribe(
         (r: CloneWorkspaceResponse) => {
-          this.router.navigate(['/workspaces', r.workspace.namespace, r.workspace.id]);
+          navigate(['/workspaces', r.workspace.namespace, r.workspace.id]);
         },
         (error) => {
           this.resetWorkspaceEditor();

--- a/ui/src/app/views/workspace-list/component.ts
+++ b/ui/src/app/views/workspace-list/component.ts
@@ -1,8 +1,8 @@
 import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 import {ErrorHandlingService} from 'app/services/error-handling.service';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 
+import {navigate} from 'app/utils/navigation';
 import {WorkspacePermissions} from 'app/utils/workspace-permissions';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
@@ -59,8 +59,6 @@ export class WorkspaceListComponent implements OnInit, OnDestroy {
 
   constructor(
     private profileStorageService: ProfileStorageService,
-    private route: ActivatedRoute,
-    private router: Router,
     private workspacesService: WorkspacesService,
   ) {}
 
@@ -105,7 +103,7 @@ export class WorkspaceListComponent implements OnInit, OnDestroy {
   }
 
   addWorkspace(): void {
-    this.router.navigate(['workspaces/build']);
+    navigate(['workspaces/build']);
   }
 
   reloadWorkspaces(): void {


### PR DESCRIPTION
Creates a few new observable 'stores' to extract route-related info from the angular router.
`urlParamsStore` contains the raw params object
`routeConfigDataStore` contains the `data` object from the route definition

Also converts a couple components to use the stores, removing dependency on the router.