### PR TITLE
[risk=no] Only show dashboard footer link scrollbars on overflow

### DIFF
--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -221,7 +221,7 @@ export const homepageStyles = reactStyles({
   footerText: {
     height: '176px', opacity: 0.87, color: '#83C3EC', fontSize: '16px',
     fontWeight: 400, lineHeight: '30px', display: 'flex', width: '100%',
-    flexDirection: 'column', flexWrap: 'nowrap', overflowY: 'scroll'
+    flexDirection: 'column', flexWrap: 'nowrap', overflowY: 'auto'
   },
   linksBlock: {
     display: 'flex', marginBottom: '1.2rem', marginLeft: '1.4rem',


### PR DESCRIPTION
Avoids this ugliness:

![image](https://user-images.githubusercontent.com/822298/54562173-adfb9400-4983-11e9-8dba-3d865ee1a55a.png)


<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
