### PR TITLE
[P3][RW-2179] include mp4s as static file types to upload to app engine

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -8,7 +8,7 @@ handlers:
 - url: /.well-known/pki-validation/gsdv.txt
   static_files: dist/assets/gsdv.txt
   upload: dist/assets/gsdv.txt
-- url: /(.*\.(css|eot|gz|html|ico|jpg|jpeg|js|map|png|svg|ttf|woff|woff2))
+- url: /(.*\.(css|eot|gz|html|ico|jpg|jpeg|js|map|mp4|png|svg|ttf|woff|woff2))
   static_files: dist/\1
   upload: dist/(.*)
   secure: always


### PR DESCRIPTION
homepage video links were never working in test + downstream envs, but always worked in local; I think this is why? Would love someone more familiar with app engine to verify that's what I'm doing in the yaml