### PR TITLE
[risk=no] add no-unused-variable lint rule

### DIFF
--- a/ui/src/app/cohort-common/combo-chart/combo-chart.component.ts
+++ b/ui/src/app/cohort-common/combo-chart/combo-chart.component.ts
@@ -29,7 +29,6 @@ export class ComboChartComponent {
     }
   };
 
-  private _raw;
   private _data: any = [];
 
   /**
@@ -42,8 +41,6 @@ export class ComboChartComponent {
    *   { name: string; series: { name: string; value: number}[]; }[]
    */
   @Input() set data(raw) {
-    this._raw = raw;
-
     this._data = raw
       .map(datum => datum.update('gender', code => this.codeMap[code]))
       .groupBy(datum => `${datum.get('gender', 'Unknown')} ${datum.get('ageRange', 'Unknown')}`)

--- a/ui/src/app/cohort-review/annotation-item/annotation-item.component.ts
+++ b/ui/src/app/cohort-review/annotation-item/annotation-item.component.ts
@@ -2,7 +2,6 @@ import {
   AfterContentChecked,
   ChangeDetectorRef,
   Component,
-  EventEmitter,
   HostListener,
   Input,
   OnChanges,

--- a/ui/src/app/cohort-review/annotation-list/annotation-list.component.spec.ts
+++ b/ui/src/app/cohort-review/annotation-list/annotation-list.component.spec.ts
@@ -5,7 +5,6 @@ import {ClarityModule} from '@clr/angular';
 import {ValidatorErrorsComponent} from 'app/cohort-common/validator-errors/validator-errors.component';
 import {AnnotationItemComponent} from 'app/cohort-review/annotation-item/annotation-item.component';
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
-import {Observable} from 'rxjs/Observable';
 import {AnnotationListComponent} from './annotation-list.component';
 
 describe('AnnotationListComponent', () => {

--- a/ui/src/app/cohort-review/annotation-list/annotation-list.component.ts
+++ b/ui/src/app/cohort-review/annotation-list/annotation-list.component.ts
@@ -1,6 +1,5 @@
 import {Component, Input, OnChanges} from '@angular/core';
 import * as fp from 'lodash/fp';
-import {Observable} from 'rxjs/Observable';
 
 import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 

--- a/ui/src/app/cohort-review/create-review-page/create-review-page.spec.ts
+++ b/ui/src/app/cohort-review/create-review-page/create-review-page.spec.ts
@@ -6,7 +6,7 @@ import {ClarityModule} from '@clr/angular';
 
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentCohortStore} from 'app/utils/navigation';
-import {CohortReview, CohortReviewService} from 'generated';
+import {CohortReviewService} from 'generated';
 import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {CreateReviewPage} from './create-review-page';
 

--- a/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.spec.ts
@@ -4,7 +4,6 @@ import {ClarityModule} from '@clr/angular';
 import {CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import 'rxjs/add/observable/of';
-import {Observable} from 'rxjs/Observable';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 

--- a/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.ts
+++ b/ui/src/app/cohort-review/detail-all-events/detail-all-events.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, Input} from '@angular/core';
 
 import {DetailTabTableComponent} from 'app/cohort-review/detail-tab-table/detail-tab-table.component';
 

--- a/ui/src/app/cohort-review/detail-header/detail-header.component.ts
+++ b/ui/src/app/cohort-review/detail-header/detail-header.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnChanges} from '@angular/core';
+import {Component, Input, OnChanges} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 
 import {Participant} from 'app/cohort-review/participant.model';

--- a/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
+++ b/ui/src/app/cohort-review/detail-page/detail-page.spec.ts
@@ -23,10 +23,9 @@ import {SetAnnotationModalComponent} from 'app/cohort-review/set-annotation-moda
 import {SidebarContentComponent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {CohortSearchActions} from 'app/cohort-search/redux';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {CohortAnnotationDefinitionService, CohortReview, CohortReviewService, WorkspaceAccessLevel} from 'generated';
+import {CohortAnnotationDefinitionService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import * as highCharts from 'highcharts';
 import {NgxPopperModule} from 'ngx-popper';
-import {Observable} from 'rxjs/Observable';
 import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {CohortSearchActionStub} from 'testing/stubs/cohort-search-action-stub';

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.spec.ts
@@ -5,7 +5,6 @@ import {ClearButtonInMemoryFilterComponent} from 'app/cohort-review/clearbutton-
 import {currentCohortStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
-import {Observable} from 'rxjs/Observable';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {DetailTabTableComponent} from './detail-tab-table.component';

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.spec.ts
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.spec.ts
@@ -9,7 +9,6 @@ import {ReviewStateService} from 'app/cohort-review/review-state.service';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import * as highCharts from 'highcharts';
-import {Observable} from 'rxjs/Observable';
 import {CohortReviewServiceStub} from 'testing/stubs/cohort-review-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.ts
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, OnDestroy, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import * as fp from 'lodash/fp';
 
 import {typeToTitle} from 'app/cohort-search/utils';
@@ -21,11 +21,6 @@ const itemTime = {
   name: 'itemDate',
   classNames: ['time-col'],
   displayName: 'Time',
-};
-const endDate = {
-  name: 'endDate',
-  classNames: ['date-col'],
-  displayName: 'End Date',
 };
 const domain = {
   name: 'domain',
@@ -52,18 +47,6 @@ const sourceVocabulary = {
 const sourceName = {
   name: 'sourceName',
   displayName: 'Source Name',
-};
-const signature = {
-  name: 'signature',
-  displayName: 'Signature',
-};
-const valueConcept = {
-  name: 'valueConcept',
-  displayName: 'Concept Value',
-};
-const valueSource = {
-  name: 'valueSource',
-  displayName: 'Source Value',
 };
 const value = {
   name: 'value',
@@ -101,10 +84,6 @@ const lastMention = {
 const dose = {
   name: 'dose',
   displayName: 'Dose',
-};
-const refills = {
-  name: 'refills',
-  displayName: 'Refills',
 };
 const strength = {
   name: 'strength',

--- a/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.spec.ts
@@ -6,9 +6,8 @@ import {ComboChartComponent} from 'app/cohort-common/combo-chart/combo-chart.com
 import {ParticipantsChartsComponent} from 'app/cohort-review/participants-charts/participant-charts';
 import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
-import {CohortBuilderService, CohortReview, CohortReviewService, WorkspaceAccessLevel} from 'generated';
+import {CohortBuilderService, CohortReviewService, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
-import {Observable} from 'rxjs/Observable';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';

--- a/ui/src/app/cohort-review/overview-page/overview-page.ts
+++ b/ui/src/app/cohort-review/overview-page/overview-page.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, OnDestroy, OnInit, Output} from '@angular/core';
-import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 import {CohortBuilderService, CohortReview, CohortReviewService, DemoChartInfoListResponse, DomainType, SearchRequest} from 'generated';
 import {fromJS, List} from 'immutable';
@@ -32,7 +32,6 @@ export class OverviewPage implements OnInit, OnDestroy {
   constructor(
     private chartAPI: CohortBuilderService,
     private reviewAPI: CohortReviewService,
-    private state: ReviewStateService,
   ) {}
 
   ngOnInit() {

--- a/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
@@ -2,8 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
-import {CohortReview} from 'generated';
-import {Observable} from 'rxjs/Observable';
 
 import {CreateReviewPage} from 'app/cohort-review/create-review-page/create-review-page';
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';

--- a/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.spec.ts
+++ b/ui/src/app/cohort-review/query-descriptive-stats/query-descriptive-stats.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ClarityModule} from '@clr/angular';
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';
-import {CohortReview} from 'generated';
 import {cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {QueryDescriptiveStatsComponent} from './query-descriptive-stats.component';
 

--- a/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.spec.ts
@@ -10,9 +10,8 @@ import {QueryReportComponent} from 'app/cohort-review/query-report/query-report.
 import {cohortReviewStore, ReviewStateService} from 'app/cohort-review/review-state.service';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
-import {CohortBuilderService, CohortReview, CohortReviewService, DataAccessLevel, WorkspaceAccessLevel} from 'generated';
+import {CohortBuilderService, CohortReviewService, DataAccessLevel, WorkspaceAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
-import {Observable} from 'rxjs/Observable';
 import {CdrVersionStorageServiceStub} from 'testing/stubs/cdr-version-storage-service-stub';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';

--- a/ui/src/app/cohort-review/query-report/query-report.component.ts
+++ b/ui/src/app/cohort-review/query-report/query-report.component.ts
@@ -1,9 +1,8 @@
 import {AfterContentChecked, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';
-import {WorkspaceData} from 'app/resolvers/workspace';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore, currentWorkspaceStore} from 'app/utils/navigation';
-import {CohortBuilderService, Workspace} from 'generated';
+import {Workspace} from 'generated';
 import {List} from 'immutable';
 import {Observable} from 'rxjs/Observable';
 
@@ -22,7 +21,7 @@ export class QueryReportComponent implements OnInit, AfterContentChecked {
   data:  Observable<List<any>>;
   workspace: Workspace;
 
-  constructor(private api: CohortBuilderService,
+  constructor(
     private cdref: ChangeDetectorRef,
     private cdrVersionStorageService: CdrVersionStorageService) {}
 

--- a/ui/src/app/cohort-review/review-state.service.ts
+++ b/ui/src/app/cohort-review/review-state.service.ts
@@ -1,9 +1,7 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 import {
-  Cohort,
   CohortAnnotationDefinition,
   CohortReview,
 } from 'generated';

--- a/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-item/set-annotation-item.component.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 
-import {ReviewStateService} from 'app/cohort-review/review-state.service';
 import {urlParamsStore} from 'app/utils/navigation';
 
 import {
@@ -34,7 +33,6 @@ export class SetAnnotationItemComponent {
 
   constructor(
     private annotationAPI: CohortAnnotationDefinitionService,
-    private state: ReviewStateService,
     private ngZone: NgZone,
   ) {}
 

--- a/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.spec.ts
@@ -2,7 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {ClarityModule} from '@clr/angular';
 import {CohortAnnotationDefinitionService} from 'generated';
-import {cohortAnnotationDefinitionStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';

--- a/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.ts
+++ b/ui/src/app/cohort-review/set-annotation-list/set-annotation-list.component.ts
@@ -1,5 +1,4 @@
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {Subscription} from 'rxjs/Subscription';
+import {Component, Input} from '@angular/core';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';
 

--- a/ui/src/app/cohort-review/set-annotation-modal/set-annotation-modal.component.spec.ts
+++ b/ui/src/app/cohort-review/set-annotation-modal/set-annotation-modal.component.spec.ts
@@ -2,7 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {ClarityModule} from '@clr/angular';
 import {CohortAnnotationDefinitionService} from 'generated';
-import {cohortAnnotationDefinitionStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {ReviewStateServiceStub} from 'testing/stubs/review-state-service-stub';
 
 import {ReviewStateService} from 'app/cohort-review/review-state.service';

--- a/ui/src/app/cohort-review/table-page/table-page.spec.ts
+++ b/ui/src/app/cohort-review/table-page/table-page.spec.ts
@@ -20,7 +20,7 @@ import {CohortSearchActions} from 'app/cohort-search/redux';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
 import {currentCohortStore} from 'app/utils/navigation';
 import {CohortBuilderService} from 'generated';
-import {CohortReview, CohortReviewService, DataAccessLevel} from 'generated';
+import {CohortReviewService, DataAccessLevel} from 'generated';
 import {NgxPopperModule} from 'ngx-popper';
 import {CdrVersionStorageServiceStub} from 'testing/stubs/cdr-version-storage-service-stub';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';

--- a/ui/src/app/cohort-review/table-page/table-page.ts
+++ b/ui/src/app/cohort-review/table-page/table-page.ts
@@ -11,7 +11,6 @@ import {currentCohortStore, currentWorkspaceStore, urlParamsStore} from 'app/uti
 
 import {ParticipantCohortStatusColumns} from 'generated';
 import {
-  Cohort,
   CohortReview,
   CohortReviewService,
   ConceptIdName,
@@ -22,7 +21,6 @@ import {
   ParticipantCohortStatuses as Request,
   ParticipantDemographics,
   SortOrder,
-  Workspace,
 } from 'generated';
 
 function isMultiSelectFilter(filter): filter is MultiSelectFilterComponent {

--- a/ui/src/app/cohort-search/code-dropdown/code-dropdown.component.ts
+++ b/ui/src/app/cohort-search/code-dropdown/code-dropdown.component.ts
@@ -1,10 +1,9 @@
-import {NgRedux, select} from '@angular-redux/store';
+import {select} from '@angular-redux/store';
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {
   activeItem,
   codeDropdownOptions,
   CohortSearchActions,
-  CohortSearchState,
 } from 'app/cohort-search/redux';
 import {getCodeOptions} from 'app/cohort-search/utils';
 import {Observable} from 'rxjs/Observable';
@@ -25,7 +24,6 @@ export class CodeDropdownComponent implements  OnInit {
   @select(activeItem) activeItem$: Observable<any>;
   @select(codeDropdownOptions) options$: Observable<any>;
   constructor(
-    private ngRedux: NgRedux<CohortSearchState>,
     private actions: CohortSearchActions
   ) {}
 

--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -175,39 +175,39 @@ export class DemographicsComponent implements OnInit, OnChanges, OnDestroy {
 
   loadNodesFromApi() {
     const cdrid = +(currentWorkspaceStore.getValue().cdrVersionId);
-        /*
-         * Each subtype's possible criteria is loaded via the API.  Race and Gender
-         * criteria nodes become options in their respective dropdowns; deceased
-         * and age are used as templates for constructing relevant seach
-         * parameters.  Upon load we immediately map the criteria to immutable
-         * objects complete with deterministically generated `parameterId`s and
-         * sort them by count, then by name.
-         */
-    const calls = [
-            TreeSubType[TreeSubType.AGE],
-            TreeSubType[TreeSubType.DEC],
-            TreeSubType[TreeSubType.GEN],
-            TreeSubType[TreeSubType.RACE],
-            TreeSubType[TreeSubType.ETH]
-        ].map(code => {
-          this.loading[code] = true;
-          this.api.getCriteriaBy(cdrid, TreeType[TreeType.DEMO], code, null, null)
-            .subscribe(response => {
-              const items = response.items
-                        .filter(item => item.parentId !== 0
-                            || code === TreeSubType[TreeSubType.DEC]);
-              items.sort(sortByCountThenName);
-              const nodes = fromJS(items).map(node => {
-                if (node.get('subtype') !== TreeSubType[TreeSubType.AGE]) {
-                  const paramId =
-                                `param${node.get('conceptId', node.get('code'))}`;
-                  node = node.set('parameterId', paramId);
-                }
-                return node;
-              });
-              this.loadOptions(nodes, code);
-            });
+    /*
+     * Each subtype's possible criteria is loaded via the API.  Race and Gender
+     * criteria nodes become options in their respective dropdowns; deceased
+     * and age are used as templates for constructing relevant seach
+     * parameters.  Upon load we immediately map the criteria to immutable
+     * objects complete with deterministically generated `parameterId`s and
+     * sort them by count, then by name.
+     */
+    [
+      TreeSubType[TreeSubType.AGE],
+      TreeSubType[TreeSubType.DEC],
+      TreeSubType[TreeSubType.GEN],
+      TreeSubType[TreeSubType.RACE],
+      TreeSubType[TreeSubType.ETH]
+    ].forEach(code => {
+      this.loading[code] = true;
+      this.api.getCriteriaBy(cdrid, TreeType[TreeType.DEMO], code, null, null)
+        .subscribe(response => {
+          const items = response.items
+                    .filter(item => item.parentId !== 0
+                        || code === TreeSubType[TreeSubType.DEC]);
+          items.sort(sortByCountThenName);
+          const nodes = fromJS(items).map(node => {
+            if (node.get('subtype') !== TreeSubType[TreeSubType.AGE]) {
+              const paramId =
+                            `param${node.get('conceptId', node.get('code'))}`;
+              node = node.set('parameterId', paramId);
+            }
+            return node;
+          });
+          this.loadOptions(nodes, code);
         });
+    });
   }
 
   loadOptions(nodes: any, subtype: string) {

--- a/ui/src/app/cohort-search/gender-chart/gender-chart.component.ts
+++ b/ui/src/app/cohort-search/gender-chart/gender-chart.component.ts
@@ -42,7 +42,6 @@ export class GenderChartComponent {
     }
   };
 
-  private _raw: any;
   private _data: any = [];
 
   /**
@@ -51,7 +50,6 @@ export class GenderChartComponent {
    * Attaches the raw data to the component for debugging purposes.
    */
   @Input() set data(raw) {
-    this._raw = raw;
     this._data = raw
       .map(datum => datum.update('gender', code => this.codeMap[code]))
       .groupBy(datum => datum.get('gender', 'Unknown'))

--- a/ui/src/app/cohort-search/modal/modal.component.ts
+++ b/ui/src/app/cohort-search/modal/modal.component.ts
@@ -1,7 +1,6 @@
 import {select} from '@angular-redux/store';
-import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, OnDestroy, OnInit } from '@angular/core';
 import {DOMAIN_TYPES, PROGRAM_TYPES} from 'app/cohort-search/constant';
-import {ModifierPageComponent} from 'app/cohort-search/modifier-page/modifier-page.component';
 import {
   activeCriteriaSubtype,
   activeCriteriaTreeType,
@@ -41,7 +40,6 @@ export class ModalComponent implements OnInit, OnDestroy {
   @select(scrollId) scrollTo$: Observable<any>;
   @select(subtreeSelected) subtree$: Observable<any>;
   @select(previewStatus) preview$;
-  @ViewChild(ModifierPageComponent) private modifiers: ModifierPageComponent;
 
   readonly domainType = DomainType;
   readonly treeType = TreeType;
@@ -285,4 +283,3 @@ export class ModalComponent implements OnInit, OnDestroy {
       || this.modifiersDisabled;
   }
 }
-

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.ts
@@ -307,7 +307,7 @@ export class ModifierPageComponent implements OnInit, OnDestroy, AfterContentChe
     this.ngAfterContentChecked();
     this.errors = new Set();
     return this.modifiers.map(mod => {
-      const {name, inputType, min, max, maxLength, modType} = mod;
+      const {name, inputType, maxLength, modType} = mod;
       if (modType === ModifierType.ENCOUNTERS) {
         if (!vals[name].operator) {
           return;

--- a/ui/src/app/cohort-search/node-info/node-info.component.ts
+++ b/ui/src/app/cohort-search/node-info/node-info.component.ts
@@ -35,7 +35,6 @@ export class NodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   private isSelected: boolean;
   private isSelectedChild: boolean;
   private subscription: Subscription;
-  private ppiSubscription: Subscription;
   @ViewChild('name') name: ElementRef;
   isTruncated = false;
   matched = false;

--- a/ui/src/app/cohort-search/overview/overview.component.ts
+++ b/ui/src/app/cohort-search/overview/overview.component.ts
@@ -7,7 +7,7 @@ import {Observable} from 'rxjs/Observable';
 import {CohortSearchActions, searchRequestError} from 'app/cohort-search/redux';
 import {navigate, urlParamsStore} from 'app/utils/navigation';
 
-import {Cohort, CohortsService, Workspace} from 'generated';
+import {Cohort, CohortsService} from 'generated';
 
 const COHORT_TYPE = 'AoU_Discover';
 

--- a/ui/src/app/cohort-search/redux/actions/service.ts
+++ b/ui/src/app/cohort-search/redux/actions/service.ts
@@ -1,15 +1,13 @@
 import {dispatch, NgRedux} from '@angular-redux/store';
 import {Injectable} from '@angular/core';
 
-import {environment} from 'environments/environment';
 
 import {
   SearchGroup,
   SearchGroupItem,
   SearchParameter,
-  SearchRequest, TemporalMention, TemporalTime,
-  TreeSubType,
-  TreeType
+  SearchRequest,
+  TreeSubType
 } from 'generated';
 
 import {stripHtml} from 'app/cohort-search/utils';

--- a/ui/src/app/cohort-search/redux/epics.ts
+++ b/ui/src/app/cohort-search/redux/epics.ts
@@ -60,7 +60,7 @@ import {
 import {CohortSearchState} from './store';
 /* tslint:enable:ordered-imports */
 
-import {CohortBuilderService, CohortReviewService} from 'generated';
+import {CohortBuilderService} from 'generated';
 
 type CSEpic = Epic<RootAction, CohortSearchState>;
 type CritRequestAction = ActionTypes[typeof BEGIN_CRITERIA_REQUEST];
@@ -89,7 +89,7 @@ const compare = (obj) => (action) => Map(obj).isSubset(Map(action));
 @Injectable()
 export class CohortSearchEpics {
   constructor(private service: CohortBuilderService,
-    private reviewservice: CohortReviewService) {}
+  ) {}
 
   fetchCriteria: CSEpic = (action$) => (
     action$.ofType(BEGIN_CRITERIA_REQUEST).mergeMap(

--- a/ui/src/app/cohort-search/redux/index.ts
+++ b/ui/src/app/cohort-search/redux/index.ts
@@ -2,7 +2,6 @@ import {DevToolsExtension, NgRedux} from '@angular-redux/store';
 import {Injectable} from '@angular/core';
 import {combineEpics, createEpicMiddleware} from 'redux-observable';
 
-import {environment} from 'environments/environment';
 
 import {CohortSearchEpics} from './epics';
 import {rootReducer} from './reducer';
@@ -15,9 +14,9 @@ import {
 export class ConfigureStore {
 
   constructor(
-    private ngRedux: NgRedux<CohortSearchState>,
-    private epics: CohortSearchEpics,
-    private devTools: DevToolsExtension,
+    ngRedux: NgRedux<CohortSearchState>,
+    epics: CohortSearchEpics,
+    devTools: DevToolsExtension,
   ) {
 
     let storeEnhancers = [];

--- a/ui/src/app/cohort-search/redux/reducer.ts
+++ b/ui/src/app/cohort-search/redux/reducer.ts
@@ -9,7 +9,6 @@ import {
   activeRole,
   CohortSearchState,
   getGroup,
-  getItem,
   initialState,
   SR_ID
 } from './store';
@@ -491,7 +490,6 @@ export const rootReducer: Reducer<CohortSearchState> =
         const itemId = item.get('id');
         const groupId = activeGroupId(state);
         const groupItems = ['entities', 'groups', groupId, 'items'];
-        const group = getGroup(groupId)(state);
         if (item.get('searchParameters', List()).isEmpty()) {
           return state
             .updateIn(groupItems, List(),

--- a/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.spec.ts
@@ -20,24 +20,6 @@ import {SearchGroupComponent} from './search-group.component';
 
 import {CohortBuilderService, TreeType} from 'generated';
 
-const itemA = fromJS({
-  id: 'itemA',
-  count: null,
-  isRequesting: false,
-  type: TreeType[TreeType.ICD9],
-  searchParameters: [],
-  modifiers: [],
-});
-
-const itemB = fromJS({
-  id: 'itemB',
-  count: null,
-  isRequesting: false,
-  type: TreeType[TreeType.ICD9],
-  searchParameters: [],
-  modifiers: [],
-});
-
 const group = fromJS({
   id: 'include0',
   count: null,

--- a/ui/src/app/cohort-search/search-group/search-group.component.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.ts
@@ -8,7 +8,7 @@ import {
   getTemporalGroupItems,
   groupError
 } from 'app/cohort-search/redux';
-import {integerAndRangeValidator, numberAndNegativeValidator} from 'app/cohort-search/validators';
+import {integerAndRangeValidator} from 'app/cohort-search/validators';
 import {SearchRequest, TemporalMention, TemporalTime, TreeType} from 'generated';
 import {List} from 'immutable';
 import {Subscription} from 'rxjs/Subscription';

--- a/ui/src/app/components/alert.tsx
+++ b/ui/src/app/components/alert.tsx
@@ -1,5 +1,4 @@
 import {reactStyles} from 'app/utils';
-import * as React from 'react';
 
 import {withStyle} from 'app/utils/index';
 

--- a/ui/src/app/components/card.tsx
+++ b/ui/src/app/components/card.tsx
@@ -1,5 +1,4 @@
 import {reactStyles, withStyle} from 'app/utils';
-import * as React from 'react';
 
 export const styles = reactStyles({
   card: {

--- a/ui/src/app/components/forms.tsx
+++ b/ui/src/app/components/forms.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 
 import {withStyle} from 'app/utils/index';
 

--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 
 import colors from 'app/styles/colors';
 import {withStyle} from 'app/utils/index';

--- a/ui/src/app/factory/InterceptedHttp.ts
+++ b/ui/src/app/factory/InterceptedHttp.ts
@@ -13,7 +13,7 @@ export class InterceptedHttp extends Http {
   public shouldPingStatus = true;
 
 
-  constructor(private backend: ConnectionBackend, private defaultOptions: RequestOptions,
+  constructor(backend: ConnectionBackend, defaultOptions: RequestOptions,
     private errorHandlingService: ErrorHandlingService) {
     super(backend, defaultOptions);
   }

--- a/ui/src/app/guards/sign-in-guard.service.ts
+++ b/ui/src/app/guards/sign-in-guard.service.ts
@@ -11,8 +11,6 @@ import {Observable} from 'rxjs/Observable';
 import {SignInService} from 'app/services/sign-in.service';
 
 
-declare const gapi: any;
-
 @Injectable()
 export class SignInGuard implements CanActivate, CanActivateChild {
   constructor(private signInService: SignInService, private router: Router) {}

--- a/ui/src/app/resolvers/workspace.ts
+++ b/ui/src/app/resolvers/workspace.ts
@@ -3,7 +3,7 @@ import {ActivatedRouteSnapshot, Resolve} from '@angular/router';
 
 import {WorkspaceStorageService} from 'app/services/workspace-storage.service';
 
-import {Workspace, WorkspaceAccessLevel, WorkspacesService} from 'generated';
+import {Workspace, WorkspaceAccessLevel} from 'generated';
 
 /**
  * Flatten a layer of nesting
@@ -15,7 +15,6 @@ export interface WorkspaceData extends Workspace {
 @Injectable()
 export class WorkspaceResolver implements Resolve<WorkspaceData> {
   constructor(
-    private api: WorkspacesService,
     private workspaceStorageService: WorkspaceStorageService,
   ) {}
 

--- a/ui/src/app/services/error-handling.service.ts
+++ b/ui/src/app/services/error-handling.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {Response} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
@@ -16,7 +16,7 @@ export class ErrorHandlingService {
   public userDisabledError: boolean;
   public profileLoadError: boolean;
 
-  constructor(private zone: NgZone) {
+  constructor() {
     this.serverError = false;
     this.profileLoadError = false;
     this.noServerResponse = false;

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -2,7 +2,6 @@
  * OAuth2 via GAPI sign-in.
  */
 import {Injectable, NgZone} from '@angular/core';
-import {Router} from '@angular/router';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
@@ -11,9 +10,6 @@ import 'rxjs/Rx';
 
 
 declare const gapi: any;
-
-const SIGNED_IN_USER = 'signedInUser';
-
 
 @Injectable()
 export class SignInService {
@@ -24,7 +20,6 @@ export class SignInService {
   public clientId = environment.clientId;
 
   constructor(private zone: NgZone,
-    private router: Router,
     serverConfigService: ServerConfigService) {
     this.zone = zone;
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -9,7 +9,6 @@ import * as ReactDOM from 'react-dom';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 export const WINDOW_REF = 'window-ref';
-import {WorkspaceData} from 'app/resolvers/workspace';
 import {currentWorkspaceStore, userProfileStore} from 'app/utils/navigation';
 
 export function isBlank(toTest: String): boolean {

--- a/ui/src/app/views/app/component.ts
+++ b/ui/src/app/views/app/component.ts
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit {
   cookiesEnabled = true;
   overriddenUrl: string = null;
   private baseTitle: string;
-  private overriddenPublicUrl: string = null;
+  overriddenPublicUrl: string = null;
 
   constructor(
     @Inject(DOCUMENT) private doc: any,

--- a/ui/src/app/views/concept-add-modal/component.ts
+++ b/ui/src/app/views/concept-add-modal/component.ts
@@ -5,7 +5,6 @@ import {
   Concept,
   ConceptSet,
   ConceptSetsService,
-  ConceptsService,
   CreateConceptSetRequest,
   Domain,
   UpdateConceptSetRequest
@@ -43,7 +42,6 @@ export class ConceptAddModalComponent {
 
   constructor(
     private conceptSetsService: ConceptSetsService,
-    private conceptService: ConceptsService,
   ) {
     const {ns, wsid} = urlParamsStore.getValue();
     this.wsNamespace = ns;

--- a/ui/src/app/views/concept-homepage/component.spec.ts
+++ b/ui/src/app/views/concept-homepage/component.spec.ts
@@ -19,12 +19,11 @@ import {
   ConceptsService,
   DomainInfo,
   StandardConceptFilter,
-  WorkspaceAccessLevel,
 } from 'generated';
 
 import {ConceptSetsServiceStub} from 'testing/stubs/concept-sets-service-stub';
 import {ConceptsServiceStub, DomainStubVariables} from 'testing/stubs/concepts-service-stub';
-import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
+import {WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
 import {simulateClick, simulateEvent, simulateInput, updateAndTick} from 'testing/test-helpers';
 
 
@@ -160,8 +159,8 @@ describe('ConceptHomepageComponent', () => {
   }));
 
   it('should display the selected concepts on header', fakeAsync(() => {
-    const spy = spyOn(TestBed.get(ConceptsService), 'searchConcepts')
-        .and.callThrough();
+    spyOn(TestBed.get(ConceptsService), 'searchConcepts')
+      .and.callThrough();
     const searchTerm = 'test';
     simulateClick(fixture, fixture.debugElement
       .query(By.css('.standard-concepts-checkbox')).children[0]);
@@ -181,8 +180,8 @@ describe('ConceptHomepageComponent', () => {
   }));
 
   it('should display the selected concepts on sliding button', fakeAsync(() => {
-    const spy = spyOn(TestBed.get(ConceptsService), 'searchConcepts')
-        .and.callThrough();
+    spyOn(TestBed.get(ConceptsService), 'searchConcepts')
+      .and.callThrough();
 
     const searchTerm = 'test';
     simulateClick(fixture, fixture.debugElement

--- a/ui/src/app/views/concept-set-list/component.spec.ts
+++ b/ui/src/app/views/concept-set-list/component.spec.ts
@@ -1,6 +1,5 @@
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';

--- a/ui/src/app/views/conceptset-create-modal/component.tsx
+++ b/ui/src/app/views/conceptset-create-modal/component.tsx
@@ -6,7 +6,7 @@ import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import {ReactWrapperBase, summarizeErrors, withCurrentWorkspace} from 'app/utils/index';
-import {ConceptSet, CreateConceptSetRequest, Domain, DomainInfo} from 'generated/fetch';
+import {ConceptSet, Domain, DomainInfo} from 'generated/fetch';
 import * as React from 'react';
 import {validate} from 'validate.js';
 

--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -248,7 +248,6 @@ export const Homepage = withUserProfile()(class extends React.Component<
   }> {
   private pageId = 'homepage';
   private timer: NodeJS.Timer;
-  private profileTimer: NodeJS.Timer;
 
   constructor(props: any) {
     super(props);
@@ -305,7 +304,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
     const {profileState: {profile, reload}} = this.props;
 
     if (fp.isEmpty(profile)) {
-      this.profileTimer = setTimeout(() => {
+      setTimeout(() => {
         reload();
       }, 10000);
     } else {
@@ -367,7 +366,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
   render() {
     const {billingProjectInitialized, videoOpen, accessTasksLoaded,
         accessTasksRemaining, eraCommonsLinked, eraCommonsError, trainingCompleted,
-        quickTour, videoLink, firstVisit} = this.state;
+        quickTour, videoLink} = this.state;
     const quickTourResources = [
       {
         src: '/assets/images/QT-thumbnail.svg',

--- a/ui/src/app/views/new-notebook-modal/component.tsx
+++ b/ui/src/app/views/new-notebook-modal/component.tsx
@@ -1,5 +1,4 @@
 import {Component, Input} from '@angular/core';
-import {Router} from '@angular/router';
 import * as React from 'react';
 import {validate} from 'validate.js';
 
@@ -9,12 +8,12 @@ import {RadioButton, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {TooltipTrigger} from 'app/components/popups';
 import {userMetricsApi} from 'app/services/swagger-fetch-clients';
-import {isBlank, ReactWrapperBase, summarizeErrors} from 'app/utils/index';
+import {ReactWrapperBase, summarizeErrors} from 'app/utils/index';
 import {navigate} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 
 
-import {FileDetail, UserMetricsService, Workspace} from 'generated';
+import {FileDetail, Workspace} from 'generated';
 
 export class NewNotebookModal extends React.Component<
   {onClose: Function, workspace: Workspace, existingNotebooks: FileDetail[]},

--- a/ui/src/app/views/notebook-redirect/component.ts
+++ b/ui/src/app/views/notebook-redirect/component.ts
@@ -13,8 +13,7 @@ import {environment} from 'environments/environment';
 import {
   Cluster,
   ClusterService,
-  ClusterStatus,
-  WorkspaceAccessLevel
+  ClusterStatus
 } from 'generated';
 import {
   ClusterService as LeoClusterService,
@@ -123,7 +122,7 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const {ns, wsid} = urlParamsStore.getValue();
-    const {creating, playgroundMode, jupyterLabMode, kernelType} = queryParamsStore.getValue();
+    const {creating, playgroundMode, jupyterLabMode} = queryParamsStore.getValue();
     this.wsNamespace = ns;
     this.wsId = wsid;
     this.creating = creating || false;
@@ -289,14 +288,6 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
 
   navigateBack(): void {
     this.locationService.back();
-  }
-
-  private initializeProgressMap(): void {
-    for (const p in Object.keys(Progress)) {
-      if (p) {
-        this.progressComplete[p] = false;
-      }
-    }
   }
 
   private incrementProgress(p: Progress): void {

--- a/ui/src/app/views/sign-in/component.tsx
+++ b/ui/src/app/views/sign-in/component.tsx
@@ -14,11 +14,6 @@ import * as React from 'react';
 
 import {styles} from './style';
 
-interface ImagesSource {
-  backgroundImgSrc: string;
-  smallerBackgroundImgSrc: string;
-}
-
 export interface SignInProps {
   onInit: () => void;
   signIn: () => void;

--- a/ui/src/app/views/unregistered/component.ts
+++ b/ui/src/app/views/unregistered/component.ts
@@ -6,7 +6,6 @@ import {ServerConfigService} from 'app/services/server-config.service';
 import {hasRegisteredAccess} from 'app/utils';
 
 import {
-  DataAccessLevel,
   IdVerificationStatus,
   ProfileService,
 } from 'generated';

--- a/ui/src/app/views/workspace-edit/component.ts
+++ b/ui/src/app/views/workspace-edit/component.ts
@@ -460,7 +460,7 @@ export class WorkspaceEditComponent implements OnInit {
 
   openStigmatizationLink() {
     const stigmatizationURL = `/definitions/stigmatization`;
-    const stigmatizationPage = window.open(stigmatizationURL, '_blank');
+    window.open(stigmatizationURL, '_blank');
   }
 
   clearAllFields() {

--- a/ui/src/app/views/workspace-share/component.tsx
+++ b/ui/src/app/views/workspace-share/component.tsx
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {userApi, workspacesApi} from 'app/services/swagger-fetch-clients';

--- a/ui/src/app/views/workspace-wrapper/component.ts
+++ b/ui/src/app/views/workspace-wrapper/component.ts
@@ -5,7 +5,6 @@ import {WorkspaceData} from 'app/resolvers/workspace';
 
 import {currentWorkspaceStore, navigate, routeConfigDataStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
-import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar/component';
 import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 
 import {

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -56,7 +56,7 @@ import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub'
 import {UserMetricsApiStub} from 'testing/stubs/user-metrics-api-stub';
 import {UserMetricsServiceStub} from 'testing/stubs/user-metrics-service-stub';
 import {UserServiceStub} from 'testing/stubs/user-service-stub';
-import {WorkspacesServiceStub, WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
+import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 
 import {NewNotebookModalComponent} from 'app/views/new-notebook-modal/component';
 import {updateAndTick} from 'testing/test-helpers';

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -1,15 +1,10 @@
 import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {Comparator, StringFilter} from '@clr/angular';
 
-import {WorkspaceData} from 'app/resolvers/workspace';
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
-import {SignInService} from 'app/services/sign-in.service';
 import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {BugReportComponent} from 'app/views/bug-report/component';
 import {ResearchPurposeItems} from 'app/views/workspace-edit/component';
-import {WorkspaceShareComponent} from 'app/views/workspace-share/component';
 
-import {NewNotebookModalComponent} from 'app/views/new-notebook-modal/component';
 import {ToolTipComponent} from 'app/views/tooltip/component';
 import {
   CdrVersion,
@@ -23,48 +18,6 @@ import {
   WorkspaceAccessLevel,
   WorkspacesService,
 } from 'generated';
-
-/*
- * Search filters used by the cohort and notebook data tables to
- * determine which of the cohorts loaded into client side memory
- * are displayed.
- */
-class CohortNameFilter implements StringFilter<Cohort> {
-  accepts(cohort: Cohort, search: string): boolean {
-    return cohort.name.toLowerCase().indexOf(search) >= 0;
-  }
-}
-class CohortDescriptionFilter implements StringFilter<Cohort> {
-  accepts(cohort: Cohort, search: string): boolean {
-    return cohort.description.toLowerCase().indexOf(search) >= 0;
-  }
-}
-class NotebookNameFilter implements StringFilter<FileDetail> {
-  accepts(notebook: FileDetail, search: string): boolean {
-    return notebook.name.toLowerCase().indexOf(search) >= 0;
-  }
-}
-
-/*
- * Sort comparators used by the cohort and notebook data tables to
- * determine the order that the cohorts loaded into client side memory
- * are displayed.
- */
-class CohortNameComparator implements Comparator<Cohort> {
-  compare(a: Cohort, b: Cohort) {
-    return a.name.localeCompare(b.name);
-  }
-}
-class CohortDescriptionComparator implements Comparator<Cohort> {
-  compare(a: Cohort, b: Cohort) {
-    return a.description.localeCompare(b.description);
-  }
-}
-class NotebookNameComparator implements Comparator<FileDetail> {
-  compare(a: FileDetail, b: FileDetail) {
-    return a.name.localeCompare(b.name);
-  }
-}
 
 enum Tabs {
   Cohorts,
@@ -111,7 +64,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
 
   constructor(
     private cohortsService: CohortsService,
-    private signInService: SignInService,
     private workspacesService: WorkspacesService,
     private cdrVersionStorageService: CdrVersionStorageService,
     private profileService: ProfileService,

--- a/ui/src/testing/stubs/cohort-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-service-stub.ts
@@ -12,7 +12,6 @@ import {
 import {convertToResources, ResourceType} from 'app/utils/resourceActions';
 import {WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
 
-import {CohortsApiStub} from './cohorts-api-stub';
 
 export let DEFAULT_COHORT_ID = 1;
 export let DEFAULT_COHORT_ID_2 = 2;

--- a/ui/src/testing/stubs/concept-sets-api-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-api-stub.ts
@@ -1,11 +1,8 @@
-import {ConceptsServiceStub} from './concepts-service-stub';
 
-import {Empty} from '@angular-devkit/core/src/virtual-fs/host';
 import {
   ConceptSet,
   ConceptSetListResponse,
-  Domain,
-  UpdateConceptSetRequest
+  Domain
 } from 'generated/fetch';
 import {ConceptSetsApi, CreateConceptSetRequest, EmptyResponse} from 'generated/fetch/api';
 

--- a/ui/src/testing/stubs/review-state-service-stub.ts
+++ b/ui/src/testing/stubs/review-state-service-stub.ts
@@ -1,8 +1,4 @@
-import {Cohort} from 'generated';
-import {AnnotationType, CohortAnnotationDefinition} from 'generated';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {Observable} from 'rxjs/Observable';
-import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 export class ReviewStateServiceStub {
   public annotationManagerOpen = new BehaviorSubject<boolean>(false);

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -1,13 +1,10 @@
 import {
   FileDetail, ShareWorkspaceRequest, ShareWorkspaceResponse,
-  UserRole,
   Workspace,
   WorkspaceAccessLevel,
   WorkspaceResponseListResponse,
   WorkspacesApi
 } from 'generated/fetch';
-
-import {UserServiceStub} from './user-service-stub';
 
 import * as fp from 'lodash/fp';
 

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -6,6 +6,7 @@
     "node_modules/tslint-eslint-rules/dist/rules"
   ],
   "rules": {
+    "no-unused-variable": [true, {"ignore-pattern": "^_$"}],
     "no-relative-imports": [
       true,
       "allow-siblings"


### PR DESCRIPTION
Disallows unused imports and variables via a lint rule, and cleans up existing violations.

This rule is technically deprecated in favor of a similar built-in check in Typescript. However, the auto-generated API code contains violations of this rule, and there seems to be no way to tell TS to exclude certain files.

Despite the deprecation, I think this rule has some nice benefits, especially during heavy refactoring.