### PR TITLE
[RW-2293][risk=no] Add rename option to cohort cards

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -56,5 +56,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": false,
     "enableBetaAccess": true
+  },
+  "cohortbuilder": {
+    "enableListSearch": false
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -55,5 +55,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": false,
     "enableBetaAccess": true
+  },
+  "cohortbuilder": {
+    "enableListSearch": false
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -55,5 +55,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": false,
     "enableBetaAccess": true
+  },
+  "cohortbuilder": {
+    "enableListSearch": false
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -55,5 +55,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": false,
     "enableBetaAccess": true
+  },
+  "cohortbuilder": {
+    "enableListSearch": false
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -56,5 +56,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": false,
     "enableBetaAccess": true
+  },
+  "cohortbuilder": {
+    "enableListSearch": false
   }
 }

--- a/api/db-cdr/generate-cdr/make-bq-data-dump.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data-dump.sh
@@ -47,12 +47,7 @@ echo "Dumping tables to csv from $BUCKET"
 # Note tables larger than 1 G need to be dumped into more than one file.
 # Namin scheme is table_name.*.csv.gz
 
-if [[ $DATASET == *public* ]] || [[ $DATASET == *PUBLIC* ]];
-then
-    tables=(achilles_analysis achilles_results achilles_results_dist concept concept_relationship criteria domain_info survey_module domain vocabulary concept_synonym domain_vocabulary_info survey_question_map)
-else
-    tables=(achilles_analysis achilles_results achilles_results_dist concept concept_relationship criteria_relationship criteria criteria_attribute domain_info survey_module domain vocabulary criteria_ancestor concept_synonym domain_vocabulary_info survey_question_map)
-fi
+tables=(concept concept_relationship criteria_relationship criteria criteria_attribute domain_info survey_module domain vocabulary criteria_ancestor concept_synonym domain_vocabulary_info survey_question_map)
 
 for table in ${tables[@]}; do
   echo "Dumping table : $table"

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -131,6 +131,9 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
                                                                       String subtype,
                                                                       Long limit) {
     cdrVersionService.setCdrVersion(cdrVersionDao.findOne(cdrVersionId));
+    if (configProvider.get().cohortbuilder.enableListSearch) {
+      log.info("List search is on: " + configProvider.get().cohortbuilder.enableListSearch);
+    }
     Long resultLimit = Optional.ofNullable(limit).orElse(DEFAULT_LIMIT);
     String matchExp = modifyKeywordMatch(value, type);
     List<Criteria> criteriaList;

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -20,6 +20,7 @@ public class WorkbenchConfig {
   public ElasticsearchConfig elasticsearch; 
   public MoodleConfig moodle;
   public AccessConfig access;
+  public CohortBuilderConfig cohortbuilder;
 
   /**
    * Creates a config with non-null-but-empty member variables, for use in testing.
@@ -38,6 +39,7 @@ public class WorkbenchConfig {
     config.elasticsearch = new ElasticsearchConfig();
     config.moodle = new MoodleConfig();
     config.access = new AccessConfig();
+    config.cohortbuilder = new CohortBuilderConfig();
     return config;
   }
 
@@ -116,5 +118,9 @@ public class WorkbenchConfig {
     public boolean enableEraCommons;
     public boolean enableDataUseAgreement;
     public boolean enableBetaAccess;
+  }
+
+  public static class CohortBuilderConfig {
+    public boolean enableListSearch;
   }
 }

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -10,12 +10,14 @@ import {Cohort, ConceptSet} from 'generated/fetch';
 
 export const ResourceCardMenu: React.FunctionComponent<{
   disabled: boolean, resourceType: ResourceType, onRenameNotebook?: Function,
-  onOpenJupyterLabNotebook?: any, onCloneResource?: Function, onDeleteResource?: Function,
-  onEditCohort?: Function, onReviewCohort?: Function, onEditConceptSet?: Function
+  onRenameCohort?: Function, onOpenJupyterLabNotebook?: any, onCloneResource?: Function,
+  onDeleteResource?: Function, onEditCohort?: Function, onReviewCohort?: Function,
+  onEditConceptSet?: Function
 }> = ({
-        disabled, resourceType, onRenameNotebook = () => {}, onOpenJupyterLabNotebook = () => {},
-        onCloneResource = () => {}, onDeleteResource = () => {}, onEditCohort = () => {},
-        onReviewCohort = () => {}, onEditConceptSet = () => {}
+        disabled, resourceType, onRenameNotebook = () => {}, onRenameCohort = () => {},
+        onOpenJupyterLabNotebook = () => {}, onCloneResource = () => {},
+        onDeleteResource = () => {}, onEditCohort = () => {}, onReviewCohort = () => {},
+        onEditConceptSet = () => {}
       }) => {
   return <PopupTrigger
     data-test-id='resource-card-menu'
@@ -45,6 +47,7 @@ export const ResourceCardMenu: React.FunctionComponent<{
         }],
         ['cohort', () => {
           return <React.Fragment>
+            <MenuItem icon='note' onClick={onRenameCohort}>Rename</MenuItem>
             <MenuItem icon='copy' onClick={onCloneResource}>Duplicate</MenuItem>
             <MenuItem icon='pencil' onClick={onEditCohort}>Edit</MenuItem>
             <MenuItem icon='grid-view' onClick={onReviewCohort}>Review</MenuItem>

--- a/ui/src/app/views/resource-card/component.tsx
+++ b/ui/src/app/views/resource-card/component.tsx
@@ -229,6 +229,10 @@ export class ResourceCard extends React.Component<ResourceCardProps, ResourceCar
     this.setState({editing: false});
   }
 
+  renameCohort(): void {
+    this.setState({editing: true});
+  }
+
   renameNotebook(): void {
     this.setState({renaming: true});
   }
@@ -385,6 +389,7 @@ export class ResourceCard extends React.Component<ResourceCardProps, ResourceCar
                               onCloneResource={() => this.cloneResource()}
                               onDeleteResource={() => this.openConfirmDelete()}
                               onRenameNotebook={() => this.renameNotebook()}
+                              onRenameCohort={() => this.renameCohort()}
                               onEditCohort={() => this.edit()}
                               onEditConceptSet={() => this.edit()}
                               onReviewCohort={() => this.reviewCohort()}


### PR DESCRIPTION
Add 'Rename' option to the snowman menu for cohort cards for editing name and description (the 'Edit' option now edits the actual criteria of the cohort).

@blrubenstein I've been tagging you on a lot of reviews lately since there have been changes to workbench components included. Let me know if should rotate others in on reviews like this.