### PR TITLE
[RW-2467][risk=no] Fix JPA issues with BillingProjectBufferEntry

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
@@ -6,8 +6,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 
 @Entity
+@Table(name ="billing_project_buffer_entry")
 public class BillingProjectBufferEntry {
 
   private long id;
@@ -49,6 +52,7 @@ public class BillingProjectBufferEntry {
     this.creationTime = creationTime;
   }
 
+  @Transient
   public BillingProjectBufferStatus getStatusEnum() {
     return StorageEnums.billingProjectBufferStatusFromStorage(status);
   }

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -63,13 +63,9 @@ public class BillingProjectBufferServiceTest {
   }
 
   @Autowired
-  private Clock clock;
-  @Autowired
   private BillingProjectBufferEntryDao billingProjectBufferEntryDao;
   @Autowired
   private FireCloudService fireCloudService;
-  @Autowired
-  private Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired
   private BillingProjectBufferService billingProjectBufferService;


### PR DESCRIPTION
Fixes the following exception on create - 
- Caused by: java.sql.SQLSyntaxErrorException: Unknown column 'statusEnum' in 'field list'

Fixes the following exception on getCurrentBufferSize() - 
- org.hibernate.hql.internal.ast.QuerySyntaxException: billing_project_buffer_entry is not mapped

One important question that we should look into... why did our tests not catch this? The tests go through both of these operations using a real Dao but they pass without these changes. These failures only come up when running it manually through the application.