### PR TITLE
[RW-2111][risk=no]: Remove box shadow from environment label (displayTag)

### DIFF
--- a/ui/src/app/views/signed-in/component.css
+++ b/ui/src/app/views/signed-in/component.css
@@ -23,7 +23,6 @@
   font-size: 8px;
   line-height:12px;
   text-align: center;
-  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16);
 }
 
 .header-container {


### PR DESCRIPTION
Got an update from Lou to remove the box-shadow from the environment label (displayTag)