### PR TITLE
[risk=no] Another attempt at fixing flaky test

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -5,16 +5,22 @@ import {DataSetGuard} from './guards/dataset-guard.service';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
+import {DataPageComponent} from 'app/views/data-page';
+import {DataUseAgreementComponent} from 'app/views/data-use-agreement';
+import {DataSetPageComponent} from 'app/views/dataset-page';
 import {AdminReviewWorkspaceComponent} from './views/admin-review-workspace/component';
 import {AdminUserComponent} from './views/admin-user/component';
+import {CohortActionsComponent} from './views/cohort-actions';
 import {CohortListComponent} from './views/cohort-list';
 import {ConceptHomepageComponent} from './views/concept-homepage';
+import {ConceptSetActionsComponent} from './views/concept-set-actions';
 import {ConceptSetDetailsComponent} from './views/concept-set-details';
 import {ConceptSetListComponent} from './views/concept-set-list';
 import {HomepageComponent} from './views/homepage';
 import {NotebookListComponent} from './views/notebook-list';
 import {NotebookRedirectComponent} from './views/notebook-redirect/component';
 import {ProfilePageComponent} from './views/profile-page';
+import {SignInComponent} from './views/sign-in';
 import {SignedInComponent} from './views/signed-in/component';
 import {StigmatizationPageComponent} from './views/stigmatization-page';
 import {WorkspaceEditComponent, WorkspaceEditMode} from './views/workspace-edit';
@@ -22,13 +28,9 @@ import {WorkspaceListComponent} from './views/workspace-list';
 import {WorkspaceWrapperComponent} from './views/workspace-wrapper/component';
 import {WorkspaceComponent} from './views/workspace/component';
 
-import {DataPageComponent} from 'app/views/data-page';
-import {DataUseAgreementComponent} from 'app/views/data-use-agreement';
-import {DataSetPageComponent} from 'app/views/dataset-page';
 import {environment} from 'environments/environment';
 import {BreadcrumbType, NavStore} from './utils/navigation';
-import {CohortActionsComponent} from './views/cohort-actions';
-import {SignInComponent} from './views/sign-in';
+
 
 declare let gtag: Function;
 
@@ -212,7 +214,14 @@ const routes: Routes = [
                     title: 'Concept Set',
                     breadcrumb: BreadcrumbType.ConceptSet
                   },
-                }]
+                }, {
+                  path: ':csid/actions',
+                  component: ConceptSetActionsComponent,
+                  data: {
+                    title: 'Concept Set Actions',
+                    breadcrumb: BreadcrumbType.ConceptSet
+                  },
+                }, ]
               }]
           }]
       },

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {CohortActionsComponent} from './views/cohort-actions';
 import {CohortListComponent} from './views/cohort-list';
 import {ConceptAddModalComponent} from './views/concept-add-modal';
 import {ConceptHomepageComponent} from './views/concept-homepage';
+import {ConceptSetActionsComponent} from './views/concept-set-actions';
 import {ConceptSetDetailsComponent} from './views/concept-set-details';
 import {ConceptSetListComponent} from './views/concept-set-list';
 import {ConceptTableComponent} from './views/concept-table';
@@ -56,7 +57,7 @@ import {StigmatizationPageComponent} from './views/stigmatization-page';
 import {TopBoxComponent} from './views/top-box/component';
 import {WorkspaceEditComponent} from './views/workspace-edit';
 import {WorkspaceListComponent} from './views/workspace-list';
-import {WorkspaceNavBarComponent} from './views/workspace-nav-bar/component';
+import {WorkspaceNavBarComponent} from './views/workspace-nav-bar';
 import {WorkspaceShareComponent} from './views/workspace-share';
 import {WorkspaceComponent} from './views/workspace/component';
 
@@ -143,6 +144,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     CohortActionsComponent,
     CohortListComponent,
     ConceptAddModalComponent,
+    ConceptSetActionsComponent,
     ConceptSetDetailsComponent,
     ConceptHomepageComponent,
     ConceptTableComponent,

--- a/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
+++ b/ui/src/app/cohort-review/page-layout/page-layout.spec.ts
@@ -8,8 +8,9 @@ import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, NavStore, urlParamsStore} from 'app/utils/navigation';
 import {CohortBuilderService} from 'generated';
-import {CohortReviewApi, CohortsApi, CriteriaListResponse} from 'generated/fetch';
+import {CohortBuilderApi, CohortReviewApi, CohortsApi, CriteriaListResponse} from 'generated/fetch';
 import {Observable} from 'rxjs/Observable';
+import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {CohortReviewServiceStub, cohortReviewStub} from 'testing/stubs/cohort-review-service-stub';
 import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
@@ -25,9 +26,6 @@ describe('PageLayout', () => {
   let fixture: ComponentFixture<PageLayout>;
 
   beforeEach(async(() => {
-    registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
-    registerApiClient(CohortsApi, new CohortsApiStub());
-
     TestBed.configureTestingModule({
       declarations: [
         CreateReviewModalComponent,
@@ -50,6 +48,9 @@ describe('PageLayout', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
+    registerApiClient(CohortsApi, new CohortsApiStub());
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(PageLayout);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
@@ -74,8 +74,6 @@ describe('CohortSearchComponent', () => {
   let mockReduxInst;
 
   beforeEach(async(() => {
-    registerApiClient(CohortsApi, new CohortsApiStub());
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());
@@ -153,6 +151,8 @@ describe('CohortSearchComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortsApi, new CohortsApiStub());
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(CohortSearchComponent);
     component = fixture.componentInstance;
     component.listSearch = false;

--- a/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.spec.ts
+++ b/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.spec.ts
@@ -13,7 +13,6 @@ describe('ListAttributesPageComponent', () => {
   let fixture: ComponentFixture<ListAttributesPageComponent>;
 
   beforeEach(async(() => {
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     TestBed.configureTestingModule({
       declarations: [ListAttributesPageComponent, ValidatorErrorsComponent],
       imports: [ClarityModule, ReactiveFormsModule],
@@ -22,6 +21,7 @@ describe('ListAttributesPageComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(ListAttributesPageComponent);
     component = fixture.componentInstance;
     component.attrs = {EXISTS: false, NUM: [{operator: 'ANY', operands: []}], CAT: []};

--- a/ui/src/app/cohort-search/list-modal/list-modal.component.spec.ts
+++ b/ui/src/app/cohort-search/list-modal/list-modal.component.spec.ts
@@ -56,7 +56,6 @@ describe('ListModalComponent', () => {
   let mockReduxInst;
 
   beforeEach(async(() => {
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());
@@ -106,6 +105,7 @@ describe('ListModalComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(ListModalComponent);
     component = fixture.componentInstance;
     component.attributesNode = {

--- a/ui/src/app/cohort-search/list-modifier-page/list-modifier-page.component.spec.ts
+++ b/ui/src/app/cohort-search/list-modifier-page/list-modifier-page.component.spec.ts
@@ -27,7 +27,6 @@ describe('ListModifierPageComponent', () => {
   let mockReduxInst;
 
   beforeEach(async(() => {
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());
@@ -53,6 +52,7 @@ describe('ListModifierPageComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(ListModifierPageComponent);
     component = fixture.componentInstance;
     component.disabled = () => {};

--- a/ui/src/app/cohort-search/list-node/list-node.component.spec.ts
+++ b/ui/src/app/cohort-search/list-node/list-node.component.spec.ts
@@ -37,7 +37,6 @@ describe('ListNodeComponent', () => {
   let mockReduxInst;
 
   beforeEach(async(() => {
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     mockReduxInst = MockNgRedux.getInstance();
     const _old = mockReduxInst.getState;
     const _wrapped = () => fromJS(_old());
@@ -68,6 +67,7 @@ describe('ListNodeComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(ListNodeComponent);
     component = fixture.componentInstance;
     component.node = {

--- a/ui/src/app/cohort-search/list-search-bar/list-search-bar.component.spec.ts
+++ b/ui/src/app/cohort-search/list-search-bar/list-search-bar.component.spec.ts
@@ -15,7 +15,6 @@ describe('ListSearchBarComponent', () => {
   let fixture: ComponentFixture<ListSearchBarComponent>;
 
   beforeEach(async(() => {
-    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     TestBed.configureTestingModule({
       declarations: [ ListOptionInfoComponent, ListSearchBarComponent, SafeHtmlPipe ],
       imports: [
@@ -29,6 +28,7 @@ describe('ListSearchBarComponent', () => {
   }));
 
   beforeEach(() => {
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     fixture = TestBed.createComponent(ListSearchBarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/components/card.tsx
+++ b/ui/src/app/components/card.tsx
@@ -33,4 +33,4 @@ export const styles = reactStyles({
 
 export const WorkspaceCardBase = withStyle(styles.workspaceCard)('div');
 export const ResourceCardBase = withStyle(styles.resourceCard)('div');
-export const CohortActionCardBase = withStyle(styles.cohortActionCard)('div');
+export const ActionCardBase = withStyle(styles.cohortActionCard)('div');

--- a/ui/src/app/views/concept-add-modal.tsx
+++ b/ui/src/app/views/concept-add-modal.tsx
@@ -107,10 +107,10 @@ export const ConceptAddModal = withCurrentWorkspace()
         addedIds: conceptIds
       };
       try {
-        await conceptSetsApi().updateConceptSetConcepts(
+        const conceptSet = await conceptSetsApi().updateConceptSetConcepts(
           namespace, id, selectedSet.id, updateConceptSetReq);
         this.setState({saving: false});
-        onSave();
+        onSave(conceptSet);
       } catch (error) {
         console.error(error);
       }
@@ -125,9 +125,10 @@ export const ConceptAddModal = withCurrentWorkspace()
         addedIds: conceptIds
       };
       try {
-        await conceptSetsApi().createConceptSet(namespace, id, request);
+        const createdConceptSet =
+          await conceptSetsApi().createConceptSet(namespace, id, request);
         this.setState({saving: false});
-        onSave();
+        onSave(createdConceptSet);
       } catch (error) {
         console.error(error);
         this.setState({errorSaving: true});

--- a/ui/src/app/views/concept-homepage.spec.tsx
+++ b/ui/src/app/views/concept-homepage.spec.tsx
@@ -174,26 +174,4 @@ describe('ConceptHomepage', () => {
     wrapper.find('[data-test-id="clear-search"]').first().simulate('click');
     expect(wrapper.find('[data-test-id="selectedConcepts"]').length).toEqual(0);
   });
-
-  it('should clear selected concepts after adding', async() => {
-    const wrapper = mount(<ConceptHomepage />);
-    await waitOneTickAndUpdate(wrapper);
-    searchTable('test', wrapper);
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper.find('span.p-checkbox-icon.p-clickable').at(1).simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('[data-test-id="selectedConcepts"]').text()).toBe('1');
-
-    wrapper.find('[data-test-id="sliding-button"]').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    wrapper.find('[data-test-id="toggle-new-set"]').first().simulate('click');
-    wrapper.find('[data-test-id="create-new-set-name"]').first()
-      .simulate('change', {target: {value: 'test-set'}});
-    wrapper.find('[data-test-id="save-concept-set"]').first().simulate('click');
-
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('[data-test-id="selectedConcepts"]').length).toEqual(0);
-  });
-
 });

--- a/ui/src/app/views/concept-homepage.tsx
+++ b/ui/src/app/views/concept-homepage.tsx
@@ -11,7 +11,7 @@ import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {conceptsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
-import {queryParamsStore} from 'app/utils/navigation';
+import {NavStore, queryParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ConceptAddModal} from 'app/views/concept-add-modal';
 import {ConceptNavigationBar} from 'app/views/concept-navigation-bar';
@@ -20,6 +20,7 @@ import {SlidingFabReact} from 'app/views/sliding-fab';
 import * as Color from 'color';
 import {
   Concept,
+  ConceptSet,
   Domain,
   DomainCount,
   DomainInfo,
@@ -320,24 +321,10 @@ export const ConceptHomepage = withCurrentWorkspace()(
       return count === 0 ? 'Add to set' : 'Add (' + count + ') to set';
     }
 
-    afterConceptsSaved() {
-      const {selectedConceptDomainMap, selectedDomain, conceptsToAdd} = this.state;
-      this.setConceptsSaveText();
-      // Once concepts are saved clear the selection from concept homepage for active Domain
-      selectedConceptDomainMap[selectedDomain.domain] = 0;
-      const remainingConcepts = conceptsToAdd.filter((c) =>
-        c.domainId.toLowerCase() !== selectedDomain.domain.toString().toLowerCase());
-      this.setState({conceptAddModalOpen: false, conceptsToAdd: remainingConcepts});
-    }
-
-    setConceptsSaveText() {
-      const {selectedConceptDomainMap, selectedDomain} = this.state;
-      const conceptsCount = selectedConceptDomainMap[selectedDomain.domain];
-      this.setState({conceptsSavedText: conceptsCount + ' ' + selectedDomain.name.toLowerCase() +
-        (conceptsCount > 1 ? ' concepts have ' : ' concept has ') + 'been added to set.'});
-      setTimeout(() => {
-        this.setState({conceptsSavedText: ''});
-      }, 5000);
+    afterConceptsSaved(conceptSet: ConceptSet) {
+      const {namespace, id} = this.props.workspace;
+      NavStore.navigate(['workspaces', namespace, id,
+        'concepts', 'sets', conceptSet.id, 'actions']);
     }
 
     render() {
@@ -383,7 +370,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
             <FadeBox>
               <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'flex-start'}}>
                 {conceptDomainCounts.map((domain) => {
-                  return <div style={{display: 'flex', flexDirection: 'column'}}>
+                  return <div style={{display: 'flex', flexDirection: 'column'}} key={domain.name}>
                     <Clickable style={styles.domainHeaderLink}
                                onClick={() => this.selectDomain(domain)}
                                disabled={this.domainLoading(domain)}
@@ -435,7 +422,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
         {conceptAddModalOpen &&
           <ConceptAddModal selectedDomain={selectedDomain}
                            selectedConcepts={conceptsToAdd}
-                           onSave={() => this.afterConceptsSaved()}
+                           onSave={(conceptSet) => this.afterConceptsSaved(conceptSet)}
                            onClose={() => this.setState({conceptAddModalOpen: false})}/>}
       </FadeBox>;
     }

--- a/ui/src/app/views/concept-set-actions.tsx
+++ b/ui/src/app/views/concept-set-actions.tsx
@@ -3,17 +3,17 @@ import {Button} from 'app/components/buttons';
 import {ActionCardBase} from 'app/components/card';
 import {FadeBox} from 'app/components/containers';
 import {SpinnerOverlay} from 'app/components/spinners';
-import {cohortsApi} from 'app/services/swagger-fetch-clients';
+import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
-import {currentCohortStore, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
+import {navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
-import {Cohort} from 'generated/fetch';
+import {ConceptSet} from 'generated/fetch';
 import * as React from 'react';
 
 const styles = reactStyles({
-  cohortsHeader: {
+  conceptSetsHeader: {
     color: colors.blue[7],
     fontSize: '20px',
     lineHeight: '24px',
@@ -54,12 +54,6 @@ const disabledButton = {
 
 const actionCards = [
   {
-    title: 'Create Review Sets',
-    description: `The review set feature allows you to select a subset of your cohort to review
-       participants row-level data and add notes and annotations.`,
-    action: 'review'
-  },
-  {
     title: 'Export to a Notebook',
     description: `Data can be exported to a cloud-based Jupyter notebook for analysis using R or
        Python programming language.`,
@@ -67,84 +61,88 @@ const actionCards = [
   },
   {
     title: 'Create a Data Set',
-    description: `Here, you can build and preview a dataset for one or more cohorts by
+    description: `Here, you can build and preview a data set for one or more cohorts by
        selecting the desired concept sets and values for the cohorts.`,
     action: 'dataSet'
   },
+  {
+    title: 'Create or update another Concept Set',
+    description: `Here, you can create or update another concept set for the same or a
+      different domain.`,
+    action: 'newConceptSet'
+  },
 ];
+
+interface State {
+  conceptSet: ConceptSet;
+  conceptSetLoading: boolean;
+}
 
 interface Props {
   workspace: WorkspaceData;
 }
 
-interface State {
-  cohort: Cohort;
-  cohortLoading: boolean;
-}
-
-const CohortActions = withCurrentWorkspace()(
+export const ConceptSetActions = withCurrentWorkspace()(
   class extends React.Component<Props, State> {
     constructor(props: any) {
       super(props);
-      this.state = {cohort: currentCohortStore.getValue(), cohortLoading: false};
+      this.state = {
+        conceptSet: undefined,
+        conceptSetLoading: false,
+      };
     }
 
     componentDidMount(): void {
-      const {cohort} = this.state;
-      if (!cohort) {
-        const cid = urlParamsStore.getValue().cid;
-        this.setState({cohortLoading: true});
-        if (cid) {
-          const {namespace, id} = this.props.workspace;
-          cohortsApi().getCohort(namespace, id, cid).then(c => {
-            if (c) {
-              currentCohortStore.next(c);
-              this.setState({cohort: c, cohortLoading: false});
-            } else {
-              navigate(['workspaces', namespace, id, 'cohorts']);
-            }
-          });
-        }
+      const csid = urlParamsStore.getValue().csid;
+      this.setState({conceptSetLoading: true});
+      if (csid) {
+        const {namespace, id} = this.props.workspace;
+        conceptSetsApi().getConceptSet(namespace, id, csid).then(cs => {
+          if (cs) {
+            this.setState({conceptSet: cs, conceptSetLoading: false});
+          } else {
+            navigate(['workspaces', namespace, id, 'concepts']);
+          }
+        });
       }
     }
 
     navigateTo(action: string): void {
-      const {cohort} = this.state;
       const {namespace, id} = this.props.workspace;
+      const {conceptSet} = this.state;
       let url = `/workspaces/${namespace}/${id}/`;
       switch (action) {
-        case 'cohort':
-          url += `cohorts/build?cohortId=${cohort.id}`;
+        case 'conceptSet':
+          url += `concepts/sets/${conceptSet.id}`;
           break;
-        case 'review':
-          url += `cohorts/${cohort.id}/review`;
+        case 'newConceptSet':
+          url += `concepts`;
           break;
         case 'notebook':
-          url += 'notebooks';
+          url += `notebooks`;
           break;
         case 'dataSet':
-          url += 'data/data-sets';
+          url += `data/data-sets`;
           break;
       }
       navigateByUrl(url);
     }
 
     render() {
-      const {cohort, cohortLoading} = this.state;
+      const {conceptSet, conceptSetLoading} = this.state;
       return <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
-        {cohortLoading && <SpinnerOverlay />}
-        {cohort && <React.Fragment>
-          <h3 style={styles.cohortsHeader}>Cohort Saved Successfully</h3>
+        {conceptSetLoading && <SpinnerOverlay />}
+        {conceptSet && <React.Fragment>
+          <h3 style={styles.conceptSetsHeader}>Concept Set Saved Successfully</h3>
           <div style={{marginTop: '0.25rem'}}>
-            The cohort
-             <a
-               style={{color: '#5DAEE1', margin: '0 4px'}}
-               onClick={() => this.navigateTo('cohort')}>
-                {cohort.name}
-             </a>
-             has been saved and can now be used in analysis and concept sets.
+            The concept set
+            <a style={{color: '#5DAEE1', margin: '0 4px'}}
+               onClick={() => this.navigateTo('conceptSet')}>
+              {conceptSet.name}
+            </a>
+            has been saved and can now be used in analysis and concept sets.
           </div>
-          <h3 style={{...styles.cohortsHeader, marginTop: '1.5rem'}}>What Next?</h3>
+          <h3 style={{...styles.conceptSetsHeader, marginTop: '1.5rem'}}>What Next?</h3>
           <div style={styles.cardArea}>
             {actionCards.map((card, i) => {
               const disabled = card.action === 'notebook' ||
@@ -177,9 +175,9 @@ const CohortActions = withCurrentWorkspace()(
 @Component({
   template: '<div #root></div>'
 })
-export class CohortActionsComponent extends ReactWrapperBase {
+export class ConceptSetActionsComponent extends ReactWrapperBase {
 
   constructor() {
-    super(CohortActions, []);
+    super(ConceptSetActions, []);
   }
 }

--- a/ui/src/app/views/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/views/workspace-nav-bar.spec.tsx
@@ -1,5 +1,5 @@
 import {currentWorkspaceStore, NavStore, urlParamsStore} from 'app/utils/navigation';
-import {WorkspaceNavBarReact} from 'app/views/workspace-nav-bar/component';
+import {WorkspaceNavBarReact} from 'app/views/workspace-nav-bar';
 import {mount} from 'enzyme';
 import * as React from 'react';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';

--- a/ui/src/app/views/workspace-nav-bar.tsx
+++ b/ui/src/app/views/workspace-nav-bar.tsx
@@ -143,7 +143,6 @@ export const WorkspaceNavBarReact = fp.flow(
 
 @Component({
   selector: 'app-workspace-nav-bar',
-  styleUrls: ['./component.css'],
   template: '<div #root></div>',
 })
 export class WorkspaceNavBarComponent extends ReactWrapperBase {

--- a/ui/src/app/views/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/views/workspace-wrapper/component.spec.ts
@@ -12,7 +12,7 @@ import {registerApiClient} from 'app/services/swagger-fetch-clients';
 
 import {BugReportComponent} from 'app/views/bug-report';
 import {ConfirmDeleteModalComponent} from 'app/views/confirm-delete-modal';
-import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar/component';
+import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar';
 import {WorkspaceShareComponent} from 'app/views/workspace-share';
 import {WorkspaceWrapperComponent} from 'app/views/workspace-wrapper/component';
 

--- a/ui/src/app/views/workspace/component.spec.ts
+++ b/ui/src/app/views/workspace/component.spec.ts
@@ -20,7 +20,7 @@ import {ResetClusterButtonComponent} from 'app/views/reset-cluster-button';
 import {ResourceCardComponent} from 'app/views/resource-card';
 import {ToolTipComponent} from 'app/views/tooltip/component';
 import {TopBoxComponent} from 'app/views/top-box/component';
-import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar/component';
+import {WorkspaceNavBarComponent} from 'app/views/workspace-nav-bar';
 import {WorkspaceShareComponent} from 'app/views/workspace-share';
 import {WorkspaceWrapperComponent} from 'app/views/workspace-wrapper/component';
 import {WorkspaceComponent} from 'app/views/workspace/component';


### PR DESCRIPTION
Moves all `registerApiClient` calls in `beforeEach(async())` to `beforeEach()` to match the rest of the app. Seems likely this has something to do with the flakes since it was mostly calls to register `CohortBuilderApi` that were moved.