### PR TITLE
[risk=no] Fix dev-up

### DIFF
--- a/api/db/load_vars.sh
+++ b/api/db/load_vars.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This script will load the necessary environment variables into your environment
+# This needs to be run when starting our services without docker which has its own mechanisms
+# for loading environment variables.
+
 for line in $(awk '!/^ *#/ && NF' $WORKBENCH_DIR/api/db/vars.env); do
   IFS='=' read -r var val <<< "$line"
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -250,7 +250,6 @@ def start_local_api()
   setup_local_environment
   common = Common.new
   common.status "Starting API server..."
-  ENV["OVERWRITE_WORKBENCH_DB_HOST"] = "true"
   common.run_inline %W{gradle appengineStart}
 end
 

--- a/api/libproject/generate_appengine_web_xml.rb
+++ b/api/libproject/generate_appengine_web_xml.rb
@@ -1,5 +1,10 @@
 xml = File.read("src/main/webapp/WEB-INF/appengine-web.xml.template")
 ENV.each { |k, v| xml.gsub! "${#{k}}", v }
+
+# Hacky fix for interpolating environment variables inside the connection strings since docker
+# does not do it when loading environment files.
+xml.gsub! "$DB_HOST", ENV["DB_HOST"]
+
 File.write("src/main/webapp/WEB-INF/appengine-web.xml", xml)
 
 puts "Generated appengine-web.xml"


### PR DESCRIPTION
`./project-rb dev-up` is not currently working because docker does not interpolate environment variables when loading env files. The generate rb scrip makes up for this by adding another step to interpolate the DB_HOST variable.