### PR TITLE
[RW-2361][risk=low] Optimize indexer and improve logging

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -164,6 +164,7 @@ public class ElasticDocument {
       Object val;
       switch (esType) {
         case INTEGER:
+        case FLOAT:
           if (isRepeated) {
             val = fv.getRepeatedValue().stream().map(FieldValue::getNumericValue)
                 .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
@@ -1,11 +1,20 @@
 package org.pmiops.workbench.elasticsearch;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Iterator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -16,13 +25,24 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Shared utilities for indexing and access All of Us data in Elasticsearch.
  */
 public final class ElasticUtils {
   private static final Logger log = Logger.getLogger(ElasticUtils.class.getName());
+
+  // These parameters were determined experimentally, and work fairly well on the default Elastic
+  // Cloud cluster configuration, but are likely not optimal.
+  // - 4/12/19 run: synthetic 1m dataset took 1h54m @ ~8.3K docs/min
   private static final int BATCH_SIZE = 200;
+  private static final int BATCH_POOL_SIZE = 3;
+
+  // Elastic timeout is ~30s, this allows for several attempts.
+  private static final int MAX_BACKOFF_INTERVAL_MS = 5 * 60 * 1000;
 
   // Recommended document type for all indices is "_doc" (types are being deprecated):
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
@@ -58,12 +78,23 @@ public final class ElasticUtils {
 
   /**
    * Ingests the given Elasticsearch documents using bulk ingestion. If documents of the same ID
-   * already exist in the index, they will instead be updated.
+   * already exist in the index, they will instead be updated. Uses a threadpool to dispatch
+   * multiple batch requests simultaneously.
    */
   public static void ingestDocuments(RestHighLevelClient client, String indexName,
-      Iterator<ElasticDocument> docs, int numDocs) throws IOException {
-    // TODO(calbach): Parallelize this.
-    int fails = 0;
+      Iterator<ElasticDocument> docs, int numDocs) throws InterruptedException {
+    // Need to define our own blocking queue; the default from Executors.fixedThreadPool() uses
+    // an unbounded queue. When the queue is full, we use a CallerRunsPolicy as the simplest
+    // fallback (by default, it throws an exception). This shouldn't significantly affect throughput
+    // since our queue size is double our thread count.
+    BlockingQueue<Runnable> queue = new ArrayBlockingQueue<>(2 * BATCH_POOL_SIZE, /* fair */ true);
+    ExecutorService pool =
+        new ThreadPoolExecutor(BATCH_POOL_SIZE, BATCH_POOL_SIZE, 0L, TimeUnit.MILLISECONDS, queue,
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
+    Stopwatch timer = Stopwatch.createStarted();
+    final AtomicInteger count = new AtomicInteger();
+    final AtomicInteger fails = new AtomicInteger();
     for (int i = 0; docs.hasNext(); i += BATCH_SIZE) {
       BulkRequest bulkReq = new BulkRequest();
       int j;
@@ -72,21 +103,78 @@ public final class ElasticUtils {
         bulkReq.add(new IndexRequest(indexName, INDEX_TYPE, doc.id)
             .source(doc.source));
       }
-      BulkResponse response = client.bulk(bulkReq, REQ_OPTS);
-      if (response.hasFailures()) {
-        for (BulkItemResponse itemResp : response.getItems()) {
-          if (itemResp.isFailed()) {
-            // TODO: Investigate retry handling or aggregate failures.
-            log.warning(itemResp.getFailureMessage());
-            fails++;
-          }
-        }
-      }
 
-      int inserted = i + j - fails;
-      log.info(String.format("Inserted %.2f%% of documents (%d/%d) (%d failed)",
-          ((float) 100 * (inserted)) / numDocs, inserted, numDocs, fails));
+      // Should block until there is room in the pool.
+      pool.submit(() -> {
+        BulkResponse response;
+        try {
+          response = retryTemplate().execute((context) -> {
+            try {
+              return client.bulk(bulkReq, REQ_OPTS);
+            } catch (IOException e) {
+              log.log(Level.WARNING,
+                  "bulk request attempt " + context.getRetryCount() + " failed, retrying...", e);
+              throw e;
+            }
+          });
+        } catch (IOException e) {
+          log.log(Level.SEVERE, "bulk insertion failed", e);
+          fails.addAndGet(bulkReq.numberOfActions());
+          return;
+        }
+
+        int numFails = 0;
+        if (response.hasFailures()) {
+          for (BulkItemResponse itemResp : response.getItems()) {
+              if (itemResp.isFailed()) {
+                // TODO: Investigate retry handling or aggregate failures.
+                log.warning(itemResp.getFailureMessage());
+                numFails++;
+              }
+            }
+          }
+          count.addAndGet(bulkReq.numberOfActions() - numFails);
+          fails.addAndGet(numFails);
+        });
+
+      int inserted = count.get();
+      int failed = fails.get();
+      int submitted = i + j - failed;
+      double rate = docsPerMinute(inserted, timer.elapsed().toMillis());
+      double hoursRemaining = ((double) (numDocs - inserted - failed)) / rate / 60.0;
+      log.info(String.format(
+          "Submitted %.2f%% of documents (%d/%d) (%d failed) @ %.2f docs/minute [~%.1fh remaining]",
+          ((float) 100 * (submitted)) / numDocs, submitted, numDocs, failed, rate,
+          hoursRemaining));
     }
+
+    log.info(String.format("All documents submitted, awaiting remaining threads"));
+    pool.shutdown();
+    pool.awaitTermination(15, TimeUnit.MINUTES);
+    timer.stop();
+
+    log.info(String.format("Indexing complete (%d/%d) (%d failed)",
+        numDocs - fails.get(), numDocs, fails.get()));
+    Duration t = timer.elapsed();
+    log.info(String.format("Indexing took %dh %dm %ds; average ~%.2f documents indexed per minute",
+        t.toHours(), t.toMinutes() % 60, t.getSeconds() % 60,
+        docsPerMinute(numDocs, t.toMillis())));
+  }
+
+  private static RetryTemplate retryTemplate() {
+    RetryTemplate tmpl = new RetryTemplate();
+    ExponentialRandomBackOffPolicy backoff = new ExponentialRandomBackOffPolicy();
+    backoff.setMaxInterval(MAX_BACKOFF_INTERVAL_MS);
+    tmpl.setBackOffPolicy(backoff);
+    SimpleRetryPolicy retry = new SimpleRetryPolicy();
+    retry.setMaxAttempts(20);
+    tmpl.setRetryPolicy(retry);
+    tmpl.setThrowLastExceptionOnExhausted(true);
+    return tmpl;
+  }
+
+  private static double docsPerMinute(int processed, long elapsedMillis) {
+    return 60 * 1000 * (((double) processed ) / ((double) elapsedMillis));
   }
 
   public static LocalDate todayMinusYears(int years) {

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
@@ -104,7 +104,7 @@ public final class ElasticUtils {
             .source(doc.source));
       }
 
-      // Should block until there is room in the pool.
+      // Adds work to the pool, or runs this callback on the current thread if the queue is full.
       pool.submit(() -> {
         BulkResponse response;
         try {
@@ -127,7 +127,6 @@ public final class ElasticUtils {
         if (response.hasFailures()) {
           for (BulkItemResponse itemResp : response.getItems()) {
               if (itemResp.isFailed()) {
-                // TODO: Investigate retry handling or aggregate failures.
                 log.warning(itemResp.getFailureMessage());
                 numFails++;
               }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/elastic/CloudStorageShardedLineIterator.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/elastic/CloudStorageShardedLineIterator.java
@@ -4,8 +4,8 @@ import com.google.cloud.storage.Blob;
 import com.google.common.collect.Lists;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.channels.Channels;
+import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Queue;
@@ -61,6 +61,8 @@ public class CloudStorageShardedLineIterator implements Iterator<String> {
   }
 
   private BufferedReader openBlob(Blob b) {
-    return new BufferedReader(new InputStreamReader(Channels.newInputStream(b.reader())));
+    // Call to GCS are slow, so use a big 64MiB buffer to minimize total requests.
+    return new BufferedReader(
+        Channels.newReader(b.reader(), Charset.forName("UTF-8").newDecoder(), 64 << 20));
   }
 }


### PR DESCRIPTION
More scalable and reliable indexer implementation. Cuts indexing time down to ~2h from ~6.5h.

- Send concurrent indexing requests via a threadpool.
- Greatly increase buffering on reading from GCS (this was the primary bottleneck, actually)
- Add timing logs
- Add bulk insertion retries
- bugfix: Fix reading from BigQuery

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
