### PR TITLE
[RW-2004][RISK=LOW] Require higher minimum length for workbench usernames

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -415,7 +415,7 @@ public class ProfileController implements ProfileApiDelegate {
     verifyInvitationKey(request.getInvitationKey());
     String userName = request.getProfile().getUsername();
     if(userName == null || userName.length() < 3 || userName.length() > 64 )
-      throw new BadRequestException("Username should be of at least 3 characters and not more than 64 characters");
+      throw new BadRequestException("Username should be at least 3 characters and not more than 64 characters");
     request.getProfile().setUsername(request.getProfile().getUsername().toLowerCase());
     validateProfileFields(request.getProfile());
     com.google.api.services.admin.directory.model.User googleUser =

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -413,6 +413,9 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Profile> createAccount(CreateAccountRequest request) {
     verifyInvitationKey(request.getInvitationKey());
+    String userName = request.getProfile().getUsername();
+    if(userName.isEmpty() || userName.length() < 3 )
+      throw new BadRequestException("Username should be of atleast 3 characters");
     request.getProfile().setUsername(request.getProfile().getUsername().toLowerCase());
     validateProfileFields(request.getProfile());
     com.google.api.services.admin.directory.model.User googleUser =

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -414,8 +414,8 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Profile> createAccount(CreateAccountRequest request) {
     verifyInvitationKey(request.getInvitationKey());
     String userName = request.getProfile().getUsername();
-    if(userName.isEmpty() || userName.length() < 3 )
-      throw new BadRequestException("Username should be of atleast 3 characters");
+    if(userName != null || userName.length() < 3 )
+      throw new BadRequestException("Username should be of at least 3 characters");
     request.getProfile().setUsername(request.getProfile().getUsername().toLowerCase());
     validateProfileFields(request.getProfile());
     com.google.api.services.admin.directory.model.User googleUser =

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -414,8 +414,8 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Profile> createAccount(CreateAccountRequest request) {
     verifyInvitationKey(request.getInvitationKey());
     String userName = request.getProfile().getUsername();
-    if(userName != null || userName.length() < 3 )
-      throw new BadRequestException("Username should be of at least 3 characters");
+    if(userName == null || userName.length() < 3 || userName.length() > 64 )
+      throw new BadRequestException("Username should be of at least 3 characters and not more than 64 characters");
     request.getProfile().setUsername(request.getProfile().getUsername().toLowerCase());
     validateProfileFields(request.getProfile());
     com.google.api.services.admin.directory.model.User googleUser =

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -208,7 +208,7 @@ public class ProfileControllerTest {
     createAccountRequest.getProfile().setUsername("12");
     accountRequest.setProfile(createAccountRequest.getProfile());
     exception.expect(BadRequestException.class);
-    exception.expectMessage("Username should be of at least 3 characters and not more than 64 characters");
+    exception.expectMessage("Username should be at least 3 characters and not more than 64 characters");
     profileController.createAccount(accountRequest);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -208,7 +208,7 @@ public class ProfileControllerTest {
     createAccountRequest.getProfile().setUsername("12");
     accountRequest.setProfile(createAccountRequest.getProfile());
     exception.expect(BadRequestException.class);
-    exception.expectMessage("Username should be of atleast 3 characters");
+    exception.expectMessage("Username should be of at least 3 characters and not more than 64 characters");
     profileController.createAccount(accountRequest);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -22,7 +22,9 @@ import javax.inject.Provider;
 import javax.mail.MessagingException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -129,6 +131,9 @@ public class ProfileControllerTest {
   private FakeClock clock;
   private User user;
 
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
   @Before
   public void setUp() throws MessagingException {
     WorkbenchConfig config = new WorkbenchConfig();
@@ -193,6 +198,18 @@ public class ProfileControllerTest {
     User user = userDao.findUserByEmail(PRIMARY_EMAIL);
     assertThat(user).isNotNull();
     assertThat(user.getDataAccessLevelEnum()).isEqualTo(DataAccessLevel.UNREGISTERED);
+  }
+
+  @Test
+  public void testCreateAccount_invalidUser() throws Exception {
+    when(cloudStorageService.readInvitationKey()).thenReturn(INVITATION_KEY);
+    CreateAccountRequest accountRequest = new CreateAccountRequest();
+    accountRequest.setInvitationKey(INVITATION_KEY);
+    createAccountRequest.getProfile().setUsername("12");
+    accountRequest.setProfile(createAccountRequest.getProfile());
+    exception.expect(BadRequestException.class);
+    exception.expectMessage("Username should be of atleast 3 characters");
+    profileController.createAccount(accountRequest);
   }
 
   @Test

--- a/ui/src/app/views/account-creation/component.spec.tsx
+++ b/ui/src/app/views/account-creation/component.spec.tsx
@@ -100,10 +100,7 @@ it('should handle username validity length less than 3 characters', () => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
-  // if username is long (not too long) but has a mismatch at end
-  let testInput = fp.repeat(50, 'a');
-  testInput = testInput + ' a';
-  wrapper.find('input#username').simulate('change', {target: {value: testInput}});
+  wrapper.find('input#username').simulate('change', {target: {value: 'a'}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 

--- a/ui/src/app/views/account-creation/component.spec.tsx
+++ b/ui/src/app/views/account-creation/component.spec.tsx
@@ -90,6 +90,17 @@ it('should handle username validity long but has mismatch at end', () => {
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
   // if username is long (not too long) but has a mismatch at end
+  let testInput = fp.repeat(50, 'abc');
+  testInput = testInput + ' abc';
+  wrapper.find('input#username').simulate('change', {target: {value: testInput}});
+  expect(wrapper.exists('#usernameError')).toBeTruthy();
+});
+
+it('should handle username validity length less than 3 characters', () => {
+  const wrapper = component();
+  expect(wrapper.exists('#username')).toBeTruthy();
+  expect(wrapper.exists('#usernameError')).toBeFalsy();
+  // if username is long (not too long) but has a mismatch at end
   let testInput = fp.repeat(50, 'a');
   testInput = testInput + ' a';
   wrapper.find('input#username').simulate('change', {target: {value: testInput}});

--- a/ui/src/app/views/account-creation/component.tsx
+++ b/ui/src/app/views/account-creation/component.tsx
@@ -109,7 +109,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     if (isBlank(username)) {
       return false;
     }
-    if (username.trim().length > 64) {
+    if (username.trim().length > 64 || username.trim().length < 3) {
       return true;
     }
     // Include alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
@@ -243,8 +243,9 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           </div>
           <TooltipTrigger content={<div>Usernames can contain only letters (a-z),
             numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)
-            (maximum of 64 characters).<br/>Usernames cannot begin or end with a period (.)
-            and may not contain more than one period (.) in a row.</div>}>
+            (minimum of 3 characters and maximum of 64 characters).<br/>Usernames cannot
+            begin or end with a period (.) and may not contain more than one period (.) in a row.
+          </div>}>
             <InfoIcon style={{'height': '22px', 'paddingLeft': '2px'}}/>
           </TooltipTrigger>
           <div style={{height: '1.5rem'}}>


### PR DESCRIPTION
1) Update UI to show error message if username is less than 3 characters
2) Update profile api
3) Update tooltip
<img width="629" alt="screen shot 2019-02-14 at 2 14 29 pm" src="https://user-images.githubusercontent.com/34481816/52811351-dfbacb80-3062-11e9-9884-30e18fcaa719.png">
