### PR TITLE
[RW-2622][risk=no] Add consume project to Billing Project Buffer API

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -30,10 +30,10 @@ public class BillingProjectBufferService {
   private static final int PROJECT_BILLING_ID_SIZE = 8;
   private static final Logger log = Logger.getLogger(BillingProjectBufferService.class.getName());
 
-  private BillingProjectBufferEntryDao billingProjectBufferEntryDao;
-  private Clock clock;
-  private FireCloudService fireCloudService;
-  private Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final BillingProjectBufferEntryDao billingProjectBufferEntryDao;
+  private final Clock clock;
+  private final FireCloudService fireCloudService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired
   public BillingProjectBufferService(BillingProjectBufferEntryDao billingProjectBufferEntryDao,
@@ -109,6 +109,7 @@ public class BillingProjectBufferService {
   }
 
   private BillingProjectBufferEntry consumeBufferEntryForAssignment() {
+    // Each call to acquire the lock will timeout in 1s if it is currently held
     while (billingProjectBufferEntryDao.acquireAssigningLock() != 1) {}
 
     BillingProjectBufferEntry entry;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
@@ -15,5 +15,7 @@ public interface BillingProjectBufferEntryDao  extends CrudRepository<BillingPro
 
   BillingProjectBufferEntry findFirstByStatusOrderByLastSyncRequestTimeAsc(short status);
 
+  BillingProjectBufferEntry findFirstByStatusOrderByCreationTimeAsc(short status);
+
   Long countByStatus(short status);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BillingProjectBufferEntryDao  extends CrudRepository<BillingProjectBufferEntry, Long> {
 
+  String ASSIGNING_LOCK = "ASSIGNING_LOCK";
+
   BillingProjectBufferEntry findByFireCloudProjectName(String fireCloudProjectName);
 
   @Query("SELECT COUNT(*) FROM BillingProjectBufferEntry WHERE status IN (0, 2)")
@@ -18,4 +20,10 @@ public interface BillingProjectBufferEntryDao  extends CrudRepository<BillingPro
   BillingProjectBufferEntry findFirstByStatusOrderByCreationTimeAsc(short status);
 
   Long countByStatus(short status);
+
+  @Query(value = "SELECT GET_LOCK('" + ASSIGNING_LOCK + "', 1)", nativeQuery = true)
+  int acquireAssigningLock();
+
+  @Query(value = "SELECT RELEASE_LOCK('" + ASSIGNING_LOCK + "')", nativeQuery = true)
+  int releaseAssigningLock();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
@@ -6,6 +6,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -18,6 +20,7 @@ public class BillingProjectBufferEntry {
   private Timestamp creationTime;
   private Timestamp lastSyncRequestTime;
   private Short status;
+  private User assignedUser;
 
   public enum BillingProjectBufferStatus {
     CREATING, // Sent a request to FireCloud to create a BillingProject. Status of BillingProject is TBD
@@ -59,6 +62,15 @@ public class BillingProjectBufferEntry {
   }
   public void setLastSyncRequestTime(Timestamp lastSyncRequestTime) {
     this.lastSyncRequestTime = lastSyncRequestTime;
+  }
+
+  @ManyToOne
+  @JoinColumn(name="assigned_user_id")
+  public User getAssignedUser() {
+    return assignedUser;
+  }
+  public void setAssignedUser(User assignedUser) {
+    this.assignedUser = assignedUser;
   }
 
   @Transient

--- a/api/src/test/java/org/pmiops/workbench/CallsRealMethodsWithDelay.java
+++ b/api/src/test/java/org/pmiops/workbench/CallsRealMethodsWithDelay.java
@@ -1,0 +1,19 @@
+package org.pmiops.workbench;
+
+import org.mockito.internal.stubbing.answers.CallsRealMethods;
+import org.mockito.invocation.InvocationOnMock;
+
+public class CallsRealMethodsWithDelay extends CallsRealMethods {
+
+  private final long delay;
+
+  public CallsRealMethodsWithDelay(long delay) {
+    this.delay = delay;
+  }
+
+  public Object answer(InvocationOnMock invocation) throws Throwable {
+    Thread.sleep(delay);
+    return super.answer(invocation);
+  }
+
+}

--- a/api/src/test/java/org/pmiops/workbench/TestLock.java
+++ b/api/src/test/java/org/pmiops/workbench/TestLock.java
@@ -1,0 +1,25 @@
+package org.pmiops.workbench;
+
+public class TestLock {
+  private boolean locked = false;
+
+  public TestLock() {}
+
+  public int lock() {
+    if (locked) {
+      return 0;
+    }
+
+    locked = true;
+    return 1;
+  }
+
+  public int release() {
+    if (locked) {
+      locked = false;
+      return 1;
+    }
+
+    return 0;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/TestLock.java
+++ b/api/src/test/java/org/pmiops/workbench/TestLock.java
@@ -1,24 +1,29 @@
 package org.pmiops.workbench;
 
 public class TestLock {
-  
+
   private boolean locked = false;
 
   public int lock() {
-    if (locked) {
-      return 0;
-    }
+    synchronized (this) {
+      if (locked) {
+        return 0;
+      }
 
-    locked = true;
-    return 1;
-  }
-
-  public int release() {
-    if (locked) {
-      locked = false;
+      locked = true;
       return 1;
     }
-
-    return 0;
   }
+
+  synchronized public int release() {
+    synchronized (this) {
+      if (locked) {
+        locked = false;
+        return 1;
+      }
+
+      return 0;
+    }
+  }
+
 }

--- a/api/src/test/java/org/pmiops/workbench/TestLock.java
+++ b/api/src/test/java/org/pmiops/workbench/TestLock.java
@@ -1,9 +1,8 @@
 package org.pmiops.workbench;
 
 public class TestLock {
+  
   private boolean locked = false;
-
-  public TestLock() {}
 
   public int lock() {
     if (locked) {

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -56,7 +56,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -55,6 +55,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -351,6 +354,7 @@ public class BillingProjectBufferServiceTest {
 
   @Test
   @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
   public void assignBillingProject_locking() throws InterruptedException, ExecutionException {
     BillingProjectBufferEntry firstEntry = new BillingProjectBufferEntry();
     firstEntry.setStatusEnum(AVAILABLE);
@@ -386,12 +390,6 @@ public class BillingProjectBufferServiceTest {
 
     assertThat(futures.get(0).get().getFireCloudProjectName())
         .isNotEqualTo(futures.get(1).get().getFireCloudProjectName());
-
-    // Need to clean up entities since they actually get committed to the database because we're not running within a transaction
-    billingProjectBufferEntryDao.delete(firstEntry);
-    billingProjectBufferEntryDao.delete(secondEntry);
-    userDao.delete(firstUser);
-    userDao.delete(secondUser);
   }
 
 }

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -1,10 +1,13 @@
 package org.pmiops.workbench.billing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.pmiops.workbench.db.model.BillingProjectBufferEntry.BillingProjectBufferStatus.ASSIGNED;
@@ -16,15 +19,25 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.inject.Provider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.pmiops.workbench.CallsRealMethodsWithDelay;
+import org.pmiops.workbench.TestLock;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.FireCloudConfig;
 import org.pmiops.workbench.db.dao.BillingProjectBufferEntryDao;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
 import org.pmiops.workbench.db.model.StorageEnums;
 import org.pmiops.workbench.db.model.User;
@@ -42,6 +55,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -73,6 +88,12 @@ public class BillingProjectBufferServiceTest {
     }
   }
 
+  @Autowired
+  private Clock clock;
+  @Autowired
+  private UserDao userDao;
+  @Autowired
+  private Provider<WorkbenchConfig> workbenchConfigProvider;
   @Autowired
   private BillingProjectBufferEntryDao billingProjectBufferEntryDao;
   @Autowired
@@ -311,6 +332,52 @@ public class BillingProjectBufferServiceTest {
     assertThat(invokedProjectName).isEqualTo("test-project-name");
 
     assertThat(billingProjectBufferEntryDao.findOne(assignedEntry.getId()).getStatusEnum()).isEqualTo(ASSIGNED);
+  }
+
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  public void assignBillingProject_locking() throws InterruptedException, ExecutionException {
+    BillingProjectBufferEntry firstEntry = new BillingProjectBufferEntry();
+    firstEntry.setStatusEnum(AVAILABLE);
+    firstEntry.setFireCloudProjectName("test-project-name-1");
+    firstEntry.setCreationTime(new Timestamp(NOW.toEpochMilli()));
+    billingProjectBufferEntryDao.save(firstEntry);
+
+    User firstUser = new User();
+    firstUser.setEmail("fake-email-1@aou.org");
+    userDao.save(firstUser);
+
+    BillingProjectBufferEntry secondEntry = new BillingProjectBufferEntry();
+    secondEntry.setStatusEnum(AVAILABLE);
+    secondEntry.setFireCloudProjectName("test-project-name-2");
+    secondEntry.setCreationTime(new Timestamp(NOW.toEpochMilli()));
+    billingProjectBufferEntryDao.save(secondEntry);
+
+    User secondUser = new User();
+    secondUser.setEmail("fake-email-2@aou.org");
+    userDao.save(secondUser);
+
+    BillingProjectBufferEntryDao dao = spy(billingProjectBufferEntryDao);
+    TestLock lock = new TestLock();
+    doAnswer(invocation -> lock.lock()).when(dao).acquireAssigningLock();
+    doAnswer(invocation -> lock.release()).when(dao).releaseAssigningLock();
+    doAnswer(new CallsRealMethodsWithDelay(500)).when(dao).save(any(BillingProjectBufferEntry.class));
+
+    BillingProjectBufferService newService = new BillingProjectBufferService(dao,
+        clock, fireCloudService, workbenchConfigProvider);
+
+    Callable<BillingProjectBufferEntry> t1 = () -> newService.assignBillingProject(firstUser);
+    Callable<BillingProjectBufferEntry> t2 = () -> newService.assignBillingProject(secondUser);
+
+    List<Callable<BillingProjectBufferEntry>> callableTasks = new ArrayList<>();
+    callableTasks.add(t1);
+    callableTasks.add(t2);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    List<Future<BillingProjectBufferEntry>> futures = executor.invokeAll(callableTasks);
+
+    assertThat(futures.get(0).get().getFireCloudProjectName())
+        .isNotEqualTo(futures.get(1).get().getFireCloudProjectName());
   }
 
 }


### PR DESCRIPTION
I ended up going with a MySQL lock after trying out transactions and table locks. I ruled out transactions since I believe they lock on a row by row basis and I needed something that locked on the table level. I chose a generic lock over table locks since I just needed the consume code to run in sequence. The consume code doesn't have to block other updates to the table.

Had to do some funky stuff to be able to test concurrency. I'm not super happy with what came out of it since there is manual clean up that needs to be done to prevent side effects and the underlying locking implementation had to be stubbed out but it works. 