### PR TITLE
[RW-2240] [risk=moderate] Simplify frontend access guard and add backfill for betaAccessBypass

### DIFF
--- a/api/db/changelog/db.changelog-61-backfill-beta-bypass.xml
+++ b/api/db/changelog/db.changelog-61-backfill-beta-bypass.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <changeSet author="gjordan" id="changelog-61-backfill-beta-bypass">
+        <!--
+          We need to backfill the beta "bypass" field (changelog 60 only backfilled the "completion" time).
+          The "bypass" time is what's read by the backend to determine a user's beta access state.
+        -->
+        <sql>
+            UPDATE user
+            SET beta_access_bypass_time = CASE WHEN id_verification_is_valid = true THEN (select NOW()) ELSE NULL END
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -68,4 +68,5 @@
   <include file="changelog/db.changelog-58-update-access-modules.xml"/>
   <include file="changelog/db.changelog-59-cluster-config-default.xml"/>
   <include file="changelog/db.changelog-60-backfill-bypass.xml"/>
+  <include file="changelog/db.changelog-61-backfill-beta-bypass.xml"/>
 </databaseChangeLog>

--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -10,7 +10,6 @@ import {Observable} from 'rxjs/Observable';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {hasRegisteredAccess} from 'app/utils';
-import {environment} from 'environments/environment';
 
 
 @Injectable()

--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -33,18 +33,12 @@ export class RegistrationGuard implements CanActivate, CanActivateChild {
           return Observable.from([true]);
         }
         return this.profileStorageService.profile$.flatMap((profile) => {
-          // TODO: Remove this logic when enableComplianceLockout feature goes in
-          //   Since dataAccessLevel is computed using the the training and eraCommons modules,
-          //   for now recalculate it using only betaAccess and emailVerification.
-          const hasAccess = environment.enableComplianceLockout ?
-              hasRegisteredAccess(profile.dataAccessLevel) :
-              (!!profile.betaAccessBypassTime &&
-                profile.emailVerificationStatus === 'subscribed');
-          if (hasAccess) {
+          if (hasRegisteredAccess(profile.dataAccessLevel)) {
             return Observable.from([true]);
+          } else {
+            this.router.navigate(['/']);
+            return Observable.from([false]);
           }
-          this.router.navigate(['/']);
-          return Observable.from([false]);
         });
       });
   }

--- a/ui/src/app/views/homepage/component.tsx
+++ b/ui/src/app/views/homepage/component.tsx
@@ -375,10 +375,11 @@ export const Homepage = withUserProfile()(class extends React.Component<
       } else {
         try {
           const config = await configApi().getConfig();
-          if (environment.enableComplianceLockout && config.enforceRegistered) {
+          if (config.enforceRegistered) {
             this.setState({
               accessTasksRemaining: !hasRegisteredAccessFetch(profile.dataAccessLevel),
-              accessTasksLoaded: true});
+              accessTasksLoaded: true
+            });
           } else {
             this.setState({accessTasksRemaining: false, accessTasksLoaded: true});
           }

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -61,12 +61,6 @@ export interface Environment {
   // Exit criteria: remove flag for Athens release.
   enableJupyterLab: boolean;
 
-  // Whether users should be redirected to link their NiH account before
-  // accessing any resources.
-  // See RW-1697 for details
-  // Exit criteria: remove flag for Athens release.
-  enableComplianceLockout: boolean;
-
   // Whether users should be able to see the dataset builder.
   // See RW-2169 for details
   // Exit Criteria: remove flag for Bedford release.

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -16,7 +16,7 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
-  useZendeskForSupport: false,
-  enableJupyterLab: false,
-  enableDatasetBuilder: false,
+  useZendeskForSupport: true,
+  enableJupyterLab: true,
+  enableDatasetBuilder: true,
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -16,8 +16,7 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
-  useZendeskForSupport: true,
-  enableJupyterLab: true,
-  enableComplianceLockout: true,
-  enableDatasetBuilder: true,
+  useZendeskForSupport: false,
+  enableJupyterLab: false,
+  enableDatasetBuilder: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -21,6 +21,5 @@ export const environment: Environment = {
   // exit criteria and Jira ticket links.
   useZendeskForSupport: false,
   enableJupyterLab: false,
-  enableComplianceLockout: false,
   enableDatasetBuilder: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -17,6 +17,5 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   useZendeskForSupport: false,
   enableJupyterLab: false,
-  enableComplianceLockout: false,
   enableDatasetBuilder: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -17,6 +17,5 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   useZendeskForSupport: false,
   enableJupyterLab: false,
-  enableComplianceLockout: false,
   enableDatasetBuilder: false,
 };

--- a/ui/src/environments/environment.test.ts
+++ b/ui/src/environments/environment.test.ts
@@ -7,6 +7,5 @@ export const environment: Environment = {
   debug: false,
   useZendeskForSupport: true,
   enableJupyterLab: true,
-  enableComplianceLockout: true,
   enableDatasetBuilder: true,
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -7,6 +7,5 @@ export const environment: Environment = {
   debug: true,
   useZendeskForSupport: false,
   enableJupyterLab: true,
-  enableComplianceLockout: true,
   enableDatasetBuilder: true,
 };


### PR DESCRIPTION
Digging into what was causing QA failures for the upcoming weekly release, I found two largely-separate issues:

1) The frontend access guard involved two pieces of complex logic based on a combination of config.enforceRegistered and environment.enableComplianceLockout. There was a subtle error in homepage/component.tsx that was causing access tasks not to be shown to new and non-beta-approved users.

I realized that the logic would be simpler to reason about & test if we removed the front-end "enableComplianceLockout" flag altogether. With this change, all front-end access decisions are made purely based on whether the user's data access level is registered or not (and whether config.enforceRegistered is true).

2) There was an issue where our bypass backfill script was updating the betaAccessCompletionTime, but the bypass UI and UserService were only looking at betaAccessBypassTime. Updating the backfill script to also change betaAccessBypassTime will cause existing users to be correctly granted access by default.