### PR TITLE
[RW-2209][risk=low] Implement per-user cluster overrides

### DIFF
--- a/api/db/changelog/db.changelog-59-cluster-config-default.xml
+++ b/api/db/changelog/db.changelog-59-cluster-config-default.xml
@@ -5,10 +5,10 @@
     xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
-  <changeSet author="calbach" id="changelog-59-cluster-config-override">
+  <changeSet author="calbach" id="changelog-59-cluster-config-default">
     <addColumn tableName="user">
       <!-- Stored as a JSON blob. -->
-      <column name="cluster_config_override" type="clob"/>
+      <column name="cluster_config_default" type="clob"/>
     </addColumn>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-59-cluster-config-override.xml
+++ b/api/db/changelog/db.changelog-59-cluster-config-override.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet author="calbach" id="changelog-59-cluster-config-override">
+    <addColumn tableName="user">
+      <!-- Stored as a JSON blob. -->
+      <column name="cluster_config_override" type="clob"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -66,4 +66,5 @@
   <include file="changelog/db.changelog-56-update-email-lowercase.xml"/>
   <include file="changelog/db.changelog-57-add-era-commons-entries.xml"/>
   <include file="changelog/db.changelog-58-update-access-modules.xml"/>
+  <include file="changelog/db.changelog-59-cluster-config-override.xml"/>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -66,5 +66,5 @@
   <include file="changelog/db.changelog-56-update-email-lowercase.xml"/>
   <include file="changelog/db.changelog-57-add-era-commons-entries.xml"/>
   <include file="changelog/db.changelog-58-update-access-modules.xml"/>
-  <include file="changelog/db.changelog-59-cluster-config-override.xml"/>
+  <include file="changelog/db.changelog-59-cluster-config-default.xml"/>
 </databaseChangeLog>

--- a/api/src/integration/java/org/pmiops/workbench/NotebooksIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/NotebooksIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.notebooks.NotebooksRetryHandler;
+import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
@@ -27,10 +28,11 @@ public class NotebooksIntegrationTest {
   @Mock
   private NotebooksApi notebooksApi;
 
-  private final NotebooksServiceImpl notebooksService = new NotebooksServiceImpl(
+  private final NotebooksService notebooksService = new NotebooksServiceImpl(
       Providers.of(clusterApi),
       Providers.of(notebooksApi),
       Providers.of(createConfig()),
+      Providers.of(null),
       new NotebooksRetryHandler(new NoBackOffPolicy()));
 
   @Test

--- a/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AuthDomainController.java
@@ -32,7 +32,7 @@ public class AuthDomainController implements AuthDomainApiDelegate {
     this.userDao = userDao;
   }
 
-  @AuthorityRequired({Authority.MANAGE_GROUP})
+  @AuthorityRequired({Authority.DEVELOPER})
   @Override
   public ResponseEntity<EmptyResponse> createAuthDomain(String groupName) {
     fireCloudService.createGroup(groupName);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -243,13 +243,13 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   @Override
-  @AuthorityRequired({Authority.MANAGE_CLUSTERS})
+  @AuthorityRequired({Authority.DEVELOPER})
   public ResponseEntity<EmptyResponse> updateClusterConfig(UpdateClusterConfigRequest body) {
     User user = userDao.findUserByEmail(body.getUserEmail());
     if (user == null) {
       throw new NotFoundException("User '" + body.getUserEmail() + "' not found");
     }
-    String oldOverride = user.getClusterConfigRaw();
+    String oldOverride = user.getClusterConfigDefaultRaw();
 
     final ClusterConfig override =
         body.getClusterConfig() != null ? new ClusterConfig() : null;
@@ -258,7 +258,7 @@ public class ClusterController implements ClusterApiDelegate {
       override.machineType = body.getClusterConfig().getMachineType();
     }
     userService.updateUserWithRetries((u) -> {
-      u.setClusterConfig(override);
+      u.setClusterConfigDefault(override);
       return u;
     }, user);
     userService.logAdminUserAction(

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -359,7 +359,7 @@ public class ProfileController implements ProfileApiDelegate {
 
     try {
       this.notebooksService.createCluster(
-          user.getFreeTierBillingProjectName(), NotebooksService.DEFAULT_CLUSTER_NAME, user.getEmail());
+          user.getFreeTierBillingProjectName(), NotebooksService.DEFAULT_CLUSTER_NAME);
       log.log(Level.INFO, String.format("created cluster %s/%s",
           user.getFreeTierBillingProjectName(), NotebooksService.DEFAULT_CLUSTER_NAME));
     } catch (ConflictException e) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -76,12 +76,18 @@ public class UserService {
    * Ensures that the data access level for the user reflects the state of other fields on the
    * user; handles conflicts with concurrent updates by retrying.
    */
-  private User updateWithRetries(Function<User, User> modifyUser) {
+  private User updateUserWithRetries(Function<User, User> modifyUser) {
     User user = userProvider.get();
-    return updateWithRetries(modifyUser, user);
+    return updateUserWithRetries(modifyUser, user);
   }
 
-  private User updateWithRetries(Function<User, User> userModifier, User user) {
+  /**
+   * Updates a user record with a modifier function.
+   *
+   * Ensures that the data access level for the user reflects the state of other fields on the
+   * user; handles conflicts with concurrent updates by retrying.
+   */
+    public User updateUserWithRetries(Function<User, User> userModifier, User user) {
     int numAttempts = 0;
     while (true) {
       user = userModifier.apply(user);
@@ -196,7 +202,7 @@ public class UserService {
 
   public User submitTermsOfService() {
     final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setTermsOfServiceCompletionTime(timestamp);
@@ -207,7 +213,7 @@ public class UserService {
 
   public User submitEthicsTraining() {
     final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setTrainingCompletionTime(timestamp);
@@ -218,7 +224,7 @@ public class UserService {
 
   public User submitDemographicSurvey() {
     final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setDemographicSurveyCompletionTime(timestamp);
@@ -257,7 +263,7 @@ public class UserService {
   }
 
   public User setClusterRetryCount(int clusterRetryCount) {
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setClusterCreateRetries(clusterRetryCount);
@@ -267,7 +273,7 @@ public class UserService {
   }
 
   public User setBillingRetryCount(int billingRetryCount) {
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setBillingProjectRetries(billingRetryCount);
@@ -277,7 +283,7 @@ public class UserService {
   }
 
   public User setBillingProjectNameAndStatus(String name, BillingProjectStatus status) {
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setFreeTierBillingProjectName(name);
@@ -289,7 +295,7 @@ public class UserService {
 
   public User setDisabledStatus(Long userId, boolean disabled) {
     User user = userDao.findUserByUserId(userId);
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setDisabled(disabled);
@@ -308,7 +314,7 @@ public class UserService {
 
   public User setIdVerificationApproved(Long userId, boolean blockscoreVerificationIsValid) {
     User user = userDao.findUserByUserId(userId);
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         user.setIdVerificationIsValid(blockscoreVerificationIsValid);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -234,7 +234,7 @@ public class UserService {
   }
 
   public User setEraCommonsStatus(NihStatus nihStatus) {
-    return updateWithRetries(new Function<User, User>() {
+    return updateUserWithRetries(new Function<User, User>() {
       @Override
       public User apply(User user) {
         if (nihStatus != null) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
@@ -39,9 +39,8 @@ public final class StorageEnums {
   private static final BiMap<Authority, Short> CLIENT_TO_STORAGE_AUTHORITY =
       ImmutableBiMap.<Authority, Short>builder()
       .put(Authority.REVIEW_RESEARCH_PURPOSE, (short) 0)
-      .put(Authority.MANAGE_GROUP, (short) 1)
+      .put(Authority.DEVELOPER, (short) 1)
       .put(Authority.REVIEW_ID_VERIFICATION, (short) 2)
-      .put(Authority.MANAGE_CLUSTERS, (short) 3)
       .build();
 
   public static Authority authorityFromStorage(Short authority) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
@@ -41,6 +41,7 @@ public final class StorageEnums {
       .put(Authority.REVIEW_RESEARCH_PURPOSE, (short) 0)
       .put(Authority.MANAGE_GROUP, (short) 1)
       .put(Authority.REVIEW_ID_VERIFICATION, (short) 2)
+      .put(Authority.MANAGE_CLUSTERS, (short) 3)
       .build();
 
   public static Authority authorityFromStorage(Short authority) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -38,13 +38,13 @@ public class User {
    *
    * Any changes to this class should produce backwards-compatible JSON.
    */
-  public static class ClusterConfigOverride {
+  public static class ClusterConfig {
     // Master persistent disk size in GB.
     public Integer masterDiskSize;
     // GCE machine type, e.g. n1-standard-2.
     public String machineType;
 
-    public ClusterConfigOverride() {}
+    public ClusterConfig() {}
   }
 
   private long userId;
@@ -309,26 +309,26 @@ public class User {
   }
 
   @Column(name = "cluster_config_override")
-  public String getClusterConfigOverrideRaw() {
+  public String getClusterConfigRaw() {
     return clusterConfigOverride;
   }
-  public void setClusterConfigOverrideRaw(String value) {
+  public void setClusterConfigRaw(String value) {
     clusterConfigOverride = value;
   }
 
   @Transient
-  public ClusterConfigOverride getClusterConfigOverride() {
+  public ClusterConfig getClusterConfig() {
     if (clusterConfigOverride == null) {
       return null;
     }
-    return new Gson().fromJson(clusterConfigOverride, ClusterConfigOverride.class);
+    return new Gson().fromJson(clusterConfigOverride, ClusterConfig.class);
   }
-  public void setClusterConfigOverride(ClusterConfigOverride value) {
+  public void setClusterConfig(ClusterConfig value) {
     String rawValue = null;
     if (value != null) {
       rawValue = new Gson().toJson(value);
     }
-    setClusterConfigOverrideRaw(rawValue);
+    setClusterConfigRaw(rawValue);
   }
 
   @Column(name = "terms_of_service_completion_time")

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -76,7 +76,7 @@ public class User {
   private Boolean requestedIdVerification;
   private Timestamp idVerificationRequestTime;
   private Set<PageVisit> pageVisits = new HashSet<>();
-  private String clusterConfigOverride;
+  private String clusterConfigDefault;
 
   private List<InstitutionalAffiliation> institutionalAffiliations = new ArrayList<>();
   private String aboutYou;
@@ -308,27 +308,27 @@ public class User {
     idVerificationIsValid = value;
   }
 
-  @Column(name = "cluster_config_override")
-  public String getClusterConfigRaw() {
-    return clusterConfigOverride;
+  @Column(name = "cluster_config_default")
+  public String getClusterConfigDefaultRaw() {
+    return clusterConfigDefault;
   }
-  public void setClusterConfigRaw(String value) {
-    clusterConfigOverride = value;
+  public void setClusterConfigDefaultRaw(String value) {
+    clusterConfigDefault = value;
   }
 
   @Transient
-  public ClusterConfig getClusterConfig() {
-    if (clusterConfigOverride == null) {
+  public ClusterConfig getClusterConfigDefault() {
+    if (clusterConfigDefault == null) {
       return null;
     }
-    return new Gson().fromJson(clusterConfigOverride, ClusterConfig.class);
+    return new Gson().fromJson(clusterConfigDefault, ClusterConfig.class);
   }
-  public void setClusterConfig(ClusterConfig value) {
+  public void setClusterConfigDefault(ClusterConfig value) {
     String rawValue = null;
     if (value != null) {
       rawValue = new Gson().toJson(value);
     }
-    setClusterConfigRaw(rawValue);
+    setClusterConfigDefaultRaw(rawValue);
   }
 
   @Column(name = "terms_of_service_completion_time")

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -43,8 +43,6 @@ public class User {
     public Integer masterDiskSize;
     // GCE machine type, e.g. n1-standard-2.
     public String machineType;
-
-    public ClusterConfig() {}
   }
 
   private long userId;

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -209,7 +209,10 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       // Fetch the user with authorities, since they aren't loaded during normal
       user = userDao.findUserWithAuthorities(user.getUserId());
       Collection<Authority> granted = user.getAuthoritiesEnum();
-      if (granted.containsAll(Arrays.asList(req.value()))) {
+
+      // DEVELOPER subsumes all other authorities.
+      if (granted.contains(Authority.DEVELOPER) ||
+          granted.containsAll(Arrays.asList(req.value()))) {
         return true;
       } else {
         log.log(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -13,12 +13,11 @@ public interface NotebooksService {
   String DEFAULT_CLUSTER_NAME = "all-of-us";
 
   /**
-   * Creates a notebooks cluster.
+   * Creates a notebooks cluster owned by the current authenticated user.
    * @param googleProject the google project that will be used for this notebooks cluster
    * @param clusterName the user assigned/auto-generated name for this notebooks cluster
-   * @param userEmail a string containing the user who is creating the cluster's email
    */
-  Cluster createCluster(String googleProject, String clusterName, String userEmail)
+  Cluster createCluster(String googleProject, String clusterName)
       throws WorkbenchException;
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.notebooks;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +79,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     User user = userProvider.get();
     return retryHandler.run((context) ->
         clusterApi.createClusterV2(googleProject, clusterName,
-            createFirecloudClusterRequest(user.getEmail(), user.getClusterConfig())));
+            createFirecloudClusterRequest(user.getEmail(), user.getClusterConfigDefault())));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.User;
-import org.pmiops.workbench.db.model.User.ClusterConfigOverride;
+import org.pmiops.workbench.db.model.User.ClusterConfig;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
 import org.pmiops.workbench.notebooks.api.StatusApi;
@@ -51,9 +51,9 @@ public class NotebooksServiceImpl implements NotebooksService {
   }
 
   private ClusterRequest createFirecloudClusterRequest(
-      String userEmail, @Nullable ClusterConfigOverride clusterOverride) {
+      String userEmail, @Nullable ClusterConfig clusterOverride) {
     if (clusterOverride == null) {
-      clusterOverride = new ClusterConfigOverride();
+      clusterOverride = new ClusterConfig();
     }
 
     WorkbenchConfig config = workbenchConfigProvider.get();
@@ -80,7 +80,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     User user = userProvider.get();
     return retryHandler.run((context) ->
         clusterApi.createClusterV2(googleProject, clusterName,
-            createFirecloudClusterRequest(user.getEmail(), user.getClusterConfigOverride())));
+            createFirecloudClusterRequest(user.getEmail(), user.getClusterConfig())));
   }
 
   @Override

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -465,7 +465,7 @@ paths:
           description: Request containing user email to update and a disabled status to update the user to.
           schema:
             $ref: "#/definitions/UpdateUserDisabledRequest"
-      summary: enable/disable a user to an auth domain if you have manage groups permission
+      summary: enable/disable a user to an auth domain if you have ID verification authority
       operationId: updateUserDisabledStatus
 
   /v1/user/{term}:
@@ -851,7 +851,7 @@ paths:
         Clusters are created with a default machine configuration. Setting this
         override changes that configuration for subsequent cluster creations.
         After making this change, a cluster reset is required for the change to
-        take effect. Currently requires MANAGE_CLUSTERS authority.
+        take effect. Currently requires DEVELOPER authority.
       operationId: updateClusterConfig
       tags:
         - cluster
@@ -1426,12 +1426,11 @@ definitions:
   # define the following authorities:
   #   1) REVIEW_RESEARCH_PURPOSE: This authority allows the user to review workspaces where
   #      the user has requested review to approve or reject.
-  #   2) MANAGE_GROUP: This is mainly only used once to create authorization domains in firecloud
-  #      and is mainly an internal authority for devs to use when setting up an environment.
+  #   2) DEVELOPER: *Grants all other authorities* as well as some internal-only
+  #      administrative endpoints, including group management and cluster
+  #      management. Intended to be granted for devops needs, e.g. for oncall.
   #   3) REVIEW_ID_VERIFICATION: This is actually basically a user admin authority, for people
   #      to perform actions on a user's enabled status and manual verification.
-  #   4) MANAGE_CLUSTERS: Ability to administratively interact with notebook clusters, e.g. setting
-  #      overrides for the default cluster configuration.
   Authority:
     type: string
     description: actions a user can have authority/permission to perform
@@ -1440,9 +1439,8 @@ definitions:
         # Java fields by default; this has no side-effect currently as there is
         # no common prefix. https://github.com/swagger-api/swagger-codegen/issues/4261
         REVIEW_RESEARCH_PURPOSE,
-        MANAGE_GROUP,
-        REVIEW_ID_VERIFICATION,
-        MANAGE_CLUSTERS
+        DEVELOPER,
+        REVIEW_ID_VERIFICATION
     ]
 
   PageVisit:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -844,7 +844,7 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
-  /v1/admin/clusters/setConfigOverride:
+  /v1/admin/clusters/updateConfig:
     post:
       summary: Sets an override for the default cluster creation request.
       description: >
@@ -852,7 +852,7 @@ paths:
         override changes that configuration for subsequent cluster creations.
         After making this change, a cluster reset is required for the change to
         take effect. Currently requires MANAGE_CLUSTERS authority.
-      operationId: setClusterConfigOverride
+      operationId: updateClusterConfig
       tags:
         - cluster
       parameters:
@@ -860,7 +860,7 @@ paths:
           name: body
           description: Override request.
           schema:
-            $ref: "#/definitions/SetClusterConfigOverrideRequest"
+            $ref: "#/definitions/UpdateClusterConfigRequest"
       responses:
         200:
           description: success
@@ -1725,7 +1725,7 @@ definitions:
       approved:
         type: boolean
 
-  ClusterConfigOverride:
+  ClusterConfig:
     properties:
       masterDiskSize:
         description: Master persistent disk size in GB.
@@ -1735,7 +1735,7 @@ definitions:
         description: GCE machine type, e.g. n1-standard-2.
         type: string
 
-  SetClusterConfigOverrideRequest:
+  UpdateClusterConfigRequest:
     description: >
       Request to override cluster configuration for a given user. Set override
       to null to clear it.
@@ -1745,8 +1745,8 @@ definitions:
     properties:
       userEmail:
         type: string
-      override:
-        $ref: "#/definitions/ClusterConfigOverride"
+      clusterConfig:
+        $ref: "#/definitions/ClusterConfig"
 
   IdVerificationReviewRequest:
     type: object

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -846,19 +846,20 @@ paths:
 
   /v1/admin/clusters/updateConfig:
     post:
-      summary: Sets an override for the default cluster creation request.
+      summary: Sets default cluster creation request parameters for a user.
       description: >
         Clusters are created with a default machine configuration. Setting this
         override changes that configuration for subsequent cluster creations.
-        After making this change, a cluster reset is required for the change to
-        take effect. Currently requires DEVELOPER authority.
+        This change only takes effect after a new cluster creation, e.g. due to
+        standard cluster expiration (~2w) or via manual reset. Requires
+        DEVELOPER authority.
       operationId: updateClusterConfig
       tags:
         - cluster
       parameters:
         - in: body
           name: body
-          description: Override request.
+          description: Cluster config update request.
           schema:
             $ref: "#/definitions/UpdateClusterConfigRequest"
       responses:
@@ -1735,8 +1736,9 @@ definitions:
 
   UpdateClusterConfigRequest:
     description: >
-      Request to override cluster configuration for a given user. Set override
-      to null to clear it.
+      Request to update the default cluster configuration for a given user.
+      Fields of the config may be omitted, in which case a default will be used.
+      Set clusterConfig to null to clear it.
     type: object
     required:
       - userEmail

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -844,6 +844,30 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
+  /v1/admin/clusters/setConfigOverride:
+    post:
+      summary: Sets an override for the default cluster creation request.
+      description: >
+        Clusters are created with a default machine configuration. Setting this
+        override changes that configuration for subsequent cluster creations.
+        After making this change, a cluster reset is required for the change to
+        take effect. Currently requires MANAGE_CLUSTERS authority.
+      operationId: setClusterConfigOverride
+      tags:
+        - cluster
+      parameters:
+        - in: body
+          name: body
+          description: Override request.
+          schema:
+            $ref: "#/definitions/SetClusterConfigOverrideRequest"
+      responses:
+        200:
+          description: success
+          schema:
+            $ref: "#/definitions/EmptyResponse"
+
+
   # Note: all requests tagged as "cron" must have the header X-Appengine-Cron:
   # true, which app engine itself only sets when invoking as a cronjob.
   # See https://cloud.google.com/appengine/docs/standard/java/config/cron#securing_urls_for_cron
@@ -1399,13 +1423,15 @@ definitions:
         type: string
 
   # Authorities are a tool used to add discrete permissions to users. We currently
-  # have three authorities that are used:
+  # define the following authorities:
   #   1) REVIEW_RESEARCH_PURPOSE: This authority allows the user to review workspaces where
   #      the user has requested review to approve or reject.
   #   2) MANAGE_GROUP: This is mainly only used once to create authorization domains in firecloud
   #      and is mainly an internal authority for devs to use when setting up an environment.
   #   3) REVIEW_ID_VERIFICATION: This is actually basically a user admin authority, for people
   #      to perform actions on a user's enabled status and manual verification.
+  #   4) MANAGE_CLUSTERS: Ability to administratively interact with notebook clusters, e.g. setting
+  #      overrides for the default cluster configuration.
   Authority:
     type: string
     description: actions a user can have authority/permission to perform
@@ -1415,7 +1441,8 @@ definitions:
         # no common prefix. https://github.com/swagger-api/swagger-codegen/issues/4261
         REVIEW_RESEARCH_PURPOSE,
         MANAGE_GROUP,
-        REVIEW_ID_VERIFICATION
+        REVIEW_ID_VERIFICATION,
+        MANAGE_CLUSTERS
     ]
 
   PageVisit:
@@ -1697,6 +1724,29 @@ definitions:
     properties:
       approved:
         type: boolean
+
+  ClusterConfigOverride:
+    properties:
+      masterDiskSize:
+        description: Master persistent disk size in GB.
+        type: integer
+        format: int32
+      machineType:
+        description: GCE machine type, e.g. n1-standard-2.
+        type: string
+
+  SetClusterConfigOverrideRequest:
+    description: >
+      Request to override cluster configuration for a given user. Set override
+      to null to clear it.
+    type: object
+    required:
+      - userEmail
+    properties:
+      userEmail:
+        type: string
+      override:
+        $ref: "#/definitions/ClusterConfigOverride"
 
   IdVerificationReviewRequest:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -39,12 +39,12 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.Cluster;
-import org.pmiops.workbench.model.ClusterConfigOverride;
+import org.pmiops.workbench.model.ClusterConfig;
 import org.pmiops.workbench.model.ClusterLocalizeRequest;
 import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.EmptyResponse;
-import org.pmiops.workbench.model.SetClusterConfigOverrideRequest;
+import org.pmiops.workbench.model.SetClusterConfigRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
@@ -252,44 +252,44 @@ public class ClusterControllerTest {
   }
 
   @Test
-  public void testSetClusterConfigOverride() {
-    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfigOverride(
-        new SetClusterConfigOverrideRequest().
+  public void testSetClusterConfig() {
+    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfig(
+        new SetClusterConfigRequest().
             userEmail(OTHER_USER_EMAIL).
-            override(new ClusterConfigOverride()
+            override(new ClusterConfig()
                 .machineType("n1-standard-4")
                 .masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
-    assertThat(updatedUser.getClusterConfigOverride().machineType).isEqualTo("n1-standard-4");
-    assertThat(updatedUser.getClusterConfigOverride().masterDiskSize).isEqualTo(100);
+    assertThat(updatedUser.getClusterConfig().machineType).isEqualTo("n1-standard-4");
+    assertThat(updatedUser.getClusterConfig().masterDiskSize).isEqualTo(100);
   }
 
   @Test
-  public void testSetClusterConfigOverrideClear() {
-    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfigOverride(
-        new SetClusterConfigOverrideRequest().
+  public void testSetClusterConfigClear() {
+    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfig(
+        new SetClusterConfigRequest().
             userEmail(OTHER_USER_EMAIL).
-            override(new ClusterConfigOverride()
+            override(new ClusterConfig()
                 .machineType("n1-standard-4")
                 .masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-    response = this.clusterController.setClusterConfigOverride(
-        new SetClusterConfigOverrideRequest().
+    response = this.clusterController.setClusterConfig(
+        new SetClusterConfigRequest().
             userEmail(OTHER_USER_EMAIL)
             .override(null));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
-    assertThat(updatedUser.getClusterConfigOverride()).isNull();
+    assertThat(updatedUser.getClusterConfig()).isNull();
   }
 
   @Test(expected=NotFoundException.class)
-  public void testSetClusterConfigOverrideUserNotFound() {
-    this.clusterController.setClusterConfigOverride(
-        new SetClusterConfigOverrideRequest().userEmail("not-found@researchallofus.org"));
+  public void testSetClusterConfigUserNotFound() {
+    this.clusterController.setClusterConfig(
+        new SetClusterConfigRequest().userEmail("not-found@researchallofus.org"));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -12,16 +11,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
-
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Map;
-
 import javax.inject.Provider;
-
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +28,6 @@ import org.mockito.Mock;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
-import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
@@ -44,9 +39,12 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.Cluster;
+import org.pmiops.workbench.model.ClusterConfigOverride;
 import org.pmiops.workbench.model.ClusterLocalizeRequest;
 import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
+import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.SetClusterConfigOverrideRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
@@ -60,6 +58,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -76,6 +75,7 @@ public class ClusterControllerTest {
   private static final String WORKSPACE_NS = "proj";
   private static final String WORKSPACE_ID = "wsid";
   private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
+  private static final String OTHER_USER_EMAIL = "alice@gmail.com";
   private static final String BUCKET_NAME = "workspace-bucket";
   private static final Instant NOW = Instant.now();
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
@@ -127,8 +127,6 @@ public class ClusterControllerTest {
   @Autowired
   UserDao userDao;
   @Autowired
-  CdrVersionDao cdrVersionDao;
-  @Autowired
   WorkspaceService workspaceService;
   @Mock
   Provider<User> userProvider;
@@ -159,6 +157,8 @@ public class ClusterControllerTest {
     user.setFreeTierBillingProjectStatusEnum(BillingProjectStatus.READY);
     when(userProvider.get()).thenReturn(user);
     clusterController.setUserProvider(userProvider);
+
+    createUser(OTHER_USER_EMAIL);
 
     UserService userService = new UserService(
         userProvider, userDao, adminActionHistoryDao, CLOCK, new FakeLongRandom(123),
@@ -238,7 +238,7 @@ public class ClusterControllerTest {
   @Test
   public void testListClustersLazyCreate() throws Exception {
     when(notebookService.getCluster(WORKSPACE_NS, "all-of-us")).thenThrow(new NotFoundException());
-    when(notebookService.createCluster(eq(WORKSPACE_NS), eq("all-of-us"), any()))
+    when(notebookService.createCluster(eq(WORKSPACE_NS), eq("all-of-us")))
         .thenReturn(testFcCluster);
 
     assertThat(clusterController.listClusters().getBody().getDefaultCluster())
@@ -249,6 +249,47 @@ public class ClusterControllerTest {
   public void testDeleteCluster() throws Exception {
     clusterController.deleteCluster(WORKSPACE_NS, "cluster");
     verify(notebookService).deleteCluster(WORKSPACE_NS, "cluster");
+  }
+
+  @Test
+  public void testSetClusterConfigOverride() {
+    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfigOverride(
+        new SetClusterConfigOverrideRequest().
+            userEmail(OTHER_USER_EMAIL).
+            override(new ClusterConfigOverride()
+                .machineType("n1-standard-4")
+                .masterDiskSize(100)));
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+    User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
+    assertThat(updatedUser.getClusterConfigOverride().machineType).isEqualTo("n1-standard-4");
+    assertThat(updatedUser.getClusterConfigOverride().masterDiskSize).isEqualTo(100);
+  }
+
+  @Test
+  public void testSetClusterConfigOverrideClear() {
+    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfigOverride(
+        new SetClusterConfigOverrideRequest().
+            userEmail(OTHER_USER_EMAIL).
+            override(new ClusterConfigOverride()
+                .machineType("n1-standard-4")
+                .masterDiskSize(100)));
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+    response = this.clusterController.setClusterConfigOverride(
+        new SetClusterConfigOverrideRequest().
+            userEmail(OTHER_USER_EMAIL)
+            .override(null));
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+    User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
+    assertThat(updatedUser.getClusterConfigOverride()).isNull();
+  }
+
+  @Test(expected=NotFoundException.class)
+  public void testSetClusterConfigOverrideUserNotFound() {
+    this.clusterController.setClusterConfigOverride(
+        new SetClusterConfigOverrideRequest().userEmail("not-found@researchallofus.org"));
   }
 
   @Test
@@ -329,4 +370,13 @@ public class ClusterControllerTest {
     // Config files only.
     assertThat(mapCaptor.getValue().size()).isEqualTo(2);
     assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/wsid");
-  }}
+  }
+
+    private void createUser(String email) {
+      User user = new User();
+      user.setGivenName("first");
+      user.setFamilyName("last");
+      user.setEmail(email);
+      userDao.save(user);
+    }
+}

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -262,8 +262,8 @@ public class ClusterControllerTest {
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
-    assertThat(updatedUser.getClusterConfig().machineType).isEqualTo("n1-standard-4");
-    assertThat(updatedUser.getClusterConfig().masterDiskSize).isEqualTo(100);
+    assertThat(updatedUser.getClusterConfigDefault().machineType).isEqualTo("n1-standard-4");
+    assertThat(updatedUser.getClusterConfigDefault().masterDiskSize).isEqualTo(100);
   }
 
   @Test
@@ -283,7 +283,7 @@ public class ClusterControllerTest {
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
-    assertThat(updatedUser.getClusterConfig()).isNull();
+    assertThat(updatedUser.getClusterConfigDefault()).isNull();
   }
 
   @Test(expected=NotFoundException.class)

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -44,7 +44,7 @@ import org.pmiops.workbench.model.ClusterLocalizeRequest;
 import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.EmptyResponse;
-import org.pmiops.workbench.model.SetClusterConfigRequest;
+import org.pmiops.workbench.model.UpdateClusterConfigRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
@@ -253,10 +253,10 @@ public class ClusterControllerTest {
 
   @Test
   public void testSetClusterConfig() {
-    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfig(
-        new SetClusterConfigRequest().
-            userEmail(OTHER_USER_EMAIL).
-            override(new ClusterConfig()
+    ResponseEntity<EmptyResponse> response = this.clusterController.updateClusterConfig(
+        new UpdateClusterConfigRequest()
+            .userEmail(OTHER_USER_EMAIL)
+            .clusterConfig(new ClusterConfig()
                 .machineType("n1-standard-4")
                 .masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -267,19 +267,19 @@ public class ClusterControllerTest {
   }
 
   @Test
-  public void testSetClusterConfigClear() {
-    ResponseEntity<EmptyResponse> response = this.clusterController.setClusterConfig(
-        new SetClusterConfigRequest().
-            userEmail(OTHER_USER_EMAIL).
-            override(new ClusterConfig()
+  public void testUpdateClusterConfigClear() {
+    ResponseEntity<EmptyResponse> response = this.clusterController.updateClusterConfig(
+        new UpdateClusterConfigRequest()
+            .userEmail(OTHER_USER_EMAIL)
+            .clusterConfig(new ClusterConfig()
                 .machineType("n1-standard-4")
                 .masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-    response = this.clusterController.setClusterConfig(
-        new SetClusterConfigRequest().
-            userEmail(OTHER_USER_EMAIL)
-            .override(null));
+    response = this.clusterController.updateClusterConfig(
+        new UpdateClusterConfigRequest()
+            .userEmail(OTHER_USER_EMAIL)
+            .clusterConfig(null));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
@@ -287,9 +287,9 @@ public class ClusterControllerTest {
   }
 
   @Test(expected=NotFoundException.class)
-  public void testSetClusterConfigUserNotFound() {
-    this.clusterController.setClusterConfig(
-        new SetClusterConfigRequest().userEmail("not-found@researchallofus.org"));
+  public void testUpdateClusterConfigUserNotFound() {
+    this.clusterController.updateClusterConfig(
+        new UpdateClusterConfigRequest().userEmail("not-found@researchallofus.org"));
   }
 
   @Test


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-2209

Will add a CLI for this in a follow-up. For now, tested manually via oauth2l+curl.

Design notes:
- Repurposes the `MANAGE_GROUP` authority as a more general `DEVELOPER` authority, used to guard this admin endpoint; this subsumes all other authorities if granted.
- The cluster override config is implemented as a JSON blob in a SQL column for easy future extension. This felt natural given we're merging this into the cluster creation request. This is the same approach we use for the server config, but is a novel pattern as a column on an existing model.
- I chose to reencode the JSON in the DB model (rather than use the Swagger version) because best practice is to keep client and storage representations independent.
- For now this requires admin permissions, and this introduces a new authority. In the future some form of this may be callable by users directly.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
