### PR TITLE
[RW-2414][risk=no] Fix field name mismatch in age_at_start

### DIFF
--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -9,7 +9,7 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181213",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "public20181213"
   },
   {
@@ -23,7 +23,7 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "synth_r_2019q1_2",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "synth_p_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -9,7 +9,7 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181213",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "public20181213"
   },
   {
@@ -23,7 +23,7 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "synth_r_2019q1_2",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "synth_p_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -9,7 +9,7 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181213",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "public20181213"
   },
   {
@@ -23,7 +23,7 @@
     "releaseNumber": 2,
     "numParticipants": 946237,
     "cdrDbName": "synth_r_2019q1_2",
-    "elasticIndexBaseName": "synth_r_2019q1_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1",
     "publicDbName": "synth_p_2019q1_1"
   }
 ]

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticUtils.java
@@ -51,7 +51,11 @@ public final class ElasticUtils {
     }
     client.indices().create(
           new CreateIndexRequest(indexName).mapping(
-              INDEX_TYPE, ImmutableMap.of("properties", ElasticDocument.PERSON_SCHEMA)),
+              INDEX_TYPE, ImmutableMap.of(
+                  // Do not allow new fields to appear in the mapping, this would indicate a
+                  // programming error.
+                  "dynamic", "strict",
+                  "properties", ElasticDocument.PERSON_SCHEMA)),
           REQ_OPTS);
     log.info("created person index: " + indexName);
   }

--- a/api/tools/src/main/resources/bigquery/es_person.sql
+++ b/api/tools/src/main/resources/bigquery/es_person.sql
@@ -29,7 +29,7 @@ LEFT JOIN (
     ARRAY_AGG(STRUCT( observation_concept_id AS concept_id,
         observation_source_concept_id AS source_concept_id,
         observation_date AS start_date,
-        DATE_DIFF(observation_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
+        DATE_DIFF(observation_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id)) observations
@@ -57,7 +57,7 @@ LEFT JOIN (
     ARRAY_AGG(STRUCT( condition_concept_id AS concept_id,
         condition_source_concept_id AS source_concept_id,
         condition_start_date AS start_date,
-        DATE_DIFF(condition_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
+        DATE_DIFF(condition_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id)) conditions
@@ -85,7 +85,7 @@ LEFT JOIN (
     ARRAY_AGG(STRUCT( drug_concept_id AS concept_id,
         drug_source_concept_id AS source_concept_id,
         drug_exposure_start_date AS start_date,
-        DATE_DIFF(drug_exposure_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
+        DATE_DIFF(drug_exposure_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id)) drugs
@@ -113,7 +113,7 @@ LEFT JOIN (
     ARRAY_AGG(STRUCT( procedure_concept_id AS concept_id,
         procedure_source_concept_id AS source_concept_id,
         procedure_date AS start_date,
-        DATE_DIFF(procedure_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
+        DATE_DIFF(procedure_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id)) procedures
@@ -141,7 +141,7 @@ LEFT JOIN (
     ARRAY_AGG(STRUCT( measurement_concept_id AS concept_id,
         measurement_source_concept_id AS source_concept_id,
         measurement_date AS start_date,
-        DATE_DIFF(measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start_date,
+        DATE_DIFF(measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         value_as_number,
         value_as_concept_id)) measurements


### PR DESCRIPTION
- Confirmed this new setting catches the regression we saw here.
- Reindexed and pointed to new indices (decided to restart the versioning suffix here at "1")

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
