### PR TITLE
[risk=no] refactor cohort review state

### DIFF
--- a/ui/src/app/cohort-review/annotation-list/annotation-list.component.ts
+++ b/ui/src/app/cohort-review/annotation-list/annotation-list.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, OnChanges} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 
 import {
   CohortAnnotationDefinition,
@@ -53,8 +53,8 @@ export class AnnotationListComponent implements OnChanges {
   constructor(private state: ReviewStateService) {}
 
   ngOnChanges(changes) {
-    const defs$ = this.state.annotationDefinitions$.filter(identity);
-    const factory$ = this.state.review$.filter(identity).pluck('cohortReviewId')
+    const defs$ = annotationDefinitionsStore.filter(identity);
+    const factory$ = cohortReviewStore.filter(identity).pluck('cohortReviewId')
       .map(rid => valueFactory([this.participant.id, rid]));
     this.annotations$ = Observable
       .combineLatest(defs$, factory$)

--- a/ui/src/app/cohort-review/create-review-page/create-review-page.spec.ts
+++ b/ui/src/app/cohort-review/create-review-page/create-review-page.spec.ts
@@ -1,25 +1,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute} from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentCohortStore} from 'app/utils/navigation';
-import {CohortReviewService} from 'generated';
+import {CohortReview, CohortReviewService} from 'generated';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {CreateReviewPage} from './create-review-page';
 
 describe('CreateReviewPage', () => {
   let component: CreateReviewPage;
   let fixture: ComponentFixture<CreateReviewPage>;
-  const activatedRouteStub = {
-    snapshot: {
-      data: {
-        review: {},
-      }
-    }
-  };
-  let route;
 
   beforeEach(async(() => {
 
@@ -33,7 +26,6 @@ describe('CreateReviewPage', () => {
       ],
       providers: [
         {provide: CohortReviewService, useValue: {}},
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
       ],
     })
       .compileComponents();
@@ -42,12 +34,12 @@ describe('CreateReviewPage', () => {
       criteria: '',
       type: '',
     });
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateReviewPage);
     component = fixture.componentInstance;
-    route = new ActivatedRoute();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/cohort-review/create-review-page/create-review-page.ts
+++ b/ui/src/app/cohort-review/create-review-page/create-review-page.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectorRef, Component, EventEmitter, OnInit, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
 
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {
   Cohort,
@@ -29,7 +29,6 @@ export class CreateReviewPage implements OnInit {
 
   constructor(
     private reviewAPI: CohortReviewService,
-    private route: ActivatedRoute,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -42,8 +41,7 @@ export class CreateReviewPage implements OnInit {
   }
 
   ngOnInit() {
-    const {review} = this.route.snapshot.data;
-    this.review = review;
+    this.review = cohortReviewStore.getValue();
     this.cohort = currentCohortStore.getValue();
 
     this.numParticipants.setValidators([

--- a/ui/src/app/cohort-review/detail-header/detail-header.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-header/detail-header.component.spec.ts
@@ -3,7 +3,8 @@ import {ClarityModule} from '@clr/angular';
 import {CohortReviewService} from 'generated';
 
 import {Participant} from 'app/cohort-review/participant.model';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {DetailHeaderComponent} from './detail-header.component';
 
 describe('DetailHeaderComponent', () => {
@@ -17,10 +18,10 @@ describe('DetailHeaderComponent', () => {
       imports: [ClarityModule],
       providers: [
         {provide: CohortReviewService, useValue: {}},
-        {provide: ReviewStateService, useValue: {}},
       ],
     })
       .compileComponents();
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/detail-header/detail-header.component.ts
+++ b/ui/src/app/cohort-review/detail-header/detail-header.component.ts
@@ -2,7 +2,7 @@ import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 
 import {Participant} from 'app/cohort-review/participant.model';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 
 import {
@@ -30,11 +30,10 @@ export class DetailHeaderComponent implements OnChanges {
 
   constructor(
     private reviewAPI: CohortReviewService,
-    private state: ReviewStateService,
   ) {}
 
   ngOnChanges(changes) {
-    this.state.review$.subscribe(review => this.update(review));
+    this.update(cohortReviewStore.getValue());
   }
 
   update(review) {
@@ -95,12 +94,12 @@ export class DetailHeaderComponent implements OnChanges {
         ? page - 1
         : page + 1;
 
-      this.state.review$
+      cohortReviewStore
         .take(1)
         .map(({page, pageSize}) => ({page: adjustPage(page), size: pageSize}))
         .mergeMap(({page, size}) => this.callAPI(page, size))
         .subscribe(review => {
-          this.state.review.next(review);
+          cohortReviewStore.next(review);
           const stat = statusGetter(review.participantCohortStatuses);
           this.navigateById(stat.participantId);
 

--- a/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
+++ b/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
@@ -16,7 +16,7 @@ import {DetailTabTableComponent} from 'app/cohort-review/detail-tab-table/detail
 import {DetailTabsComponent} from 'app/cohort-review/detail-tabs/detail-tabs.component';
 import {IndividualParticipantsChartsComponent} from 'app/cohort-review/individual-participants-charts/individual-participants-charts';
 import {ParticipantStatusComponent} from 'app/cohort-review/participant-status/participant-status.component';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {SetAnnotationCreateComponent} from 'app/cohort-review/set-annotation-create/set-annotation-create.component';
 import {SetAnnotationItemComponent} from 'app/cohort-review/set-annotation-item/set-annotation-item.component';
 import {SetAnnotationListComponent} from 'app/cohort-review/set-annotation-list/set-annotation-list.component';
@@ -24,11 +24,12 @@ import {SetAnnotationModalComponent} from 'app/cohort-review/set-annotation-moda
 import {SidebarContentComponent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {CohortSearchActions} from 'app/cohort-search/redux';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {CohortAnnotationDefinitionService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
+import {CohortAnnotationDefinitionService, CohortReview, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import * as highCharts from 'highcharts';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
-import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
+import {cohortAnnotationDefinitionStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
+import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {CohortSearchActionStub} from 'testing/stubs/cohort-search-action-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
@@ -95,6 +96,8 @@ describe('DetailPage', () => {
       ...WorkspacesServiceStub.stubWorkspace(),
       accessLevel: WorkspaceAccessLevel.OWNER,
     });
+    cohortReviewStore.next(cohortReviewStub);
+    annotationDefinitionsStore.next([cohortAnnotationDefinitionStub]);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/detail-page/detail-page.ts
+++ b/ui/src/app/cohort-review/detail-page/detail-page.ts
@@ -3,7 +3,6 @@ import {ActivatedRoute} from '@angular/router';
 import {Subscription} from 'rxjs/Subscription';
 
 import {Participant} from 'app/cohort-review/participant.model';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
 
 @Component({
   templateUrl: './detail-page.html',
@@ -15,11 +14,9 @@ export class DetailPage implements OnInit, OnDestroy {
   participant: Participant;
   subscription: Subscription;
   participantId: number;
-  constructor(private route: ActivatedRoute, private state: ReviewStateService) {}
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    const {annotationDefinitions} = this.route.snapshot.data;
-    this.state.annotationDefinitions.next(annotationDefinitions);
     this.subscription = this.route.data.subscribe(({participant, annotations}) => {
       participant.annotations = annotations;
       this.participant = participant;

--- a/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
@@ -1,17 +1,16 @@
 import {NgRedux} from '@angular-redux/store';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {ComboChartComponent} from 'app/cohort-common/combo-chart/combo-chart.component';
 import {ParticipantsChartsComponent} from 'app/cohort-review/participants-charts/participant-charts';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
-import {CohortBuilderService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
+import {CohortBuilderService, CohortReview, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
-import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
+import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {OverviewPage} from './overview-page';
@@ -21,15 +20,7 @@ import {OverviewPage} from './overview-page';
 describe('OverviewPage', () => {
   let component: OverviewPage;
   let fixture: ComponentFixture<OverviewPage>;
-  const activatedRouteStub = {
-    snapshot: {
-      data: {
-        review: {}
-      }
-    }
-  };
 
-  let route;
   beforeEach(async(() => {
 
     TestBed.configureTestingModule({
@@ -40,7 +31,6 @@ describe('OverviewPage', () => {
         {provide: CohortReviewService, useValue: new CohortReviewServiceStub()},
         {provide: CohortBuilderService, useValue: new CohortBuilderServiceStub()},
         {provide: ReviewStateService, useValue: new ReviewStateServiceStub()},
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
       ],
     })
       .compileComponents();
@@ -59,12 +49,12 @@ describe('OverviewPage', () => {
       wsid: 'workspaceId',
       cid: 1
     });
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OverviewPage);
     component = fixture.componentInstance;
-    route = new ActivatedRoute();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/cohort-review/overview-page/overview-page.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.ts
@@ -1,6 +1,5 @@
 import {Component, EventEmitter, OnDestroy, OnInit, Output} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 import {CohortBuilderService, CohortReview, CohortReviewService, DemoChartInfoListResponse, DomainType, SearchRequest} from 'generated';
 import {fromJS, List} from 'immutable';
@@ -34,11 +33,9 @@ export class OverviewPage implements OnInit, OnDestroy {
     private chartAPI: CohortBuilderService,
     private reviewAPI: CohortReviewService,
     private state: ReviewStateService,
-    private route: ActivatedRoute,
   ) {}
 
   ngOnInit() {
-    const {review} = this.route.snapshot.data;
     const workspace = currentWorkspaceStore.getValue();
     const cohort = currentCohortStore.getValue();
     const request = <SearchRequest>(JSON.parse(cohort.criteria));
@@ -49,8 +46,8 @@ export class OverviewPage implements OnInit, OnDestroy {
         this.dataItems.emit(this.data);
         this.buttonsDisableFlag = false;
       });
-    this.review = review;
-    this.totalParticipantCount = review.matchedParticipantCount;
+    this.review = cohortReviewStore.getValue();
+    this.totalParticipantCount = this.review.matchedParticipantCount;
 
 
     this.openChartContainer = true;

--- a/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
@@ -1,29 +1,19 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute, Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 import {CohortReview} from 'generated';
 import {Observable} from 'rxjs/Observable';
-import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
 import {CreateReviewPage} from 'app/cohort-review/create-review-page/create-review-page';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
+import {NavStore} from 'app/utils/navigation';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {PageLayout} from './page-layout';
 
 describe('PageLayout', () => {
   let component: PageLayout;
   let fixture: ComponentFixture<PageLayout>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-  const activatedRouteStub = {
-    snapshot: {
-      data: {
-        review: <CohortReview> {}
-      }
-    },
-    data: Observable.of({})
-  };
-  let route;
 
   beforeEach(async(() => {
 
@@ -33,19 +23,16 @@ describe('PageLayout', () => {
         PageLayout,
       ],
       imports: [ClarityModule, ReactiveFormsModule, RouterTestingModule],
-      providers: [
-        {provide: ReviewStateService, useValue: new ReviewStateServiceStub()},
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
-        {provide: Router, useValue: routerSpy},
-      ],
+      providers: [],
     })
       .compileComponents();
+    NavStore.navigate = jasmine.createSpy('navigate');
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PageLayout);
     component = fixture.componentInstance;
-    route = new ActivatedRoute();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/cohort-review/page-layout/page-layout.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.ts
@@ -1,8 +1,7 @@
 import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
-import {currentCohortStore} from 'app/utils/navigation';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
+import {navigate, urlParamsStore} from 'app/utils/navigation';
 import {ReviewStatus} from 'generated';
 
 @Component({
@@ -13,20 +12,16 @@ export class PageLayout implements OnInit {
 
   subscription: any;
   create = false;
-  constructor(
-    private state: ReviewStateService,
-    private route: ActivatedRoute,
-    private router: Router,
-  ) {}
+  constructor() {}
 
   ngOnInit() {
-    const {review} = this.route.snapshot.data;
-    this.state.review.next(review);
+    const review = cohortReviewStore.getValue();
 
     if (review.reviewStatus === ReviewStatus.NONE) {
       this.create = true;
     } else {
-      this.router.navigate(['participants'], {relativeTo: this.route});
+      const {ns, wsid, cid} = urlParamsStore.getValue();
+      navigate(['workspaces', ns, wsid, 'cohorts', cid, 'review', 'participants']);
     }
   }
 

--- a/ui/src/app/cohort-review/query-cohort-definition/query-cohort-definition.component.spec.ts
+++ b/ui/src/app/cohort-review/query-cohort-definition/query-cohort-definition.component.spec.ts
@@ -1,7 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {QueryCohortDefinitionComponent} from 'app/cohort-review/query-cohort-definition/query-cohort-definition.component';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {CohortBuilderService} from 'generated';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 
 
 describe('QueryCohortDefinitionComponent', () => {
@@ -19,6 +21,7 @@ describe('QueryCohortDefinitionComponent', () => {
       ]
     })
       .compileComponents();
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.spec.ts
+++ b/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.spec.ts
@@ -1,7 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ClarityModule} from '@clr/angular';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
-import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
+import {CohortReview} from 'generated';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {QueryDescriptiveStatsComponent} from './query-descriptive-stats.component';
 
 
@@ -20,11 +21,10 @@ describe('QueryDescriptiveStatsComponent', () => {
       imports: [
         ClarityModule,
       ],
-      providers: [
-        {provide: ReviewStateService, useValue: new ReviewStateServiceStub()},
-      ]
+      providers: []
     })
       .compileComponents();
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.ts
+++ b/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnChanges, OnDestroy, OnInit} from '@angular/core';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {List} from 'immutable';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
@@ -19,7 +19,7 @@ export class QueryDescriptiveStatsComponent implements OnInit, OnChanges, OnDest
   ];
   totalCount: number;
   enablePrint = false;
-  constructor(private state: ReviewStateService) {}
+  constructor() {}
 
   ngOnChanges() {
     if (this.demoData) {
@@ -33,7 +33,7 @@ export class QueryDescriptiveStatsComponent implements OnInit, OnChanges, OnDest
   }
 
   ngOnInit() {
-    this.subscription = this.state.review$.subscribe(review => {
+    this.subscription = cohortReviewStore.subscribe(review => {
       this.totalCount = review.matchedParticipantCount;
     });
   }

--- a/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {ComboChartComponent} from 'app/cohort-common/combo-chart/combo-chart.component';
@@ -8,15 +7,15 @@ import {ParticipantsChartsComponent} from 'app/cohort-review/participants-charts
 import {QueryCohortDefinitionComponent} from 'app/cohort-review/query-cohort-definition/query-cohort-definition.component';
 import {QueryDescriptiveStatsComponent} from 'app/cohort-review/query-descriptive-stats/query-descriptive-stats.component';
 import {QueryReportComponent} from 'app/cohort-review/query-report/query-report.component';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
-import {CohortBuilderService, CohortReviewService, DataAccessLevel, WorkspaceAccessLevel} from 'generated';
+import {CohortBuilderService, CohortReview, CohortReviewService, DataAccessLevel, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {Observable} from 'rxjs/Observable';
 import {CdrVersionStorageServiceStub} from 'testing/stubs/cdr-version-storage-service-stub';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
-import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
+import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 
@@ -45,14 +44,6 @@ describe('QueryReportComponent', () => {
     }],
     excludes: []
   };
-  const activatedRouteStub = {
-    snapshot: {
-      data: {
-        review: {}
-      }
-    }
-  };
-  let route;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -70,7 +61,6 @@ describe('QueryReportComponent', () => {
         NgxPopperModule,
       ],
       providers: [
-        {provide: ActivatedRoute, useValue: activatedRouteStub},
         { provide: CdrVersionStorageService,
           useValue: new CdrVersionStorageServiceStub({
             defaultCdrVersionId: WorkspacesServiceStub.stubWorkspace().cdrVersionId,
@@ -102,12 +92,12 @@ describe('QueryReportComponent', () => {
       wsid: 'workspaceId',
       cid: 1
     });
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QueryReportComponent);
     component = fixture.componentInstance;
-    route = new ActivatedRoute();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/cohort-review/query-report/query-report.component.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.ts
@@ -1,5 +1,5 @@
 import {AfterContentChecked, ChangeDetectorRef, Component, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore, currentWorkspaceStore} from 'app/utils/navigation';
@@ -23,15 +23,13 @@ export class QueryReportComponent implements OnInit, AfterContentChecked {
   workspace: Workspace;
 
   constructor(private api: CohortBuilderService,
-    private route: ActivatedRoute,
     private cdref: ChangeDetectorRef,
     private cdrVersionStorageService: CdrVersionStorageService) {}
 
   ngOnInit() {
-    const {review} = this.route.snapshot.data;
     this.cohort = currentCohortStore.getValue();
     this.workspace = currentWorkspaceStore.getValue();
-    this.review = review;
+    this.review = cohortReviewStore.getValue();
     this.cdrVersionStorageService.cdrVersions$.subscribe(resp => {
       this.cdrDetails = resp.items.find(v => v.cdrVersionId === this.workspace.cdrVersionId);
     });

--- a/ui/src/app/cohort-review/review-state.service.ts
+++ b/ui/src/app/cohort-review/review-state.service.ts
@@ -10,15 +10,11 @@ import {
 
 @Injectable()
 export class ReviewStateService {
-  /* Data Subjects */
-  review = new ReplaySubject<CohortReview>(1);
-  annotationDefinitions = new ReplaySubject<CohortAnnotationDefinition[]>(1);
-
-  /* Observable views on the data Subjects */
-  review$ = this.review.asObservable();
-  annotationDefinitions$ = this.annotationDefinitions.asObservable();
-
   /* Flags */
   annotationManagerOpen = new BehaviorSubject<boolean>(false);
   editAnnotationManagerOpen = new BehaviorSubject<boolean>(false);
 }
+
+export const cohortReviewStore = new BehaviorSubject<CohortReview>(undefined);
+export const annotationDefinitionsStore =
+  new BehaviorSubject<CohortAnnotationDefinition[]>(undefined);

--- a/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-create/set-annotation-create.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {urlParamsStore} from 'app/utils/navigation';
 
 import {
@@ -79,7 +79,7 @@ export class SetAnnotationCreateComponent {
         .getCohortAnnotationDefinitions(ns, wsid, cid)
         .pluck('items'))
       .do((defns: CohortAnnotationDefinition[]) =>
-        this.state.annotationDefinitions.next(defns))
+        annotationDefinitionsStore.next(defns))
       .subscribe(_ => {
         this.open = false;
         this.form.reset();

--- a/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.spec.ts
@@ -2,8 +2,9 @@ import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {ClarityModule} from '@clr/angular';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {urlParamsStore} from 'app/utils/navigation';
+import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {SetAnnotationItemComponent} from './set-annotation-item.component';
 
 import {
@@ -63,6 +64,7 @@ describe('SetAnnotationItemComponent', () => {
       wsid: 'workspaceId',
       cid: 1
     });
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   it('Should render', () => {

--- a/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {urlParamsStore} from 'app/utils/navigation';
 
 import {
@@ -78,7 +78,7 @@ export class SetAnnotationItemComponent {
         .getCohortAnnotationDefinitions(ns, wsid, cid)
         .pluck('items'))
       .do((defns: CohortAnnotationDefinition[]) =>
-                this.state.annotationDefinitions.next(defns))
+                annotationDefinitionsStore.next(defns))
       .subscribe(_ => {
         this.editing = false;
         this.isPosting.emit(false);
@@ -104,7 +104,7 @@ export class SetAnnotationItemComponent {
         .getCohortAnnotationDefinitions(ns, wsid, cid)
         .pluck('items'))
       .do((defns: CohortAnnotationDefinition[]) =>
-                this.state.annotationDefinitions.next(defns))
+                annotationDefinitionsStore.next(defns))
       .subscribe(_ => this.isPosting.emit(false));
   }
 }

--- a/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.spec.ts
@@ -3,9 +3,10 @@ import {ReactiveFormsModule} from '@angular/forms';
 import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {CohortAnnotationDefinitionService} from 'generated';
+import {cohortAnnotationDefinitionStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {SetAnnotationItemComponent} from 'app/cohort-review/set-annotation-item/set-annotation-item.component';
 import {SetAnnotationListComponent} from './set-annotation-list.component';
 
@@ -26,6 +27,7 @@ describe('SetAnnotationListComponent', () => {
       ],
     })
       .compileComponents();
+    annotationDefinitionsStore.next([cohortAnnotationDefinitionStub]);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Subscription} from 'rxjs/Subscription';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 
 import {CohortAnnotationDefinition} from 'generated';
 
@@ -20,7 +20,7 @@ export class SetAnnotationListComponent implements OnInit, OnDestroy {
   constructor(private state: ReviewStateService) {}
 
   ngOnInit() {
-    this.subscription = this.state.annotationDefinitions$
+    this.subscription = annotationDefinitionsStore
             .subscribe(defns => this.definitions = defns);
   }
 

--- a/ui/src/app/cohort-review/set-annotation-modal/set-annotation-modal.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-modal/set-annotation-modal.component.spec.ts
@@ -3,9 +3,10 @@ import {ReactiveFormsModule} from '@angular/forms';
 import {ActivatedRoute} from '@angular/router';
 import {ClarityModule} from '@clr/angular';
 import {CohortAnnotationDefinitionService} from 'generated';
+import {cohortAnnotationDefinitionStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {annotationDefinitionsStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {SetAnnotationCreateComponent} from 'app/cohort-review/set-annotation-create/set-annotation-create.component';
 import {SetAnnotationItemComponent} from 'app/cohort-review/set-annotation-item/set-annotation-item.component';
 import {SetAnnotationListComponent} from 'app/cohort-review/set-annotation-list/set-annotation-list.component';
@@ -33,6 +34,7 @@ describe('SetAnnotationModalComponent', () => {
       ],
     })
       .compileComponents();
+    annotationDefinitionsStore.next([cohortAnnotationDefinitionStub]);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/table-page/table-page.spec.ts
+++ b/ui/src/app/cohort-review/table-page/table-page.spec.ts
@@ -14,18 +14,17 @@ import {ParticipantsChartsComponent} from 'app/cohort-review/participants-charts
 import {QueryCohortDefinitionComponent} from 'app/cohort-review/query-cohort-definition/query-cohort-definition.component';
 import {QueryDescriptiveStatsComponent} from 'app/cohort-review/query-descriptive-stats/query-descriptive-stats.component';
 import {QueryReportComponent} from 'app/cohort-review/query-report/query-report.component';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {StatusFilterComponent} from 'app/cohort-review/status-filter/status-filter.component';
 import {CohortSearchActions} from 'app/cohort-search/redux';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore} from 'app/utils/navigation';
 import {CohortBuilderService} from 'generated';
-import {CohortReviewService, DataAccessLevel} from 'generated';
+import {CohortReview, CohortReviewService, DataAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {CdrVersionStorageServiceStub} from 'testing/stubs/cdr-version-storage-service-stub';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
-import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
-import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
+import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {TablePage} from './table-page';
 
@@ -83,7 +82,6 @@ describe('TablePage', () => {
         {provide: CohortSearchActions},
         {provide: APP_BASE_HREF, useValue: '/'},
         {provide: CohortBuilderService, useValue: new CohortBuilderServiceStub()},
-        {provide: ReviewStateService, useValue: new ReviewStateServiceStub()},
         {provide: ActivatedRoute, useValue: activatedRouteStub},
         {provide: CohortReviewService, useValue: new CohortReviewServiceStub()},
       ],
@@ -94,6 +92,7 @@ describe('TablePage', () => {
       criteria: '',
       type: '',
     });
+    cohortReviewStore.next(cohortReviewStub);
   }));
 
   beforeEach(() => {

--- a/ui/src/app/cohort-review/table-page/table-page.ts
+++ b/ui/src/app/cohort-review/table-page/table-page.ts
@@ -6,7 +6,7 @@ import {Subscription} from 'rxjs/Subscription';
 import {ClearButtonFilterComponent} from 'app/cohort-review/clearbutton-filter/clearbutton-filter.component';
 import {MultiSelectFilterComponent} from 'app/cohort-review/multiselect-filter/multiselect-filter.component';
 import {Participant} from 'app/cohort-review/participant.model';
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 
 import {ParticipantCohortStatusColumns} from 'generated';
@@ -69,14 +69,13 @@ export class TablePage implements OnInit, OnDestroy {
 
   constructor(
     private reviewAPI: CohortReviewService,
-    private state: ReviewStateService,
     private route: ActivatedRoute,
   ) {}
 
   ngOnInit() {
     this.loading = false;
     this.cohortName = currentCohortStore.getValue().name;
-    this.subscription = this.state.review$.subscribe(review => {
+    this.subscription = cohortReviewStore.subscribe(review => {
       this.review = review;
       this.participants = review.participantCohortStatuses.map(Participant.fromStatus);
       this.totalParticipantCount = review.matchedParticipantCount;
@@ -87,11 +86,6 @@ export class TablePage implements OnInit, OnDestroy {
     this.races = this.extractDemographics(concepts.raceList);
     this.genders = this.extractDemographics(concepts.genderList);
     this.ethnicities = this.extractDemographics(concepts.ethnicityList);
-    // this.subscription.add(this.state.review$.subscribe(review => {
-    //   this.review = review;
-    //
-    //
-    // }));
   }
 
 
@@ -155,7 +149,7 @@ export class TablePage implements OnInit, OnDestroy {
       .getParticipantCohortStatuses(ns, wsid, cid, cdrid, query)
       .do(_ => this.loading = false)
       .subscribe(review => {
-        this.state.review.next(review);
+        cohortReviewStore.next(review);
       });
   }
 

--- a/ui/src/app/resolvers/annotation-definitions.ts
+++ b/ui/src/app/resolvers/annotation-definitions.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 
+import {annotationDefinitionsStore} from 'app/cohort-review/review-state.service';
 import {
   Cohort,
   CohortAnnotationDefinition,
@@ -21,7 +22,8 @@ export class AnnotationDefinitionsResolver implements Resolve<CohortAnnotationDe
 
     // console.log(`Resolving annotation definitions for ${ns}/${wsid}:${cid}`);
 
-    const call = this.api.getCohortAnnotationDefinitions(ns, wsid, cid).pluck('items');
-    return (call as Observable<CohortAnnotationDefinition[]>);
+    return this.api.getCohortAnnotationDefinitions(ns, wsid, cid).map(({items}) => items).do(v => {
+      annotationDefinitionsStore.next(v);
+    });
   }
 }

--- a/ui/src/app/resolvers/review.ts
+++ b/ui/src/app/resolvers/review.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {
   Cohort,
   CohortReview,
@@ -36,6 +37,9 @@ export class ReviewResolver implements Resolve<CohortReview> {
       pageFilterType: PageFilterType.ParticipantCohortStatuses,
     };
 
-    return this.api.getParticipantCohortStatuses(ns, wsid, cid, cdrid, request);
+    return this.api.getParticipantCohortStatuses(ns, wsid, cid, cdrid, request).map(v => {
+      cohortReviewStore.next(v);
+      return v;
+    });
   }
 }

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -12,6 +12,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import {annotationDefinitionsStore, cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentWorkspaceStore, currentCohortStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
@@ -32,6 +33,8 @@ beforeEach(() => {
   urlParamsStore.next({});
   queryParamsStore.next({});
   routeConfigDataStore.next({});
+  cohortReviewStore.next(undefined);
+  annotationDefinitionsStore.next(undefined);
 });
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/ui/src/testing/stubs/cohort-annotation-definition-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-annotation-definition-service-stub.ts
@@ -1,0 +1,8 @@
+import {AnnotationType} from 'generated';
+
+export const cohortAnnotationDefinitionStub = {
+  cohortAnnotationDefinitionId: 1,
+  cohortId: 2,
+  columnName: 'test',
+  annotationType: AnnotationType.BOOLEAN
+};

--- a/ui/src/testing/stubs/cohort-review-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-review-service-stub.ts
@@ -1,6 +1,23 @@
 import {CohortReview, ParticipantDataListResponse} from 'generated';
 import {Observable} from 'rxjs/Observable';
 
+export const cohortReviewStub = {
+  cohortReviewId: 1,
+  cohortId: 1,
+  cdrVersionId: 1,
+  creationTime: '',
+  matchedParticipantCount: 1,
+  reviewSize: 1,
+  reviewedCount: 1,
+  queryResultSize: 1,
+  reviewStatus: 'CREATED' as 'CREATED',
+  participantCohortStatuses: [],
+  page: 1,
+  pageSize: 1,
+  sortOrder: '',
+  sortColumn: '',
+};
+
 export class CohortReviewServiceStub {
 
   constructor() {}

--- a/ui/src/testing/stubs/review-state-service-stub.ts
+++ b/ui/src/testing/stubs/review-state-service-stub.ts
@@ -1,32 +1,12 @@
-import {Cohort, CohortReview} from 'generated';
+import {Cohort} from 'generated';
 import {AnnotationType, CohortAnnotationDefinition} from 'generated';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Observable} from 'rxjs/Observable';
 import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 export class ReviewStateServiceStub {
-  public annotationDefinitions = new ReplaySubject<CohortAnnotationDefinition[]>(1);
   public annotationManagerOpen = new BehaviorSubject<boolean>(false);
   public editAnnotationManagerOpen = new BehaviorSubject<boolean>(false);
-  public cohort = new ReplaySubject<Cohort>(1);
-  public review = new ReplaySubject<CohortReview>(1);
-
-  public annotationDefinitions$ = Observable.of([
-    <CohortAnnotationDefinition> {
-      cohortAnnotationDefinitionId: 1,
-      cohortId: 2,
-      columnName: 'test',
-      annotationType: AnnotationType.BOOLEAN
-    }
-  ]);
-  public cohort$ = Observable.of(<Cohort>{
-    name: 'test',
-    criteria: '[]',
-    type: 'type'
-  });
-  public review$ = Observable.of({
-    participantCohortStatuses: []
-  });
 
   constructor() {}
 }


### PR DESCRIPTION
Moves the cohort review and annotation definition state out of the review state service into standalone stores. This allows us to remove some router dependencies, and will allow this data to be accessed from React.