### PR TITLE
[RW-2357][risk=no] build QueryJobConfiguration for BQ for participant ids.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -254,7 +254,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     SearchRequest searchRequest = new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);
 
     TableResult result = bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(
-      participantCounter.buildParticipantIdQuery(new ParticipantCriteria(searchRequest),
+      participantCounter.buildRandomParticipantQuery(new ParticipantCriteria(searchRequest),
         request.getSize(), 0L)));
     Map<String, Integer> rm = bigQueryService.getResultMapper(result);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
@@ -118,6 +118,8 @@ public class ParticipantCounter {
           endSql, PERSON_TABLE);
     }
 
+  //TODO: implemented for use with the Data Set Builder. Please remove it this does not become the preferred solution
+  //https://docs.google.com/document/d/1-wzSCHDM_LSaBRARyLFbsTGcBaKi5giRs-eDmaMBr0Y/edit#
   public QueryJobConfiguration buildParticipantIdQuery(ParticipantCriteria participantCriteria) {
     return buildQuery(participantCriteria, ID_SQL_TEMPLATE.replace("${table}", SEARCH_PERSON_TABLE), "", SEARCH_PERSON_TABLE);
   }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCounter.java
@@ -28,8 +28,13 @@ public class ParticipantCounter {
       "from `${projectId}.${dataSetId}.${table}` ${table}\n" +
       "where\n";
 
-  private static final String ID_SQL_TEMPLATE =
+  private static final String RANDOM_SQL_TEMPLATE =
     "select rand() as x, person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime\n" +
+      "from `${projectId}.${dataSetId}.${table}` ${table}\n" +
+      "where\n";
+
+  private static final String ID_SQL_TEMPLATE =
+    "select person_id\n" +
       "from `${projectId}.${dataSetId}.${table}` ${table}\n" +
       "where\n";
 
@@ -61,7 +66,7 @@ public class ParticipantCounter {
       "order by count desc, name asc\n" +
       "limit ${limit}\n";
 
-    private static final String ID_SQL_ORDER_BY = "order by x\nlimit";
+    private static final String RANDOM_SQL_ORDER_BY = "order by x\nlimit";
 
     private static final String OFFSET_SUFFIX = " offset ";
 
@@ -102,16 +107,20 @@ public class ParticipantCounter {
       return buildQuery(participantCriteria, DOMAIN_CHART_INFO_SQL_TEMPLATE, endSqlTemplate, QueryBuilderConstants.REVIEW_TABLE);
     }
 
-  public QueryJobConfiguration buildParticipantIdQuery(ParticipantCriteria participantCriteria,
-                                                       long resultSize,
-                                                       long offset) {
-        String endSql = ID_SQL_ORDER_BY + " " + resultSize;
+  public QueryJobConfiguration buildRandomParticipantQuery(ParticipantCriteria participantCriteria,
+                                                           long resultSize,
+                                                           long offset) {
+        String endSql = RANDOM_SQL_ORDER_BY + " " + resultSize;
         if (offset > 0) {
             endSql += OFFSET_SUFFIX + offset;
         }
-        return buildQuery(participantCriteria, ID_SQL_TEMPLATE.replace("${table}", PERSON_TABLE),
+        return buildQuery(participantCriteria, RANDOM_SQL_TEMPLATE.replace("${table}", PERSON_TABLE),
           endSql, PERSON_TABLE);
     }
+
+  public QueryJobConfiguration buildParticipantIdQuery(ParticipantCriteria participantCriteria) {
+    return buildQuery(participantCriteria, ID_SQL_TEMPLATE.replace("${table}", SEARCH_PERSON_TABLE), "", SEARCH_PERSON_TABLE);
+  }
 
     public QueryJobConfiguration buildQuery(ParticipantCriteria participantCriteria,
         String sqlTemplate, String endSql, String mainTable) {


### PR DESCRIPTION
Build QueryJobConfiguration for BQ for participant ids.
This method will produce a sql template that varies depending on the cohort definition. The base sql template is as follows:
`select person_id
    from `${projectId}.${dataSetId}.search_person` search_person
 where search_person.person_id in (
        select criteria.person_id from (
             select person_id, entry_date, concept_id
               from `${projectId}.${dataSetId}.search_all_domains`
             where concept_id in(@p0)
        ) criteria
)`

To use with the DataSetBuilderController please drop the following code block into your specific method. Make sure to inject BigQueryService and ParticipantCounter into your controller. Need to make sure that proper access is required and that the cdr version is set as well. Ex: https://github.com/all-of-us/workbench/blob/master/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java#L523
```
TableResult result = bigQueryService.executeQuery(
bigQueryService.filterBigQueryConfig(participantCounter.buildParticipantIdQuery(new ParticipantCriteria(searchRequest))));
Map<String, Integer> rm = bigQueryService.getResultMapper(result);
List<Long> participantIds = new ArrayList();
for (List<FieldValue> row : result.iterateAll()) {
      participantIds.add(bigQueryService.getLong(row, rm.get("person_id")));
}
```