### PR TITLE
[RW-2647][RISK=NO]Column names on Data Set Builder don't fit

### DIFF
--- a/ui/src/app/views/dataset-page.tsx
+++ b/ui/src/app/views/dataset-page.tsx
@@ -8,8 +8,6 @@ import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 
-import * as ReactDOM from 'react-dom';
-
 import {
   cohortsApi,
   conceptsApi,
@@ -393,7 +391,6 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         if (element.offsetWidth < element.scrollWidth) {
           return false;
         }
-
       }
       return true;
     }

--- a/ui/src/app/views/dataset-page.tsx
+++ b/ui/src/app/views/dataset-page.tsx
@@ -5,7 +5,9 @@ import * as React from 'react';
 import {Button, Clickable} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {ClrIcon} from 'app/components/icons';
+import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
+
 import {
   cohortsApi,
   conceptsApi,
@@ -378,6 +380,33 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
       }
     }
 
+    isEllipsisActive(text) {
+      // For Data table with column title as active text, enable the tooltip if column's scroll
+      // width is greater than offsetWidth as that represents the textOverflow style has been
+      // applied and it has ellipsis at the end
+
+      const column = document.getElementsByClassName('p-column-title');
+      for (let i = 0; i < column.length; i++) {
+        const element = column[i].children[0] as HTMLElement;
+        if (element.innerText === text) {
+          if (element.offsetWidth < element.scrollWidth) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+
+    getHeaderValue(value) {
+      const text = value.value;
+      return <TooltipTrigger side='top' content={text} disabled={this.isEllipsisActive(text)}>
+        <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+          {text}
+        </div>
+      </TooltipTrigger>;
+    }
+
+
     renderPreviewDataTable() {
       const filteredPreviewData =
           this.state.previewList.filter(
@@ -387,9 +416,9 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
                         style={{width: '100%'}}
                         value={this.getDataTableValue(filteredPreviewData.values)}>
         {filteredPreviewData.values.map(value =>
-            <Column header={value.value}
-                    headerStyle={{textAlign: 'left', width: '5rem', wordBreak: 'break-all'}}
-                    style={{width: '5rem'}} field={value.value}/>
+          <Column header={this.getHeaderValue(value)}
+                  headerStyle={{textAlign: 'left', width: '5rem'}} style={{width: '5rem'}}
+                  field={value.value}/>
         )}
       </DataTable>;
     }

--- a/ui/src/app/views/dataset-page.tsx
+++ b/ui/src/app/views/dataset-page.tsx
@@ -164,8 +164,7 @@ interface State {
 
 const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
   class extends React.Component<Props, State> {
-    dt: DataTable;
-    myRef: any;
+    dt: any;
     constructor(props) {
       super(props);
       this.state = {
@@ -188,7 +187,6 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         valuesLoading: false,
         selectAll: false
       };
-      this.myRef = React.createRef();
     }
 
     get editing() {

--- a/ui/src/app/views/dataset-page.tsx
+++ b/ui/src/app/views/dataset-page.tsx
@@ -384,10 +384,12 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
     isEllipsisActive(text) {
       if (this.dt) {
         const columnIndex = this.dt.props.children.findIndex(child => child.key === text);
-        const element = document.getElementsByClassName('p-column-title')
-            .item(columnIndex).children[0] as HTMLElement;
-        if (element.offsetWidth < element.scrollWidth) {
-          return false;
+        const columnTitlesDOM = document.getElementsByClassName('p-column-title');
+        if (columnTitlesDOM && columnTitlesDOM.item(columnIndex)) {
+          const element = columnTitlesDOM.item(columnIndex).children[0] as HTMLElement;
+          if (element.offsetWidth < element.scrollWidth) {
+            return false;
+          }
         }
       }
       return true;


### PR DESCRIPTION
Tooltip will appear only when textOverflow property is applied 
![Screen Shot 2019-05-29 at 4 33 01 PM](https://user-images.githubusercontent.com/34481816/58589316-9405e980-822f-11e9-9180-ad7c7ae516ac.png)
