### PR TITLE
[RW-2489][risk=no] Use original Workspace Name on Clone/Duplicate Workspace page

### DIFF
--- a/ui/src/app/views/workspace-edit/component.tsx
+++ b/ui/src/app/views/workspace-edit/component.tsx
@@ -311,7 +311,9 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         case WorkspaceEditMode.Edit:
           return 'Edit workspace \"' + this.state.workspace.name + '\"';
         case WorkspaceEditMode.Clone:
-          return 'Clone workspace \"' + this.state.workspace.name + '\"';
+          // use workspace name from props instead of state here
+          // because it's a record of the initial value
+          return 'Clone workspace \"' + this.props.workspace.name + '\"';
       }
     }
 

--- a/ui/src/app/views/workspace-edit/component.tsx
+++ b/ui/src/app/views/workspace-edit/component.tsx
@@ -318,7 +318,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     renderButtonText() {
       switch (this.props.routeConfigData.mode) {
         case WorkspaceEditMode.Create: return 'Create Workspace';
-        case WorkspaceEditMode.Edit: return 'Update Worspace';
+        case WorkspaceEditMode.Edit: return 'Update Workspace';
         case WorkspaceEditMode.Clone: return 'Duplicate Workspace';
       }
     }


### PR DESCRIPTION
<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
Use the `props` Workspace Name instead of the `state` Workspace Name in the header text, making it equal to the _fixed_ original name instead of the _editable_ cloned name.

Also fix a typo