### PR TITLE
[risk=no] reset state between tests

### DIFF
--- a/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.spec.ts
@@ -2,14 +2,16 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
-import {CohortReviewService} from 'generated';
+import {CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import 'rxjs/add/observable/of';
 import {Observable} from 'rxjs/Observable';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 
 import {ClearButtonInMemoryFilterComponent} from 'app/cohort-review/clearbutton-in-memory-filter/clearbutton-in-memory-filter.component';
 import {DetailTabTableComponent} from 'app/cohort-review/detail-tab-table/detail-tab-table.component';
+import {currentCohortStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {DetailAllEventsComponent} from './detail-all-events.component';
 
 describe('DetailAllEventsComponent', () => {
@@ -17,9 +19,6 @@ describe('DetailAllEventsComponent', () => {
   let fixture: ComponentFixture<DetailAllEventsComponent>;
   const activatedRouteStub = {
     data: Observable.of({
-      workspace: {
-        cdrVersionId: '1'
-      },
       cohort: {},
       participant: {}
     })
@@ -37,6 +36,15 @@ describe('DetailAllEventsComponent', () => {
       ],
     })
       .compileComponents();
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
+    currentCohortStore.next({
+      name: '',
+      criteria: '{}',
+      type: '',
+    });
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
+++ b/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
@@ -23,13 +23,15 @@ import {SetAnnotationListComponent} from 'app/cohort-review/set-annotation-list/
 import {SetAnnotationModalComponent} from 'app/cohort-review/set-annotation-modal/set-annotation-modal.component';
 import {SidebarContentComponent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {CohortSearchActions} from 'app/cohort-search/redux';
-import {CohortAnnotationDefinitionService, CohortReviewService} from 'generated';
+import {currentWorkspaceStore} from 'app/utils/navigation';
+import {CohortAnnotationDefinitionService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import * as highCharts from 'highcharts';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
 import {CohortSearchActionStub} from 'testing/stubs/cohort-search-action-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {DetailPage} from './detail-page';
 
 
@@ -47,31 +49,6 @@ describe('DetailPage', () => {
     snapshot: {
       data: {},
     },
-    parent: {
-      snapshot: {
-        data: {
-          workspace: {
-            cdrVersionId: 1
-          },
-          cohort: {
-            name: ''
-          }
-        },
-        params: {
-          ns: '',
-          wsid: '',
-          cid: ''
-        }
-      }
-    },
-    params: {
-      ns: '',
-      wsid: '',
-      cid: ''
-    }
-
-
-
   };
   let route;
   beforeEach(async(() => {
@@ -114,6 +91,10 @@ describe('DetailPage', () => {
       ],
     })
       .compileComponents();
+    currentWorkspaceStore.next({
+      ...WorkspacesServiceStub.stubWorkspace(),
+      accessLevel: WorkspaceAccessLevel.OWNER,
+    });
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
@@ -20,6 +20,7 @@ import {OptionInfoComponent} from 'app/cohort-search/option-info/option-info.com
 import {OverviewComponent} from 'app/cohort-search/overview/overview.component';
 import {
   cancelWizard,
+  clearStore,
   CohortSearchActions,
   finishWizard,
   resetStore
@@ -45,6 +46,7 @@ class MockActions {
   @dispatch() cancelWizard = cancelWizard;
   @dispatch() finishWizard = finishWizard;
   @dispatch() resetStore = resetStore;
+  @dispatch() clearStore = clearStore;
 }
 
 describe('CohortSearchComponent', () => {

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -12,6 +12,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import {currentWorkspaceStore, currentCohortStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -25,6 +26,13 @@ getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
 );
+beforeEach(() => {
+  currentWorkspaceStore.next(undefined);
+  currentCohortStore.next(undefined);
+  urlParamsStore.next({});
+  queryParamsStore.next({});
+  routeConfigDataStore.next({});
+});
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
There were some test failures due to missing state stubs, but they were not showing up consistently because data from previous tests was sticking around.

This adds the needed stubs, and also resets the stores between each test so these cases should show up consistently in the future.