### PR TITLE
[RW-1302][RW-319][risk=no] Return a 400 on bad requests

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import org.pmiops.workbench.model.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -13,6 +14,15 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 public class ExceptionAdvice {
+  private static final Logger log = Logger.getLogger(ExceptionAdvice.class.getName());
+
+  @ExceptionHandler({HttpMessageNotReadableException.class})
+  public ResponseEntity<?> messageNotReadableError(Exception e) {
+    log.log(Level.INFO, "failed to parse HTTP request message, returning 400", e);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+        WorkbenchException.errorResponse("failed to parse valid JSON request message")
+            .statusCode(HttpStatus.BAD_REQUEST.value()));
+  }
 
   @ExceptionHandler({Exception.class})
   public ResponseEntity<?> serverError(Exception e) {
@@ -41,7 +51,6 @@ public class ExceptionAdvice {
 
     // only log error if it's a server error
     if (statusCode >= 500) {
-      Logger log = Logger.getLogger(ExceptionAdvice.class.getName());
       log.log(Level.SEVERE, relevantError.getClass().getName(), e);
     }
 


### PR DESCRIPTION
Fixes a long-standing bug where we return a 500 errors on malformed requests. Looking at a security ticket complaining about these 500s finally forced the issue.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
