### PR TITLE
[RW:2514][RISK:LOW] When sharing a workspace - clicking the cancel button causes the entire page to refresh

### DIFF
--- a/ui/src/app/views/workspace-share/component.tsx
+++ b/ui/src/app/views/workspace-share/component.tsx
@@ -253,6 +253,12 @@ export class WorkspaceShare extends React.Component<WorkspaceShareProps, Workspa
       });
   }
 
+  onCancel(): void {
+    // Reload the workspace to remove the temp added user/user roles in state variable workspace
+    this.reloadWorkspace();
+    this.props.onClose();
+  }
+
   removeCollaborator(user: UserRole): void {
     this.setState(({workspace}) => ({
       workspace: {...workspace,
@@ -470,7 +476,7 @@ export class WorkspaceShare extends React.Component<WorkspaceShareProps, Workspa
         </ModalBody>
         <ModalFooter>
             <Button type='secondary' style={{marginRight: '.8rem', border: 'none'}}
-                    onClick={() => this.props.onClose()}>Cancel</Button>
+                    onClick={() => this.onCancel()}>Cancel</Button>
             <Button data-test-id='save' disabled={!this.hasPermission}
                     onClick={() => this.save()}>Save</Button>
         </ModalFooter>
@@ -485,7 +491,7 @@ export class WorkspaceShare extends React.Component<WorkspaceShareProps, Workspa
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => this.reloadWorkspace()}>Reload Workspace</Button>
-          <Button onClick={() => this.props.onClose()}>Cancel Sharing</Button>
+          <Button onClick={() => this.onCancel()}>Cancel Sharing</Button>
         </ModalFooter>
       </Modal>}
     </React.Fragment>;

--- a/ui/src/app/views/workspace-wrapper/component.ts
+++ b/ui/src/app/views/workspace-wrapper/component.ts
@@ -120,8 +120,6 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
 
   closeShare(): void {
     this.sharing = false;
-    // TODO: RW-1919 - remove this
-    window.location.reload();
   }
 
   submitWorkspaceDeleteBugReport(): void {

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -189,8 +189,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
 
   closeShare(): void {
     this.sharing = false;
-    // TODO: RW-1919 - remove this
-    window.location.reload();
   }
 
   updateAclList(userRoleList: UserRole[]): void {


### PR DESCRIPTION
There already was a to-do at workspace component close to remove the reload, once workspace component is moved from angular - react.

The reload was done to refresh the userRole parameter inside Workspace object. This is solved by using the reloadWorkspace method inside workspace-share before emitting the closing event.
