### PR TITLE
[RW-2392] [risk=no] Improve stability of access module completion timestamps

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -77,7 +77,6 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         errorCount++;
         log.severe(String.format("Error syncing compliance training status for user %s: %s",
             user.getEmail(), e.getMessage()));
-        return null;
       }
     }
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -77,6 +77,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         errorCount++;
         log.severe(String.format("Error syncing compliance training status for user %s: %s",
             user.getEmail(), e.getMessage()));
+        return null;
       }
     }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -421,11 +421,7 @@ public class UserService {
       List<BadgeDetails> badgeResponse = complianceService.getUserBadge(moodleId);
       // The assumption here is that the User will always get 1 badge which will be AoU
       if (badgeResponse != null && badgeResponse.size() > 0) {
-        // Only set the completion time if the existing time is null, because we don't want to
-        // overwrite an older completion time with the "now" value.
-        if (user.getComplianceTrainingCompletionTime() == null) {
-          user.setComplianceTrainingCompletionTime(now);
-        }
+        user.setComplianceTrainingCompletionTime(now);
 
         BadgeDetails badge = badgeResponse.get(0);
         if (badge.getDateexpire() == null) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -421,7 +421,11 @@ public class UserService {
       List<BadgeDetails> badgeResponse = complianceService.getUserBadge(moodleId);
       // The assumption here is that the User will always get 1 badge which will be AoU
       if (badgeResponse != null && badgeResponse.size() > 0) {
-        user.setComplianceTrainingCompletionTime(now);
+        // Only set the completion time if the existing time is null, because we don't want to
+        // overwrite an older completion time with the "now" value.
+        if (user.getComplianceTrainingCompletionTime() == null) {
+          user.setComplianceTrainingCompletionTime(now);
+        }
 
         BadgeDetails badge = badgeResponse.get(0);
         if (badge.getDateexpire() == null) {

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -796,7 +796,7 @@ definitions:
           type: object
       linkExpireTime:
         type: integer
-        description: The FireCloud-calculated expiration time
+        description: The FireCloud-calculated expiration time, in Epoch seconds
         format: int64
         default: 0
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -48,7 +48,7 @@ public class UserServiceTest {
 
   // An arbitrary timestamp to use as the anchor time for access module test cases.
   private static final long TIMESTAMP_MSECS = 100;
-  private static final FakeClock CLOCK = new FakeClock(Instant.ofEpochMilli(TIMESTAMP_MSECS));
+  private static final FakeClock CLOCK = new FakeClock();
 
   @Autowired
   private UserDao userDao;
@@ -67,6 +67,7 @@ public class UserServiceTest {
 
   @Before
   public void setUp() {
+    CLOCK.setInstant(Instant.ofEpochMilli(TIMESTAMP_MSECS));
     Provider<WorkbenchConfig> configProvider = Providers.of(WorkbenchConfig.createEmptyConfig());
     testUser = insertUser(EMAIL_ADDRESS);
 
@@ -102,6 +103,7 @@ public class UserServiceTest {
         new Timestamp(12345));
 
     // Completion timestamp should not change when the method is called again.
+    CLOCK.increment(1000);
     Timestamp completionTime = user.getComplianceTrainingCompletionTime();
     userService.syncComplianceTrainingStatus();
     assertThat(user.getComplianceTrainingCompletionTime()).isEqualTo(completionTime);
@@ -160,6 +162,7 @@ public class UserServiceTest {
     assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo("nih-user");
 
     // Completion timestamp should not change when the method is called again.
+    CLOCK.increment(1000);
     Timestamp completionTime = user.getEraCommonsCompletionTime();
     userService.syncEraCommonsStatus();
     assertThat(user.getEraCommonsCompletionTime()).isEqualTo(completionTime);
@@ -194,6 +197,7 @@ public class UserServiceTest {
     assertThat(user.getTwoFactorAuthCompletionTime()).isNotNull();
 
     // twoFactorAuthCompletionTime should not change when already set
+    CLOCK.increment(1000);
     Timestamp twoFactorAuthCompletionTime = user.getTwoFactorAuthCompletionTime();
     userService.syncTwoFactorAuthStatus();
     user = userDao.findUserByEmail(EMAIL_ADDRESS);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -100,6 +100,11 @@ public class UserServiceTest {
         new Timestamp(TIMESTAMP_MSECS));
     assertThat(user.getComplianceTrainingExpirationTime()).isEqualTo(
         new Timestamp(12345));
+
+    // Completion timestamp should not change when the method is called again.
+    Timestamp completionTime = user.getComplianceTrainingCompletionTime();
+    userService.syncComplianceTrainingStatus();
+    assertThat(user.getComplianceTrainingCompletionTime()).isEqualTo(completionTime);
   }
 
   @Test
@@ -140,7 +145,8 @@ public class UserServiceTest {
   public void testSyncEraCommonsStatus() throws Exception {
     NihStatus nihStatus = new NihStatus();
     nihStatus.setLinkedNihUsername("nih-user");
-    nihStatus.setLinkExpireTime(TIMESTAMP_MSECS + 1);
+    // FireCloud stores the NIH status in seconds, not msecs.
+    nihStatus.setLinkExpireTime(TIMESTAMP_MSECS / 1000);
 
     when(fireCloudService.getNihStatus()).thenReturn(nihStatus);
 
@@ -150,8 +156,13 @@ public class UserServiceTest {
     assertThat(user.getEraCommonsCompletionTime()).isEqualTo(
         new Timestamp(TIMESTAMP_MSECS));
     assertThat(user.getEraCommonsLinkExpireTime()).isEqualTo(
-        new Timestamp(TIMESTAMP_MSECS + 1));
+        new Timestamp(TIMESTAMP_MSECS / 1000));
     assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo("nih-user");
+
+    // Completion timestamp should not change when the method is called again.
+    Timestamp completionTime = user.getEraCommonsCompletionTime();
+    userService.syncEraCommonsStatus();
+    assertThat(user.getEraCommonsCompletionTime()).isEqualTo(completionTime);
   }
 
   @Test


### PR DESCRIPTION
While testing the cron jobs locally, I noticed that a couple of the sync processes were continually updating the "completionTime" for the given access module every time the sync ran. This stabilizes the completion times so they don't get updated for all users on every run.