### PR TITLE
[RW-2578] [risk=no] Additional logging for data access level changes and sync jobs.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -65,7 +65,6 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         errorCount++;
         log.severe(String.format("Error syncing compliance training status for user %s: %s",
             user.getEmail(), e.getMessage()));
-        return null;
       }
     }
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -49,6 +49,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
+
         if (newTime != oldTime) {
           log.info(String.format(
               "Compliance training completion changed for user %s. Old %s, new %s",

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -94,12 +94,11 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
     for (User user : userService.getAllUsers()) {
       try {
-        userService.syncEraCommonsStatusUsingImpersonation(user);
 
         Timestamp oldTime = user.getEraCommonsCompletionTime();
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 
-        User updatedUser = userService.syncTwoFactorAuthStatus(user);
+        User updatedUser = userService.syncEraCommonsStatusUsingImpersonation(user);
 
         Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
@@ -158,12 +157,12 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
         User updatedUser = userService.syncTwoFactorAuthStatus(user);
 
-        Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
+        Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
 
         if (newTime != oldTime) {
           log.info(String.format(
-              "Two-factor completion changed for user %s. Old %s, new %s",
+              "Two-factor auth completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));
           changeCount++;
         }
@@ -175,7 +174,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         }
       } catch (Exception e) {
         errorCount++;
-        log.severe(String.format("Error syncing 2FA status for user %s: %s",
+        log.severe(String.format("Error syncing two-factor auth status for user %s: %s",
                 user.getEmail(), e.getMessage()));
       }
     }
@@ -186,7 +185,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
     if (errorCount > 0) {
       throw new ServerErrorException(
-              String.format("%d errors encountered during 2FA sync", errorCount));
+              String.format("%d errors encountered during two-factor auth sync", errorCount));
     }
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -93,8 +93,8 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     int accessLevelChangeCount = 0;
 
     for (User user : userService.getAllUsers()) {
+      userCount++;
       try {
-
         Timestamp oldTime = user.getEraCommonsCompletionTime();
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -4,7 +4,6 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.DataAccessLevel;
-import org.pmiops.workbench.moodle.ApiException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.logging.Logger;
 
 /**

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.api;
 
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.User;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +49,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         User updatedUser = userService.syncComplianceTrainingStatus(user);
 
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
-        DataAccessLevel newLevel = user.getDataAccessLevelEnum();
+        DataAccessLevel newLevel = updatedUser.getDataAccessLevelEnum();
 
         if (newTime != oldTime) {
           log.info(String.format(
@@ -62,7 +63,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
               user.getEmail(), oldLevel.toString(), newLevel.toString()));
           accessLevelChangeCount++;
         }
-      } catch (Exception e) {
+      } catch (org.pmiops.workbench.moodle.ApiException | NotFoundException e) {
         errorCount++;
         log.severe(String.format("Error syncing compliance training status for user %s: %s",
             user.getEmail(), e.getMessage()));

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -28,6 +28,16 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     this.userService = userService;
   }
 
+  private boolean timestampsEqual(Timestamp a, Timestamp b) {
+    if (a != null) {
+      return a.equals(b);
+    } else if (b != null) {
+      return b.equals(a);
+    } else {
+      return a == b;
+    }
+  }
+
   /**
    * Updates moodle information for all users in the database.
    *
@@ -51,7 +61,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
         DataAccessLevel newLevel = updatedUser.getDataAccessLevelEnum();
 
-        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
+        if (!timestampsEqual(newTime, oldTime)) {
           log.info(String.format(
               "Compliance training completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));
@@ -105,7 +115,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
 
-        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
+        if (!timestampsEqual(newTime, oldTime)) {
           log.info(String.format(
               "eRA Commons completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));
@@ -162,7 +172,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
 
-        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
+        if (!timestampsEqual(newTime, oldTime)) {
           log.info(String.format(
               "Two-factor auth completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -51,7 +51,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
         DataAccessLevel newLevel = updatedUser.getDataAccessLevelEnum();
 
-        if (newTime != oldTime) {
+        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
           log.info(String.format(
               "Compliance training completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));
@@ -105,7 +105,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
 
-        if (newTime != oldTime) {
+        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
           log.info(String.format(
               "eRA Commons completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));
@@ -162,7 +162,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
 
-        if (newTime != oldTime) {
+        if (newTime != oldTime || (newTime != null && !newTime.equals(oldTime))) {
           log.info(String.format(
               "Two-factor auth completion changed for user %s. Old %s, new %s",
               user.getEmail(), oldTime, newTime));

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -421,11 +421,7 @@ public class UserService {
       List<BadgeDetails> badgeResponse = complianceService.getUserBadge(moodleId);
       // The assumption here is that the User will always get 1 badge which will be AoU
       if (badgeResponse != null && badgeResponse.size() > 0) {
-        // Only set the completion time if the existing time is null, because we don't want to
-        // overwrite an older completion time with the "now" value.
-        if (user.getComplianceTrainingCompletionTime() == null) {
-          user.setComplianceTrainingCompletionTime(now);
-        }
+        user.setComplianceTrainingCompletionTime(now);
 
         BadgeDetails badge = badgeResponse.get(0);
         if (badge.getDateexpire() == null) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -514,7 +514,7 @@ public class UserService {
         // We'll catch the NOT_FOUND ApiException here, since we expect many users to have an empty
         // eRA Commons linkage.
         log.info(String.format("NIH Status not found for user %s", user.getEmail()));
-        return null;
+        return user;
       } else {
         throw e;
       }

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -71,12 +72,15 @@ public class OfflineUserControllerTest {
 
   @Test
   public void testBulkSyncTrainingStatus() throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
+    // Mock out the service under test to simply return the passed user argument.
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatus(any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
     verify(userService, times(3)).syncComplianceTrainingStatus(any());
   }
 
   @Test(expected=ServerErrorException.class)
   public void testBulkSyncTrainingStatusWithSingleUserError() throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatus(any());
     doThrow(new org.pmiops.workbench.moodle.ApiException("Unknown error"))
         .when(userService).syncComplianceTrainingStatus(argThat(user -> user.getEmail().equals("a@fake-research-aou.org")));
     offlineUserController.bulkSyncComplianceTrainingStatus();
@@ -86,12 +90,14 @@ public class OfflineUserControllerTest {
 
   @Test
   public void testBulkSyncEraCommonsStatus() throws IOException, org.pmiops.workbench.firecloud.ApiException {
+    doAnswer(i -> i.getArgument(0)).when(userService).syncEraCommonsStatusUsingImpersonation(any());
     offlineUserController.bulkSyncEraCommonsStatus();
     verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any());
   }
 
   @Test(expected=ServerErrorException.class)
   public void testBulkSyncEraCommonsStatusWithSingleUserError() throws ApiException, NotFoundException, IOException, org.pmiops.workbench.firecloud.ApiException {
+    doAnswer(i -> i.getArgument(0)).when(userService).syncEraCommonsStatusUsingImpersonation(any());
     doThrow(new org.pmiops.workbench.firecloud.ApiException("Unknown error"))
         .when(userService).syncEraCommonsStatusUsingImpersonation(argThat(user -> user.getEmail().equals("a@fake-research-aou.org")));
     offlineUserController.bulkSyncEraCommonsStatus();


### PR DESCRIPTION
While digging into the past weekend's Terra incident (see RW-2578 for details) I found it was very hard to tell exactly how many times the workbench was making changes to the all-of-us-registered-prod group.

This PR adds some add'l logging which will help us more confidently assess how many changes are happening.