### PR TITLE
[RW-2677][risk=low] Avoid uniqueness conflicts with deleted workspaces

### DIFF
--- a/api/db/changelog/db.changelog-79-drop-fc-index.xml
+++ b/api/db/changelog/db.changelog-79-drop-fc-index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="calbach" id="db.changelog-79-drop-fc-index">
+    <dropIndex
+        indexName="idx_workspace_firecloud_name"
+        tableName="workspace" />
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -86,4 +86,5 @@
   <include file="changelog/db.changelog-76-add-assigned_user-billing-buffer.xml"/>
   <include file="changelog/db.changelog-77-data-set-last-modified.xml"/>
   <include file="changelog/db.changelog-78-data-set-etag.xml"/>
+  <include file="changelog/db.changelog-79-drop-fc-index.xml"/>
 </databaseChangeLog>

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -2,8 +2,6 @@ package org.pmiops.workbench.db.dao;
 
 import java.util.Collection;
 import java.util.List;
-import org.pmiops.workbench.db.model.CdrVersion;
-import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -17,18 +15,17 @@ import org.springframework.data.repository.query.Param;
  * Use of @Query is discouraged; if desired, define aliases in WorkspaceService.
  */
 public interface WorkspaceDao extends CrudRepository<Workspace, Long> {
-  Workspace findByWorkspaceNamespaceAndFirecloudName(
-      String workspaceNamespace, String firecloudName);
-  Workspace findByWorkspaceNamespaceAndName(String workspaceNamespace, String name);
+  Workspace findByWorkspaceNamespaceAndFirecloudNameAndActiveStatus(
+      String workspaceNamespace, String firecloudName, short activeStatus);
+  Workspace findByWorkspaceNamespaceAndNameAndActiveStatus(
+      String workspaceNamespace, String name, short activeStatus);
 
   @Query("SELECT w FROM Workspace w LEFT JOIN FETCH w.cohorts c LEFT JOIN FETCH c.cohortReviews" +
-      " WHERE w.workspaceNamespace = (:ns) AND w.firecloudName = (:fcName)")
-  Workspace findByFirecloudWithEagerCohorts(
-      @Param("ns") String workspaceNamespace, @Param("fcName") String fcName);
+      " WHERE w.workspaceNamespace = (:ns) AND w.firecloudName = (:fcName)" +
+      " AND w.activeStatus = (:status)")
+  Workspace findByFirecloudNameAndActiveStatusWithEagerCohorts(
+      @Param("ns") String workspaceNamespace, @Param("fcName") String fcName, @Param("status") short status);
 
-  List<Workspace> findByWorkspaceNamespace(String workspaceNamespace);
-  List<Workspace> findByCreatorOrderByNameAsc(User creator);
   List<Workspace> findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested();
   List<Workspace> findAllByFirecloudUuidIn(Collection<String> firecloudUuids);
-  Workspace findFirstByCdrVersion(CdrVersion cdrVersion);
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -4,12 +4,17 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyListOf;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.api.ConceptsControllerTest.makeConcept;
 
 import com.google.cloud.bigquery.FieldValue;
@@ -29,13 +34,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.assertj.core.util.Sets;
+import javax.inject.Provider;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -63,11 +69,6 @@ import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
-import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
-import org.pmiops.workbench.model.CopyNotebookRequest;
-import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
-import org.pmiops.workbench.workspaces.WorkspaceMapper;
-import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -78,6 +79,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
+import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.CloneWorkspaceRequest;
@@ -87,6 +89,7 @@ import org.pmiops.workbench.model.CohortAnnotationDefinitionListResponse;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptSet;
+import org.pmiops.workbench.model.CopyNotebookRequest;
 import org.pmiops.workbench.model.CreateConceptSetRequest;
 import org.pmiops.workbench.model.CreateReviewRequest;
 import org.pmiops.workbench.model.DataAccessLevel;
@@ -107,8 +110,11 @@ import org.pmiops.workbench.model.UpdateWorkspaceRequest;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.SearchRequests;
+import org.pmiops.workbench.workspaces.WorkspaceMapper;
+import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -124,8 +130,6 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.inject.Provider;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -523,7 +527,7 @@ public class WorkspacesControllerTest {
   public void testCreateWorkspace_createDeleteCycleSameName() throws Exception {
     Workspace workspace = createWorkspace();
 
-    Set<String> uniqueIds = Sets.newHashSet();
+    Set<String> uniqueIds = new HashSet<>();
     for (int i = 0; i < 3; i++) {
       workspace = workspacesController.createWorkspace(workspace).getBody();
       uniqueIds.add(workspace.getId());

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -32,8 +32,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.assertj.core.util.Sets;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -515,6 +517,20 @@ public class WorkspacesControllerTest {
         workspacesController.getWorkspace(workspace.getNamespace(), workspace.getId())
             .getBody().getWorkspace();
     assertThat(workspace2.getResearchPurpose().getApproved()).isNotEqualTo(true);
+  }
+
+  @Test
+  public void testCreateWorkspace_createDeleteCycleSameName() throws Exception {
+    Workspace workspace = createWorkspace();
+
+    Set<String> uniqueIds = Sets.newHashSet();
+    for (int i = 0; i < 3; i++) {
+      workspace = workspacesController.createWorkspace(workspace).getBody();
+      uniqueIds.add(workspace.getId());
+
+      workspacesController.deleteWorkspace(workspace.getNamespace(), workspace.getName());
+    }
+    assertThat(uniqueIds.size()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
- Add regression test
- Drop index
- Push active status filtering down to the DAO level (this is necessary for DAO methods that return single elements)

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
