### PR TITLE
[RW-2373][risk=no] Add 'Show more' link for long names in review

### DIFF
--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -1,7 +1,7 @@
 import {Component, Input} from '@angular/core';
 import {ReviewDomainChartsComponent} from 'app/cohort-review/review-domain-charts/review-domain-charts';
 import {vocabOptions} from 'app/cohort-review/review-state.service';
-import {css} from 'app/cohort-review/review-utils/primeReactCss.utils';
+import {datatableStyles} from 'app/cohort-review/review-utils/primeReactCss.utils';
 import {TextInput} from 'app/components/inputs';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
@@ -17,6 +17,74 @@ import {OverlayPanel} from 'primereact/overlaypanel';
 import {TabPanel, TabView} from 'primereact/tabview';
 import * as React from 'react';
 
+const css = `
+  .name-container {
+    overflow: hidden;
+  }
+  .name-container:before {
+    content:"";
+    float: left;
+    width: 1px;
+    height: 100%;
+  }
+  .name-wrapper {
+    float: right;
+    width: 100%;
+    margin-left: -1px;
+  }
+  .name-content {
+    margin: 0;
+  }
+  .show-more {
+    box-sizing: content-box;
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    float: right;
+    position: relative;
+    margin-right: 1px;
+    text-align: right;
+  }
+  /* page specific styling */
+  .name-container {
+    height: 1.2rem;
+  }
+  .name-content {
+    /* it's critical to set a fixed font-size and line-height in order for
+    the ellipsis position to be predictable */
+    font-size: 12px;
+    line-height: 0.6rem;
+  }
+  .show-more {
+    /* set width of ellipsis.  width must equal margin-left */
+    width: 60px;
+    margin-left: -60px;
+    /* set ellipsis position */
+    bottom: 22px;
+    left: 201px;
+    /* add a gradient background */
+    background: -webkit-gradient(linear, left top, right top,
+      from(rgba(255, 255, 255, 0)), to(white), color-stop(50%, white));
+    background: -moz-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+    background: -o-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+    background: -ms-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+    background: linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+  }
+  /* make the ellipsis a link */
+  .ellipsis a {
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    height: 16px;
+    background-color: #ddd;
+    border-radius: 3px;
+    margin-right: 3px;
+    padding: 3px;
+    line-height: 5px;
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+  }
+`;
 
 const styles = reactStyles({
   container: {
@@ -255,11 +323,18 @@ export const DetailTabTable = withCurrentWorkspace()(
 
     overlayTemplate(rowData: any, column: any) {
       let vl: any;
-      const valueField = (rowData.refRange || rowData.unit ) && column.field === 'value';
+      const valueField = (rowData.refRange || rowData.unit) && column.field === 'value';
       const nameField = rowData.route && column.field === 'standardName';
-      return <div style={{position: 'relative'}}>
-        { column.field === 'value' && <span>{rowData.value}</span>}
-        { column.field === 'standardName' && <span>{rowData.standardName}</span>}
+      return <div className={column.field === 'standardName' ? 'name-container' : ''}
+        style={{position: 'relative'}}>
+        {column.field === 'value' && <span>{rowData.value}</span>}
+        {column.field === 'standardName' && <React.Fragment>
+          <div className='name-wrapper'>
+            <p className='name-content'>{rowData.standardName}</p>
+          </div>
+          <span className='show-more'>Show more</span>
+        </React.Fragment>
+        }
         {(valueField || nameField)
         && <i className='pi pi-caret-down' style={styles.caretIcon} onClick={(e) => vl.toggle(e)}/>}
         <OverlayPanel className='labOverlay' ref={(el) => vl = el}
@@ -617,7 +692,7 @@ export const DetailTabTable = withCurrentWorkspace()(
       });
 
       return <div style={styles.container}>
-        <style>{css}</style>
+        <style>{datatableStyles + css}</style>
         {filteredData && <DataTable
           expandedRows={this.state.expandedRows}
           onRowToggle={(e) => this.setState({expandedRows: e.data})}

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -291,31 +291,37 @@ export const DetailTabTable = withCurrentWorkspace()(
     }
 
     overlayTemplate(rowData: any, column: any) {
-      let vl: any;
+      let nl, vl: any;
       const valueField = (rowData.refRange || rowData.unit) && column.field === 'value';
       const nameField = rowData.route && column.field === 'standardName';
-      return <div className={column.field === 'standardName' ? 'name-container' : ''}
-        style={{position: 'relative'}}>
-        {column.field === 'value' && <span>{rowData.value}</span>}
-        {column.field === 'standardName' && <React.Fragment>
-          <div style={styles.nameWrapper}>
-            <p style={styles.nameContent}>{rowData.standardName}</p>
+      return <React.Fragment>
+        <div style={{position: 'relative'}}>
+          {column.field === 'value' && <span>{rowData.value}</span>}
+          {column.field === 'standardName' && <div className='name-container'>
+            <div style={styles.nameWrapper}>
+              <p style={styles.nameContent}>{rowData.standardName}</p>
+            </div>
+            <span style={styles.showMore} onClick={(e) => nl.toggle(e)}>Show more</span>
+            <OverlayPanel className='labOverlay' ref={(el) => nl = el}
+                          showCloseIcon={true} dismissable={true}>
+              <div style={{paddingBottom: '0.2rem'}}>{rowData.standardName}</div>
+            </OverlayPanel>
           </div>
-          <span style={styles.showMore}>Show more</span>
-        </React.Fragment>
-        }
-        {(valueField || nameField)
-        && <i className='pi pi-caret-down' style={styles.caretIcon} onClick={(e) => vl.toggle(e)}/>}
-        <OverlayPanel className='labOverlay' ref={(el) => vl = el}
-                      showCloseIcon={true} dismissable={true}>
-          {(rowData.refRange &&  column.field === 'value') &&
-          <div style={{paddingBottom: '0.2rem'}}>Reference Range: {rowData.refRange}</div>}
-          {(rowData.unit && column.field === 'value') &&
-          <div>Units: {rowData.unit}</div>}
-          {nameField &&
-          <div>Route: {rowData.route}</div>}
-        </OverlayPanel>
-      </div>;
+          }
+          {(valueField || nameField)
+          && <i className='pi pi-caret-down' style={styles.caretIcon}
+              onClick={(e) => vl.toggle(e)}/>}
+          <OverlayPanel className='labOverlay' ref={(el) => vl = el}
+                        showCloseIcon={true} dismissable={true}>
+            {(rowData.refRange &&  column.field === 'value') &&
+            <div style={{paddingBottom: '0.2rem'}}>Reference Range: {rowData.refRange}</div>}
+            {(rowData.unit && column.field === 'value') &&
+            <div>Units: {rowData.unit}</div>}
+            {nameField &&
+            <div>Route: {rowData.route}</div>}
+          </OverlayPanel>
+        </div>
+      </React.Fragment>;
     }
 
     updateData = (event, colName, namesArray) => {

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -602,6 +602,7 @@ export const DetailTabTable = withCurrentWorkspace()(
       </TabView>
       </React.Fragment>;
     }
+
     hideGraphIcon = (rowData: any) => {
       const {filterState: {vocab}} = this.props;
       const noConcept = rowData[`${vocab}Name`]

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -290,21 +290,22 @@ export const DetailTabTable = withCurrentWorkspace()(
       this.setState({start: event.first});
     }
 
-    overlayTemplate(rowData: any, column: any) {
-      let nl, vl: any;
+    overlayTemplate = (rowData: any, column: any) => {
+      let nl: any, vl: any;
+      const {filterState: {vocab}} = this.props;
       const valueField = (rowData.refRange || rowData.unit) && column.field === 'value';
-      const nameField = rowData.route && column.field === 'standardName';
+      const nameField = rowData.route && column.field === `${vocab}Name`;
       return <React.Fragment>
         <div style={{position: 'relative'}}>
           {column.field === 'value' && <span>{rowData.value}</span>}
-          {column.field === 'standardName' && <div className='name-container'>
+          {column.field === `${vocab}Name` && <div className='name-container'>
             <div style={styles.nameWrapper}>
-              <p style={styles.nameContent}>{rowData.standardName}</p>
+              <p style={styles.nameContent}>{rowData[`${vocab}Name`]}</p>
             </div>
             <span style={styles.showMore} onClick={(e) => nl.toggle(e)}>Show more</span>
             <OverlayPanel className='labOverlay' ref={(el) => nl = el}
                           showCloseIcon={true} dismissable={true}>
-              <div style={{paddingBottom: '0.2rem'}}>{rowData.standardName}</div>
+              <div style={{paddingBottom: '0.2rem'}}>{rowData[`${vocab}Name`]}</div>
             </OverlayPanel>
           </div>
           }
@@ -578,12 +579,13 @@ export const DetailTabTable = withCurrentWorkspace()(
 
     rowExpansionTemplate = (rowData: any) => {
       const {data} = this.state;
+      const {filterState: {vocab}} = this.props;
       const conceptIdBasedData = fp.groupBy('standardConceptId', data);
       const unitsObj = fp.groupBy( 'unit', conceptIdBasedData[rowData.standardConceptId]);
       const unitKey = Object.keys(unitsObj);
       let valueArray;
       return <React.Fragment>
-        <div style={styles.headerStyle}>{rowData.standardName}</div>
+        <div style={styles.headerStyle}>{rowData[`${vocab}Name`]}</div>
       <TabView className='unitTab'>
         {unitKey.map((k, i) => {
           const name = k === 'null' ? 'No Unit' : k;
@@ -601,12 +603,15 @@ export const DetailTabTable = withCurrentWorkspace()(
       </React.Fragment>;
     }
     hideGraphIcon = (rowData: any) => {
-      const noConcept = rowData.standardName && rowData.standardName === 'No matching concept';
+      const {filterState: {vocab}} = this.props;
+      const noConcept = rowData[`${vocab}Name`]
+        && rowData[`${vocab}Name`] === 'No matching concept';
       return {'graphExpander' : noConcept};
     }
 
     render() {
       const {filteredData, loading, start, sortField, sortOrder} = this.state;
+      const {filterState: {vocab}, tabName} = this.props;
       let pageReportTemplate;
       if (filteredData !== null) {
         const lastRowOfPage = (start + rows) > filteredData.length
@@ -620,7 +625,7 @@ export const DetailTabTable = withCurrentWorkspace()(
       const columns = this.props.columns.map((col) => {
         const asc = sortField === col.name && sortOrder === 1;
         const desc = sortField === col.name && sortOrder === -1;
-        const colName = col.name === 'value' || col.name === 'standardName';
+        const colName = col.name === 'value' || col.name === `${vocab}Name`;
         const hasCheckboxFilter = [
           'domain',
           'sourceVocabulary',
@@ -639,7 +644,7 @@ export const DetailTabTable = withCurrentWorkspace()(
           'survey'
         ].includes(col.name);
         const isExpanderNeeded = col.name === 'graph' &&
-          (this.props.tabName === 'Vitals' || this.props.tabName === 'Labs');
+          (tabName === 'Vitals' || tabName === 'Labs');
         const overlayTemplate = colName && this.overlayTemplate;
         const header = <React.Fragment>
           <span

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -20,69 +20,13 @@ import * as React from 'react';
 const css = `
   .name-container {
     overflow: hidden;
+    height: 1.2rem;
   }
   .name-container:before {
     content:"";
     float: left;
     width: 1px;
     height: 100%;
-  }
-  .name-wrapper {
-    float: right;
-    width: 100%;
-    margin-left: -1px;
-  }
-  .name-content {
-    margin: 0;
-  }
-  .show-more {
-    box-sizing: content-box;
-    -webkit-box-sizing: content-box;
-    -moz-box-sizing: content-box;
-    float: right;
-    position: relative;
-    margin-right: 1px;
-    text-align: right;
-  }
-  /* page specific styling */
-  .name-container {
-    height: 1.2rem;
-  }
-  .name-content {
-    /* it's critical to set a fixed font-size and line-height in order for
-    the ellipsis position to be predictable */
-    font-size: 12px;
-    line-height: 0.6rem;
-  }
-  .show-more {
-    /* set width of ellipsis.  width must equal margin-left */
-    width: 60px;
-    margin-left: -60px;
-    /* set ellipsis position */
-    bottom: 22px;
-    left: 201px;
-    /* add a gradient background */
-    background: -webkit-gradient(linear, left top, right top,
-      from(rgba(255, 255, 255, 0)), to(white), color-stop(50%, white));
-    background: -moz-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
-    background: -o-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
-    background: -ms-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
-    background: linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
-  }
-  /* make the ellipsis a link */
-  .ellipsis a {
-    text-decoration: none;
-    display: inline-block;
-    font-size: 16px;
-    height: 16px;
-    background-color: #ddd;
-    border-radius: 3px;
-    margin-right: 3px;
-    padding: 3px;
-    line-height: 5px;
-    box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
   }
 `;
 
@@ -183,6 +127,31 @@ const styles = reactStyles({
     lineHeight: '1.25rem',
     opacity: 0.5,
   },
+  nameWrapper: {
+    float: 'right',
+    width: '100%',
+    marginLeft: '-1px',
+  },
+  nameContent: {
+    margin: 0,
+    fontSize: '12px',
+    lineHeight: '0.6rem',
+  },
+  showMore: {
+    width: '70px',
+    marginLeft: '-80px',
+    bottom: '14px',
+    left: '100%',
+    background: '#ffffff',
+    color: '#2691d0',
+    boxSizing: 'content-box',
+    float: 'right',
+    position: 'relative',
+    marginRight: '1px',
+    paddingLeft: '10px',
+    textAlign: 'left',
+    cursor: 'pointer',
+  }
 });
 const filterIcons = {
   active: {
@@ -329,10 +298,10 @@ export const DetailTabTable = withCurrentWorkspace()(
         style={{position: 'relative'}}>
         {column.field === 'value' && <span>{rowData.value}</span>}
         {column.field === 'standardName' && <React.Fragment>
-          <div className='name-wrapper'>
-            <p className='name-content'>{rowData.standardName}</p>
+          <div style={styles.nameWrapper}>
+            <p style={styles.nameContent}>{rowData.standardName}</p>
           </div>
-          <span className='show-more'>Show more</span>
+          <span style={styles.showMore}>Show more</span>
         </React.Fragment>
         }
         {(valueField || nameField)

--- a/ui/src/app/cohort-review/review-utils/primeReactCss.utils.ts
+++ b/ui/src/app/cohort-review/review-utils/primeReactCss.utils.ts
@@ -1,4 +1,4 @@
-export const css = `
+export const datatableStyles = `
   body .p-datatable .p-sortable-column:not(.p-highlight):hover,
   body .p-datatable .p-sortable-column.p-highlight {
     color: #333333;

--- a/ui/src/app/cohort-review/review-utils/primeReactCss.utils.ts
+++ b/ui/src/app/cohort-review/review-utils/primeReactCss.utils.ts
@@ -70,8 +70,8 @@ export const datatableStyles = `
     color: #0086C1;
   }
   body .labOverlay.p-overlaypanel {
-    top: 19px!important;
-    left: 0px!important;
+    top: 1.25rem!important;
+    left: -2.75rem!important;
     width:9.5rem;
   }
   body .labOverlay.p-overlaypanel .p-overlaypanel-close:hover {

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -8,7 +8,7 @@ import {
   multiOptions,
   vocabOptions
 } from 'app/cohort-review/review-state.service';
-import {css} from 'app/cohort-review/review-utils/primeReactCss.utils';
+import {datatableStyles} from 'app/cohort-review/review-utils/primeReactCss.utils';
 import {Button} from 'app/components/buttons';
 import {TextInput} from 'app/components/inputs';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -545,7 +545,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
           sortable/>;
       });
       return <div>
-        <style>{css}</style>
+        <style>{datatableStyles}</style>
         {!cohortDescription && <React.Fragment>
           <button
             style={styles.backBtn}

--- a/ui/src/app/views/dataset-page/component.spec.tsx
+++ b/ui/src/app/views/dataset-page/component.spec.tsx
@@ -1,6 +1,7 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 
+import {Button} from 'app/components/buttons';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
 import {DataSetPage} from 'app/views/dataset-page/component';
@@ -8,10 +9,10 @@ import {WorkspaceAccessLevel} from 'generated';
 import {CohortsApi, ConceptsApi, ConceptSetsApi, DataSet} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {CohortsApiStub, exampleCohortStubs} from 'testing/stubs/cohorts-api-stub';
-import {ConceptsApiStub} from 'testing/stubs/concepts-api-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
-import {WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
+import {ConceptsApiStub} from 'testing/stubs/concepts-api-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
+import {WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
 
 describe('DataSet', () => {
   beforeEach(() => {
@@ -51,5 +52,56 @@ describe('DataSet', () => {
       .toBe(exampleCohortStubs.length);
   });
 
+  it('should display values based on Domain of Concept selected in workspace', async() => {
+    const wrapper = mount(<DataSetPage />);
+    await waitOneTickAndUpdate(wrapper);
+    await waitOneTickAndUpdate(wrapper);
 
+    // First Concept set in concept set list has domain "Condition"
+    const condition_concept = wrapper.find('[data-test-id="concept-set-list-item"]').first()
+        .find('input').first();
+    condition_concept.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="value-list-items"]').length).toBe(2);
+
+    // Second Concept set in concept set list has domain "Measurement"
+    const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
+        .find('input').first();
+    measurement_concept.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="value-list-items"]').length).toBe(5);
+  });
+
+  it('should enable all buttons once cohorts, concepts and values are selected', async() => {
+    const wrapper = mount(<DataSetPage />);
+    await waitOneTickAndUpdate(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Preview Button by default should be disabled
+    const previewButton = wrapper.find(Button).find('[data-test-id="preview-button"]')
+        .first();
+    expect(previewButton.prop('disabled')).toBeTruthy();
+
+    // After all cohort concept and values are selected all the buttons will be enabled
+
+    wrapper.find('[data-test-id="cohort-list-item"]').first()
+      .find('input').first().simulate('click');
+    wrapper.update();
+
+    wrapper.find('[data-test-id="concept-set-list-item"]').first()
+      .find('input').first().simulate('click');
+
+    await waitOneTickAndUpdate(wrapper);
+
+    wrapper.find('[data-test-id="value-list-items"]').find('input').first()
+      .simulate('change');
+
+    // Buttons should now be enabled
+    const buttons = wrapper.find(Button);
+    expect(buttons.find('[data-test-id="preview-button"]').first().prop('disabled'))
+      .toBeFalsy();
+    expect(buttons.find('[data-test-id="save-button"]').first().prop('disabled'))
+      .toBeFalsy();
+  });
 });

--- a/ui/src/app/views/dataset-page/component.tsx
+++ b/ui/src/app/views/dataset-page/component.tsx
@@ -84,8 +84,7 @@ export const ValueListItem: React.FunctionComponent <
   ({domainValue, onSelect, checked}) => {
     return <div style={{display: 'flex', color: 'black', height: '1.2rem'}}>
       <input type='checkbox' value={domainValue.value} onChange={() => onSelect()}
-             style={styles.valueListItemCheckboxStyling}
-             checked={checked}/>
+             style={styles.valueListItemCheckboxStyling} checked={checked}/>
       <div style={{lineHeight: '1.5rem', wordWrap: 'break-word'}}>{domainValue.value}</div>
     </div>;
   };
@@ -528,7 +527,7 @@ const DataSetPage = withCurrentWorkspace()(class extends React.Component<Props, 
                         {fp.capitalize(valueSet.domain.toString())}
                       </div>
                       {valueSet.values.items.map(domainValue =>
-                        <ValueListItem data-test-id='value-items'
+                        <ValueListItem data-test-id='value-list-items'
                           key={domainValue.value} domainValue={domainValue}
                           onSelect={() => this.selectDomainValue(valueSet.domain, domainValue)}
                           checked={fp.some({domain: valueSet.domain, value: domainValue.value},
@@ -548,13 +547,14 @@ const DataSetPage = withCurrentWorkspace()(class extends React.Component<Props, 
             position: 'relative'}}>
             <div style={{color: '#000000', fontSize: '14px'}}>A visualization
               of your data table based on the variable and value you selected above</div>
-            <Button style={{position: 'absolute', right: '8rem', top: '0.25rem'}}
+            <Button data-test-id='preview-button' style={{position: 'absolute', right: '8rem',
+              top: '0.25rem'}}
                     disabled={this.disableSave()} onClick={() => {this.getPreviewList(); }}>
               PREVIEW DATA SET
             </Button>
-            <Button style={{position: 'absolute', right: '1rem', top: '.25rem'}}
-                    onClick ={() => this.setState({openSaveModal: true})}
-                    disabled={this.disableSave()}>
+            <Button data-test-id='save-button' style={{position: 'absolute', right: '1rem',
+              top: '.25rem'}} onClick ={() => this.setState({openSaveModal: true})}
+              disabled={this.disableSave()}>
               SAVE DATA SET
             </Button>
           </div>

--- a/ui/src/testing/stubs/concepts-api-stub.ts
+++ b/ui/src/testing/stubs/concepts-api-stub.ts
@@ -1,14 +1,15 @@
 import {
   Concept,
   ConceptListResponse,
+  ConceptsApi,
   Domain,
   DomainCount,
   DomainInfo,
   DomainInfoResponse,
+  DomainValuesResponse,
   SearchConceptsRequest,
   StandardConceptFilter
 } from 'generated/fetch';
-import {ConceptsApi} from 'generated/fetch/api';
 
 export class ConceptStubVariables {
   static STUB_CONCEPTS: Concept[] = [
@@ -171,6 +172,26 @@ export class ConceptsApiStub extends ConceptsApi {
       });
       resolve(response);
     });
+  }
+
+  public getValuesFromDomain(workspaceNamespace: string, workspaceId: string, domain: string)
+  : Promise<DomainValuesResponse> {
+    const domainValueItems = [];
+    switch (domain) {
+      case 'CONDITION':
+        domainValueItems.push({value: 'Condition1'});
+        domainValueItems.push({value: 'Condition2'});
+        break;
+      case 'MEASUREMENT':
+        domainValueItems.push({value: 'Measurement1'});
+        domainValueItems.push({value: 'Measurement2'});
+        domainValueItems.push({value: 'Measurement3'});
+        break;
+      case 'DRUG':
+        domainValueItems.push({value: 'Drug1'});
+        break;
+    }
+    return Promise.resolve({items: domainValueItems});
   }
 
 }


### PR DESCRIPTION
Restrict names in the participant detail table in review to 2 lines. If the text overflows, show a 'Show more' link that displays an overlay with the full text when clicked.

<img width="639" alt="Screen Shot 2019-05-10 at 8 59 00 AM" src="https://user-images.githubusercontent.com/40036095/57538266-ac0fda80-730d-11e9-91a8-91eb1ec94043.png">
