### PR TITLE
[risk=no] fix research purpose regression on ws about page

### DIFF
--- a/ui/src/app/views/workspace/component.html
+++ b/ui/src/app/views/workspace/component.html
@@ -67,6 +67,7 @@
               </div>
             </app-tooltip>
           </h4>
+          <div class="description-text">{{workspace.researchPurpose.intendedStudy}}</div>
           <div class="research-purpose-items">
             <div class="column">
               <div class="research-purpose-item" *ngFor="let researchPurposeDescription of leftResearchPurposes">

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -105,11 +105,14 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.workspace.userRoles = fp.sortBy('familyName', workspace.userRoles);
     this.accessLevel = workspace.accessLevel;
     this.researchPurposeArray = [];
-    Object.keys(ResearchPurposeItems).forEach((key) => {
-      if (this.workspace.researchPurpose[key]) {
-        let shortDescription = ResearchPurposeItems[key].shortDescription;
-        if (key === 'diseaseFocusedResearch') {
+    ResearchPurposeItems.forEach((key) => {
+      if (this.workspace.researchPurpose[key.shortName]) {
+        let shortDescription = key.shortDescription;
+        if (key.shortName === 'diseaseFocusedResearch') {
           shortDescription += ': ' + this.workspace.researchPurpose.diseaseOfFocus;
+        }
+        if (key.shortName === 'otherPurpose') {
+          shortDescription += ': ' + this.workspace.researchPurpose.otherPurposeDetails;
         }
         this.researchPurposeArray.push(shortDescription);
       }

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -105,13 +105,13 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.workspace.userRoles = fp.sortBy('familyName', workspace.userRoles);
     this.accessLevel = workspace.accessLevel;
     this.researchPurposeArray = [];
-    ResearchPurposeItems.forEach((key) => {
-      if (this.workspace.researchPurpose[key.shortName]) {
-        let shortDescription = key.shortDescription;
-        if (key.shortName === 'diseaseFocusedResearch') {
+    ResearchPurposeItems.forEach((item) => {
+      if (this.workspace.researchPurpose[item.shortName]) {
+        let shortDescription = item.shortDescription;
+        if (item.shortName === 'diseaseFocusedResearch') {
           shortDescription += ': ' + this.workspace.researchPurpose.diseaseOfFocus;
         }
-        if (key.shortName === 'otherPurpose') {
+        if (item.shortName === 'otherPurpose') {
           shortDescription += ': ' + this.workspace.researchPurpose.otherPurposeDetails;
         }
         this.researchPurposeArray.push(shortDescription);


### PR DESCRIPTION
Updates to the workspace create/edit page with new research purpose fields created a regression in the workspace About page causing nothing to show up underneath the "Research Purpose" header.  This PR fixes it so that it displays the same information that it used to (the "description" field was renamed "intendedStudy" and reallocated to that rp question).  The `ResearchPurposeItems` object also changed into a list with new fields. 

Although this page will change with the release of the new About page with dataset builder, this fixes things until Bedford.