### PR TITLE
[RW-1478][risk=no] Turn off all magic spring endpoints

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -24,3 +24,8 @@ spring.datasource.min-idle=1
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.pmiops.workbench.cdr.MySQLDialect
+
+# See https://docs.spring.io/spring-boot/docs/1.5.3.RELEASE/reference/html/production-ready-endpoints.html
+# and https://precisionmedicineinitiative.atlassian.net/browse/RW-1478
+# Disable all spring-boot endpoints unless specifically necessary
+endpoints.enabled=false


### PR DESCRIPTION
Addresses https://precisionmedicineinitiative.atlassian.net/browse/RW-1478

Spring enables `health` and `info` endpoints by default (as well as many other JMX endpoints). Turn all of them off so we can enable them purposefully when needed. 