### PR TITLE
[risk=no] Don't expose Elastic outside localhost

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
     ports:
-      - 9200:9200
+      - 127.0.0.1:9200:9200
     environment:
       # Disable bootstrap checks so users don't have to fiddle with
       # vm.max_map_count. Note that this file is not used in production


### PR DESCRIPTION
This makes it so that Elastic is not accessible e.g. via an internal corporate DNS for your workstation.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
