### PR TITLE
[RW-1665][risk=no] Speed up GET /me

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -268,9 +268,6 @@ public class ProfileController implements ProfileApiDelegate {
       return user;
     }
 
-    // Check if 2FA is set up on account
-    userService.syncTwoFactorAuthStatus(user);
-
     // On first sign-in, create a FC user, billing project, and set the first sign in time.
     if (user.getFirstSignInTime() == null) {
       // If the user is already registered, their profile will get updated.


### PR DESCRIPTION
Doing a 2FA sync on every call to GET /me added a significant amount of lag to the endpoint based on local testing. This PR removes the 2FA sync. It should be a safe change since we make an explicit call to sync 2FA whenever the user hits the homepage.

Local Testing Results of 50 GET /me calls
average w/ sync - .96312 s
average w/o sync - .163540 s