### PR TITLE
[risk=no] Don't leak internal exception details to end users

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -35,14 +35,14 @@ public class ExceptionAdvice {
       relevantError = e.getCause();
     }
 
-    errorResponse.setMessage(relevantError.getMessage());
-    errorResponse.setErrorClassName(relevantError.getClass().getName());
-
     // if exception class has an HTTP status associated with it, grab it
     if (relevantError.getClass().getAnnotation(ResponseStatus.class) != null) {
       statusCode = relevantError.getClass().getAnnotation(ResponseStatus.class).value().value();
     }
     if (relevantError instanceof WorkbenchException) {
+      // Only include Exception details on Workbench errors.
+      errorResponse.setMessage(relevantError.getMessage());
+      errorResponse.setErrorClassName(relevantError.getClass().getName());
       WorkbenchException workbenchException = (WorkbenchException) relevantError;
       if (workbenchException.getErrorResponse() != null && workbenchException.getErrorResponse().getErrorCode() != null) {
         errorResponse.setErrorCode(workbenchException.getErrorResponse().getErrorCode());


### PR DESCRIPTION
Mirrors what I did in data-browser to fix a security issue where we leaked a SQL exception with details (could be used by an attacker to gain additional information and find an exploit potentially).

https://github.com/all-of-us/data-browser/pull/136

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
