### PR TITLE
[P0][RW-2220][risk=no] fix concept set create modal

### DIFF
--- a/ui/src/app/views/conceptset-create-modal/component.tsx
+++ b/ui/src/app/views/conceptset-create-modal/component.tsx
@@ -32,7 +32,7 @@ export const CreateConceptSetModal = withCurrentWorkspace()
     this.state = {
       name: '',
       description: '',
-      domain: props.conceptDomainList[0] as unknown as Domain,
+      domain: props.conceptDomainList[0].domain as unknown as Domain,
       nameTouched: false,
       saving: false,
       savingError: false

--- a/ui/src/app/views/resource-card/component.tsx
+++ b/ui/src/app/views/resource-card/component.tsx
@@ -113,12 +113,10 @@ const styles = reactStyles({
     boxShadow: '0 0 0 0'
   },
   cardName: {
-    fontSize: '18px',
-    fontWeight: 500,
-    lineHeight: '22px',
-    color: '#2691D0',
-    cursor: 'pointer',
-    wordBreak: 'break-all'
+    fontSize: '18px', fontWeight: 500, lineHeight: '22px', color: '#2691D0',
+    cursor: 'pointer', wordBreak: 'break-all', textOverflow: 'ellipsis',
+    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical'
   },
   cardDescription: {
     textOverflow: 'ellipsis', overflow: 'hidden', display: '-webkit-box',

--- a/ui/src/app/views/resource-card/component.tsx
+++ b/ui/src/app/views/resource-card/component.tsx
@@ -120,6 +120,10 @@ const styles = reactStyles({
     cursor: 'pointer',
     wordBreak: 'break-all'
   },
+  cardDescription: {
+    textOverflow: 'ellipsis', overflow: 'hidden', display: '-webkit-box',
+    WebkitLineClamp: 4, WebkitBoxOrient: 'vertical'
+  },
   lastModified: {
     color: '#4A4A4A',
     fontSize: '11px',
@@ -439,7 +443,7 @@ export class ResourceCard extends React.Component<ResourceCardProps, ResourceCar
               </div>
             </Clickable>
           </div>
-          <div>{this.description}</div>
+          <div style={styles.cardDescription}>{this.description}</div>
         </div>
         <div style={styles.cardFooter}>
           <div style={styles.lastModified}>


### PR DESCRIPTION
This fixes a bug that if you don't select a domain when creating a concept set and choose the default instead, the default is set in correctly and is a bogus value that covers the whole card.  Default is now `CONDITION`.  

Also fixes a bug which did not truncate resource card descriptions; descriptions are now truncated at 4 lines like in image below.

![screen shot 2019-02-28 at 12 06 38 pm](https://user-images.githubusercontent.com/10012023/53584687-2aa00d00-3b52-11e9-8faf-caffa55286b0.png)
