### PR TITLE
[risk=no] extract current cohort from route

### DIFF
--- a/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
@@ -6,12 +6,14 @@ import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {ComboChartComponent} from 'app/cohort-common/combo-chart/combo-chart.component';
 import {ParticipantsChartsComponent} from 'app/cohort-review/participants-charts/participant-charts';
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
-import {CohortBuilderService, CohortReviewService} from 'generated';
+import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
+import {CohortBuilderService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {OverviewPage} from './overview-page';
 
 
@@ -20,51 +22,11 @@ describe('OverviewPage', () => {
   let component: OverviewPage;
   let fixture: ComponentFixture<OverviewPage>;
   const activatedRouteStub = {
-    data: Observable.of({
-      participant: {},
-      annotations: [],
-    }),
     snapshot: {
       data: {
-        workspace: {
-          cdrVersionId: 1
-        },
-        cohort: {
-          name: '',
-          criteria: '{}'
-        },
-        review: {},
-        params: {
-          ns: 'workspaceNamespace',
-          wsid: 'workspaceId',
-          cid: 1
-        }
-      },
-    },
-    parent: {
-      snapshot: {
-        data: {
-          workspace: {
-            cdrVersionId: 1
-          },
-          cohort: {
-            name: ''
-          },
-          params: {
-            ns: 'workspaceNamespace',
-            wsid: 'workspaceId',
-            cid: 1
-          }
-        },
-        params: {
-          ns: 'workspaceNamespace',
-          wsid: 'workspaceId',
-          cid: 1
-        }
-      },
-
-    },
-
+        review: {}
+      }
+    }
   };
 
   let route;
@@ -82,6 +44,21 @@ describe('OverviewPage', () => {
       ],
     })
       .compileComponents();
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      cdrVersionId: '1',
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
+    currentCohortStore.next({
+      name: '',
+      criteria: '{}',
+      type: '',
+    });
+    urlParamsStore.next({
+      ns: 'workspaceNamespace',
+      wsid: 'workspaceId',
+      cid: 1
+    });
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/overview-page/overview-page.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.ts
@@ -1,6 +1,7 @@
 import {Component, EventEmitter, OnDestroy, OnInit, Output} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 import {CohortBuilderService, CohortReview, CohortReviewService, DemoChartInfoListResponse, DomainType, SearchRequest} from 'generated';
 import {fromJS, List} from 'immutable';
 import {Subscription} from 'rxjs/Subscription';
@@ -37,9 +38,11 @@ export class OverviewPage implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    const {cohort, review, workspace} = this.route.snapshot.data;
+    const {review} = this.route.snapshot.data;
+    const workspace = currentWorkspaceStore.getValue();
+    const cohort = currentCohortStore.getValue();
     const request = <SearchRequest>(JSON.parse(cohort.criteria));
-    this.chartAPI.getDemoChartInfo(workspace.cdrVersionId, request)
+    this.chartAPI.getDemoChartInfo(+workspace.cdrVersionId, request)
       .map(response => (<DemoChartInfoListResponse>response).items)
       .subscribe(data => {
         this.data = fromJS(data);
@@ -61,8 +64,8 @@ export class OverviewPage implements OnInit, OnDestroy {
     this.buttonsDisableFlag = true;
     this.showTitle = false;
     const limit = 10;
-    const cdrid = +(this.route.parent.snapshot.data.workspace.cdrVersionId);
-    const {ns, wsid, cid} = this.route.parent.snapshot.params;
+    const cdrid = +(currentWorkspaceStore.getValue().cdrVersionId);
+    const {ns, wsid, cid} = urlParamsStore.getValue();
     this.typesList.map(domainName => {
       this.domainsData[domainName] = {
         conditionTitle: '',

--- a/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
@@ -4,6 +4,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 import {CohortReview} from 'generated';
+import {Observable} from 'rxjs/Observable';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
 import {CreateReviewPage} from 'app/cohort-review/create-review-page/create-review-page';
@@ -19,7 +20,8 @@ describe('PageLayout', () => {
       data: {
         review: <CohortReview> {}
       }
-    }
+    },
+    data: Observable.of({})
   };
   let route;
 

--- a/ui/src/app/cohort-review/page-layout/page-layout.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.ts
@@ -1,15 +1,17 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {currentCohortStore} from 'app/utils/navigation';
 import {ReviewStatus} from 'generated';
 
 @Component({
   templateUrl: './page-layout.html',
   styleUrls: ['./page-layout.css']
 })
-export class PageLayout implements OnInit {
+export class PageLayout implements OnInit, OnDestroy {
 
+  subscription: any;
   create = false;
   constructor(
     private state: ReviewStateService,
@@ -18,8 +20,11 @@ export class PageLayout implements OnInit {
   ) {}
 
   ngOnInit() {
-    const {cohort, review} = this.route.snapshot.data;
-    this.state.cohort.next(cohort);
+    const {review} = this.route.snapshot.data;
+    this.subscription = this.route.data.subscribe(({cohort}) => {
+      this.state.cohort.next(cohort);
+      currentCohortStore.next(cohort);
+    });
     this.state.review.next(review);
 
     if (review.reviewStatus === ReviewStatus.NONE) {
@@ -27,6 +32,10 @@ export class PageLayout implements OnInit {
     } else {
       this.router.navigate(['participants'], {relativeTo: this.route});
     }
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 
   reviewCreated(created: boolean) {

--- a/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
@@ -10,7 +10,8 @@ import {QueryDescriptiveStatsComponent} from 'app/cohort-review/query-descriptiv
 import {QueryReportComponent} from 'app/cohort-review/query-report/query-report.component';
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
-import {CohortBuilderService, CohortReviewService, DataAccessLevel} from 'generated';
+import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
+import {CohortBuilderService, CohortReviewService, DataAccessLevel, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 import {CdrVersionStorageServiceStub} from 'testing/stubs/cdr-version-storage-service-stub';
@@ -45,55 +46,11 @@ describe('QueryReportComponent', () => {
     excludes: []
   };
   const activatedRouteStub = {
-    data: Observable.of({
-      participant: {},
-      annotations: [],
-    }),
     snapshot: {
       data: {
-        workspace: {
-          cdrVersionId: 1
-        },
-        cohort: {
-          name: '',
-          criteria: JSON.stringify(criteria)
-        },
-        review: {},
-        params: {
-          ns: 'workspaceNamespace',
-          wsid: 'workspaceId',
-          cid: 1
-        }
-      },
-      params: {
-        ns: 'workspaceNamespace',
-        wsid: 'workspaceId',
-        cid: 1
+        review: {}
       }
-    },
-    parent: {
-      snapshot: {
-        data: {
-          workspace: {
-            cdrVersionId: 1
-          },
-          cohort: {
-            name: ''
-          },
-          params: {
-            ns: 'workspaceNamespace',
-            wsid: 'workspaceId',
-            cid: 1
-          }
-        },
-        params: {
-          ns: 'workspaceNamespace',
-          wsid: 'workspaceId',
-          cid: 1
-        }
-      },
-
-    },
+    }
   };
   let route;
 
@@ -130,6 +87,21 @@ describe('QueryReportComponent', () => {
       ]
     })
       .compileComponents();
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      cdrVersionId: '1',
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
+    currentCohortStore.next({
+      name: '',
+      criteria: JSON.stringify(criteria),
+      type: '',
+    });
+    urlParamsStore.next({
+      ns: 'workspaceNamespace',
+      wsid: 'workspaceId',
+      cid: 1
+    });
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/query-report/query-report.component.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.ts
@@ -2,6 +2,7 @@ import {AfterContentChecked, ChangeDetectorRef, Component, OnInit} from '@angula
 import {ActivatedRoute} from '@angular/router';
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
+import {currentCohortStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {CohortBuilderService, Workspace} from 'generated';
 import {List} from 'immutable';
 import {Observable} from 'rxjs/Observable';
@@ -27,10 +28,9 @@ export class QueryReportComponent implements OnInit, AfterContentChecked {
     private cdrVersionStorageService: CdrVersionStorageService) {}
 
   ngOnInit() {
-    const {cohort, review} = this.route.snapshot.data;
-    const wsData: WorkspaceData = this.route.snapshot.data.workspace;
-    this.workspace = wsData;
-    this.cohort = cohort;
+    const {review} = this.route.snapshot.data;
+    this.cohort = currentCohortStore.getValue();
+    this.workspace = currentWorkspaceStore.getValue();
     this.review = review;
     this.cdrVersionStorageService.cdrVersions$.subscribe(resp => {
       this.cdrDetails = resp.items.find(v => v.cdrVersionId === this.workspace.cdrVersionId);

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -1,4 +1,5 @@
 import {WorkspaceData} from 'app/resolvers/workspace';
+import {Cohort} from 'generated/fetch';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 export const NavStore = {
@@ -7,6 +8,7 @@ export const NavStore = {
 };
 
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
+export const currentCohortStore = new BehaviorSubject<Cohort>(undefined);
 export const urlParamsStore = new BehaviorSubject<any>({});
 export const routeConfigDataStore = new BehaviorSubject<any>(undefined);
 


### PR DESCRIPTION
This creates `currentCohortStore` as a mechanism to expose the current cohort without depending on the router. Also converts `page-layout` and `overview-page` as example usages.