### PR TITLE
[RW-2392] [risk=no] Avoid syncing access modules for service accounts

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -176,11 +176,7 @@ public class UserService {
     }
   }
 
-  /**
-   * Determines whether the given user is a service account based on the whitelisted set of allowed
-   * service account user emails.
-   */
-  public boolean isServiceAccount(User user) {
+  private boolean isServiceAccount(User user) {
     return configProvider.get().auth.serviceAccountApiUsers.contains(user.getEmail());
   }
 

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -29,6 +29,7 @@ public class WorkbenchConfig {
     WorkbenchConfig config = new WorkbenchConfig();
     config.firecloud = new FireCloudConfig();
     config.auth = new AuthConfig();
+    config.auth.serviceAccountApiUsers = new ArrayList();
     config.cdr = new CdrConfig();
     config.googleCloudStorageService = new GoogleCloudStorageServiceConfig();
     config.googleDirectoryService = new GoogleDirectoryServiceConfig();


### PR DESCRIPTION
This fixes the one remaining "fixable" issue with the failing cron jobs in our test environment.

Most of the rest of our failures are due to user rows for nonexistent GSuite accounts, which isn't worth the effort to clean up for now.

On prod, our jobs are currently succeeding except for the eRA Commons. That one is still pending enablement of credential impersonation on prod, https://precisionmedicineinitiative.atlassian.net/browse/PD-3409