### PR TITLE
[RW-1948][risk=no] Switch to events, fix visits, minor schema code cleanup

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -64,7 +64,7 @@ public class ElasticDocument {
       .build();
 
   private static Map<String, Object> esType(ElasticType t) {
-    return ImmutableMap.of("type", ElasticType.KEYWORD.lower());
+    return ImmutableMap.of("type", t.lower());
   }
 
   public final String id;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -38,7 +38,7 @@ public class ElasticDocument {
       .put("source_concept_id", 1)
       .put("start_date", 2)
       .put("age_at_start", 3)
-      .put("visit_type_concept_id", 4)
+      .put("visit_concept_id", 4)
       .put("value_as_number", 5)
       .put("value_as_concept", 6)
       .build();
@@ -46,22 +46,26 @@ public class ElasticDocument {
   private static final Map<String, Object> NESTED_FOREIGN_SCHEMA = ImmutableMap.of(
       "type", ElasticType.NESTED.lower(),
       "properties", ImmutableMap.builder()
-          .put("concept_id", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
-          .put("source_concept_id", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
+          .put("concept_id", esType(ElasticType.KEYWORD))
+          .put("source_concept_id", esType(ElasticType.KEYWORD))
           // Domain-dependent fields follow (may be unpopulated).
-          .put("start_date", ImmutableMap.of("type", ElasticType.DATE.lower()))
-          .put("age_at_start", ImmutableMap.of("type", ElasticType.INTEGER.lower()))
-          .put("visit_type_concept_id", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
-          .put("value_as_number", ImmutableMap.of("type", ElasticType.INTEGER.lower()))
-          .put("value_as_concept", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
+          .put("start_date", esType(ElasticType.DATE))
+          .put("age_at_start", esType(ElasticType.INTEGER))
+          .put("visit_concept_id", esType(ElasticType.KEYWORD))
+          .put("value_as_number", esType(ElasticType.INTEGER))
+          .put("value_as_concept", esType(ElasticType.KEYWORD))
           .build());
 
   public static final Map<String, Object> PERSON_SCHEMA = ImmutableMap.<String, Object>builder()
-      .put("gender_concept_id", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
-      .put("condition_concept_ids", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
-      .put("condition_source_concept_ids", ImmutableMap.of("type", ElasticType.KEYWORD.lower()))
-      .put("conditions", NESTED_FOREIGN_SCHEMA)
+      .put("gender_concept_id", esType(ElasticType.KEYWORD))
+      .put("condition_concept_ids", esType(ElasticType.KEYWORD))
+      .put("condition_source_concept_ids", esType(ElasticType.KEYWORD))
+      .put("events", NESTED_FOREIGN_SCHEMA)
       .build();
+
+  private static Map<String, Object> esType(ElasticType t) {
+    return ImmutableMap.of("type", ElasticType.KEYWORD.lower());
+  }
 
   public final String id;
   public final XContentBuilder source;

--- a/api/tools/src/main/resources/bigquery/es_person.sql
+++ b/api/tools/src/main/resources/bigquery/es_person.sql
@@ -9,7 +9,8 @@ SELECT
   ec.concept_name ethnicity_concept_name,
   condition_concept_ids,
   condition_source_concept_ids,
-  conditions
+  /* TODO(calbach): Expand this to UNION events across all domains. */
+  conditions AS events
 FROM
   `{BQ_DATASET}.person` p
 LEFT JOIN (
@@ -21,7 +22,7 @@ LEFT JOIN (
         condition_source_concept_id AS source_concept_id,
         condition_start_date AS start_date,
         DATE_DIFF(condition_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
-        v.visit_type_concept_id,
+        v.visit_concept_id,
         NULL AS value_as_number,
         NULL AS value_as_concept)) conditions
   FROM


### PR DESCRIPTION
Splitting this PR out for discussion primarily. This is a design change (also made a comment in the design doc: https://docs.google.com/document/d/1N_TDTOi-moTH6wrXn1Ix4dwUlw4j8GT9OsL9yXYXYmY/edit?hl=en#heading=h.jduorqros7hm)

This changes from a per-domain event approach to a single schema and nested field for all events. This maintains the top level per-domain ID fields to allow for "TOP N conditions" type aggregations.

Pros:
- Single template for all search group queries, don't need to worry about mixed domain types in a criteria tree (as much)

Cons:
- May be less useful for aggregation later in unforeseen use cases.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
