### PR TITLE
[RISK=LOW]Correcting path for failing bulk sync training status cron job

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -484,7 +484,7 @@ paths:
           type: string
           required: false
 
-  /v1/account/bulkSyncTrainingStatus:
+  /v1/cron/bulkSyncTrainingStatus:
     post:
       tags:
         - user

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -484,24 +484,7 @@ paths:
           type: string
           required: false
 
-  /v1/cron/bulkSyncTrainingStatus:
-    post:
-      tags:
-        - user
-        - cron
-      description: sync moodle badge/training status for all user
-      operationId: bulkSyncTrainingStatus
-      responses:
-        200:
-          description: The user table is updated with training status.
-        404:
-          description: User not found while retrieving  badge.
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-
-
+ 
   # Notebook clusters ####################################################################
 
   /v1/clusters:
@@ -841,6 +824,23 @@ paths:
           description: Clusters were checked and handled successfully.
           schema:
             $ref: "#/definitions/CheckClustersResponse"
+
+  /v1/cron/bulkSyncTrainingStatus:
+    post:
+      tags:
+        - user
+        - cron
+      description: sync moodle badge/training status for all user
+      operationId: bulkSyncTrainingStatus
+      responses:
+        200:
+          description: The user table is updated with training status.
+        404:
+          description: User not found while retrieving  badge.
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
 
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
     parameters:


### PR DESCRIPTION
Cron job xml had the following entry
  <cron>
    <url>/v1/cron/bulkSyncTrainingStatus</url>
    <target>api</target>
    <description>Periodic Sync users training status</description>
    <schedule>every 24 hours</schedule>
  </cron>