### PR TITLE
[RW-2260][risk=no] Fix "Save As" URI encoding on shared workspaces

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -21,6 +21,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
@@ -51,7 +52,6 @@ public class ClusterController implements ClusterApiDelegate {
   // delocalization of saved files back to a given GCS location. See
   // https://github.com/DataBiosphere/leonardo/blob/develop/jupyter-docker/jupyter_delocalize.py#L12
   private static final String DELOCALIZE_CONFIG_FILENAME = ".delocalize.json";
-  public static final String WORKSPACE_DELIMITER = "__";
 
   // This file is used by the All of Us libraries to access workspace/CDR metadata.
   private static final String AOU_CONFIG_FILENAME = ".all_of_us_config.json";
@@ -205,11 +205,11 @@ public class ClusterController implements ClusterApiDelegate {
     );
     String workspacePath = body.getWorkspaceId();
     if (!projectName.equals(body.getWorkspaceNamespace())) {
-      workspacePath = body.getWorkspaceNamespace() + WORKSPACE_DELIMITER + body.getWorkspaceId();
+      workspacePath = body.getWorkspaceNamespace() + FireCloudServiceImpl.WORKSPACE_DELIMITER + body.getWorkspaceId();
     }
     String apiDir = "workspaces/" + workspacePath;
     if (body.getPlaygroundMode()) {
-      apiDir = "workspaces" + WORKSPACE_DELIMITER + "playground/" + workspacePath;
+      apiDir = "workspaces_playground/" + workspacePath;
     }
     String localDir = "~/" + apiDir;
 

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -21,7 +21,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
@@ -205,7 +204,7 @@ public class ClusterController implements ClusterApiDelegate {
     );
     String workspacePath = body.getWorkspaceId();
     if (!projectName.equals(body.getWorkspaceNamespace())) {
-      workspacePath = body.getWorkspaceNamespace() + FireCloudServiceImpl.WORKSPACE_DELIMITER + body.getWorkspaceId();
+      workspacePath = body.getWorkspaceNamespace() + FireCloudService.WORKSPACE_DELIMITER + body.getWorkspaceId();
     }
     String apiDir = "workspaces/" + workspacePath;
     if (body.getPlaygroundMode()) {

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -51,7 +51,7 @@ public class ClusterController implements ClusterApiDelegate {
   // delocalization of saved files back to a given GCS location. See
   // https://github.com/DataBiosphere/leonardo/blob/develop/jupyter-docker/jupyter_delocalize.py#L12
   private static final String DELOCALIZE_CONFIG_FILENAME = ".delocalize.json";
-  private static final String WORKSPACE_DELIMITER = "___";
+  public static final String WORKSPACE_DELIMITER = "__";
 
   // This file is used by the All of Us libraries to access workspace/CDR metadata.
   private static final String AOU_CONFIG_FILENAME = ".all_of_us_config.json";

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -51,6 +51,7 @@ public class ClusterController implements ClusterApiDelegate {
   // delocalization of saved files back to a given GCS location. See
   // https://github.com/DataBiosphere/leonardo/blob/develop/jupyter-docker/jupyter_delocalize.py#L12
   private static final String DELOCALIZE_CONFIG_FILENAME = ".delocalize.json";
+  private static final String WORKSPACE_DELIMITER = "___";
 
   // This file is used by the All of Us libraries to access workspace/CDR metadata.
   private static final String AOU_CONFIG_FILENAME = ".all_of_us_config.json";
@@ -204,11 +205,11 @@ public class ClusterController implements ClusterApiDelegate {
     );
     String workspacePath = body.getWorkspaceId();
     if (!projectName.equals(body.getWorkspaceNamespace())) {
-      workspacePath = body.getWorkspaceNamespace() + ":" + body.getWorkspaceId();
+      workspacePath = body.getWorkspaceNamespace() + WORKSPACE_DELIMITER + body.getWorkspaceId();
     }
     String apiDir = "workspaces/" + workspacePath;
     if (body.getPlaygroundMode()) {
-      apiDir = "workspaces:playground/" + workspacePath;
+      apiDir = "workspaces" + WORKSPACE_DELIMITER + "playground/" + workspacePath;
     }
     String localDir = "~/" + apiDir;
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -18,7 +18,8 @@ import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
  */
 public interface FireCloudService {
 
-  public static final String BIGQUERY_JOB_USER_GOOGLE_ROLE = "bigquery.jobUser";
+  String BIGQUERY_JOB_USER_GOOGLE_ROLE = "bigquery.jobUser";
+  String WORKSPACE_DELIMITER = "__";
 
   /**
    * @return true if firecloud is okay, false if firecloud is down.

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.firecloud;
 
-import static org.pmiops.workbench.api.ClusterController.WORKSPACE_DELIMITER;
-
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
@@ -43,6 +41,8 @@ import java.util.logging.Logger;
 @Service
 // TODO: consider retrying internally when FireCloud returns a 503
 public class FireCloudServiceImpl implements FireCloudService {
+
+  public static final String WORKSPACE_DELIMITER = "__";
   private static final Logger log = Logger.getLogger(FireCloudServiceImpl.class.getName());
 
   private final Provider<WorkbenchConfig> configProvider;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.firecloud;
 
+import static org.pmiops.workbench.api.ClusterController.WORKSPACE_DELIMITER;
+
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
@@ -192,6 +194,10 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public void createAllOfUsBillingProject(String projectName) {
+    if (projectName.contains(WORKSPACE_DELIMITER)) {
+      throw new RuntimeException("Attempting to create billing project with name that contains workspace delimiter : " + projectName);
+    }
+
     BillingApi billingApi = billingApiProvider.get();
     CreateRawlsBillingProjectFullRequest request = new CreateRawlsBillingProjectFullRequest();
     request.setBillingAccount("billingAccounts/"+configProvider.get().firecloud.billingAccountId);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -42,7 +42,6 @@ import java.util.logging.Logger;
 // TODO: consider retrying internally when FireCloud returns a 503
 public class FireCloudServiceImpl implements FireCloudService {
 
-  public static final String WORKSPACE_DELIMITER = "__";
   private static final Logger log = Logger.getLogger(FireCloudServiceImpl.class.getName());
 
   private final Provider<WorkbenchConfig> configProvider;
@@ -195,7 +194,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public void createAllOfUsBillingProject(String projectName) {
     if (projectName.contains(WORKSPACE_DELIMITER)) {
-      throw new RuntimeException("Attempting to create billing project with name that contains workspace delimiter : " + projectName);
+      throw new IllegalArgumentException("Attempting to create billing project with name that contains workspace delimiter : " + projectName);
     }
 
     BillingApi billingApi = billingApiProvider.get();

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -194,7 +194,9 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public void createAllOfUsBillingProject(String projectName) {
     if (projectName.contains(WORKSPACE_DELIMITER)) {
-      throw new IllegalArgumentException("Attempting to create billing project with name that contains workspace delimiter : " + projectName);
+      throw new IllegalArgumentException(
+          String.format("Attempting to create billing project with name (%s) that contains workspace delimiter (%s)",
+              projectName, WORKSPACE_DELIMITER));
     }
 
     BillingApi billingApi = billingApiProvider.get();

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -334,7 +334,7 @@ public class ClusterControllerTest {
     assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces_playground/wsid");
     verify(notebookService).localize(eq(WORKSPACE_NS), eq("cluster"), mapCaptor.capture());
     Map<String, String> localizeMap = mapCaptor.getValue();
-    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces:playground/wsid/.all_of_us_config.json"));
+    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces_playground/wsid/.all_of_us_config.json"));
     assertThat(aouJson.getString("WORKSPACE_ID")).isEqualTo(WORKSPACE_ID);
     assertThat(aouJson.getString("BILLING_CLOUD_PROJECT")).isEqualTo(WORKSPACE_NS);
     assertThat(aouJson.getString("API_HOST")).isEqualTo(API_HOST);

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -331,7 +331,7 @@ public class ClusterControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, LOGGED_IN_USER_EMAIL);
     ClusterLocalizeResponse resp =
       clusterController.localize(WORKSPACE_NS, "cluster", req).getBody();
-    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces" + WORKSPACE_DELIMITER + "playground/wsid");
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces_playground/wsid");
     verify(notebookService).localize(eq(WORKSPACE_NS), eq("cluster"), mapCaptor.capture());
     Map<String, String> localizeMap = mapCaptor.getValue();
     JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces:playground/wsid/.all_of_us_config.json"));

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.firecloud.FireCloudServiceImpl.WORKSPACE_DELIMITER;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
@@ -330,7 +331,7 @@ public class ClusterControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, LOGGED_IN_USER_EMAIL);
     ClusterLocalizeResponse resp =
       clusterController.localize(WORKSPACE_NS, "cluster", req).getBody();
-    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces:playground/wsid");
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces" + WORKSPACE_DELIMITER + "playground/wsid");
     verify(notebookService).localize(eq(WORKSPACE_NS), eq("cluster"), mapCaptor.capture());
     Map<String, String> localizeMap = mapCaptor.getValue();
     JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces:playground/wsid/.all_of_us_config.json"));
@@ -353,9 +354,9 @@ public class ClusterControllerTest {
 
     Map<String, String> localizeMap = mapCaptor.getValue();
     assertThat(localizeMap).containsEntry(
-        "~/workspaces/proj:wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb");
-    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/proj:wsid");
-    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces/proj:wsid/.all_of_us_config.json"));
+        "~/workspaces/proj" + WORKSPACE_DELIMITER + "wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb");
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/proj" + WORKSPACE_DELIMITER + "wsid");
+    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces/proj" + WORKSPACE_DELIMITER + "wsid/.all_of_us_config.json"));
     assertThat(aouJson.getString("BILLING_CLOUD_PROJECT")).isEqualTo("other-proj");
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.firecloud.FireCloudServiceImpl.WORKSPACE_DELIMITER;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
@@ -354,9 +353,9 @@ public class ClusterControllerTest {
 
     Map<String, String> localizeMap = mapCaptor.getValue();
     assertThat(localizeMap).containsEntry(
-        "~/workspaces/proj" + WORKSPACE_DELIMITER + "wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb");
-    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/proj" + WORKSPACE_DELIMITER + "wsid");
-    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces/proj" + WORKSPACE_DELIMITER + "wsid/.all_of_us_config.json"));
+        "~/workspaces/proj__wsid/foo.ipynb", "gs://workspace-bucket/notebooks/foo.ipynb");
+    assertThat(resp.getClusterLocalDirectory()).isEqualTo("workspaces/proj__wsid");
+    JSONObject aouJson = dataUriToJson(localizeMap.get("~/workspaces/proj__wsid/.all_of_us_config.json"));
     assertThat(aouJson.getString("BILLING_CLOUD_PROJECT")).isEqualTo("other-proj");
   }
 


### PR DESCRIPTION
Shared Workspaces cannot use "Save As" since the modal encodes the URI which turns our current delimiter `:` into characters that Jupyter doesn't decode correctly when it goes back to their API.

The solution is to change it into characters that do not get encoded. We chose `__`.