### PR TITLE
[risk=no] Fix docs and value_as_number index type

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Requires that Elastic is running (via run-api or dev-up).
 Show the top 5 standard condition concept IDs:
 
 ```
-curl -H "Content-Type: application/json" "localhost:9200/cdr/_doc/_search?pretty" -d '{"size": 0, "aggs": {"aggs": {"terms": {"field": "condition_concept_ids", "size": 5 }}}}'
+curl -H "Content-Type: application/json" "localhost:9200/cdr_person/_doc/_search?pretty" -d '{"size": 0, "aggs": {"aggs": {"terms": {"field": "condition_concept_ids", "size": 5 }}}}'
 ```
 
 The above IDs can be cross-referenced against the Criteria table in SQL or
@@ -455,7 +455,7 @@ BigQuery to determine cohort builder search targets.
 Dump all participants matching a condition source concept ID (disclaimer: large):
 
 ```
-curl -H "Content-Type: application/json" "localhost:9200/cdr/_doc/_search?pretty" -d '{"query": {"term": {"condition_source_concept_ids": "44833466"}}}' > dump.json
+curl -H "Content-Type: application/json" "localhost:9200/cdr_person/_doc/_search?pretty" -d '{"query": {"term": {"condition_source_concept_ids": "44833466"}}}' > dump.json
 ```
 
 ###

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 public class ElasticDocument {
   /** The Elasticsearch primitive index types we utilize. */
   private enum ElasticType {
-    KEYWORD, INTEGER, DATE, NESTED, TEXT;
+    KEYWORD, INTEGER, FLOAT, DATE, NESTED, TEXT;
 
     String lower() {
       return this.name().toLowerCase();
@@ -52,7 +52,7 @@ public class ElasticDocument {
           .put("start_date", esType(ElasticType.DATE))
           .put("age_at_start", esType(ElasticType.INTEGER))
           .put("visit_concept_id", esType(ElasticType.KEYWORD))
-          .put("value_as_number", esType(ElasticType.INTEGER))
+          .put("value_as_number", esType(ElasticType.FLOAT))
           .put("value_as_concept_id", esType(ElasticType.KEYWORD))
           .build());
 


### PR DESCRIPTION
Number may be floats and should be indexed as such.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
