### PR TITLE
[risk=no][RW-1974] Drop data browser services references from deploy scripts

### DIFF
--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -30,9 +30,7 @@ def get_live_gae_version(project, validate_version=true)
     exit 1
   end
 
-  # TODO(RW-1974): Remove public-* services.
-  wb_services = Set["api", "default"]
-  services = wb_services + Set["public-api", "public-ui"]
+  services = Set["api", "default"]
   actives = JSON.parse(versions).select{|v| v["traffic_split"] == 1.0}
   active_services = actives.map{|v| v["service"]}.to_set
   if actives.empty?
@@ -44,8 +42,7 @@ def get_live_gae_version(project, validate_version=true)
     return nil
   end
 
-  # TODO(RW-1974): Revert this filtering once public services are gone.
-  versions = actives.select{|v| wb_services.include?(v["service"])}.map{|v| v["id"]}.to_set
+  versions = actives.map{|v| v["id"]}.to_set
   if versions.length != 1
     common.warning "Found varying IDs across GAE services in project '#{project}': " +
                    "[#{versions.to_a.join(', ')}]"


### PR DESCRIPTION
Note: I've removed these services in all environments, deploys may fail by default in the meantime. This can be worked around by explicitly specifying `--app-version TAG --git-version TAG` to the deploy command.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
