### PR TITLE
[RW-2263][risk=no] Implement counts for all types except(Deceased and BP)

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -45,7 +45,7 @@
   },
   "elasticsearch": {
     "host": "elastic:9200",
-    "enableElasticsearchBackend": false
+    "enableElasticsearchBackend": true
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -45,7 +45,7 @@
   },
   "elasticsearch": {
     "host": "elastic:9200",
-    "enableElasticsearchBackend": true
+    "enableElasticsearchBackend": false
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",

--- a/api/demos/physical-measurements.json
+++ b/api/demos/physical-measurements.json
@@ -1,0 +1,22 @@
+{
+  "type": "concept_set",
+  "concept_set": {
+    "name": "Physical Measurements",
+    "description": "demo",
+    "domain": "MEASUREMENT",
+    "concept_ids": [
+      903111,
+      903115,
+      903118,
+      903120,
+      903121,
+      903124,
+      903126,
+      903133,
+      903135,
+      903136,
+      1586218
+    ],
+    "participant_count": 453536
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.pmiops.workbench.cdr.dao.CriteriaDao;
 import org.pmiops.workbench.cdr.model.Criteria;
 import org.pmiops.workbench.exceptions.BadRequestException;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -245,11 +245,14 @@ public final class ElasticFilters {
       right = now.minusYears(Long.parseLong(attr.getOperands().get(0))).toLocalDate();
       if (attr.getOperands().size() > 1) {
         //use high end of the age range to calculate the low end(left) of the date range
-        left = now.minusYears(Long.parseLong(attr.getOperands().get(1))).minusYears(1).plusDays(1).toLocalDate();
+        //Ex: 2019-03-19(current date) - 55year(age) - 1 year = 1963-03-19
+        //Need to use GT to make sure not to include 1963-03-19 which evaluates to 56 years old
+        //which is out the range of 55. 1963-03-20 evaluates to 55 years 11 months 30 days.
+        left = now.minusYears(Long.parseLong(attr.getOperands().get(1))).minusYears(1).toLocalDate();
       }
       switch (attr.getOperator()) {
         case BETWEEN:
-          rq.gte(left).lte(right).format("yyyy-MM-dd");
+          rq.gt(left).lte(right).format("yyyy-MM-dd");
           break;
         default:
           throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -212,50 +212,49 @@ public final class ElasticFilters {
     if (AttrName.CAT.equals(attr.getName())) {
       //Currently the UI only uses the In operator for CAT which fits the terms query
       return QueryBuilders.termsQuery("events.value_as_concept_id", attr.getOperands());
-    } else {
-      Object left = null, right = null;
-      RangeQueryBuilder rq;
-      if (AttrName.NUM.equals(attr.getName())) {
-        rq = QueryBuilders.rangeQuery("events.value_as_number");
-        left = Float.parseFloat(attr.getOperands().get(0));
-        if (attr.getOperands().size() > 1) {
-          right = Float.parseFloat(attr.getOperands().get(1));
-        }
-        switch (attr.getOperator()) {
-          case LESS_THAN_OR_EQUAL_TO:
-            rq.lte(left);
-            break;
-          case GREATER_THAN_OR_EQUAL_TO:
-            rq.gte(left);
-            break;
-          case BETWEEN:
-            rq.gte(left).lte(right);
-            break;
-          case EQUAL:
-            rq.gte(left).lte(left);
-            break;
-          default:
-            throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());
-        }
-        return rq;
-      } else if (AttrName.AGE.equals(attr.getName())) {
-        rq = QueryBuilders.rangeQuery("birth_datetime");
-        //use the low end of the age range to calculate the high end(right) of the date range
-        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-        right = now.minusYears(Long.parseLong(attr.getOperands().get(0))).toLocalDate();
-        if (attr.getOperands().size() > 1) {
-          //use high end of the age range to calculate the low end(left) of the date range
-          left = now.minusYears(Long.parseLong(attr.getOperands().get(1))).minusYears(1).plusDays(1).toLocalDate();
-        }
-        switch (attr.getOperator()) {
-          case BETWEEN:
-            rq.gte(left).lte(right).format("yyyy-MM-dd");
-            break;
-          default:
-            throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());
-        }
-        return rq;
+    }
+    Object left = null, right = null;
+    RangeQueryBuilder rq;
+    if (AttrName.NUM.equals(attr.getName())) {
+      rq = QueryBuilders.rangeQuery("events.value_as_number");
+      left = Float.parseFloat(attr.getOperands().get(0));
+      if (attr.getOperands().size() > 1) {
+        right = Float.parseFloat(attr.getOperands().get(1));
       }
+      switch (attr.getOperator()) {
+        case LESS_THAN_OR_EQUAL_TO:
+          rq.lte(left);
+          break;
+        case GREATER_THAN_OR_EQUAL_TO:
+          rq.gte(left);
+          break;
+        case BETWEEN:
+          rq.gte(left).lte(right);
+          break;
+        case EQUAL:
+          rq.gte(left).lte(left);
+          break;
+        default:
+          throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());
+      }
+      return rq;
+    } else if (AttrName.AGE.equals(attr.getName())) {
+      rq = QueryBuilders.rangeQuery("birth_datetime");
+      //use the low end of the age range to calculate the high end(right) of the date range
+      OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+      right = now.minusYears(Long.parseLong(attr.getOperands().get(0))).toLocalDate();
+      if (attr.getOperands().size() > 1) {
+        //use high end of the age range to calculate the low end(left) of the date range
+        left = now.minusYears(Long.parseLong(attr.getOperands().get(1))).minusYears(1).plusDays(1).toLocalDate();
+      }
+      switch (attr.getOperator()) {
+        case BETWEEN:
+          rq.gte(left).lte(right).format("yyyy-MM-dd");
+          break;
+        default:
+          throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());
+      }
+      return rq;
     }
     throw new RuntimeException("attribute name is not an attr name type: " + attr.getName());
   }

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -96,7 +96,7 @@ public final class ElasticFilters {
   private static Set<TreeType> HIERARCHICAL_CODE_TREES =
       ImmutableSet.of(TreeType.ICD9, TreeType.ICD10);
 
-  private static Map<String, String> nonNestedFields = ImmutableMap.of(
+  private static Map<String, String> NON_NESTED_FIELDS = ImmutableMap.of(
     TreeSubType.GEN.toString(), "gender_concept_id",
     TreeSubType.RACE.toString(), "race_concept_id",
     TreeSubType.ETH.toString(), "ethnicity_concept_id");
@@ -171,7 +171,7 @@ public final class ElasticFilters {
       for (SearchParameter param : sgi.getSearchParameters()) {
         String conceptField = "events." + (isStandardConcept(param) ? "concept_id" : "source_concept_id");
         if (isNonNestedSchema(param)) {
-          conceptField = nonNestedFields.get(param.getSubtype());
+          conceptField = NON_NESTED_FIELDS.get(param.getSubtype());
         }
         Set<String> leafConceptIds = toleafConceptIds(ImmutableList.of(param));
         BoolQueryBuilder b = QueryBuilders.boolQuery();

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -207,8 +207,6 @@ public final class ElasticFilters {
       throw new RuntimeException("attribute name is not an attr name type: " + attr.getName());
     }
     switch (attr.getOperator()) {
-      case LESS_THAN:
-      case GREATER_THAN:
       case LESS_THAN_OR_EQUAL_TO:
         rq.lte(left);
         break;
@@ -218,11 +216,13 @@ public final class ElasticFilters {
       case BETWEEN:
         rq.gte(left).lte(right);
         break;
-      case LIKE:
-      case IN:
       case EQUAL:
         rq.gte(left).lte(left);
         break;
+      case LESS_THAN:
+      case GREATER_THAN:
+      case LIKE:
+      case IN:
       case NOT_EQUAL:
       default:
         throw new BadRequestException("Bad operator for attribute: " + attr.getOperator());

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -96,8 +96,10 @@ public final class ElasticFilters {
   private static Set<TreeType> HIERARCHICAL_CODE_TREES =
       ImmutableSet.of(TreeType.ICD9, TreeType.ICD10);
 
-  private static Map<String, String> nonNestedFields = ImmutableMap.of(TreeSubType.GEN.toString(), "gender_concept_id",
-    TreeSubType.RACE.toString(), "race_concept_id", TreeSubType.ETH.toString(), "ethnicity_concept_id");
+  private static Map<String, String> nonNestedFields = ImmutableMap.of(
+    TreeSubType.GEN.toString(), "gender_concept_id",
+    TreeSubType.RACE.toString(), "race_concept_id",
+    TreeSubType.ETH.toString(), "ethnicity_concept_id");
 
   private final CriteriaDao criteriaDao;
 

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -319,10 +319,8 @@ public final class ElasticFilters {
                 .stream()
                 .map(id -> Long.toString(id))
                 .collect(Collectors.toSet()));
-      } else {
-        if (param.getConceptId() != null) {
-          out.add(Long.toString(param.getConceptId()));
-        }
+      } else if (param.getConceptId() != null) {
+        out.add(Long.toString(param.getConceptId()));
       }
     }
     return out;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -418,7 +418,6 @@ public final class ElasticFilters {
 
       List<Criteria> parents = Lists.newArrayList();
       List<Criteria> leaves = Lists.newArrayList();
-      Criteria allDrugs = criteriaDao.findOne(5L);
       criteriaDao.findCriteriaLeavesAndParentsByTypeAndParentConceptIds(
           treeType.type.toString(), treeType.subType.toString(), parentConceptIds)
           .forEach(c -> {

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -184,7 +184,7 @@ public final class ElasticFilters {
         }
 
         if (isNonNestedSchema(param)) {
-          // setup non nested filter with proper demographic field
+          // setup non nested filter with proper field
           sgiFilter.should(b);
         } else {
           // "should" gives us "OR" behavior so long as we're in a filter context, which we are. This

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.pmiops.workbench.cdr.dao.CriteriaDao;
 import org.pmiops.workbench.cdr.model.Criteria;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -418,6 +419,7 @@ public final class ElasticFilters {
 
       List<Criteria> parents = Lists.newArrayList();
       List<Criteria> leaves = Lists.newArrayList();
+      Criteria allDrugs = criteriaDao.findOne(5L);
       criteriaDao.findCriteriaLeavesAndParentsByTypeAndParentConceptIds(
           treeType.type.toString(), treeType.subType.toString(), parentConceptIds)
           .forEach(c -> {

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -160,12 +160,12 @@ public final class ElasticFilters {
         }
       }
 
-      // TODO(calbach): Handle Attribute modifiers here, e.g. value_as_number < 10.
       // TODO(calbach): Handle non-code values, e.g. question answers here.
       for (SearchParameter param : sgi.getSearchParameters()) {
         String conceptField = "events." + (isStandardConcept(param) ? "concept_id" : "source_concept_id");
         BoolQueryBuilder b = QueryBuilders.boolQuery()
             .filter(QueryBuilders.termsQuery(conceptField, toleafConceptIds(ImmutableList.of(param))));
+        // TODO(calbach): Handle Attribute modifiers here, e.g. value_as_number < 10.
         for (Attribute attr : param.getAttributes()) {
           b.filter(attributeToQuery(attr));
         }

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -138,10 +138,6 @@ public final class ElasticFilters {
     }
 
     for (SearchGroupItem sgi : sg.getItems()) {
-      // Note: Later we could investigate starting with an inexpensive presence filter; would need
-      // to map each concept ID into the right domain first though.
-      BoolQueryBuilder sgiFilter = QueryBuilders.boolQuery();
-
       // Modifiers apply to all criteria in this SearchGroupItem, but will be reapplied to each
       // subquery generated for each criteria ID.
       List<QueryBuilder> modFilters = Lists.newArrayList();
@@ -187,11 +183,11 @@ public final class ElasticFilters {
 
         if (isNonNestedSchema(param)) {
           // setup non nested filter with proper field
-          sgiFilter.should(b);
+          filter.should(b);
         } else {
           // "should" gives us "OR" behavior so long as we're in a filter context, which we are. This
           // translates to N occurrences of criteria 1 OR N occurrences of criteria 2, etc.
-          sgiFilter.should(
+          filter.should(
             QueryBuilders.functionScoreQuery(
               QueryBuilders.nestedQuery(
                 // We sum a constant score for each matching document, yielding the total number
@@ -200,8 +196,6 @@ public final class ElasticFilters {
               .setMinScore(occurredAtLeast));
         }
       }
-      //SGI should "OR"
-      filter.should(sgiFilter);
     }
 
     return filter;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -165,7 +165,7 @@ public final class ElasticFilters {
         }
       }
 
-      // TODO(calbach): Handle non-code values, e.g. question answers here.
+      // TODO(freemabd): Handle Blood Pressure and Deceased
       for (SearchParameter param : sgi.getSearchParameters()) {
         String conceptField = "events." + (isStandardConcept(param) ? "concept_id" : "source_concept_id");
         if (isNonNestedSchema(param)) {
@@ -173,7 +173,6 @@ public final class ElasticFilters {
         }
         BoolQueryBuilder b = QueryBuilders.boolQuery()
             .filter(QueryBuilders.termsQuery(conceptField, toleafConceptIds(ImmutableList.of(param))));
-        // TODO(calbach): Handle Attribute modifiers here, e.g. value_as_number < 10.
         for (Attribute attr : param.getAttributes()) {
           b.filter(attributeToQuery(attr));
         }
@@ -182,6 +181,7 @@ public final class ElasticFilters {
         }
 
         if (isNonNestedSchema(param)) {
+          // setup non nested filter with proper demographic field
           sgiFilter.should(b);
         } else {
           // "should" gives us "OR" behavior so long as we're in a filter context, which we are. This
@@ -233,6 +233,7 @@ public final class ElasticFilters {
       }
       return rq;
     } else if (AttrName.CAT.equals(attr.getName())) {
+      //Currently the UI only uses the In operator for CAT
       return QueryBuilders.termsQuery("events.value_as_concept_id", attr.getOperands());
     } else {
       throw new RuntimeException("attribute name is not an attr name type: " + attr.getName());

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -204,7 +204,7 @@ public final class ElasticFilters {
         right = attr.getOperands().get(1);
       }
     } else {
-      throw new RuntimeException("attribute name is not a attr name type: " + attr.getName());
+      throw new RuntimeException("attribute name is not an attr name type: " + attr.getName());
     }
     switch (attr.getOperator()) {
       case LESS_THAN:

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -96,7 +96,7 @@ public final class ElasticFilters {
   private static Set<TreeType> HIERARCHICAL_CODE_TREES =
       ImmutableSet.of(TreeType.ICD9, TreeType.ICD10);
 
-  private static ImmutableMap<String, String> nonNestedFields = ImmutableMap.of(TreeSubType.GEN.toString(), "gender_concept_id",
+  private static Map<String, String> nonNestedFields = ImmutableMap.of(TreeSubType.GEN.toString(), "gender_concept_id",
     TreeSubType.RACE.toString(), "race_concept_id", TreeSubType.ETH.toString(), "ethnicity_concept_id");
 
   private final CriteriaDao criteriaDao;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -320,6 +320,8 @@ public final class ElasticFilters {
                 .map(id -> Long.toString(id))
                 .collect(Collectors.toSet()));
       } else if (param.getConceptId() != null) {
+        //not all SearchParameter have a concept id, so attributes/modifiers
+        //are used to find matches in those scenarios.
         out.add(Long.toString(param.getConceptId()));
       }
     }

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -256,7 +256,7 @@ public final class ElasticFilters {
       }
       return rq;
     }
-    throw new RuntimeException("attribute name is not an attr name type: " + attr.getName());
+    throw new BadRequestException("attribute name is not an attr name type: " + attr.getName());
   }
 
   private static QueryBuilder dateModifierToQuery(Modifier mod) {

--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -681,9 +681,6 @@ definitions:
       name:
         description: name/type of modifier
         $ref: "#/definitions/ModifierType"
-      encounterType:
-        type: string
-        description: If encounter then this prop will hold the type
       operator:
         description: Machine name of the operator
         $ref: "#/definitions/Operator"

--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -558,7 +558,6 @@ definitions:
       - parameterId
       - name
       - type
-      - subtype
       - group
       - attributes
     properties:

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -609,7 +609,7 @@ public class ElasticFiltersTest {
   @Test
   public void testAgeQuery() {
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-    Object left = now.minusYears(34).minusYears(1).plusDays(1).toLocalDate();
+    Object left = now.minusYears(34).minusYears(1).toLocalDate();
     Object right = now.minusYears(20).toLocalDate();
     SearchParameter ethParam = new SearchParameter()
       .type(TreeType.DEMO.toString())
@@ -626,13 +626,13 @@ public class ElasticFiltersTest {
             .addSearchParametersItem(ethParam))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(nonNestedQuery(
-      QueryBuilders.rangeQuery("birth_datetime").gte(left).lte(right).format("yyyy-MM-dd")));
+      QueryBuilders.rangeQuery("birth_datetime").gt(left).lte(right).format("yyyy-MM-dd")));
   }
 
   @Test
   public void testAgeAndVisitQuery() {
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-    Object left = now.minusYears(34).minusYears(1).plusDays(1).toLocalDate();
+    Object left = now.minusYears(34).minusYears(1).toLocalDate();
     Object right = now.minusYears(20).toLocalDate();
     SearchParameter ageParam = new SearchParameter()
       .type(TreeType.DEMO.toString())
@@ -656,7 +656,7 @@ public class ElasticFiltersTest {
             .searchParameters(Arrays.asList(ageParam, ethParam)))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(nonNestedQuery(
-      QueryBuilders.rangeQuery("birth_datetime").gte(left).lte(right).format("yyyy-MM-dd"),
+      QueryBuilders.rangeQuery("birth_datetime").gt(left).lte(right).format("yyyy-MM-dd"),
       QueryBuilders.termsQuery("ethnicity_concept_id", ImmutableList.of(conceptId))));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -317,7 +317,7 @@ public class ElasticFiltersTest {
     Attribute attr = new Attribute()
       .name(AttrName.NUM)
       .operator(Operator.EQUAL)
-      .addOperandsItem("45880929");
+      .addOperandsItem("1");
     ElasticFilterResponse<QueryBuilder> resp =
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
         .addIncludesItem(new SearchGroup()
@@ -330,7 +330,8 @@ public class ElasticFiltersTest {
               .addAttributesItem(attr)))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQuery(
-      QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("777"))));
+      QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("777")),
+      QueryBuilders.rangeQuery("events.value_as_number").gte(1.0F).lte(1.0F)));
   }
 
   @Test
@@ -486,8 +487,7 @@ public class ElasticFiltersTest {
       .conceptId(Long.parseLong(conceptId))
       .type(TreeType.DEMO.toString())
       .subtype(TreeSubType.GEN.toString())
-      .group(false)
-      .conceptId(Long.parseLong(conceptId));
+      .group(false);
     ElasticFilterResponse<QueryBuilder> resp =
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
         .addIncludesItem(new SearchGroup()
@@ -505,8 +505,7 @@ public class ElasticFiltersTest {
       .conceptId(Long.parseLong(conceptId))
       .type(TreeType.DEMO.toString())
       .subtype(TreeSubType.RACE.toString())
-      .group(false)
-      .conceptId(Long.parseLong(conceptId));
+      .group(false);
     ElasticFilterResponse<QueryBuilder> resp =
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
         .addIncludesItem(new SearchGroup()
@@ -549,7 +548,6 @@ public class ElasticFiltersTest {
       .type(TreeType.PM.toString())
       .subtype(TreeSubType.PREG.toString())
       .group(false)
-      .conceptId(Long.parseLong(conceptId))
       .attributes(Arrays.asList(attr));
     ElasticFilterResponse<QueryBuilder> resp =
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
@@ -573,10 +571,9 @@ public class ElasticFiltersTest {
       .operands(Arrays.asList(operand1, operand2));
     SearchParameter ethParam = new SearchParameter()
       .conceptId(Long.parseLong(conceptId))
-      .type(TreeType.PM.toString())
-      .subtype(TreeSubType.PREG.toString())
+      .type(TreeType.MEAS.toString())
+      .subtype(TreeSubType.LAB.toString())
       .group(false)
-      .conceptId(Long.parseLong(conceptId))
       .attributes(Arrays.asList(attr));
     ElasticFilterResponse<QueryBuilder> resp =
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
@@ -585,7 +582,24 @@ public class ElasticFiltersTest {
             .addSearchParametersItem(ethParam))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQuery(
-      QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
+      QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId)),
       QueryBuilders.termsQuery("events.value_as_concept_id", ImmutableList.of(operand1, operand2))));
+  }
+
+  @Test
+  public void testVisitQuery() {
+    String conceptId = "9202";
+    SearchParameter ethParam = new SearchParameter()
+      .conceptId(Long.parseLong(conceptId))
+      .type(TreeType.VISIT.toString())
+      .group(false);
+    ElasticFilterResponse<QueryBuilder> resp =
+      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
+        .addIncludesItem(new SearchGroup()
+          .addItemsItem(new SearchGroupItem()
+            .addSearchParametersItem(ethParam))));
+    assertThat(resp.isApproximate()).isFalse();
+    assertThat(resp.value()).isEqualTo(singleNestedQuery(
+      QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId))));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -75,6 +75,9 @@ public class ElasticFiltersTest {
   }
 
   private SearchParameter leafParam2;
+  private Attribute numEqualAttr;
+  private SearchParameter ageParam;
+  private Attribute ageAttr;
 
   @Before
   public void setUp() {
@@ -211,6 +214,15 @@ public class ElasticFiltersTest {
         .type(TreeType.ICD9.toString())
         .subtype(TreeSubType.CM.toString())
         .group(false);
+    numEqualAttr = new Attribute()
+      .name(AttrName.NUM)
+      .operator(Operator.EQUAL)
+      .operands(Arrays.asList("1"));
+
+    ageAttr = new Attribute()
+      .name(AttrName.AGE)
+      .operator(Operator.EQUAL)
+      .operands(Arrays.asList("1"));
   }
 
   private static final QueryBuilder singleNestedQuery(QueryBuilder... inners) {

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -613,63 +613,10 @@ public class ElasticFiltersTest {
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
         .addIncludesItem(new SearchGroup()
           .addItemsItem(new SearchGroupItem()
-            .addSearchParametersItem(visitParam))));
+            .addSearchParametersItem(heightEqualParam))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQuery(
-      QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId))));
-  }
-
-  @Test
-  public void testAgeQuery() {
-    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-    Object left = now.minusYears(34).minusYears(1).plusDays(1).toLocalDate();
-    Object right = now.minusYears(20).toLocalDate();
-    SearchParameter ethParam = new SearchParameter()
-      .type(TreeType.DEMO.toString())
-      .subtype(TreeSubType.AGE.toString())
-      .group(false)
-      .addAttributesItem(new Attribute()
-      .name(AttrName.AGE)
-      .operator(Operator.BETWEEN)
-      .operands(Arrays.asList("20", "34")));
-    ElasticFilterResponse<QueryBuilder> resp =
-      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
-        .addIncludesItem(new SearchGroup()
-          .addItemsItem(new SearchGroupItem()
-            .addSearchParametersItem(ethParam))));
-    assertThat(resp.isApproximate()).isFalse();
-    assertThat(resp.value()).isEqualTo(nonNestedQuery(
-      QueryBuilders.rangeQuery("birth_datetime").gte(left).lte(right).format("yyyy-MM-dd")));
-  }
-
-  @Test
-  public void testAgeAndVisitQuery() {
-    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-    Object left = now.minusYears(34).minusYears(1).plusDays(1).toLocalDate();
-    Object right = now.minusYears(20).toLocalDate();
-    SearchParameter ageParam = new SearchParameter()
-      .type(TreeType.DEMO.toString())
-      .subtype(TreeSubType.AGE.toString())
-      .group(false)
-      .addAttributesItem(new Attribute()
-        .name(AttrName.AGE)
-        .operator(Operator.BETWEEN)
-        .operands(Arrays.asList("20", "34")));
-    String conceptId = "38003563";
-    SearchParameter ethParam = new SearchParameter()
-      .conceptId(Long.parseLong(conceptId))
-      .type(TreeType.DEMO.toString())
-      .subtype(TreeSubType.ETH.toString())
-      .group(false)
-      .conceptId(Long.parseLong(conceptId));
-    ElasticFilterResponse<QueryBuilder> resp =
-      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
-        .addIncludesItem(new SearchGroup()
-          .addItemsItem(new SearchGroupItem()
-            .searchParameters(Arrays.asList(ageParam, ethParam)))));
-    assertThat(resp.isApproximate()).isFalse();
-    assertThat(resp.value()).isEqualTo(nonNestedQuery(
-      QueryBuilders.rangeQuery("birth_datetime").gte(left).lte(right).format("yyyy-MM-dd"),
-      QueryBuilders.termsQuery("ethnicity_concept_id", ImmutableList.of(conceptId))));
+      QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(heightEqualParam.getConceptId().toString())),
+      QueryBuilders.rangeQuery("events.value_as_number").gt(numEqualAttr.getOperands().get(0)).lt(numEqualAttr.getOperands().get(0))));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -39,6 +39,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 
+import java.util.Arrays;
+
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @Import(LiquibaseAutoConfiguration.class)
@@ -66,6 +68,7 @@ public class ElasticFiltersTest {
 
   private static Criteria basicsCriteria() {
     return new Criteria()
+        .domainId("Observation")
         .type(TreeType.PPI.toString())
         .subtype(TreeSubType.BASICS.toString())
         .attribute(Boolean.FALSE);
@@ -409,6 +412,18 @@ public class ElasticFiltersTest {
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQueryOccurrences(
         13, QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
+  }
+
+  @Test
+  public void testAgeQuery() {
+    ElasticFilterResponse<QueryBuilder> resp =
+      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
+        .addIncludesItem(new SearchGroup()
+          .addItemsItem(new SearchGroupItem()
+            .addSearchParametersItem(ageParam))));
+    assertThat(resp.isApproximate()).isFalse();
+    assertThat(resp.value()).isEqualTo(singleNestedQuery(
+      QueryBuilders.rangeQuery("events.birth_datetime").from("1981-03-12").to("1981-03-12").format("yyyy-MM-dd")));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -75,9 +75,6 @@ public class ElasticFiltersTest {
   }
 
   private SearchParameter leafParam2;
-  private Attribute numEqualAttr;
-  private SearchParameter ageParam;
-  private Attribute ageAttr;
 
   @Before
   public void setUp() {
@@ -214,15 +211,6 @@ public class ElasticFiltersTest {
         .type(TreeType.ICD9.toString())
         .subtype(TreeSubType.CM.toString())
         .group(false);
-    numEqualAttr = new Attribute()
-      .name(AttrName.NUM)
-      .operator(Operator.EQUAL)
-      .operands(Arrays.asList("1"));
-
-    ageAttr = new Attribute()
-      .name(AttrName.AGE)
-      .operator(Operator.EQUAL)
-      .operands(Arrays.asList("1"));
   }
 
   private static final QueryBuilder singleNestedQuery(QueryBuilder... inners) {
@@ -625,7 +613,7 @@ public class ElasticFiltersTest {
       ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
         .addIncludesItem(new SearchGroup()
           .addItemsItem(new SearchGroupItem()
-            .addSearchParametersItem(heightEqualParam))));
+            .addSearchParametersItem(visitParam))));
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQuery(
       QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(heightEqualParam.getConceptId().toString())),

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -221,14 +221,14 @@ public class ElasticFiltersTest {
     for (QueryBuilder in : inners) {
       b.filter(in);
     }
-    return QueryBuilders.boolQuery().filter(QueryBuilders.boolQuery().should(
+    return QueryBuilders.boolQuery().filter(
         QueryBuilders.boolQuery().should(
             QueryBuilders.functionScoreQuery(
                 QueryBuilders.nestedQuery(
                     "events", QueryBuilders.constantScoreQuery(b), ScoreMode.Total)
             ).setMinScore(n)
         )
-    ));
+    );
   }
 
   private static final QueryBuilder nonNestedQuery(QueryBuilder... inners) {
@@ -237,7 +237,7 @@ public class ElasticFiltersTest {
       BoolQueryBuilder b = QueryBuilders.boolQuery().filter(in);
       innerBuilder.should(b);
     }
-    return QueryBuilders.boolQuery().filter(QueryBuilders.boolQuery().should(innerBuilder));
+    return QueryBuilders.boolQuery().filter(innerBuilder);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -63,6 +63,8 @@ public class ElasticFiltersTest {
   }
 
   private SearchParameter leafParam2;
+  private SearchParameter ageParam;
+  private Attribute ageAttr;
   private Attribute numEqualAttr;
 
   @Before
@@ -162,6 +164,16 @@ public class ElasticFiltersTest {
       .name(AttrName.NUM)
       .operator(Operator.EQUAL)
       .operands(Arrays.asList("1"));
+
+    ageAttr = new Attribute()
+      .name(AttrName.AGE)
+      .operator(Operator.EQUAL)
+      .operands(Arrays.asList("38"));
+    ageParam = new SearchParameter()
+      .type(TreeType.DEMO.toString())
+      .subtype(TreeSubType.AGE.toString())
+      .group(false)
+      .attributes(Arrays.asList(ageAttr));
   }
 
   private static final QueryBuilder singleNestedQuery(QueryBuilder... inners) {
@@ -332,6 +344,18 @@ public class ElasticFiltersTest {
     assertThat(resp.isApproximate()).isFalse();
     assertThat(resp.value()).isEqualTo(singleNestedQueryOccurrences(
         13, QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
+  }
+
+  @Test
+  public void testAgeQuery() {
+    ElasticFilterResponse<QueryBuilder> resp =
+      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
+        .addIncludesItem(new SearchGroup()
+          .addItemsItem(new SearchGroupItem()
+            .addSearchParametersItem(ageParam))));
+    assertThat(resp.isApproximate()).isFalse();
+    assertThat(resp.value()).isEqualTo(singleNestedQuery(
+      QueryBuilders.rangeQuery("events.birth_datetime").from("1981-03-12").to("1981-03-12").format("yyyy-MM-dd")));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -347,18 +347,6 @@ public class ElasticFiltersTest {
   }
 
   @Test
-  public void testAgeQuery() {
-    ElasticFilterResponse<QueryBuilder> resp =
-      ElasticFilters.fromCohortSearch(criteriaDao, new SearchRequest()
-        .addIncludesItem(new SearchGroup()
-          .addItemsItem(new SearchGroupItem()
-            .addSearchParametersItem(ageParam))));
-    assertThat(resp.isApproximate()).isFalse();
-    assertThat(resp.value()).isEqualTo(singleNestedQuery(
-      QueryBuilders.rangeQuery("events.birth_datetime").from("1981-03-12").to("1981-03-12").format("yyyy-MM-dd")));
-  }
-
-  @Test
   public void testAnyHeightQuery() {
     SearchParameter anyHeightParam = new SearchParameter()
       .conceptId(903133L)

--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -221,7 +221,7 @@ export const homepageStyles = reactStyles({
   footerText: {
     height: '176px', opacity: 0.87, color: '#83C3EC', fontSize: '16px',
     fontWeight: 400, lineHeight: '30px', display: 'flex', width: '100%',
-    flexDirection: 'column', flexWrap: 'nowrap', overflowY: 'scroll'
+    flexDirection: 'column', flexWrap: 'nowrap', overflowY: 'auto'
   },
   linksBlock: {
     display: 'flex', marginBottom: '1.2rem', marginLeft: '1.4rem',

--- a/ui/src/app/views/notebook-redirect/component.html
+++ b/ui/src/app/views/notebook-redirect/component.html
@@ -41,7 +41,7 @@
       It is All of Us data use policy that researchers should not make copies of
       or download individual-level data (including taking screenshots or other means
       of viewing individual-level data) outside of the All of Us research environment
-      without approval from AoU Resource Access Board (RAB).
+      without approval from All of Us Resource Access Board (RAB).
     </div>
   </div>
 </div>


### PR DESCRIPTION
Implement counts for all types except(Deceased and BP). We now produce counts for all trees:
1) Surveys - All Surveys, Questions and Answers
2) PM - All types except **Blood Pressure**
3) Condition(ICD9/10, Snomed) - All types
4) Procedure(ICD9/10, CPT, Snomed) - All types
5) Demographics - All age, gender, race and ethnicity except **Deceased**
6) Drugs - All types
7) Measurements - All types
8) Visits - All types