### PR TITLE
[risk=no] fix participant chart

### DIFF
--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.html
@@ -16,9 +16,7 @@
                   </span>
                 </clr-alert-item>
               </clr-alert>
-              <app-individual-participants-charts [chartData] ="chartData[charts]"
-                                                  [chartKey]="i"
-                                                  [shouldReRender]="chartData[charts].loading">
+              <app-individual-participants-charts [chartData]="chartData[charts]">
               </app-individual-participants-charts>
             </div>
           </div>

--- a/ui/src/app/cohort-review/individual-participants-charts/individual-participants-charts.spec.tsx
+++ b/ui/src/app/cohort-review/individual-participants-charts/individual-participants-charts.spec.tsx
@@ -1,34 +1,23 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
-import {
-  ChartReactProps,
-  IndividualParticipantsChartsComponent,
-  IndividualParticipantsReactCharts
-} from './individual-participants-charts';
+
+import {IndividualParticipantsCharts} from './individual-participants-charts';
 
 describe('IndividualParticipantsChartsComponent', () => {
-
-  let props: ChartReactProps;
-  const component = () => {
-    return shallow<IndividualParticipantsReactCharts, ChartReactProps>
-    (<IndividualParticipantsReactCharts {...props}/>);
-  };
-
-  beforeEach(() => {
-    props = {
-      chartData: {
-        loading: true,
-        conditionTitle: '',
-        items: [],
-      },
-      chartKey: 0,
-    };
-  });
-
   it('should render IndividualParticipantsChartsComponent', () => {
-    const wrapper = component();
-    expect(wrapper).toBeTruthy();
+    const wrapper = shallow(<IndividualParticipantsCharts
+      chartData={{
+        loading: false,
+        conditionTitle: '',
+        items: [{
+          startDate: '2019-01-01',
+          standardName: 'a',
+          standardVocabulary: 'b',
+          ageAtEvent: 1,
+          rank: 1
+        }]
+      }}
+    />);
+    expect(wrapper.exists()).toBeTruthy();
   });
-
 });
-


### PR DESCRIPTION
This fixes two issues with the participant charts:
* Charts no longer display stale data when switching between participants via the navigation buttons.
* Charts render more quickly when switching tabs.

Note that the root cause of the staleness issue was the data being placed in instance variables in the component. This should be avoided in most cases, since it creates 'pseudo-state' that persists on the component. In this case, that data was leaking across re-renders, causing subsequent chart pages to show incorrect information.

The fix is to compute the chart series directly in the render path, without storing it anywhere. This is the preferred approach for all kinds of derived data needed for rendering.