### PR TITLE
Read Only Notebook Prototype 

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -30,6 +30,7 @@ import {environment} from 'environments/environment';
 import {BreadcrumbType, NavStore} from './utils/navigation';
 import {CohortActionsComponent} from './views/cohort-actions/cohort-actions.component';
 import {SignInComponent} from './views/sign-in/component';
+import {ReadOnlyNotebookComponent} from "./views/read-only-notebook/ReadOnlyNotebookComponent";
 
 declare let gtag: Function;
 
@@ -121,6 +122,14 @@ const routes: Routes = [
                     component: NotebookRedirectComponent,
                     data: {
                       title: 'Notebook',
+                      breadcrumb: BreadcrumbType.Notebook,
+                      minimizeChrome: true
+                    }
+                  }, {
+                    path: 'readonly/:nbName',
+                    component: ReadOnlyNotebookComponent,
+                    data: {
+                      title: 'Read Only Notebook',
                       breadcrumb: BreadcrumbType.Notebook,
                       minimizeChrome: true
                     }

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -83,6 +83,7 @@ import {
 } from 'notebooks-generated';
 import { HighlightSearchComponent } from './highlight-search/highlight-search.component';
 import {ToolTipComponent} from './views/tooltip/component';
+import {ReadOnlyNotebookComponent} from "./views/read-only-notebook/ReadOnlyNotebookComponent";
 
 // Unfortunately stackdriver-errors-js doesn't properly declare dependencies, so
 // we need to explicitly load its StackTrace dep:
@@ -157,6 +158,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     NewNotebookModalComponent,
     NotebookListComponent,
     NotebookRedirectComponent,
+    ReadOnlyNotebookComponent,
     PageTemplateSignedOutComponent,
     ProfilePageComponent,
     QuickTourModalComponent,

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -42,15 +42,18 @@ export class SignInService {
 
   private makeAuth2(config: ConfigResponse): Promise<any> {
     return new Promise((resolve) => {
-      gapi.load('auth2', () => {
-        gapi.auth2.init({
-          client_id: this.clientId,
-          hosted_domain: config.gsuiteDomain,
-          scope: 'https://www.googleapis.com/auth/plus.login openid profile'
-        }).then(() => {
-          this.subscribeToAuth2User();
+      gapi.load('auth2:client', () => {
+        gapi.client.load('storage', 'v1', authResult => {
+          gapi.auth2.init({
+            client_id: this.clientId,
+            hosted_domain: config.gsuiteDomain,
+            scope: 'https://www.googleapis.com/auth/plus.login openid profile https://www.googleapis.com/auth/devstorage.read_only'
+          }).then(() => {
+            this.subscribeToAuth2User();
+          });
+
+          resolve(gapi.auth2);
         });
-        resolve(gapi.auth2);
       });
     });
   }
@@ -87,6 +90,9 @@ export class SignInService {
     } else {
       const authResponse = gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true);
       if (authResponse !== null) {
+        console.log(authResponse.access_token);
+        console.log(gapi);
+        // console.log(gapi.client.storage);
         return authResponse.access_token;
       } else {
         return null;

--- a/ui/src/app/views/notebook-redirect/component.ts
+++ b/ui/src/app/views/notebook-redirect/component.ts
@@ -190,6 +190,7 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
         } else {
           url = this.notebookUrl(this.cluster, nbName);
         }
+        console.log(url);
         this.leoUrl = this.sanitizer
           .bypassSecurityTrustResourceUrl(url);
 
@@ -232,6 +233,7 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
   }
 
   private notebookUrl(cluster: Cluster, nbName: string): string {
+    console.log(cluster);
     return encodeURI(
       environment.leoApiUrl + '/notebooks/'
         + cluster.clusterNamespace + '/'

--- a/ui/src/app/views/read-only-notebook/ReadOnlyNotebookComponent.ts
+++ b/ui/src/app/views/read-only-notebook/ReadOnlyNotebookComponent.ts
@@ -4,6 +4,8 @@ import {Cluster} from "../../../generated";
 import {environment} from "../../../environments/environment";
 import {DomSanitizer} from "@angular/platform-browser";
 import {ClusterService as LeoClusterService} from "../../../notebooks-generated";
+import {Headers, RequestMethod, RequestOptions, RequestOptionsArgs, Response} from "@angular/http";
+import {Observable} from "rxjs";
 
 declare const gapi: any;
 
@@ -44,4 +46,50 @@ export class ReadOnlyNotebookComponent implements OnInit, OnDestroy {
       + namespace + '/'
       + name + '/notebooks/' + nbName);
   }
+
+  // This was added to cluster.service.ts
+  // 
+  // public readOnly(body: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
+  //   let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
+  //
+  //   // authentication (googleoauth) required
+  //   if (this.configuration.accessToken) {
+  //     const accessToken = typeof this.configuration.accessToken === 'function'
+  //       ? this.configuration.accessToken()
+  //       : this.configuration.accessToken;
+  //     headers.set('Authorization', 'Bearer ' + accessToken);
+  //   }
+  //
+  //   // to determine the Accept header
+  //   let httpHeaderAccepts: string[] = [
+  //     'application/json'
+  //   ];
+  //   const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+  //   if (httpHeaderAcceptSelected != undefined) {
+  //     headers.set('Accept', httpHeaderAcceptSelected);
+  //   }
+  //
+  //   // to determine the Content-Type header
+  //   const consumes: string[] = [
+  //     'application/json'
+  //   ];
+  //   const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+  //   if (httpContentTypeSelected != undefined) {
+  //     headers.set('Content-Type', httpContentTypeSelected);
+  //   }
+  //
+  //   let requestOptions: RequestOptionsArgs = new RequestOptions({
+  //     method: RequestMethod.Post,
+  //     headers: headers,
+  //     body: body,
+  //     withCredentials:this.configuration.withCredentials
+  //   });
+  //   // https://github.com/swagger-api/swagger-codegen/issues/4037
+  //   if (extraHttpRequestParams) {
+  //     requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
+  //   }
+  //
+  //
+  //   return this.http.request(`https://terra-calhoun-dev.appspot.com/api/convert`, requestOptions);
+  // }
 }

--- a/ui/src/app/views/read-only-notebook/ReadOnlyNotebookComponent.ts
+++ b/ui/src/app/views/read-only-notebook/ReadOnlyNotebookComponent.ts
@@ -1,0 +1,47 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {urlParamsStore} from "../../utils/navigation";
+import {Cluster} from "../../../generated";
+import {environment} from "../../../environments/environment";
+import {DomSanitizer} from "@angular/platform-browser";
+import {ClusterService as LeoClusterService} from "../../../notebooks-generated";
+
+declare const gapi: any;
+
+@Component({
+  templateUrl: './component.html',
+})
+export class ReadOnlyNotebookComponent implements OnInit, OnDestroy {
+
+  private readOnlyNotebook: string;
+
+  constructor(private sanitizer: DomSanitizer,
+              private leoClusterService: LeoClusterService) {}
+
+  ngOnInit(): void {
+    const {ns, wsid, nbName} = urlParamsStore.getValue();
+
+    let url = this.notebookUrl(wsid, "all-of-us", nbName);
+    let leoUrl = "https://leonardo.dsde-dev.broadinstitute.org/notebooks/aou-rw-local1-1933908639/all-of-us/api/contents/workspaces/duplicateoftestcreate/test.ipynb"
+
+    gapi.client.storage.objects.get({
+      bucket: 'fc-ef7e6293-0ba2-4116-8eac-a45884d82e25',
+      object: 'notebooks/test.ipynb',
+      alt: 'media'
+    }).then(body => {
+      this.leoClusterService.readOnly(body.body).subscribe(resp => {
+        this.readOnlyNotebook = resp.text();
+        let newWindow = window.open();
+        newWindow.document.write(this.readOnlyNotebook);
+      });
+    });
+  }
+
+  ngOnDestroy(): void {}
+
+  private notebookUrl(namespace: string, name: string, nbName: string): string {
+    return encodeURI(
+      environment.leoApiUrl + '/notebooks/'
+      + namespace + '/'
+      + name + '/notebooks/' + nbName);
+  }
+}

--- a/ui/src/app/views/read-only-notebook/component.html
+++ b/ui/src/app/views/read-only-notebook/component.html
@@ -1,0 +1,3 @@
+<div>
+    hello
+</div>


### PR DESCRIPTION
Veeery rough prototype of what read only notebooks can look like. Mainly proves that we can actually perform the full end to end flow of...

- retrieving notebook contents from Cloud Storage
- sending contents to Calhoun
- display response from Calhoun (HTML)