### PR TITLE
[risk=no] Return 401 rather than 404 for invalid user identities

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -141,7 +141,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       if (!userEmail.endsWith(gsuiteDomainSuffix)) {
         log.log(Level.INFO, "User {0} isn't in domain {1}, can't access the workbench",
             new Object[] { userEmail, gsuiteDomainSuffix });
-        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         return false;
       }
     }

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -171,7 +171,7 @@ public class AuthInterceptorTest {
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByEmail("bob@also-bad-domain.org")).thenReturn(null);
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test


### PR DESCRIPTION
Context: I tried running a CLI as my pmi-ops.org account (to disable a user). I confusingly received a 404 error message from the API. Authentication issues should return a 401.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
