### PR TITLE
[risk=no] extract concept set state into store

### DIFF
--- a/ui/src/app/resolvers/concept-set.ts
+++ b/ui/src/app/resolvers/concept-set.ts
@@ -6,6 +6,9 @@ import {
   ConceptSetsService,
   Workspace
 } from 'generated';
+import {ConceptSet as FetchConceptSet} from 'generated/fetch';
+
+import {currentConceptSetStore} from 'app/utils/navigation';
 
 @Injectable()
 export class ConceptSetResolver implements Resolve<ConceptSet> {
@@ -18,6 +21,8 @@ export class ConceptSetResolver implements Resolve<ConceptSet> {
     const wsid: Workspace['id'] = route.params.wsid;
     const csid: ConceptSet['id'] = route.params.csid;
 
-    return this.api.getConceptSet(ns, wsid, csid).toPromise();
+    return this.api.getConceptSet(ns, wsid, csid).do(v => {
+      currentConceptSetStore.next(v as unknown as FetchConceptSet);
+    }).toPromise();
   }
 }

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -1,6 +1,6 @@
 import {WorkspaceData} from 'app/resolvers/workspace';
 import {Profile} from 'generated';
-import {Cohort} from 'generated/fetch';
+import {Cohort, ConceptSet} from 'generated/fetch';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 export const NavStore = {
@@ -10,6 +10,7 @@ export const NavStore = {
 
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
 export const currentCohortStore = new BehaviorSubject<Cohort>(undefined);
+export const currentConceptSetStore = new BehaviorSubject<ConceptSet>(undefined);
 export const urlParamsStore = new BehaviorSubject<any>({});
 export const queryParamsStore = new BehaviorSubject<any>({});
 export const routeConfigDataStore = new BehaviorSubject<any>({});

--- a/ui/src/app/views/concept-set-details/component.spec.ts
+++ b/ui/src/app/views/concept-set-details/component.spec.ts
@@ -3,13 +3,12 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
 import { HighlightSearchComponent } from 'app/highlight-search/highlight-search.component';
 import {EditComponent} from 'app/icons/edit/component';
-import {currentWorkspaceStore, NavStore, urlParamsStore} from 'app/utils/navigation';
+import {currentConceptSetStore, currentWorkspaceStore, NavStore, urlParamsStore} from 'app/utils/navigation';
 import {ConceptAddModalComponent} from 'app/views/concept-add-modal/component';
 import {ConceptSetDetailsComponent} from 'app/views/concept-set-details/component';
 import {ConceptTableComponent} from 'app/views/concept-table/component';
@@ -23,6 +22,7 @@ import {
   Domain,
   WorkspaceAccessLevel,
 } from 'generated';
+import {ConceptSet as FetchConceptSet} from 'generated/fetch';
 
 import {ConceptSetsServiceStub} from 'testing/stubs/concept-sets-service-stub';
 import {ConceptStubVariables} from 'testing/stubs/concepts-service-stub';
@@ -38,16 +38,8 @@ import {
 describe('ConceptSetDetailsComponent', () => {
   let fixture: ComponentFixture<ConceptSetDetailsComponent>;
   let conceptSetsStub: ConceptSetsServiceStub;
-  let routeStub: any;
   beforeEach(fakeAsync(() => {
     conceptSetsStub = new ConceptSetsServiceStub([]);
-    routeStub = {
-      snapshot: {
-        data: {
-          conceptSet: newConceptSet()
-        }
-      }
-    };
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
@@ -68,7 +60,6 @@ describe('ConceptSetDetailsComponent', () => {
       ],
       providers: [
         { provide: ConceptSetsService, useValue: conceptSetsStub },
-        { provide: ActivatedRoute, useFactory: () => routeStub }
       ]}).compileComponents();
     urlParamsStore.next({
       ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
@@ -98,7 +89,7 @@ describe('ConceptSetDetailsComponent', () => {
     if (!conceptSet) {
       conceptSet = newConceptSet();
     }
-    routeStub.snapshot.data.conceptSet = conceptSet;
+    currentConceptSetStore.next(conceptSet as unknown as FetchConceptSet);
     if (!conceptSetsStub.conceptSets.length) {
       conceptSetsStub.conceptSets = [conceptSet];
     }

--- a/ui/src/app/views/concept-set-details/component.ts
+++ b/ui/src/app/views/concept-set-details/component.ts
@@ -1,7 +1,6 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
 
-import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
+import {currentConceptSetStore, currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {ConceptTableComponent} from 'app/views/concept-table/component';
 
 import {
@@ -38,7 +37,6 @@ export class ConceptSetDetailsComponent implements OnInit {
 
   constructor(
     private conceptSetsService: ConceptSetsService,
-    private route: ActivatedRoute,
   ) {
     this.receiveDelete = this.receiveDelete.bind(this);
     this.closeConfirmDelete = this.closeConfirmDelete.bind(this);
@@ -50,7 +48,7 @@ export class ConceptSetDetailsComponent implements OnInit {
     this.wsId = wsid;
     const {accessLevel} = currentWorkspaceStore.getValue();
     this.accessLevel = accessLevel;
-    this.conceptSet = this.route.snapshot.data.conceptSet;
+    this.conceptSet = currentConceptSetStore.getValue() as unknown as ConceptSet;
     this.editName = this.conceptSet.name;
     this.editDescription = this.conceptSet.description;
   }

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -13,7 +13,7 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';
-import {currentWorkspaceStore, currentCohortStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
+import {currentWorkspaceStore, currentCohortStore, currentConceptSetStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -30,6 +30,7 @@ getTestBed().initTestEnvironment(
 beforeEach(() => {
   currentWorkspaceStore.next(undefined);
   currentCohortStore.next(undefined);
+  currentConceptSetStore.next(undefined);
   urlParamsStore.next({});
   queryParamsStore.next({});
   routeConfigDataStore.next({});


### PR DESCRIPTION
This extracts the concept set into a store, in order to remove dependence on the router. This is the same pattern used for the other resolver data.