### PR TITLE
[RW-2758][risk=no] rm settings button, settings view was removed

### DIFF
--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -27,7 +27,6 @@
       </div>
       <clr-dropdown-menu clrPosition="bottom-right" *clrIfOpen>
         <a routerLink="/profile" clrDropdownItem>Profile</a>
-        <a routerLink="/settings" clrDropdownItem>Settings</a>
         <div class="dropdown-divider"></div>
         <a href="javascript:;" (click)="signOut()" clrDropdownItem>Sign Out</a>
       </clr-dropdown-menu>


### PR DESCRIPTION
I missed this in review.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
