### PR TITLE
[RW-2034][risk=no] Auto-populate Institution and contact email address for new users

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -4,10 +4,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.apache.ApacheHttpTransport;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Clock;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -30,8 +32,8 @@ public class DirectoryServiceImplIntegrationTest {
   public void setUp() throws MessagingException {
     MailService mailService = Mockito.mock(MailServiceImpl.class);
     service = new DirectoryServiceImpl(
-        Providers.of(googleCredential), Providers.of(workbenchConfig), httpTransport,
-        new GoogleRetryHandler(new NoBackOffPolicy()));
+      Providers.of(googleCredential), Providers.of(workbenchConfig), httpTransport,
+      new GoogleRetryHandler(new NoBackOffPolicy()));
   }
 
   @Test
@@ -52,9 +54,9 @@ public class DirectoryServiceImplIntegrationTest {
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(service.getContactEmailAddress(userName).equals("notasecret@gmail.com"));
     assertThat(
-            service.getUserByUsername(userName).getCustomSchemas()
-                    .get("All_of_Us_Workbench")
-                    .get("Institution").equals("All of Us Research Workbench"));
+      service.getUserByUsername(userName).getCustomSchemas()
+        .get("All_of_Us_Workbench")
+        .get("Institution").equals("All of Us Research Workbench"));
     service.deleteUser(userName);
     assertThat(service.isUsernameTaken(userName)).isFalse();
   }

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -47,8 +47,14 @@ public class DirectoryServiceImplIntegrationTest {
   @Test
   public void testCreateAndDeleteTestUser() {
     String userName = String.format("integration.test.%d", Clock.systemUTC().millis());
-    service.createUser("Integration", "Test", userName, "notasecret");
+    service.createUser("Integration", "Test", userName, "notasecret@gmail.com");
     assertThat(service.isUsernameTaken(userName)).isTrue();
+    // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
+    assertThat(service.getContactEmailAddress(userName).equals("notasecret@gmail.com"));
+    assertThat(
+            service.getUserByUsername(userName).getCustomSchemas()
+                    .get("All_of_Us_Workbench")
+                    .get("Institution").equals("All of Us Research Workbench"));
     service.deleteUser(userName);
     assertThat(service.isUsernameTaken(userName)).isFalse();
   }

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -172,12 +172,6 @@ public class DirectoryServiceImpl implements DirectoryService {
     return user;
   }
 
-  // Updates a user in GSuite. The Directory API follows patch semantics, so only non-empty fields
-  // will overwrite existing values (and a null value will clear a field).
-  public User updateUser(String email, User user) {
-    return retryHandler.run((context) -> getGoogleDirectoryService().users().update(email, user).execute());
-  }
-
   @Override
   public User resetUserPassword(String email) {
     User user = getUser(email);

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -127,7 +127,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     return getUserByUsername(username) != null;
   }
 
-  // Returns a user's contact email address, stored as a custom schema field via the directory API.
+  // Returns a user's contact email address via the custom schema in the directory API.
   public String getContactEmailAddress(String username) {
     return (String) getUserByUsername(username)
         .getCustomSchemas()

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -18,7 +18,11 @@ import org.springframework.stereotype.Service;
 import javax.inject.Provider;
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -97,7 +101,7 @@ public class DirectoryServiceImpl implements DirectoryService {
   }
 
   public User getUserByUsername(String username) {
-    return getUser(username+"@" + gSuiteDomain());
+    return getUser(username + "@" + gSuiteDomain());
   }
 
   @Override
@@ -126,9 +130,9 @@ public class DirectoryServiceImpl implements DirectoryService {
   // Returns a user's contact email address, stored as a custom schema field via the directory API.
   public String getContactEmailAddress(String username) {
     return (String) getUserByUsername(username)
-            .getCustomSchemas()
-            .get(GSUITE_AOU_SCHEMA_NAME)
-            .get(GSUITE_FIELD_CONTACT_EMAIL);
+        .getCustomSchemas()
+        .get(GSUITE_AOU_SCHEMA_NAME)
+        .get(GSUITE_FIELD_CONTACT_EMAIL);
   }
 
   @Override
@@ -141,7 +145,8 @@ public class DirectoryServiceImpl implements DirectoryService {
     // was primarily set up for Moodle SSO integration.
     Map<String, Object> aouCustomFields = new HashMap<String, Object>();
     // The value of this field must match one of the allowed values in the Moodle installation.
-    // Since this value is unlikely to ever change, we use a hard-coded constant rather than an env variable.
+    // Since this value is unlikely to ever change, we use a hard-coded constant rather than an env
+    // variable.
     aouCustomFields.put(GSUITE_FIELD_INSTITUTION, INSTITUTION_FIELD_VALUE);
     // This gives us a structured place to store researchers' contact email addresses, in
     // case we want to pass it to other systems (e.g. Zendesk or Moodle) via SAML mapped fields.
@@ -152,10 +157,11 @@ public class DirectoryServiceImpl implements DirectoryService {
         .setPassword(password)
         .setName(new UserName().setGivenName(givenName).setFamilyName(familyName))
         // In addition to the custom schema value, we store each user's contact email as a secondary
-        // email address with type "work"
+        // email address with type "home". This makes it show up nicely in GSuite admin as the
+        // user's "Secondary email".
         .setEmails(Lists.newArrayList(
-                new UserEmail().setType("work").setAddress(primaryEmail).setPrimary(true),
-                new UserEmail().setType("home").setAddress(contactEmail)))
+            new UserEmail().setType("work").setAddress(primaryEmail).setPrimary(true),
+            new UserEmail().setType("home").setAddress(contactEmail)))
         .setCustomSchemas(Collections.singletonMap(GSUITE_AOU_SCHEMA_NAME, aouCustomFields))
         .setChangePasswordAtNextLogin(true);
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -8,6 +8,7 @@ import com.google.api.services.admin.directory.DirectoryScopes;
 import com.google.api.services.admin.directory.model.User;
 import com.google.api.services.admin.directory.model.UserEmail;
 import com.google.api.services.admin.directory.model.UserName;
+import com.google.common.collect.Lists;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +18,7 @@ import org.springframework.stereotype.Service;
 import javax.inject.Provider;
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -27,8 +27,17 @@ import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
 @Service
 public class DirectoryServiceImpl implements DirectoryService {
 
-  private static final String APPLICATION_NAME = "All of Us Researcher Workbench";
   private static final String ALLOWED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()";
+  private static final String APPLICATION_NAME = "All of Us Researcher Workbench";
+  // Name of the GSuite custom schema containing AOU custom fields.
+  private static final String GSUITE_AOU_SCHEMA_NAME = "All_of_Us_Workbench";
+  // Name of the "contact email" custom field, which is stored within the AoU GSuite custom schema.
+  private static final String GSUITE_FIELD_CONTACT_EMAIL = "Contact_email_address";
+  // Name of the "institution" custom field, whose value is the same for all Workbench users.
+  private static final String GSUITE_FIELD_INSTITUTION = "Institution";
+  private static final String INSTITUTION_FIELD_VALUE = "All of Us Research Workbench";
+
+
   private static SecureRandom rnd = new SecureRandom();
 
   // This list must exactly match the scopes allowed via the GSuite Domain Admin page here:
@@ -83,11 +92,20 @@ public class DirectoryServiceImpl implements DirectoryService {
         .build();
   }
 
+  private String gSuiteDomain() {
+    return configProvider.get().googleDirectoryService.gSuiteDomain;
+  }
+
+  public User getUserByUsername(String username) {
+    return getUser(username+"@" + gSuiteDomain());
+  }
+
   @Override
   public User getUser(String email) {
     try {
+      // We use the "full" projection to include custom schema fields in the Directory API response.
       return retryHandler.runAndThrowChecked((context) ->
-          getGoogleDirectoryService().users().get(email).execute());
+          getGoogleDirectoryService().users().get(email).setProjection("full").execute());
     } catch (GoogleJsonResponseException e) {
       // Handle the special case where we're looking for a not found user by returning
       // null.
@@ -102,39 +120,62 @@ public class DirectoryServiceImpl implements DirectoryService {
 
   @Override
   public boolean isUsernameTaken(String username) {
-    String gSuiteDomain = configProvider.get().googleDirectoryService.gSuiteDomain;
-    return getUser(username + "@" + gSuiteDomain) != null;
+    return getUserByUsername(username) != null;
+  }
+
+  // Returns a user's contact email address, stored as a custom schema field via the directory API.
+  public String getContactEmailAddress(String username) {
+    return (String) getUserByUsername(username)
+            .getCustomSchemas()
+            .get(GSUITE_AOU_SCHEMA_NAME)
+            .get(GSUITE_FIELD_CONTACT_EMAIL);
   }
 
   @Override
   public User createUser(String givenName, String familyName, String username, String contactEmail) {
-    String gSuiteDomain = configProvider.get().googleDirectoryService.gSuiteDomain;
+    String primaryEmail = username + "@" + gSuiteDomain();
     String password = randomString();
+
+    // GSuite custom fields for Workbench user accounts.
+    // See the Moodle integration doc (broad.io/aou-moodle) for more details, as this
+    // was primarily set up for Moodle SSO integration.
+    Map<String, Object> aouCustomFields = new HashMap<String, Object>();
+    // The value of this field must match one of the allowed values in the Moodle installation.
+    // Since this value is unlikely to ever change, we use a hard-coded constant rather than an env variable.
+    aouCustomFields.put(GSUITE_FIELD_INSTITUTION, INSTITUTION_FIELD_VALUE);
+    // This gives us a structured place to store researchers' contact email addresses, in
+    // case we want to pass it to other systems (e.g. Zendesk or Moodle) via SAML mapped fields.
+    aouCustomFields.put(GSUITE_FIELD_CONTACT_EMAIL, contactEmail);
+
     User user = new User()
-        .setPrimaryEmail(username+"@"+gSuiteDomain)
+        .setPrimaryEmail(primaryEmail)
         .setPassword(password)
         .setName(new UserName().setGivenName(givenName).setFamilyName(familyName))
-        .setEmails(new UserEmail().setType("custom").setAddress(contactEmail).setCustomType("contact"))
+        // In addition to the custom schema value, we store each user's contact email as a secondary
+        // email address with type "work"
+        .setEmails(Lists.newArrayList(
+                new UserEmail().setType("work").setAddress(primaryEmail).setPrimary(true),
+                new UserEmail().setType("home").setAddress(contactEmail)))
+        .setCustomSchemas(Collections.singletonMap(GSUITE_AOU_SCHEMA_NAME, aouCustomFields))
         .setChangePasswordAtNextLogin(true);
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());
     return user;
   }
 
   @Override
-  public User resetUserPassword(String userKey) {
-    User user = getUser(userKey);
+  public User resetUserPassword(String email) {
+    User user = getUser(email);
     String password = randomString();
     user.setPassword(password);
-    retryHandler.run((context) -> getGoogleDirectoryService().users().update(userKey, user).execute());
+    retryHandler.run((context) -> getGoogleDirectoryService().users().update(email, user).execute());
     return user;
   }
 
   @Override
   public void deleteUser(String username) {
-    String gSuiteDomain = configProvider.get().googleDirectoryService.gSuiteDomain;
     try {
       retryHandler.runAndThrowChecked((context) -> getGoogleDirectoryService().users()
-          .delete(username + "@" + gSuiteDomain).execute());
+          .delete(username + "@" + gSuiteDomain()).execute());
     } catch (GoogleJsonResponseException e) {
       if (e.getDetails().getCode() == HttpStatus.NOT_FOUND.value()) {
         // Deleting a user that doesn't exist will have no effect.

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -1,3 +1,7 @@
+/**
+ * Note: this file is tested with integration tests rather than unit tests. See
+ * src/integration/.../DirectoryServiceImplIntegrationTest.java for test cases.
+ */
 package org.pmiops.workbench.google;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -166,6 +170,12 @@ public class DirectoryServiceImpl implements DirectoryService {
         .setChangePasswordAtNextLogin(true);
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());
     return user;
+  }
+
+  // Updates a user in GSuite. The Directory API follows patch semantics, so only non-empty fields
+  // will overwrite existing values (and a null value will clear a field).
+  public User updateUser(String email, User user) {
+    return retryHandler.run((context) -> getGoogleDirectoryService().users().update(email, user).execute());
   }
 
   @Override


### PR DESCRIPTION
This PR makes a few changes to populate the custom GSuite schema fields required for Moodle SAML integration.

While I was in this code, I also changed the way we store a user's contact email address in GSuite. This will now show up in two places:

1) The "Contact_email_address" custom schema field.
2) A secondary email address with type "home".

Plus some small additions to the integration test to verify these things work.

RELEASE COORDINATION: the custom schema has already been added to our dev GSuite, but not prod. I will make those changes before this PR gets merged, after which point this PR will be safe to run in all environments.