### PR TITLE
[RW-2657][risk=moderate] Grant canCompute to workspace editors/owners

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -44,7 +44,26 @@ import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageService;
-import org.pmiops.workbench.model.*;
+import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.CloneWorkspaceRequest;
+import org.pmiops.workbench.model.CloneWorkspaceResponse;
+import org.pmiops.workbench.model.CopyNotebookRequest;
+import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.model.NotebookRename;
+import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
+import org.pmiops.workbench.model.ShareWorkspaceRequest;
+import org.pmiops.workbench.model.ShareWorkspaceResponse;
+import org.pmiops.workbench.model.UpdateWorkspaceRequest;
+import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.model.Workspace;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
+import org.pmiops.workbench.model.WorkspaceListResponse;
+import org.pmiops.workbench.model.WorkspaceResponse;
+import org.pmiops.workbench.model.WorkspaceResponseListResponse;
 import org.pmiops.workbench.notebooks.BlobAlreadyExistsException;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.workspaces.WorkspaceMapper;
@@ -625,7 +644,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       newUserRole.setRoleEnum(role.getRole());
       dbUserRoles.add(newUserRole);
     }
-    // This automatically enforces owner role.
+    // This automatically enforces the "canShare" permission.
     dbWorkspace = workspaceService.updateUserRoles(dbWorkspace, dbUserRoles);
     ShareWorkspaceResponse resp = new ShareWorkspaceResponse();
     resp.setWorkspaceEtag(Etags.fromVersion(dbWorkspace.getVersion()));

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -235,16 +235,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     for (WorkspaceUserRole currentWorkspaceUser : workspace.getWorkspaceUserRoles()) {
       WorkspaceACLUpdate currentUpdate = new WorkspaceACLUpdate();
       currentUpdate.setEmail(currentWorkspaceUser.getUser().getEmail());
-      currentUpdate.setCanCompute(false);
       WorkspaceAccessLevel access = currentWorkspaceUser.getRoleEnum();
       if (access == WorkspaceAccessLevel.OWNER) {
         currentUpdate.setCanShare(true);
+        currentUpdate.setCanCompute(true);
         currentUpdate.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
       } else if (access == WorkspaceAccessLevel.WRITER) {
         currentUpdate.setCanShare(false);
+        currentUpdate.setCanCompute(true);
         currentUpdate.setAccessLevel(WorkspaceAccessLevel.WRITER.toString());
       } else {
         currentUpdate.setCanShare(false);
+        currentUpdate.setCanCompute(false);
         currentUpdate.setAccessLevel(WorkspaceAccessLevel.READER.toString());
       }
       updateACLRequestList.add(currentUpdate);

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -208,6 +208,8 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
 
   workspaceClusterBillingProjectId(): string {
     if (this.useBillingProjectBuffer === undefined) {
+      // The server config hasn't loaded yet, we don't yet know which billing
+      // project should be used for clusters.
       return null;
     }
     if (!this.useBillingProjectBuffer) {

--- a/ui/src/app/views/workspace/component.ts
+++ b/ui/src/app/views/workspace/component.ts
@@ -2,6 +2,7 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import * as fp from 'lodash/fp';
 
 import {CdrVersionStorageService} from 'app/services/cdr-version-storage.service';
+import {ServerConfigService} from 'app/services/server-config.service';
 import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ResearchPurposeItems} from 'app/views/workspace-edit';
@@ -30,6 +31,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   cdrVersion: CdrVersion;
   wsId: string;
   wsNamespace: string;
+  useBillingProjectBuffer: boolean;
   freeTierBillingProject: string;
   cohortsLoading = true;
   cohortsError = false;
@@ -54,6 +56,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   private subscriptions = [];
 
   constructor(
+    private serverConfigService: ServerConfigService,
     private cdrVersionStorageService: CdrVersionStorageService
   ) {
     this.closeNotebookModal = this.closeNotebookModal.bind(this);
@@ -67,6 +70,10 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         this.reloadWorkspace(workspace);
       }
     }));
+    this.serverConfigService.getConfig().subscribe(({useBillingProjectBuffer}) => {
+      this.useBillingProjectBuffer = useBillingProjectBuffer;
+    });
+
     // TODO: RW-1057
     profileApi().getMe().then(
       profile => {
@@ -200,14 +207,16 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   workspaceClusterBillingProjectId(): string {
-    if (this.workspace.namespace === this.freeTierBillingProject) {
+    if (this.useBillingProjectBuffer === undefined) {
+      return null;
+    }
+    if (!this.useBillingProjectBuffer) {
       return this.freeTierBillingProject;
     }
 
     if ([WorkspaceAccessLevel.WRITER, WorkspaceAccessLevel.OWNER].includes(this.accessLevel)) {
       return this.workspace.namespace;
     }
-
     return null;
   }
 


### PR DESCRIPTION
- Upon sharing, this enables writers/owners to launch clusters in that project.
- This will not actually be utilized yet within the application.
- Recode the reset cluster button, as this would have created conflicting clusters in the wrong project before we launched `useProjectBillingBuffer`

Will backfill these roles as a follow-up.

FYI @jmthibault79 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
