### PR TITLE
[RW-2556][risk=no] return source or standard matches for list search

### DIFF
--- a/api/db-cdr/changelog-schema/db.changelog-27.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-27.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet author="brianfreeman" id="changelog-27">
+
+    <createIndex
+      indexName="idx_cb_criteria_code"
+      tableName="cb_criteria"
+      unique="false">
+      <column name="code"/>
+    </createIndex>
+
+  </changeSet>
+</databaseChangeLog>

--- a/api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -33,4 +33,5 @@
   <include file="changelog-schema/db.changelog-24.xml"/>
   <include file="changelog-schema/db.changelog-25.xml"/>
   <include file="changelog-schema/db.changelog-26.xml"/>
+  <include file="changelog-schema/db.changelog-27.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -293,7 +293,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     List<CBCriteria> criteriaList = new ArrayList<>();
     int resultLimit = Optional.ofNullable(limit).orElse(DEFAULT_CRITERIA_SEARCH_LIMIT).intValue();
     List<StandardProjection> projections = cbCriteriaDao.findStandardProjectionByCode(domain, term);
-    boolean isStandard = projections.isEmpty() || projections.get(0).getStandard() == true;
+    boolean isStandard = projections.isEmpty() || projections.get(0).getStandard();
     if (projections.isEmpty()) {
       criteriaList = cbCriteriaDao.findCriteriaByDomainAndSynonyms(domain, isStandard, modifyTermMatch(term), new PageRequest(0, resultLimit));
     }

--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -60,11 +60,6 @@ paths:
           required: true
           description: the term to search for
         - in: query
-          name: isStandard
-          type: boolean
-          required: true
-          description: specifies if search is standard or source
-        - in: query
           name: limit
           type: integer
           format: int64

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -29,7 +29,6 @@ import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
 import org.pmiops.workbench.model.TreeSubType;
-import org.pmiops.workbench.model.TreeType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -54,10 +53,6 @@ import static org.mockito.Mockito.when;
 @AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
 public class CohortBuilderControllerTest {
-
-  private static final String SUBTYPE_LAB = "LAB";
-  private static final String SUBTYPE_ATC = "ATC";
-  private static final String SUBTYPE_BRAND = "BRAND";
 
   private CohortBuilderController controller;
 
@@ -320,12 +315,66 @@ public class CohortBuilderControllerTest {
   }
 
   @Test
-  public void findCriteriaByDomainAndSearchTerm() throws Exception {
+  public void findCriteriaByDomainAndSearchTermMatchesSourceCode() throws Exception {
     CBCriteria criteria = new CBCriteria()
       .code("001")
       .count("10")
       .conceptId("123")
-      .domainId(DomainType.MEASUREMENT.toString())
+      .domainId(DomainType.CONDITION.toString())
+      .group(Boolean.TRUE)
+      .selectable(Boolean.TRUE)
+      .name("chol blah")
+      .parentId(0)
+      .type(CriteriaType.LOINC.toString())
+      .attribute(Boolean.FALSE)
+      .standard(false)
+      .synonyms("[rank1]");
+    cbCriteriaDao.save(criteria);
+
+    assertEquals(
+      createResponseCriteria(criteria),
+      controller
+        .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(), "001", null)
+        .getBody()
+        .getItems()
+        .get(0)
+    );
+  }
+
+  @Test
+  public void findCriteriaByDomainAndSearchTermMatchesStandardCode() throws Exception {
+    CBCriteria criteria = new CBCriteria()
+      .code("LP12")
+      .count("10")
+      .conceptId("123")
+      .domainId(DomainType.CONDITION.toString())
+      .group(Boolean.TRUE)
+      .selectable(Boolean.TRUE)
+      .name("chol blah")
+      .parentId(0)
+      .type(CriteriaType.LOINC.toString())
+      .attribute(Boolean.FALSE)
+      .standard(true)
+      .synonyms("[rank1]");
+    cbCriteriaDao.save(criteria);
+
+    assertEquals(
+      createResponseCriteria(criteria),
+      controller
+        .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(),"LP12",null)
+        .getBody()
+        .getItems()
+        .get(0)
+    );
+  }
+
+  @Test
+  public void findCriteriaByDomainAndSearchTermMatchesSynonyms() throws Exception {
+    CBCriteria criteria = new CBCriteria()
+      .code("001")
+      .count("10")
+      .conceptId("123")
+      .domainId(DomainType.CONDITION.toString())
       .group(Boolean.TRUE)
       .selectable(Boolean.TRUE)
       .name("chol blah")
@@ -334,12 +383,12 @@ public class CohortBuilderControllerTest {
       .attribute(Boolean.FALSE)
       .standard(true)
       .synonyms("LP12*\"[rank1]\"");
-    CBCriteria labMeasurement = cbCriteriaDao.save(criteria);
+    cbCriteriaDao.save(criteria);
 
     assertEquals(
-      createResponseCriteria(labMeasurement),
+      createResponseCriteria(criteria),
       controller
-        .findCriteriaByDomainAndSearchTerm(1L, DomainType.MEASUREMENT.name(),"LP12", true, null)
+        .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(),"LP12",null)
         .getBody()
         .getItems()
         .get(0)

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.cdr.dao;
 
 import org.pmiops.workbench.cdr.model.CBCriteria;
+import org.pmiops.workbench.cdr.model.StandardProjection;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -19,8 +20,18 @@ public interface CBCriteriaDao extends CrudRepository<CBCriteria, Long> {
   List<CBCriteria> findCriteriaByDomainAndTypeOrderByIdAsc(@Param("domain") String domain,
                                                            @Param("type") String type);
 
-  @Query(value = "select c from CBCriteria c where domainId=:domain and standard=:standard and match(synonyms, :term) > 0 order by c.count desc")
-  List<CBCriteria> findCriteriaByDomainAndSearchTerm(@Param("domain") String domain,
+  @Query(value = "select c.standard as standard from CBCriteria c where domainId=:domain and code=:term order by standard desc")
+  List<StandardProjection> findStandardProjectionByCode(@Param("domain") String domain,
+                                                        @Param("term") String term);
+
+  @Query(value = "select c from CBCriteria c where domainId=:domain and standard=:standard and code like upper(concat(:term,'%')) and match(synonyms, '+[rank1]') > 0 and c.count > 0 order by c.count desc")
+  List<CBCriteria> findCriteriaByDomainAndCode(@Param("domain") String domain,
+                                               @Param("standard") Boolean isStandard,
+                                               @Param("term") String term,
+                                               Pageable page);
+
+  @Query(value = "select c from CBCriteria c where domainId=:domain and standard=:standard and match(synonyms, :term) > 0 and c.count > 0 order by c.count desc")
+  List<CBCriteria> findCriteriaByDomainAndSynonyms(@Param("domain") String domain,
                                                      @Param("standard") Boolean isStandard,
                                                      @Param("term") String term,
                                                      Pageable page);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -32,9 +32,9 @@ public interface CBCriteriaDao extends CrudRepository<CBCriteria, Long> {
 
   @Query(value = "select c from CBCriteria c where domainId=:domain and standard=:standard and match(synonyms, :term) > 0 and c.count > 0 order by c.count desc")
   List<CBCriteria> findCriteriaByDomainAndSynonyms(@Param("domain") String domain,
-                                                     @Param("standard") Boolean isStandard,
-                                                     @Param("term") String term,
-                                                     Pageable page);
+                                                   @Param("standard") Boolean isStandard,
+                                                   @Param("term") String term,
+                                                   Pageable page);
 
   @Query(value = "select c from CBCriteria c where domainId=:domain and type=:type and hierarchy=1 and (match(synonyms, :modifiedTerm) > 0 or code like upper(concat(:term,'%'))) order by c.count desc")
   List<CBCriteria> findCriteriaByDomainAndTypeForCodeOrName(@Param("domain") String domain,

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/StandardProjection.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/StandardProjection.java
@@ -1,0 +1,5 @@
+package org.pmiops.workbench.cdr.model;
+
+public interface StandardProjection {
+  Boolean getStandard();
+}

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -115,7 +115,7 @@ export const ListSearch = withCurrentWorkspace()(
         this.setState({data: null, loading: true});
         const {wizard: {domain}, workspace: {cdrVersionId}} = this.props;
         cohortBuilderApi().findCriteriaByDomainAndSearchTerm(
-          +cdrVersionId, domain, event.target.value, true
+          +cdrVersionId, domain, event.target.value
         ).then(resp => {
           const data = resp.items.length ? resp.items : null;
           this.setState({data, loading: false});


### PR DESCRIPTION
3 cases:
1) if search term only matches source code then return list of source codes like search term
2) if search term matches both source/standard codes then return list of standard codes like search term
3) if search term does not match on code, then return list of standard synonyms like search term