### PR TITLE
[RW-1885] [risk=no] Small tweak: change Zendesk config to properly set the form title.

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -34,12 +34,8 @@
             // research workbench. This helps distinguish from tickets filed via other
             // AoU sub-products, e.g. Research Hub or Data Browser.
             tags: ['research_workbench'],
-            title: 'Help Desk'
-          },
-          contactOptions: {
-            enabled: true,
-            contactButton: {
-              '*': 'Send'
+            title: {
+              '*': 'Help Desk',
             },
           },
           helpCenter: {


### PR DESCRIPTION
While checking in on the Zendesk dialog again, I noticed that the dialog title wasn't getting set properly.

Turns out the web widget config needs to be used a bit differently... this makes the fix.

Contact us --> Help Desk

Before:

<img width="355" alt="screen shot 2019-03-01 at 4 53 08 pm" src="https://user-images.githubusercontent.com/51842/53668651-83e76980-3c42-11e9-92b0-87758ddd2c89.png">

After:

<img width="359" alt="screen shot 2019-02-28 at 1 47 06 pm" src="https://user-images.githubusercontent.com/51842/53668625-6fa36c80-3c42-11e9-9c1c-a5a8429eb124.png">
