### PR TITLE
API Server start speed up - take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,43 @@ Other available operations may be discovered by running:
 ./project.rb
 ```
 
+#### API: Faster API startup for MacOS
+The above steps for starting the API server can take upwards of 8-10 minutes on MacOS, most likely due to performance issues with Docker for Mac. Follow these steps to set up your developer environment to start the API server outside of docker. A full restart should take ~30 seconds with this method.
+
+All commands should be run from `workbench/api`
+
+##### Setup
+* Install Java 8
+* Add following to `~/.bash_profile`. Note: Your Java8 library directory may be different
+    * ```Shell
+      export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home
+      export OVERWRITE_WORKBENCH_DB_HOST=true
+      ```
+    * Source your bash profile or open a new terminal
+      ```Shell
+      source `~/.bash_profile`
+      ```
+* Install Java App Engine components
+    * ```Shell
+      gcloud components install app-engine-java
+      ```
+* Generate Google Cloud access token
+    * ```Shell
+      ./project.rb get-test-service-creds
+      ```
+
+##### Usage
+* If you have schema migrations or pending configuration updates, run through the [normal docker developer startup process](#api-dev-appengine-appserver) at least once successfully. This is typically only necessary when switching between branches.
+* Start services required for API server
+    * ```Shell
+      ./project.rb start-api-reqs
+      # the counterpart command is ./project.rb stop-api-reqs
+      ```
+* Start API server through gradle
+    * ```Shell
+      ./gradlew appengineRun
+      ```
+
 #### Hot Code Swapping
 
 While the API is running locally, saving a .java file should cause a recompile and reload of that class. Status is logged to the console. Not all changes reload correctly (e.g., model classes do not appear to reload more than once).

--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ All commands should be run from `workbench/api`
 
 ##### Setup
 * Install Java 8
-* Add following to `~/.bash_profile`. Note: Your Java8 library directory may be different
-    * ```Shell
+* Add following to `~/.bash_profile`. Note: 
+    * Your Java8 library directory may be different.  
+      YOUR_WORKBENCH_DIRECTORY_PATH is the pathname to your workbench git repo.
+      ```Shell
       export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home
-      export OVERWRITE_WORKBENCH_DB_HOST=true
+      export WORKBENCH_DIR=[YOUR_WORKBENCH_DIRECTORY_PATH]
+      source $WORKBENCH_DIR/api/db/load_vars.sh
       ```
     * Source your bash profile or open a new terminal
       ```Shell

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -158,8 +158,8 @@ task generateMoodleClient {
 }
 
 task generate_local_appengine_web_xml(type: Exec) {
-  executable "bash"
-  args "libproject/generate_appengine_web_xml.sh"
+  executable "ruby"
+  args "libproject/generate_appengine_web_xml.rb"
 }
 
 configurations {
@@ -275,6 +275,7 @@ compileGeneratedJava.dependsOn generateMoodleClient
 classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
 
+war.dependsOn compileGeneratedJava
 war.dependsOn generate_local_appengine_web_xml
 
 clean.doFirst {
@@ -438,6 +439,8 @@ appengine {  // App Engine tasks configuration
     // Give dev_appserver 2 minutes to start up when running appengineStart; by
     // default it will fail after 1 minute. (This is particularly a problem in CircleCI.)
     startSuccessTimeout = 120
+
+    environment = [GOOGLE_APPLICATION_CREDENTIALS: file("$rootDir/sa-key.json").getAbsolutePath()]
   }
 
   // dmohs: You may see this message [1], but don't implement the suggested fix because it breaks

--- a/api/db/load_vars.sh
+++ b/api/db/load_vars.sh
@@ -1,0 +1,11 @@
+for line in $(awk '!/^ *#/ && NF' $WORKBENCH_DIR/api/db/vars.env); do
+  IFS='=' read -r var val <<< "$line"
+
+  if [ "$var" == "DB_HOST" ]; then
+    export DB_HOST=localhost
+    continue
+  fi
+
+  evaluatedString=$(echo $(eval "echo $val"))
+  export $var=$evaluatedString
+done

--- a/api/db/load_vars.sh
+++ b/api/db/load_vars.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 for line in $(awk '!/^ *#/ && NF' $WORKBENCH_DIR/api/db/vars.env); do
   IFS='=' read -r var val <<< "$line"
 

--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -1,12 +1,14 @@
-# "db" hostname is established for the local docker network via docker-compose.yaml
-DB_CONNECTION_STRING=jdbc:mysql://db/workbench?useSSL=false
-CDR_DB_CONNECTION_STRING=jdbc:mysql://db/workbench?useSSL=false
-# TODO: change to public DB once it exists
-PUBLIC_DB_CONNECTION_STRING=jdbc:mysql://db/public?useSSL=false
 DB_DRIVER=com.mysql.jdbc.Driver
+# "db" hostname is established for the local docker network via docker-compose.yaml
 DB_HOST=db
 DB_PORT=3306
 DB_NAME=workbench
+
+DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
+CDR_DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
+# TODO: change to public DB once it exists
+PUBLIC_DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/public?useSSL=false
+
 LIQUIBASE_DB_USER=liquibase
 LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       - db/vars.env
     volumes:
       - db:/var/lib/mysql
+    ports:
+      - 3306:3306
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
     ports:

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -173,6 +173,7 @@ def dev_up()
     docker-compose run update-config
     -Pconfig_key=cdrBigQuerySchema -Pconfig_file=config/cdm/cdm_5_2.json
   }
+
   run_api()
 end
 
@@ -181,6 +182,35 @@ Common.register_command({
   :description => "Brings up the development environment, including db migrations and config " \
      "update. (You can use run-api instead if database and config are up-to-date.)",
   :fn => ->() { dev_up() }
+})
+
+def start_api_reqs()
+  common = Common.new
+  common.status "Starting database..."
+  common.run_inline %W{docker-compose up -d db}
+  common.status "Starting elastic..."
+  common.run_inline %W{docker-compose up -d elastic}
+end
+
+Common.register_command({
+  :invocation => "start-api-reqs",
+  :description => "Starts up the services required for the API server" \
+     "(assumes database and config are already up-to-date.)",
+  :fn => Proc.new { start_api_reqs() }
+})
+
+def stop_api_reqs()
+  common = Common.new
+  common.status "Stopping database..."
+  common.run_inline %W{docker-compose stop db}
+  common.status "Stopping elastic..."
+  common.run_inline %W{docker-compose stop elastic}
+end
+
+Common.register_command({
+  :invocation => "stop-api-reqs",
+  :description => "Stops the services required for the API server",
+  :fn => Proc.new { stop_api_reqs() }
 })
 
 def setup_local_environment()
@@ -220,6 +250,7 @@ def start_local_api()
   setup_local_environment
   common = Common.new
   common.status "Starting API server..."
+  ENV["OVERWRITE_WORKBENCH_DB_HOST"] = "true"
   common.run_inline %W{gradle appengineStart}
 end
 

--- a/api/libproject/generate_appengine_web_xml.rb
+++ b/api/libproject/generate_appengine_web_xml.rb
@@ -1,0 +1,26 @@
+def evaluate_env_vars(str, env)
+  env.each { |k, v| str.gsub! "$" + k, v }
+  return str
+end
+
+xml = File.read("src/main/webapp/WEB-INF/appengine-web.xml.template")
+
+env = {}
+for line in File.read("db/vars.env").split("\n").reject { |c| c.empty? }
+  line = line.strip()
+  if line[0] == '#'
+    next
+  end
+
+  var, val = line.split("=", 2)
+  if var == "DB_HOST" && ENV["OVERWRITE_WORKBENCH_DB_HOST"]
+    val = "localhost"
+  else
+    val = evaluate_env_vars(val, env)
+  end
+
+  env[var] = val
+  xml.gsub! "${#{var}}", val
+end
+
+File.write("src/main/webapp/WEB-INF/appengine-web.xml", xml)

--- a/api/libproject/generate_appengine_web_xml.rb
+++ b/api/libproject/generate_appengine_web_xml.rb
@@ -24,3 +24,6 @@ for line in File.read("db/vars.env").split("\n").reject { |c| c.empty? }
 end
 
 File.write("src/main/webapp/WEB-INF/appengine-web.xml", xml)
+
+puts "Generated appengine-web.xml"
+puts xml

--- a/api/libproject/generate_appengine_web_xml.rb
+++ b/api/libproject/generate_appengine_web_xml.rb
@@ -1,28 +1,5 @@
-def evaluate_env_vars(str, env)
-  env.each { |k, v| str.gsub! "$" + k, v }
-  return str
-end
-
 xml = File.read("src/main/webapp/WEB-INF/appengine-web.xml.template")
-
-env = {}
-for line in File.read("db/vars.env").split("\n").reject { |c| c.empty? }
-  line = line.strip()
-  if line[0] == '#'
-    next
-  end
-
-  var, val = line.split("=", 2)
-  if var == "DB_HOST" && ENV["OVERWRITE_WORKBENCH_DB_HOST"]
-    val = "localhost"
-  else
-    val = evaluate_env_vars(val, env)
-  end
-
-  env[var] = val
-  xml.gsub! "${#{var}}", val
-end
-
+ENV.each { |k, v| xml.gsub! "${#{k}}", v }
 File.write("src/main/webapp/WEB-INF/appengine-web.xml", xml)
 
 puts "Generated appengine-web.xml"

--- a/api/libproject/generate_appengine_web_xml.sh
+++ b/api/libproject/generate_appengine_web_xml.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-IFS=$'\n\t'
-
-envsubst < src/main/webapp/WEB-INF/appengine-web.xml.template \
-  > src/main/webapp/WEB-INF/appengine-web.xml


### PR DESCRIPTION
There was a bug with the first revision where the generate xml step would always use the vars from db/vars.env.

We now use the vars in the environment and added steps on how to load the db/vars.env to your local setup to the README