### PR TITLE
[risk=no] Update link to CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Replace this this template with your PR description.
-Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
+Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](workbench/.github/CONTRIBUTING.md) and to 
 include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title
 
 * **no**: None 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
-Replace this this template with your PR description.
-Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](workbench/.github/CONTRIBUTING.md) and to 
+Replace this template with your PR description.
+Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
 include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title
 
 * **no**: None 


### PR DESCRIPTION
I think this will make it easier to open up the CONTRIBUTING.md doc. 

As currently written, it tries to open a PR:

>Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 

With the change, it will contain the link that can be used to access the file.


<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
