### PR TITLE
[risk=no] refactor away router dependencies

### DIFF
--- a/ui/src/app/cohort-review/page-layout/page-layout.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
@@ -9,7 +9,7 @@ import {ReviewStatus} from 'generated';
   templateUrl: './page-layout.html',
   styleUrls: ['./page-layout.css']
 })
-export class PageLayout implements OnInit, OnDestroy {
+export class PageLayout implements OnInit {
 
   subscription: any;
   create = false;
@@ -21,10 +21,6 @@ export class PageLayout implements OnInit, OnDestroy {
 
   ngOnInit() {
     const {review} = this.route.snapshot.data;
-    this.subscription = this.route.data.subscribe(({cohort}) => {
-      this.state.cohort.next(cohort);
-      currentCohortStore.next(cohort);
-    });
     this.state.review.next(review);
 
     if (review.reviewStatus === ReviewStatus.NONE) {
@@ -32,10 +28,6 @@ export class PageLayout implements OnInit, OnDestroy {
     } else {
       this.router.navigate(['participants'], {relativeTo: this.route});
     }
-  }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
   }
 
   reviewCreated(created: boolean) {

--- a/ui/src/app/cohort-review/review-state.service.ts
+++ b/ui/src/app/cohort-review/review-state.service.ts
@@ -12,12 +12,10 @@ import {
 export class ReviewStateService {
   /* Data Subjects */
   review = new ReplaySubject<CohortReview>(1);
-  cohort = new ReplaySubject<Cohort>(1);
   annotationDefinitions = new ReplaySubject<CohortAnnotationDefinition[]>(1);
 
   /* Observable views on the data Subjects */
   review$ = this.review.asObservable();
-  cohort$ = this.cohort.asObservable();
   annotationDefinitions$ = this.annotationDefinitions.asObservable();
 
   /* Flags */

--- a/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {CohortAnnotationDefinitionService} from 'generated';
 
@@ -10,7 +9,6 @@ import {SetAnnotationCreateComponent} from './set-annotation-create.component';
 describe('SetAnnotationCreateComponent', () => {
   let component: SetAnnotationCreateComponent;
   let fixture: ComponentFixture<SetAnnotationCreateComponent>;
-  let route;
 
   beforeEach(async(() => {
 
@@ -18,7 +16,6 @@ describe('SetAnnotationCreateComponent', () => {
       declarations: [ SetAnnotationCreateComponent ],
       imports: [ClarityModule, ReactiveFormsModule],
       providers: [
-        {provide: ActivatedRoute, useValue: {}},
         {provide: CohortAnnotationDefinitionService, useValue: {}},
         {provide: ReviewStateService, useValue: {}},
       ],
@@ -29,7 +26,6 @@ describe('SetAnnotationCreateComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SetAnnotationCreateComponent);
     component = fixture.componentInstance;
-    route = new ActivatedRoute();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.ts
@@ -1,8 +1,8 @@
 import {Component, EventEmitter, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {urlParamsStore} from 'app/utils/navigation';
 
 import {
   AnnotationType,
@@ -51,12 +51,11 @@ export class SetAnnotationCreateComponent {
   constructor(
     private annotationAPI: CohortAnnotationDefinitionService,
     private state: ReviewStateService,
-    private route: ActivatedRoute,
   ) {}
 
   create(): void {
     this.posting = true;
-    const {ns, wsid, cid} = this.route.snapshot.params;
+    const {ns, wsid, cid} = urlParamsStore.getValue();
 
     const request = <CohortAnnotationDefinition>{
       cohortId: cid,

--- a/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.spec.ts
@@ -1,9 +1,9 @@
 import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {urlParamsStore} from 'app/utils/navigation';
 import {SetAnnotationItemComponent} from './set-annotation-item.component';
 
 import {
@@ -15,17 +15,6 @@ import {
   CohortAnnotationDefinition,
   CohortAnnotationDefinitionService,
 } from 'generated';
-
-
-class StubRoute {
-  snapshot = {params: {
-    ns: 'workspaceNamespace',
-    wsid: 'workspaceId',
-    cid: 1
-  }};
-}
-
-const stubRoute = new StubRoute();
 
 const stubDefinition = <CohortAnnotationDefinition>{
   cohortAnnotationDefinitionId: 1,
@@ -59,7 +48,6 @@ describe('SetAnnotationItemComponent', () => {
         providers: [
           ReviewStateService,
           {provide: CohortAnnotationDefinitionService, useValue: new ApiSpy()},
-          {provide: ActivatedRoute, useValue: stubRoute},
         ],
       }).compileComponents().then((resp) => {
         fixture = TestBed.createComponent(SetAnnotationItemComponent);
@@ -70,6 +58,11 @@ describe('SetAnnotationItemComponent', () => {
         component.definition = stubDefinition;
         updateAndTick(fixture);
       });
+    urlParamsStore.next({
+      ns: 'workspaceNamespace',
+      wsid: 'workspaceId',
+      cid: 1
+    });
   }));
 
   it('Should render', () => {

--- a/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
@@ -7,9 +7,9 @@ import {
     ViewChild
 } from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {urlParamsStore} from 'app/utils/navigation';
 
 import {
     CohortAnnotationDefinition,
@@ -32,7 +32,6 @@ export class SetAnnotationItemComponent {
   @ViewChild('nameInput') nameInput;
 
   constructor(
-    private route: ActivatedRoute,
     private annotationAPI: CohortAnnotationDefinitionService,
     private state: ReviewStateService,
     private ngZone: NgZone,
@@ -69,7 +68,7 @@ export class SetAnnotationItemComponent {
     }
 
     const request = <ModifyCohortAnnotationDefinitionRequest>{columnName};
-    const {ns, wsid, cid} = this.route.snapshot.params;
+    const {ns, wsid, cid} = urlParamsStore.getValue();
     const id = this.definition.cohortAnnotationDefinitionId;
     this.isPosting.emit(true);
 
@@ -95,7 +94,7 @@ export class SetAnnotationItemComponent {
   }
 
   delete(): void {
-    const {ns, wsid, cid} = this.route.snapshot.params;
+    const {ns, wsid, cid} = urlParamsStore.getValue();
     const id = this.definition.cohortAnnotationDefinitionId;
     this.isPosting.emit(true);
 

--- a/ui/src/app/cohort-search/demographics/demographics.component.spec.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.spec.ts
@@ -2,7 +2,6 @@ import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {MultiSelectComponent} from 'app/cohort-search/multi-select/multi-select.component';
 import {fromJS} from 'immutable';
@@ -49,12 +48,6 @@ describe('DemographicsComponent', () => {
         {provide: NgRedux, useValue: mockReduxInst},
         {provide: CohortBuilderService, useValue: {}},
         {provide: CohortSearchActions, useValue: new MockActions()},
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {data: {workspace: {cdrVersionId: '1'}}}
-          }
-        },
       ],
     })
       .compileComponents();

--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -1,7 +1,6 @@
 import {NgRedux, select} from '@angular-redux/store';
 import {Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output} from '@angular/core';
 import {FormControl, FormGroup} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {fromJS, List, Map} from 'immutable';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -12,6 +11,7 @@ import {
   participantsCount,
   previewStatus,
 } from 'app/cohort-search/redux';
+import {currentWorkspaceStore} from 'app/utils/navigation';
 
 import {Attribute, CohortBuilderService, Operator, TreeSubType, TreeType} from 'generated';
 
@@ -93,7 +93,6 @@ export class DemographicsComponent implements OnInit, OnChanges, OnDestroy {
   showCalculateContainer = false;
   count: any;
   constructor(
-    private route: ActivatedRoute,
     private api: CohortBuilderService,
     private actions: CohortSearchActions,
     private ngRedux: NgRedux<CohortSearchState>
@@ -175,7 +174,7 @@ export class DemographicsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   loadNodesFromApi() {
-    const cdrid = this.route.snapshot.data.workspace.cdrVersionId;
+    const cdrid = +(currentWorkspaceStore.getValue().cdrVersionId);
         /*
          * Each subtype's possible criteria is loaded via the API.  Race and Gender
          * criteria nodes become options in their respective dropdowns; deceased

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.spec.ts
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.spec.ts
@@ -2,14 +2,15 @@ import {dispatch, NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 
 import {ValidatorErrorsComponent} from 'app/cohort-common/validator-errors/validator-errors.component';
 import {activeModifierList, CohortSearchActions, previewStatus} from 'app/cohort-search/redux';
-import {CohortBuilderService} from 'generated';
+import {currentWorkspaceStore} from 'app/utils/navigation';
+import {CohortBuilderService, WorkspaceAccessLevel} from 'generated';
 import {fromJS} from 'immutable';
 import {NgxPopperModule} from 'ngx-popper';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {ModifierPageComponent} from './modifier-page.component';
 
 class MockActions {
@@ -42,13 +43,13 @@ describe('ModifierPageComponent', () => {
         {provide: NgRedux, useValue: mockReduxInst},
         {provide: CohortBuilderService, useValue: {}},
         {provide: CohortSearchActions, useValue: new MockActions()},
-        {
-          provide: ActivatedRoute,
-          useValue: {snapshot: {data: {workspace: {cdrid: 1}}}}
-        },
       ],
     })
       .compileComponents();
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
@@ -9,7 +9,6 @@ import {
   Output
 } from '@angular/core';
 import {FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 import {
   activeCriteriaType,
   activeModifierList,
@@ -17,6 +16,7 @@ import {
   previewStatus,
 } from 'app/cohort-search/redux';
 import {dateValidator, integerAndRangeValidator} from 'app/cohort-search/validators';
+import {currentWorkspaceStore} from 'app/utils/navigation';
 import {CohortBuilderService, ModifierType, Operator, TreeType} from 'generated';
 import {fromJS, List, Map} from 'immutable';
 import * as moment from 'moment';
@@ -128,11 +128,10 @@ export class ModifierPageComponent implements OnInit, OnDestroy, AfterContentChe
     private actions: CohortSearchActions,
     private api: CohortBuilderService,
     private cdref: ChangeDetectorRef,
-    private route: ActivatedRoute
   ) {}
 
   ngOnInit() {
-    const cdrid = this.route.snapshot.data.workspace.cdrVersionId;
+    const cdrid = +(currentWorkspaceStore.getValue().cdrVersionId);
     this.subscription = this.modifiers$.subscribe(mods => this.existing = mods);
     this.subscription.add(this.ctype$
       .filter(ctype => !! ctype)

--- a/ui/src/app/cohort-search/overview/overview.component.spec.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.spec.ts
@@ -2,7 +2,6 @@ import {NgRedux} from '@angular-redux/store';
 import {MockNgRedux} from '@angular-redux/store/testing';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {ActivatedRoute, Router} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {fromJS} from 'immutable';
 import {Observable} from 'rxjs/Observable';
@@ -40,8 +39,6 @@ describe('OverviewComponent', () => {
           {provide: NgRedux, useValue: mockReduxInst},
           {provide: CohortsService, useValue: {}},
           {provide: CohortBuilderService, useValue: {}},
-          {provide: Router, useValue: {}},
-          {provide: ActivatedRoute, useValue: {}},
           {provide: CohortSearchActions, useValue: new MockActions()},
         ],
         schemas: [NO_ERRORS_SCHEMA],

--- a/ui/src/app/cohort-search/overview/overview.component.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.ts
@@ -1,11 +1,11 @@
 import {select} from '@angular-redux/store';
 import {Component, Input} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {ActivatedRoute, Router} from '@angular/router';
 import {List} from 'immutable';
 import {Observable} from 'rxjs/Observable';
 
 import {CohortSearchActions, searchRequestError} from 'app/cohort-search/redux';
+import {navigate, urlParamsStore} from 'app/utils/navigation';
 
 import {Cohort, CohortsService, Workspace} from 'generated';
 
@@ -41,8 +41,6 @@ export class OverviewComponent {
   constructor(
     private actions: CohortSearchActions,
     private cohortApi: CohortsService,
-    private route: ActivatedRoute,
-    private router: Router,
   ) {}
 
   get name() {
@@ -57,15 +55,14 @@ export class OverviewComponent {
   }
 
   submit() {
-    const ns: Workspace['namespace'] = this.route.snapshot.params.ns;
-    const wsid: Workspace['id'] = this.route.snapshot.params.wsid;
+    const {ns, wsid} = urlParamsStore.getValue();
 
     const name = this.cohortForm.get('name').value;
     const description = this.cohortForm.get('description').value;
     const criteria = JSON.stringify(this.actions.mapAll());
     const cohort = <Cohort>{name, description, criteria, type: COHORT_TYPE};
     this.cohortApi.createCohort(ns, wsid, cohort).subscribe((_) => {
-      this.router.navigate(['workspaces', ns, wsid, 'cohorts']);
+      navigate(['workspaces', ns, wsid, 'cohorts']);
     }, (error) => {
       if (error.status === 400) {
         this.showConflictError = true;

--- a/ui/src/app/resolvers/cohort.ts
+++ b/ui/src/app/resolvers/cohort.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 
+import {currentCohortStore} from 'app/utils/navigation';
 import {Cohort, CohortsService, Workspace} from 'generated';
 
 @Injectable()
@@ -17,6 +18,9 @@ export class CohortResolver implements Resolve<Cohort> {
     // console.log(`Resolving cohort ${cid}:`);
     // console.dir(route);
 
-    return this.api.getCohort(ns, wsid, cid);
+    return this.api.getCohort(ns, wsid, cid).map(c => {
+      currentCohortStore.next(c);
+      return c;
+    });
   }
 }

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -11,12 +11,12 @@ export const NavStore = {
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
 export const currentCohortStore = new BehaviorSubject<Cohort>(undefined);
 export const urlParamsStore = new BehaviorSubject<any>({});
-export const routeConfigDataStore = new BehaviorSubject<any>(undefined);
+export const queryParamsStore = new BehaviorSubject<any>({});
+export const routeConfigDataStore = new BehaviorSubject<any>({});
 export const userProfileStore = new BehaviorSubject<{ profile: Profile, reload: Function }>({
   profile: {} as Profile,
   reload: () => {}
 });
-
 
 // NOTE: Because these are wired up directly to the router component,
 // all navigation done from here will effectively use absolute paths.

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -11,7 +11,7 @@ import {
 
 
 import {cookiesEnabled} from 'app/utils';
-import {routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
+import {queryParamsStore, routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 
 export const overriddenUrlKey = 'allOfUsApiUrlOverride';
@@ -95,9 +95,10 @@ export class AppComponent implements OnInit {
         this.initialSpinner = false;
       }
       if (e instanceof NavigationEnd) {
-        const leafRoute = this.getLeafRoute();
-        urlParamsStore.next(leafRoute.snapshot.params);
-        routeConfigDataStore.next(leafRoute.snapshot.routeConfig.data);
+        const {snapshot: {params, queryParams, routeConfig}} = this.getLeafRoute();
+        urlParamsStore.next(params);
+        queryParamsStore.next(queryParams);
+        routeConfigDataStore.next(routeConfig.data);
       }
     });
 

--- a/ui/src/app/views/concept-add-modal/component.spec.ts
+++ b/ui/src/app/views/concept-add-modal/component.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 import {
@@ -27,7 +26,6 @@ import {ConceptAddModalComponent} from './component';
 
 class ConceptSetAddPage {
   fixture: ComponentFixture<ConceptAddModalComponent>;
-  route: UrlSegment[];
   conceptSetService: ConceptSetsService;
   workspacesService: WorkspacesService;
   workspaceNamespace: string;
@@ -39,7 +37,6 @@ class ConceptSetAddPage {
 
   constructor(testBed: typeof TestBed) {
     this.fixture = testBed.createComponent(ConceptAddModalComponent);
-    this.route = this.fixture.debugElement.injector.get(ActivatedRoute).snapshot.url;
     this.workspacesService = this.fixture.debugElement.injector.get(WorkspacesService);
     this.conceptSetService = this.fixture.debugElement.injector.get(ConceptSetsService);
     this.workspacesService.getWorkspace(
@@ -52,8 +49,6 @@ class ConceptSetAddPage {
   readPageData() {
     updateAndTick(this.fixture);
     updateAndTick(this.fixture);
-    this.workspaceNamespace = this.route[1].path;
-    this.workspaceId = this.route[2].path;
     const de = this.fixture.debugElement;
     this.save = de.query(By.css('.btn-primary'));
     const selects = de.queryAll(By.css('.concept-select'));
@@ -69,19 +64,6 @@ class ConceptSetAddPage {
 
   }
 }
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-      {path: 'workspaces'},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID},
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    }
-  }
-};
 
 describe('ConceptSetAddComponent', () => {
   let conceptSetAddCreatePage: ConceptSetAddPage;
@@ -101,7 +83,6 @@ describe('ConceptSetAddComponent', () => {
       providers: [
         {provide: ConceptsService, useValue: conceptServiceStub},
         {provide: ConceptSetsService, useValue: conceptSetServiceStub},
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
         {provide: WorkspacesService, useValue: new WorkspacesServiceStub() }
       ]
     }).compileComponents().then(() => {
@@ -177,4 +158,3 @@ describe('ConceptSetAddComponent', () => {
         expect(description).not.toBeNull();
       }));
 });
-

--- a/ui/src/app/views/concept-add-modal/component.ts
+++ b/ui/src/app/views/concept-add-modal/component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
 
+import {urlParamsStore} from 'app/utils/navigation';
 import {
   Concept,
   ConceptSet,
@@ -44,9 +44,10 @@ export class ConceptAddModalComponent {
   constructor(
     private conceptSetsService: ConceptSetsService,
     private conceptService: ConceptsService,
-    private route: ActivatedRoute) {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
+  ) {
+    const {ns, wsid} = urlParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
   }
 
   open(): void {

--- a/ui/src/app/views/concept-homepage/component.spec.ts
+++ b/ui/src/app/views/concept-homepage/component.spec.ts
@@ -2,11 +2,11 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
 import {HighlightSearchComponent} from 'app/highlight-search/highlight-search.component';
+import {urlParamsStore} from 'app/utils/navigation';
 import {ConceptAddModalComponent} from 'app/views/concept-add-modal/component';
 import {ConceptHomepageComponent} from 'app/views/concept-homepage/component';
 import {ConceptTableComponent} from 'app/views/concept-table/component';
@@ -27,28 +27,6 @@ import {ConceptsServiceStub, DomainStubVariables} from 'testing/stubs/concepts-s
 import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
 import {simulateClick, simulateEvent, simulateInput, updateAndTick} from 'testing/test-helpers';
 
-
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-      {path: 'workspaces'},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID},
-      {path: 'concepts'}
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    },
-    data: {
-      workspace: {
-        ...WorkspacesServiceStub.stubWorkspace(),
-        accessLevel: WorkspaceAccessLevel.OWNER,
-      }
-    },
-    queryParams: {}
-  }
-};
 
 function isSelectedDomain(
   domain: DomainInfo, fixture: ComponentFixture<ConceptHomepageComponent>): boolean {
@@ -83,7 +61,6 @@ describe('ConceptHomepageComponent', () => {
       providers: [
         { provide: ConceptsService, useValue: new ConceptsServiceStub() },
         { provide: ConceptSetsService, useValue: new ConceptSetsServiceStub() },
-        { provide: ActivatedRoute, useValue: activatedRouteStub }
       ]}).compileComponents().then(() => {
         fixture = TestBed.createComponent(ConceptHomepageComponent);
         // This tick initializes the component.
@@ -93,6 +70,10 @@ describe('ConceptHomepageComponent', () => {
         // This finishes the page reloading.
         updateAndTick(fixture);
       });
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+    });
   }));
 
   it('should have one card per domain.', fakeAsync(() => {

--- a/ui/src/app/views/concept-homepage/component.ts
+++ b/ui/src/app/views/concept-homepage/component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
 
+import {queryParamsStore, urlParamsStore} from 'app/utils/navigation';
 import {ConceptAddModalComponent} from 'app/views/concept-add-modal/component';
 import {ConceptTableComponent} from 'app/views/concept-table/component';
 
@@ -87,13 +87,13 @@ export class ConceptHomepageComponent implements OnInit {
 
   constructor(
     private conceptsService: ConceptsService,
-    private route: ActivatedRoute,
   ) {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
   }
 
   ngOnInit(): void {
+    const {ns, wsid} = urlParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
     this.loadingDomains = true;
     this.conceptsService.getDomainInfo(this.wsNamespace, this.wsId).subscribe((response) => {
       this.conceptDomainList = response.items;
@@ -110,10 +110,11 @@ export class ConceptHomepageComponent implements OnInit {
         });
         this.selectedDomain = this.conceptDomainCounts[0];
       });
-      if (this.route.snapshot.queryParams['domain'] !== undefined) {
+      const {domain: currentDomain} = queryParamsStore.getValue();
+      if (currentDomain !== undefined) {
         this.browseDomain(
           this.conceptDomainList.find(
-            domainInfo => domainInfo.domain === this.route.snapshot.queryParams['domain']));
+            domainInfo => domainInfo.domain === currentDomain));
       }
       this.loadingDomains = false;
     });

--- a/ui/src/app/views/concept-set-details/component.ts
+++ b/ui/src/app/views/concept-set-details/component.ts
@@ -1,6 +1,7 @@
-import {Component, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 
+import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {ConceptTableComponent} from 'app/views/concept-table/component';
 
 import {
@@ -18,7 +19,7 @@ import {
     './component.css'],
   templateUrl: './component.html',
 })
-export class ConceptSetDetailsComponent {
+export class ConceptSetDetailsComponent implements OnInit {
   @ViewChild(ConceptTableComponent) conceptTable;
 
   wsNamespace: string;
@@ -37,14 +38,18 @@ export class ConceptSetDetailsComponent {
 
   constructor(
     private conceptSetsService: ConceptSetsService,
-    private router: Router,
     private route: ActivatedRoute,
   ) {
     this.receiveDelete = this.receiveDelete.bind(this);
     this.closeConfirmDelete = this.closeConfirmDelete.bind(this);
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
-    this.accessLevel = this.route.snapshot.data.workspace.accessLevel;
+  }
+
+  ngOnInit() {
+    const {ns, wsid} = urlParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
+    const {accessLevel} = currentWorkspaceStore.getValue();
+    this.accessLevel = accessLevel;
     this.conceptSet = this.route.snapshot.data.conceptSet;
     this.editName = this.conceptSet.name;
     this.editDescription = this.conceptSet.description;
@@ -80,7 +85,7 @@ export class ConceptSetDetailsComponent {
   receiveDelete() {
     this.conceptSetsService.deleteConceptSet(this.wsNamespace, this.wsId, this.conceptSet.id)
       .subscribe(() => {
-        this.router.navigate(['workspaces', this.wsNamespace, this.wsId, 'concepts', 'sets']);
+        navigate(['workspaces', this.wsNamespace, this.wsId, 'concepts', 'sets']);
         this.closeConfirmDelete();
       });
   }

--- a/ui/src/app/views/conceptset-create-modal/component.spec.ts
+++ b/ui/src/app/views/conceptset-create-modal/component.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, UrlSegment} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 import {
@@ -25,7 +24,6 @@ import {CreateConceptSetModalComponent} from './component';
 
 class ConceptSetCreatePage {
   fixture: ComponentFixture<CreateConceptSetModalComponent>;
-  route: UrlSegment[];
   conceptSetService: ConceptSetsService;
   workspacesService: WorkspacesService;
   workspaceNamespace: string;
@@ -39,7 +37,6 @@ class ConceptSetCreatePage {
 
   constructor(testBed: typeof TestBed) {
     this.fixture = testBed.createComponent(CreateConceptSetModalComponent);
-    this.route = this.fixture.debugElement.injector.get(ActivatedRoute).snapshot.url;
     this.workspacesService = this.fixture.debugElement.injector.get(WorkspacesService);
 
     this.conceptSetService = this.fixture.debugElement.injector.get(ConceptSetsService);
@@ -57,8 +54,6 @@ class ConceptSetCreatePage {
   readPageData() {
     updateAndTick(this.fixture);
     updateAndTick(this.fixture);
-    this.workspaceNamespace = this.route[1].path;
-    this.workspaceId = this.route[2].path;
     const de = this.fixture.debugElement;
     this.name = de.query(By.css('.input-name'));
     this.description = de.query(By.css('.input-description'));
@@ -74,19 +69,6 @@ class ConceptSetCreatePage {
     }
   }
 }
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-        {path: 'workspaces'},
-        {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-        {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID},
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    }
-  }
-};
 
 describe('ConceptSetComponent', () => {
   let conceptSetCreatePage: ConceptSetCreatePage;
@@ -106,7 +88,6 @@ describe('ConceptSetComponent', () => {
       providers: [
         {provide: ConceptsService, useValue: conceptServiceStub},
         {provide: ConceptSetsService, useValue: conceptSetServiceStub},
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
         {provide: WorkspacesService, useValue: new WorkspacesServiceStub() }
       ]
     }).compileComponents().then(() => {
@@ -149,4 +130,3 @@ describe('ConceptSetComponent', () => {
       WorkspaceStubVariables.DEFAULT_WORKSPACE_ID, request);
   }));
 });
-

--- a/ui/src/app/views/conceptset-create-modal/component.ts
+++ b/ui/src/app/views/conceptset-create-modal/component.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Output} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+import {urlParamsStore} from 'app/utils/navigation';
 import {ConceptSet, ConceptsService, CreateConceptSetRequest, DomainInfo} from 'generated';
 import {ConceptSetsService} from 'generated/api/conceptSets.service';
 import {Domain} from 'generated/model/domain';
@@ -28,9 +28,10 @@ export class CreateConceptSetModalComponent {
 
   constructor(private conceptsService: ConceptsService,
     private conceptSetService: ConceptSetsService,
-    private route: ActivatedRoute) {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
+  ) {
+    const {ns, wsid} = urlParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
   }
 
   open(): void {
@@ -76,4 +77,3 @@ export class CreateConceptSetModalComponent {
       });
   }
 }
-

--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -1,13 +1,12 @@
 import {Component, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
-import {navigate} from 'app/utils/navigation';
+import {navigate, queryParamsStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {environment} from 'environments/environment';
 
 import * as React from 'react';
 
-import {ActivatedRoute} from '@angular/router';
 import {
   Clickable,
   styles as buttonStyles
@@ -267,7 +266,6 @@ export class HomepageComponent implements OnInit, OnDestroy {
     private profileService: ProfileService,
     private profileStorageService: ProfileStorageService,
     private serverConfigService: ServerConfigService,
-    private route: ActivatedRoute,
   ) {
     // create bound methods to use as callbacks
     this.closeQuickTour = this.closeQuickTour.bind(this);
@@ -287,7 +285,8 @@ export class HomepageComponent implements OnInit, OnDestroy {
       // TODO RW-1184 set trainingCompleted flag
       this.eraCommonsLinked = !!profile.linkedNihUsername;
 
-      if (this.route.snapshot.queryParams.workbenchAccessTasks) {
+      const {workbenchAccessTasks} = queryParamsStore.getValue();
+      if (workbenchAccessTasks) {
         // To reach the access tasks component from dev use /?workbenchAccessTasks=true
         this.accessTasksRemaining = true;
       } else {

--- a/ui/src/app/views/notebook-redirect/component.spec.ts
+++ b/ui/src/app/views/notebook-redirect/component.spec.ts
@@ -2,13 +2,13 @@ import {ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick} from '
 import {Response} from '@angular/http';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, convertToParamMap} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 import {AsyncSubject} from 'rxjs/AsyncSubject';
 import {Observable} from 'rxjs/Observable';
 
 import {NotebookComponent} from 'app/icons/notebook/component';
+import {queryParamsStore, urlParamsStore} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 import {NotebookRedirectComponent} from 'app/views/notebook-redirect/component';
 import {TopBoxComponent} from 'app/views/top-box/component';
@@ -100,29 +100,21 @@ describe('NotebookRedirectComponent', () => {
         { provide: LeoClusterService, useValue: new LeoClusterServiceStub() },
         { provide: NotebooksService, useFactory: () => blockingNotebooksStub },
         { provide: JupyterService, useValue: new JupyterServiceStub() },
-        { provide: ActivatedRoute, useValue: {
-          snapshot: {
-            params: {
-              'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-              'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
-              'nbName': 'blah blah'
-            },
-            queryParams: {
-              'kernelType': Kernels.R,
-              'creating': true
-            },
-            queryParamMap: convertToParamMap({
-              'kernelType': Kernels.R,
-              'creating': true
-            })
-          }
-        }},
       ]}).compileComponents().then(() => {
         fixture = TestBed.createComponent(NotebookRedirectComponent);
         spyOn(window.history, 'replaceState').and.stub();
         blockingClusterStub.release();
         blockingNotebooksStub.release();
       });
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+      nbName: 'blah blah'
+    });
+    queryParamsStore.next({
+      kernelType: Kernels.R,
+      creating: true
+    });
   }));
 
   function spinner() {
@@ -357,29 +349,21 @@ describe('NotebookRedirectComponent', () => {
         { provide: LeoClusterService, useValue: new LeoClusterServiceStub() },
         { provide: NotebooksService, useFactory: () => blockingNotebooksStub },
         { provide: JupyterService, useValue: new JupyterServiceStub() },
-        { provide: ActivatedRoute, useValue: {
-          snapshot: {
-            params: {
-              'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-              'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
-              'nbName': '1%2B1'
-            },
-            queryParams: {
-              'kernelType': Kernels.R,
-              'creating': true
-            },
-            queryParamMap: convertToParamMap({
-              'kernelType': Kernels.R,
-              'creating': true
-            })
-          }
-        }},
       ]}).compileComponents().then(() => {
         fixture = TestBed.createComponent(NotebookRedirectComponent);
         spyOn(window.history, 'replaceState').and.stub();
         blockingClusterStub.release();
         blockingNotebooksStub.release();
       });
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+      nbName: '1%2B1'
+    });
+    queryParamsStore.next({
+      kernelType: Kernels.R,
+      creating: true
+    });
   }));
 
 

--- a/ui/src/app/views/notebook-redirect/component.ts
+++ b/ui/src/app/views/notebook-redirect/component.ts
@@ -1,12 +1,12 @@
 import {Location} from '@angular/common';
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
-import {ActivatedRoute} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 import {timer} from 'rxjs/observable/timer';
 import {mapTo} from 'rxjs/operators';
 import {Subscription} from 'rxjs/Subscription';
 
+import {queryParamsStore, urlParamsStore} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 import {environment} from 'environments/environment';
 
@@ -102,8 +102,6 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   creating: boolean;
 
-  kernelType: Kernels;
-
   leoUrl: SafeResourceUrl;
 
   private wsId: string;
@@ -116,7 +114,6 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   constructor(
     private locationService: Location,
-    private route: ActivatedRoute,
     private clusterService: ClusterService,
     private leoClusterService: LeoClusterService,
     private leoNotebooksService: NotebooksService,
@@ -125,16 +122,15 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
-    this.creating = this.route.snapshot.queryParams['creating'] || false;
-    this.playground = (this.route.snapshot.queryParams['playgroundMode'] === 'true');
-    this.jupyterLabMode = (this.route.snapshot.queryParams['jupyterLabMode'] === 'true');
+    const {ns, wsid} = urlParamsStore.getValue();
+    const {creating, playgroundMode, jupyterLabMode, kernelType} = queryParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
+    this.creating = creating || false;
+    this.playground = playgroundMode === 'true';
+    this.jupyterLabMode = jupyterLabMode === 'true';
     this.setNotebookNames();
 
-    if (this.creating) {
-      this.kernelType = Kernels[this.route.snapshot.queryParamMap.get('kernelType')];
-    }
     this.loadingSub = this.clusterService.listClusters()
       .flatMap((resp) => {
         const c = resp.defaultCluster;
@@ -215,15 +211,16 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   // this maybe overkill, but should handle all situations
   setNotebookNames(): void {
+    const {nbName} = urlParamsStore.getValue();
     this.notebookName =
-      decodeURIComponent(this.route.snapshot.params['nbName']);
-    if (this.route.snapshot.params['nbName'].endsWith('.ipynb')) {
+      decodeURIComponent(nbName);
+    if (nbName.endsWith('.ipynb')) {
       this.fullNotebookName =
-        decodeURIComponent(this.route.snapshot.params['nbName']);
+        decodeURIComponent(nbName);
       this.notebookName = this.fullNotebookName.replace('.ipynb$', '');
     } else {
       this.notebookName =
-        decodeURIComponent(this.route.snapshot.params['nbName']);
+        decodeURIComponent(nbName);
       this.fullNotebookName = this.notebookName + '.ipynb';
     }
   }
@@ -257,7 +254,8 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   private newNotebook(): Observable<string> {
     const fileContent = commonNotebookFormat;
-    if (this.route.snapshot.queryParamMap.get('kernelType') === Kernels.R.toString()) {
+    const {kernelType} = queryParamsStore.getValue();
+    if (kernelType === Kernels.R.toString()) {
       fileContent.metadata = rNotebookMetadata;
     } else {
       fileContent.metadata = pyNotebookMetadata;

--- a/ui/src/app/views/signed-in/component.ts
+++ b/ui/src/app/views/signed-in/component.ts
@@ -1,10 +1,5 @@
 import {Location} from '@angular/common';
 import {Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {
-  ActivatedRoute,
-  NavigationEnd,
-  Router,
-} from '@angular/router';
 import {Subscription} from 'rxjs/Subscription';
 
 import {ErrorHandlingService} from 'app/services/error-handling.service';
@@ -12,6 +7,7 @@ import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {SignInService} from 'app/services/sign-in.service';
 import {hasRegisteredAccess} from 'app/utils';
+import {routeConfigDataStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {environment} from 'environments/environment';
 import {Authority, BillingProjectStatus} from 'generated';
@@ -76,8 +72,6 @@ export class SignedInComponent implements OnInit, OnDestroy {
     private profileStorageService: ProfileStorageService,
     /* Angular's */
     private locationService: Location,
-    private router: Router,
-    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
@@ -94,7 +88,6 @@ export class SignedInComponent implements OnInit, OnDestroy {
         this.familyName = profile.familyName;
         this.aouAccountEmailAddress = profile.username;
         this.contactEmailAddress = profile.contactEmail;
-        this.minimizeChrome = this.shouldMinimize();
       });
     });
 
@@ -119,12 +112,9 @@ export class SignedInComponent implements OnInit, OnDestroy {
       }
     });
 
-    this.subscriptions.push(
-      this.router.events.filter(event => event instanceof NavigationEnd)
-        .subscribe(event => {
-          this.minimizeChrome = this.shouldMinimize();
-        }));
-
+    this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
+      this.minimizeChrome = minimizeChrome;
+    }));
   }
 
   ngOnDestroy() {
@@ -142,14 +132,6 @@ export class SignedInComponent implements OnInit, OnDestroy {
   signOut(): void {
     this.signInService.signOut();
     this.navigateSignOut();
-  }
-
-  shouldMinimize(): boolean {
-    let leaf = this.route.snapshot;
-    while (leaf.firstChild != null) {
-      leaf = leaf.firstChild;
-    }
-    return leaf.data.minimizeChrome;
   }
 
   private navigateSignOut(): void {

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -3,7 +3,6 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Http} from '@angular/http';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
@@ -13,6 +12,7 @@ import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {SignInService} from 'app/services/sign-in.service';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import {currentWorkspaceStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {ConfirmDeleteModalComponent} from 'app/views/confirm-delete-modal/component';
 import {RecentWorkComponent} from 'app/views/recent-work/component';
@@ -61,26 +61,6 @@ import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/works
 import {NewNotebookModalComponent} from 'app/views/new-notebook-modal/component';
 import {updateAndTick} from 'testing/test-helpers';
 
-const activatedRouteStub  = {
-  snapshot: {
-    url: [
-      {path: 'workspaces'},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS},
-      {path: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID}
-    ],
-    params: {
-      'ns': WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      'wsid': WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
-    },
-    data: {
-      workspace: {
-        ...WorkspacesServiceStub.stubWorkspace(),
-        accessLevel: WorkspaceAccessLevel.OWNER,
-      }
-    }
-  }
-};
-
 describe('WorkspaceComponent', () => {
   let fixture: ComponentFixture<WorkspaceComponent>;
   beforeEach(fakeAsync(() => {
@@ -119,7 +99,6 @@ describe('WorkspaceComponent', () => {
         { provide: SignInService, useValue: SignInService },
         { provide: WorkspacesService, useValue: new WorkspacesServiceStub() },
         { provide: UserMetricsService, useValue: new UserMetricsServiceStub() },
-        { provide: ActivatedRoute, useValue: activatedRouteStub },
         { provide: ProfileService, useValue: new ProfileServiceStub() },
         { provide: UserService, useValue: new UserServiceStub() },
         {
@@ -144,6 +123,10 @@ describe('WorkspaceComponent', () => {
         fixture = TestBed.createComponent(WorkspaceComponent);
         updateAndTick(fixture);
       });
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
     registerApiClient(UserMetricsApi, new UserMetricsApiStub());
   }));
 

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -1,10 +1,10 @@
 import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 import {Comparator, StringFilter} from '@clr/angular';
 
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {SignInService} from 'app/services/sign-in.service';
+import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {ResearchPurposeItems} from 'app/views/workspace-edit/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
@@ -110,15 +110,17 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   bugReportComponent: BugReportComponent;
 
   constructor(
-    private route: ActivatedRoute,
     private cohortsService: CohortsService,
-    private router: Router,
     private signInService: SignInService,
     private workspacesService: WorkspacesService,
     private cdrVersionStorageService: CdrVersionStorageService,
     private profileService: ProfileService,
   ) {
-    const wsData: WorkspaceData = this.route.snapshot.data.workspace;
+    this.closeNotebookModal = this.closeNotebookModal.bind(this);
+  }
+
+  ngOnInit(): void {
+    const wsData = currentWorkspaceStore.getValue();
     this.workspace = wsData;
     this.accessLevel = wsData.accessLevel;
     Object.keys(ResearchPurposeItems).forEach((key) => {
@@ -137,12 +139,9 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         this.leftResearchPurposes.length,
         this.researchPurposeArray.length);
     this.showTip = false;
-    this.closeNotebookModal = this.closeNotebookModal.bind(this);
-  }
-
-  ngOnInit(): void {
-    this.wsNamespace = this.route.snapshot.params['ns'];
-    this.wsId = this.route.snapshot.params['wsid'];
+    const {ns, wsid} = urlParamsStore.getValue();
+    this.wsNamespace = ns;
+    this.wsId = wsid;
     // TODO: RW-1057
     this.profileService.getMe().subscribe(
       profile => {
@@ -203,7 +202,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   buildCohort(): void {
-    this.router.navigate(['cohorts', 'build'], {relativeTo: this.route});
+    navigate(['/workspaces', this.wsNamespace, this.wsId, 'cohorts', 'build']);
   }
 
   get workspaceCreationTime(): string {


### PR DESCRIPTION
This transforms several components with the goal of removing direct router dependencies. The general approach is to read directly from our new 'stores', instead of the router data. Adds `queryParamsStore` to hold url query params. It also cleans up a couple pieces of data that were unused.