### PR TITLE
[risk=no] Upgrade Mockito and add the mock-maker-inline extension

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -341,7 +341,7 @@ dependencies {
   toolsCompile 'commons-cli:commons-cli:1.4'
 
   testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.mockito:mockito-core:2.18.3'
   testCompile "com.google.appengine:appengine-api-stubs:${GAE_VERSION}"
   testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"
   testCompile 'com.google.truth:truth:0.42'
@@ -505,6 +505,16 @@ task backfillGSuiteUserData(type: JavaExec) {
 task elasticSearchIndexer(type: JavaExec) {
   classpath = sourceSets.tools.runtimeClasspath
   main = "org.pmiops.workbench.tools.elastic.ElasticSearchIndexer"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
+// See api/project.rb fetch-firecloud-user-profiles
+task fetchFireCloudUserProfile(type: JavaExec) {
+  classpath = sourceSets.tools.runtimeClasspath
+  main = "org.pmiops.workbench.tools.FetchFireCloudUserProfile"
   systemProperties = commandLineSpringProperties
   if (project.hasProperty("appArgs")) {
     args Eval.me(appArgs)

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -510,13 +510,3 @@ task elasticSearchIndexer(type: JavaExec) {
     args Eval.me(appArgs)
   }
 }
-
-// See api/project.rb fetch-firecloud-user-profiles
-task fetchFireCloudUserProfile(type: JavaExec) {
-  classpath = sourceSets.tools.runtimeClasspath
-  main = "org.pmiops.workbench.tools.FetchFireCloudUserProfile"
-  systemProperties = commandLineSpringProperties
-  if (project.hasProperty("appArgs")) {
-    args Eval.me(appArgs)
-  }
-}

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -143,7 +143,7 @@ public class UserMetricsControllerTest {
         .thenReturn(workspaceResponse2);
 
     when(cloudStorageService.blobsExist(anyListOf(BlobId.class))).then((i) -> {
-      List<BlobId> ids = i.getArgumentAt(0, List.class);
+      List<BlobId> ids = i.getArgument(0);
       if (ids.contains(null)) {
         throw new NullPointerException();
       }

--- a/api/src/test/resources/mockito-extensions/README.md
+++ b/api/src/test/resources/mockito-extensions/README.md
@@ -1,0 +1,8 @@
+The extension file in this directory enables Mockito functionality to mock final classes,
+as described in https://www.baeldung.com/mockito-final and
+https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#unmockable .
+
+This enables seamless mocking of final classes and methods. The one potential downside is that
+this has a known tendency to slow down test runs. If we notice unit tests begin to take too long,
+we could try disabling this feature. The downside is that we'll have to remove unit tests which
+rely on mocking final classes (which will hopefully be few and far between).

--- a/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
While working on some unit tests for RW-2236 I found myself stuck in a corner where I couldn't make progress without being able to mock a method on GoogleCredential. The problem was that all of GoogleCredential's core methods were marked as final.

Based on my reading of https://www.baeldung.com/mockito-final and https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2, Mockito 2 added some tricks to support this in a reasonably easy-to-use way.

I'm not by any means an expert here, so I don't know if this would have unintended consequences. But it worked like a charm for my use case, and doesn't seem to break any other tests.

I'm not attached to this at all. If there are strong objections, I'm happy to revert! The only impact is, I won't be able to test the impersonated-credential code as well... but testing ability there is already somewhat limited, so it wouldn't be a huge loss.