### PR TITLE
[RW-2647][RISK=NO] Column names on Data Set Builder don't fit

### DIFF
--- a/ui/src/app/views/dataset-page/component.tsx
+++ b/ui/src/app/views/dataset-page/component.tsx
@@ -108,6 +108,12 @@ export const styles = reactStyles({
     flexDirection: 'column',
     alignItems: 'center',
     height: '10rem'
+  },
+  previewDataTableHeader: {
+    textAlign: 'left',
+    width: '5rem',
+    wordBreak: 'break-all',
+    wordWrap: 'break-word'
   }
 });
 
@@ -388,7 +394,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
                         value={this.getDataTableValue(filteredPreviewData.values)}>
         {filteredPreviewData.values.map(value =>
             <Column header={value.value}
-                    headerStyle={{textAlign: 'left', width: '5rem', wordBreak: 'break-all'}}
+                    headerStyle={styles.previewDataTableHeader}
                     style={{width: '5rem'}} field={value.value}/>
         )}
       </DataTable>;


### PR DESCRIPTION
<img width="1241" alt="Screen Shot 2019-05-28 at 4 22 45 PM" src="https://user-images.githubusercontent.com/34481816/58509950-bd5a4300-8165-11e9-9ee4-0ccf9695ce09.png">
