### PR TITLE
[RW-2392] [risk=low] Fix eRA Commons logic, and finish module rename.

### DIFF
--- a/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
+++ b/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+    <changeSet author="gjuggler" id="db.changelog-67-compliance-training-expiration">
+        <addColumn tableName="user">
+            <column name="compliance_training_expiration_time" type="datetime"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
+++ b/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-    <changeSet author="gjuggler" id="db.changelog-67-compliance-training-expiration">
-        <addColumn tableName="user">
-            <column name="compliance_training_expiration_time" type="datetime"/>
-        </addColumn>
-    </changeSet>
+  <changeSet author="gjuggler" id="db.changelog-66-compliance-training-expiration">
+    <addColumn tableName="user">
+      <column name="compliance_training_expiration_time" type="datetime"/>
+    </addColumn>
+    <sql>
+      UPDATE user
+      SET compliance_training_expiration_time = training_expiration_time
+    </sql>
+    <dropColumn columnName="training_expiration_time" tableName="user"/>
+  </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
+++ b/api/db/changelog/db.changelog-67-compliance-training-expiration.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="gjuggler" id="db.changelog-66-compliance-training-expiration">
+  <changeSet author="gjuggler" id="db.changelog-67-compliance-training-expiration">
     <addColumn tableName="user">
       <column name="compliance_training_expiration_time" type="datetime"/>
     </addColumn>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -74,4 +74,5 @@
   <include file="changelog/db.changelog-64.xml"/>
   <include file="changelog/db.changelog-65.xml"/>
   <include file="changelog/db.changelog-66.xml"/>
+  <include file="changelog/db.changelog-67-compliance-training-expiration.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -85,8 +85,8 @@ public class ProfileService {
     if (user.getTermsOfServiceCompletionTime() != null) {
       profile.setTermsOfServiceCompletionTime(user.getTermsOfServiceCompletionTime().getTime());
     }
-    if (user.getTrainingCompletionTime() != null) {
-      profile.setTrainingCompletionTime(user.getTrainingCompletionTime().getTime());
+    if (user.getComplianceTrainingCompletionTime() != null) {
+      profile.setComplianceTrainingCompletionTime(user.getComplianceTrainingCompletionTime().getTime());
     }
     if (user.getComplianceTrainingCompletionTime() != null) {
       profile.setComplianceTrainingCompletionTime(user.getComplianceTrainingCompletionTime().getTime());

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -398,11 +398,9 @@ public class UserService {
         moodleId = complianceService.getMoodleId(user.getEmail());
         if (moodleId == null) {
           // User has not yet created/logged into MOODLE
-          user.setComplianceTrainingCompletionTime(null);
-          user.setComplianceTrainingExpirationTime(null);
-        } else {
-          user.setMoodleId(moodleId);
+          return;
         }
+        user.setMoodleId(moodleId);
       }
 
       if (moodleId != null) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -403,25 +403,23 @@ public class UserService {
         user.setMoodleId(moodleId);
       }
 
-      if (moodleId != null) {
-        List<BadgeDetails> badgeResponse = complianceService.getUserBadge(moodleId);
-        // The assumption here is that the User will always get 1 badge which will be AoU
-        if (badgeResponse != null && badgeResponse.size() > 0) {
-          user.setComplianceTrainingCompletionTime(now);
+      List<BadgeDetails> badgeResponse = complianceService.getUserBadge(moodleId);
+      // The assumption here is that the User will always get 1 badge which will be AoU
+      if (badgeResponse != null && badgeResponse.size() > 0) {
+        user.setComplianceTrainingCompletionTime(now);
 
-          BadgeDetails badge = badgeResponse.get(0);
-          if (badge.getDateexpire() == null) {
-            //This can happen if date expire is set to never
-            user.setComplianceTrainingExpirationTime(null);
-          } else {
-            user.setComplianceTrainingExpirationTime(new Timestamp(Long.parseLong(badge.getDateexpire())));
-          }
-        } else {
-          // Moodle has returned zero badges for the given user -- we should clear the user's
-          // training completion & expiration time.
-          user.setComplianceTrainingCompletionTime(null);
+        BadgeDetails badge = badgeResponse.get(0);
+        if (badge.getDateexpire() == null) {
+          //This can happen if date expire is set to never
           user.setComplianceTrainingExpirationTime(null);
+        } else {
+          user.setComplianceTrainingExpirationTime(new Timestamp(Long.parseLong(badge.getDateexpire())));
         }
+      } else {
+        // Moodle has returned zero badges for the given user -- we should clear the user's
+        // training completion & expiration time.
+        user.setComplianceTrainingCompletionTime(null);
+        user.setComplianceTrainingExpirationTime(null);
       }
 
       updateUserWithRetries(dbUser -> {

--- a/api/src/main/java/org/pmiops/workbench/db/model/User.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/User.java
@@ -67,7 +67,6 @@ public class User {
   private Set<WorkspaceUserRole> workspaceUserRoles = new HashSet<>();
   private Boolean idVerificationIsValid;
   private Timestamp termsOfServiceCompletionTime;
-  private Timestamp trainingCompletionTime;
   private Timestamp demographicSurveyCompletionTime;
   private boolean disabled;
   private Short emailVerificationStatus;
@@ -83,7 +82,8 @@ public class User {
   private Integer clusterCreateRetries;
   private Integer billingProjectRetries;
   private Integer moodleId;
-  private Timestamp trainingExpirationTime;
+
+  // Access module fields go here. See http://broad.io/aou-access-modules for docs.
   private String eraCommonsLinkedNihUsername;
   private Timestamp eraCommonsLinkExpireTime;
   private Timestamp eraCommonsCompletionTime;
@@ -93,6 +93,7 @@ public class User {
   private Timestamp dataUseAgreementBypassTime;
   private Timestamp complianceTrainingCompletionTime;
   private Timestamp complianceTrainingBypassTime;
+  private Timestamp complianceTrainingExpirationTime;
   private Timestamp eraCommonsBypassTime;
   private Timestamp emailVerificationCompletionTime;
   private Timestamp emailVerificationBypassTime;
@@ -338,15 +339,6 @@ public class User {
     this.termsOfServiceCompletionTime = termsOfServiceCompletionTime;
   }
 
-  @Column(name = "training_completion_time")
-  public Timestamp getTrainingCompletionTime() {
-    return trainingCompletionTime;
-  }
-
-  public void setTrainingCompletionTime(Timestamp trainingCompletionTime) {
-    this.trainingCompletionTime = trainingCompletionTime;
-  }
-
   @Column(name = "demographic_survey_completion_time")
   public Timestamp getDemographicSurveyCompletionTime() {
     return demographicSurveyCompletionTime;
@@ -472,13 +464,6 @@ public class User {
     this.moodleId = moodleId;
   }
 
-  @Column(name = "training_expiration_time")
-  public Timestamp getTrainingExpirationTime() { return trainingExpirationTime; }
-
-  public void setTrainingExpirationTime( Timestamp trainingExpirationTime) {
-    this.trainingExpirationTime = trainingExpirationTime;
-  }
-
   @Column(name = "era_commons_linked_nih_username")
   public String getEraCommonsLinkedNihUsername() { return eraCommonsLinkedNihUsername; }
 
@@ -526,6 +511,13 @@ public class User {
 
   public void setComplianceTrainingBypassTime(Timestamp complianceTrainingBypassTime) {
     this.complianceTrainingBypassTime = complianceTrainingBypassTime;
+  }
+
+  @Column(name = "compliance_training_expiration_time")
+  public Timestamp getComplianceTrainingExpirationTime() {return complianceTrainingExpirationTime; }
+
+  public void setComplianceTrainingExpirationTime(Timestamp complianceTrainingExpirationTime) {
+    this.complianceTrainingExpirationTime = complianceTrainingExpirationTime;
   }
 
   @Column(name = "beta_access_completion_time")

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2213,10 +2213,6 @@ definitions:
       idVerificationStatus:
         $ref: "#/definitions/IdVerificationStatus"
         description: Status of ID verification
-      trainingCompletionTime:
-        type: integer
-        format: int64
-        description: Timestamp when the user completed ethics training in milliseconds since the UNIX epoch.
       demographicSurveyCompletionTime:
         type: integer
         format: int64

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -138,18 +138,19 @@ public class ProfileControllerTest {
 
   @Before
   public void setUp() throws MessagingException {
-    WorkbenchConfig config = new WorkbenchConfig();
-    config.firecloud = new FireCloudConfig();
+    WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
     config.firecloud.billingProjectPrefix = BILLING_PROJECT_PREFIX;
     config.firecloud.billingRetryCount = 2;
     config.firecloud.registeredDomainName = "";
-    config.access = new AccessConfig();
     config.access.enableEraCommons = false;
     config.access.enableComplianceTraining = false;
-    config.admin = new WorkbenchConfig.AdminConfig();
     config.admin.adminIdVerification = "adminIdVerify@dummyMockEmail.com";
-    config.access = new WorkbenchConfig.AccessConfig();
+    // All access modules are enabled for these tests. So completing any one module should maintain
+    // UNREGISTERED status.
     config.access.enableComplianceTraining = true;
+    config.access.enableBetaAccess = true;
+    config.access.enableEraCommons = true;
+    config.access.enableDataUseAgreement = true;
 
     WorkbenchEnvironment environment = new WorkbenchEnvironment(true, "appId");
     WorkbenchEnvironment cloudEnvironment = new WorkbenchEnvironment(false, "appId");
@@ -252,32 +253,6 @@ public class ProfileControllerTest {
     assertThat(profile.getTermsOfServiceCompletionTime()).isNull();
     assertThat(profile.getComplianceTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
   }
-
-  @Test
-  public void testSubmitEverything_success() throws Exception {
-    createUser();
-    Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-    Profile profile = profileController.completeEthicsTraining().getBody();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.UNREGISTERED);
-    IdVerificationReviewRequest reviewStatus = new IdVerificationReviewRequest();
-    reviewStatus.setNewStatus(IdVerificationStatus.VERIFIED);
-    profileController.reviewIdVerification(profile.getUserId(), reviewStatus);
-    profile = profileController.submitDemographicsSurvey().getBody();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.UNREGISTERED);
-    user = userProvider.get();
-    user.setDataUseAgreementCompletionTime(timestamp);
-    user.setEraCommonsCompletionTime(timestamp);
-    user.setComplianceTrainingCompletionTime(timestamp);
-    profile = profileController.submitTermsOfService().getBody();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.REGISTERED);
-    verify(fireCloudService).addUserToGroup("bob@researchallofus.org", "");
-
-    assertThat(profile.getIdVerificationStatus()).isEqualTo(IdVerificationStatus.VERIFIED);
-    assertThat(profile.getDemographicSurveyCompletionTime()).isEqualTo(NOW.toEpochMilli());
-    assertThat(profile.getTermsOfServiceCompletionTime()).isEqualTo(NOW.toEpochMilli());
-    assertThat(profile.getComplianceTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
-  }
-
 
   @Test(expected = ServerErrorException.class)
   public void testCreateAccount_directoryServiceFail() throws Exception {

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -228,7 +228,7 @@ public class ProfileControllerTest {
     assertThat(profile.getIdVerificationStatus()).isEqualTo(IdVerificationStatus.UNVERIFIED);
     assertThat(profile.getDemographicSurveyCompletionTime()).isEqualTo(NOW.toEpochMilli());
     assertThat(profile.getTermsOfServiceCompletionTime()).isNull();
-    assertThat(profile.getTrainingCompletionTime()).isNull();
+    assertThat(profile.getComplianceTrainingCompletionTime()).isNull();
   }
 
   @Test
@@ -239,7 +239,7 @@ public class ProfileControllerTest {
     assertThat(profile.getIdVerificationStatus()).isEqualTo(IdVerificationStatus.UNVERIFIED);
     assertThat(profile.getDemographicSurveyCompletionTime()).isNull();
     assertThat(profile.getTermsOfServiceCompletionTime()).isEqualTo(NOW.toEpochMilli());
-    assertThat(profile.getTrainingCompletionTime()).isNull();
+    assertThat(profile.getComplianceTrainingCompletionTime()).isNull();
   }
 
   @Test
@@ -250,7 +250,7 @@ public class ProfileControllerTest {
     assertThat(profile.getIdVerificationStatus()).isEqualTo(IdVerificationStatus.UNVERIFIED);
     assertThat(profile.getDemographicSurveyCompletionTime()).isNull();
     assertThat(profile.getTermsOfServiceCompletionTime()).isNull();
-    assertThat(profile.getTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
+    assertThat(profile.getComplianceTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
   }
 
   @Test
@@ -275,7 +275,7 @@ public class ProfileControllerTest {
     assertThat(profile.getIdVerificationStatus()).isEqualTo(IdVerificationStatus.VERIFIED);
     assertThat(profile.getDemographicSurveyCompletionTime()).isEqualTo(NOW.toEpochMilli());
     assertThat(profile.getTermsOfServiceCompletionTime()).isEqualTo(NOW.toEpochMilli());
-    assertThat(profile.getTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
+    assertThat(profile.getComplianceTrainingCompletionTime()).isEqualTo(NOW.toEpochMilli());
   }
 
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -101,16 +101,11 @@ public class UserServiceTest {
 
   @Test
   public void testSyncComplianceTrainingStatusNoMoodleId() throws Exception {
-    // Without a Moodle ID, we should clear the completion bit.
-    User user = userDao.findUserByEmail(EMAIL_ADDRESS);
-    user.setComplianceTrainingCompletionTime(new Timestamp(12345));
-    userDao.save(user);
-
     when(complianceService.getMoodleId(EMAIL_ADDRESS)).thenReturn(null);
     userService.syncComplianceTrainingStatus();
 
     verify(complianceService, never()).getUserBadge(anyInt());
-    user = userDao.findUserByEmail(EMAIL_ADDRESS);
+    User user = userDao.findUserByEmail(EMAIL_ADDRESS);
     assertThat(user.getComplianceTrainingCompletionTime()).isNull();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -93,29 +93,39 @@ public class UserServiceTest {
 
     // The user should be updated in the database with a non-empty completion and expiration time.
     User user = userDao.findUserByEmail(EMAIL_ADDRESS);
-    assertThat(user.getTrainingCompletionTime()).isEqualTo(
+    assertThat(user.getComplianceTrainingCompletionTime()).isEqualTo(
         new Timestamp(TIMESTAMP_MSECS));
-    assertThat(user.getTrainingExpirationTime()).isEqualTo(
+    assertThat(user.getComplianceTrainingExpirationTime()).isEqualTo(
         new Timestamp(12345));
   }
 
-  @Test()
+  @Test
   public void testSyncComplianceTrainingStatusNoMoodleId() throws Exception {
+    // Without a Moodle ID, we should clear the completion bit.
+    User user = userDao.findUserByEmail(EMAIL_ADDRESS);
+    user.setComplianceTrainingCompletionTime(new Timestamp(12345));
+    userDao.save(user);
+
     when(complianceService.getMoodleId(EMAIL_ADDRESS)).thenReturn(null);
     userService.syncComplianceTrainingStatus();
 
     verify(complianceService, never()).getUserBadge(anyInt());
-    User user = userDao.findUserByEmail(EMAIL_ADDRESS);
-    assertThat(user.getTrainingCompletionTime()).isNull();
+    user = userDao.findUserByEmail(EMAIL_ADDRESS);
+    assertThat(user.getComplianceTrainingCompletionTime()).isNull();
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void testSyncComplianceTrainingStatusNullBadge() throws Exception {
-    // We consider it an error if we have a valid Moodle ID but the Moodle API returns a NOT_FOUND
-    // response.
+    // When Moodle returns an empty badge response, we should clear the completion bit.
+    User user = userDao.findUserByEmail(EMAIL_ADDRESS);
+    user.setComplianceTrainingCompletionTime(new Timestamp(12345));
+    userDao.save(user);
+
     when(complianceService.getMoodleId(EMAIL_ADDRESS)).thenReturn(1);
     when(complianceService.getUserBadge(1)).thenReturn(null);
     userService.syncComplianceTrainingStatus();
+    user = userDao.findUserByEmail(EMAIL_ADDRESS);
+    assertThat(user.getComplianceTrainingCompletionTime()).isNull();
   }
 
   @Test(expected = NotFoundException.class)

--- a/ui/src/testing/stubs/profile-service-stub.ts
+++ b/ui/src/testing/stubs/profile-service-stub.ts
@@ -112,7 +112,7 @@ export class ProfileServiceStub extends ProfileService {
   }
 
   public completeEthicsTraining(extraHttpRequestParams?: any): Observable<Profile> {
-    this.profile.trainingCompletionTime = this.now();
+    this.profile.complianceTrainingCompletionTime = this.now();
     return Observable.from([this.profile]);
   }
 }


### PR DESCRIPTION
This PR fixes an issue with the eRA Commons logic where we were too aggressive in returning error statuses from the UserService method.

Specifically: when we have a Moodle ID for a user, but that user hasn't completed any trainings, we seem to get an empty response from the Moodle API. (See examples in the RW-2392 description.) Instead of returning an error in that case, we should clear out the compliance training completion bit.

I also took the chance to finish up the rename of training --> complianceTraining.