### PR TITLE
[risk=no] Downgrade gcloud to 215.0.0 to avoid gsutil error

### DIFF
--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add openjdk8
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
 #
 
-ENV CLOUD_SDK_VERSION 217.0.0
+ENV CLOUD_SDK_VERSION 215.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -17,7 +17,7 @@ FROM circleci/openjdk:8-jdk-node-browsers
 
 USER circleci
 
-ENV CLOUD_SDK_VERSION 217.0.0
+ENV CLOUD_SDK_VERSION 215.0.0
 
 RUN cd && \
   wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -O gcloud.tgz && \

--- a/public-ui/src/dev/server/Dockerfile
+++ b/public-ui/src/dev/server/Dockerfile
@@ -10,7 +10,7 @@ RUN groupmod -g 666 node \
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
 #
 
-ENV CLOUD_SDK_VERSION 217.0.0
+ENV CLOUD_SDK_VERSION 215.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 

--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -10,7 +10,7 @@ RUN groupmod -g 666 node \
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
 #
 
-ENV CLOUD_SDK_VERSION 217.0.0
+ENV CLOUD_SDK_VERSION 215.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 


### PR DESCRIPTION
Some project.rb commands result in `Failure: 'getpwuid(): uid not found: 1992018429'` in certain situations, particularly when creds are uninitialized. There are other ways to get around it, but downgrading avoids the issue entirely.

https://github.com/GoogleCloudPlatform/gsutil/issues/575

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
