### PR TITLE
[RW-2657][risk=moderate] Implement canCompute backfill script

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -529,6 +529,16 @@ task backfillGSuiteUserData(type: JavaExec) {
   }
 }
 
+// See project.rb command: backfill-can-compute
+task backfillCanCompute(type: JavaExec) {
+  classpath = sourceSets.tools.runtimeClasspath
+  main = "org.pmiops.workbench.tools.BackfillCanCompute"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
 // See project.rb command: load-es-index
 task elasticSearchIndexer(type: JavaExec) {
   classpath = sourceSets.tools.runtimeClasspath

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1067,7 +1067,7 @@ end
 
 Common.register_command({
   :invocation => "backfill-can-compute",
-  :description => "Backfills the can compute permission for editors/owners",
+  :description => "Backfills the canCompute permission for editors/owners",
   :fn => ->(*args) {backfill_can_compute("backfill-can-compute", *args)}
 })
 
@@ -1608,13 +1608,11 @@ def get_fc_config(project)
 end
 
 def get_leo_api_url(project)
-  config_json = get_config(project)
-  return JSON.parse(File.read("config/#{config_json}"))["firecloud"]["leoBaseUrl"]
+  return get_fc_config(project)["leoBaseUrl"]
 end
 
 def get_auth_domain(project)
-  config_json = get_config(project)
-  return JSON.parse(File.read("config/#{config_json}"))["firecloud"]["registeredDomainName"]
+  return get_fc_config(project)["registeredDomainName"]
 end
 
 def get_es_base_url(env)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1026,6 +1026,51 @@ Common.register_command({
   :fn => ->(*args) {backfill_gsuite_user_data("backfill-gsuite-user-data", *args)}
 })
 
+def backfill_can_compute(cmd_name, *args)
+  common = Common.new
+  ensure_docker cmd_name, args
+
+  op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = true
+  op.opts.project = TEST_PROJECT
+
+  op.add_typed_option(
+      "--dry_run=[dry_run]",
+      TrueClass,
+      ->(opts, v) { opts.dry_run = v},
+      "When true, print debug lines instead of performing writes. Defaults to true.")
+
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate()
+
+  if op.opts.dry_run
+    common.status "DRY RUN -- CHANGES WILL NOT BE PERSISTED"
+  end
+
+  fc_config = get_fc_config(op.opts.project)
+  flags = ([
+    ["--fc-base-url", fc_config["baseUrl"]],
+    ["--billing-project-prefix", fc_config["billingProjectPrefix"]]
+  ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
+  if op.opts.dry_run
+    flags += ["--dry-run"]
+  end
+  # Gradle args need to be single-quote wrapped.
+  flags.map! { |f| "'#{f}'" }
+  ServiceAccountContext.new(gcc.project).run do
+    common.run_inline %W{
+        gradle backfillCanCompute
+       -PappArgs=[#{flags.join(',')}]}
+  end
+end
+
+Common.register_command({
+  :invocation => "backfill-can-compute",
+  :description => "Backfills the can compute permission for editors/owners",
+  :fn => ->(*args) {backfill_can_compute("backfill-can-compute", *args)}
+})
+
 def fetch_firecloud_user_profile(cmd_name, *args)
   common = Common.new
   ensure_docker cmd_name, args
@@ -1555,6 +1600,11 @@ def migrate_workbench_data()
   Dir.chdir("db") do
     common.run_inline(%W{gradle update -PrunList=data -Pcontexts=cloud})
   end
+end
+
+def get_fc_config(project)
+  config_json = get_config(project)
+  return JSON.parse(File.read("config/#{config_json}"))["firecloud"]
 end
 
 def get_leo_api_url(project)

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -397,8 +397,26 @@ paths:
           description: Workspace does not exist
         500:
           description: Internal Server Error
-
   /api/workspaces/{workspaceNamespace}/{workspaceName}/acl:
+    get:
+      tags:
+        - Workspaces
+      operationId: getWorkspaceAcl
+      summary: Get workspace ACL
+      parameters:
+        - $ref: '#/parameters/workspaceNamespaceParam'
+        - $ref: '#/parameters/workspaceNameParam'
+      responses:
+        200:
+          description: Successful Request
+          schema:
+            $ref: '#/definitions/WorkspaceACL'
+        400:
+          description: Can't retrieve ACL for workspace
+        404:
+          description: Workspace not found
+        500:
+          description: Internal Server Error
     patch:
       tags:
         - Workspaces
@@ -1040,6 +1058,17 @@ definitions:
       runningSubmissionsCount:
         type: integer
         description: Count of all the running submissions
+
+  WorkspaceACL:
+    description: ''
+    required:
+      - acl
+    type: object
+    properties:
+      acl:
+        type: object
+        description: Map[String, WorkspaceAccessEntry]
+
   WorkspaceACLUpdate:
     description: ''
     required:
@@ -1102,6 +1131,28 @@ definitions:
         description: the users or groups who were not found
         items:
           $ref: '#/definitions/WorkspaceACLUpdate'
+
+  WorkspaceAccessEntry:
+    description: ''
+    required:
+      - accessLevel
+      - pending
+      - canShare
+      - canCompute
+    type: object
+    properties:
+      accessLevel:
+        type: string
+        description: The access level granted to this user or group (OWNER, READER, WRITER, NO ACCESS)
+      pending:
+        type: boolean
+        description: The status of the users access
+      canShare:
+        type: boolean
+        description: True if the user can share the workspace with others, false otherwise
+      canCompute:
+        type: boolean
+        description: True if the user can launch compute in this workspace, false otherwise
 
   ManagedGroupAccessResponse:
     description: an element of a list of groups a user has access to

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -397,6 +397,7 @@ paths:
           description: Workspace does not exist
         500:
           description: Internal Server Error
+
   /api/workspaces/{workspaceNamespace}/{workspaceName}/acl:
     get:
       tags:

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillCanCompute.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillCanCompute.java
@@ -124,7 +124,7 @@ public class BackfillCanCompute {
           extractAclResponse(workspacesApi.getWorkspaceAcl(w.getNamespace(), w.getName()));
       for (String user : acl.keySet()) {
         WorkspaceAccessEntry entry = acl.get(user);
-        if (!CAN_COMPUTE_UPGRADE_ROLES.contains(entry.getAccessLevel()) || entry.getCanCompute()) {
+        if (entry.getCanCompute() || !CAN_COMPUTE_UPGRADE_ROLES.contains(entry.getAccessLevel())) {
           // This user already has sufficient canCompute permission.
           continue;
         }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillCanCompute.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillCanCompute.java
@@ -1,0 +1,169 @@
+package org.pmiops.workbench.tools;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.pmiops.workbench.firecloud.ApiClient;
+import org.pmiops.workbench.firecloud.ApiException;
+import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+import org.pmiops.workbench.firecloud.model.Workspace;
+import org.pmiops.workbench.firecloud.model.WorkspaceACL;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
+import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
+import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Backfill script for granting canCompute permission to all AoU editors and owners. For
+ * http://broad.io/1ppw, collaborators will need canCompute in order to launch clusters within
+ * shared billing projects.
+ */
+@Configuration
+public class BackfillCanCompute {
+  private static Option fcBaseUrlOpt =
+      Option.builder()
+          .longOpt("fc-base-url")
+          .desc("Firecloud API base URL")
+          .required()
+          .hasArg()
+          .build();
+  private static Option billingProjectPrefixOpt =
+      Option.builder()
+          .longOpt("billing-project-prefix")
+          .desc("Billing project prefix to filter by, other workspaces are ignored")
+          .required()
+          .hasArg()
+          .build();
+  private static Option dryRunOpt =
+      Option.builder()
+          .longOpt("dry-run")
+          .desc("If specified, the tool runs in dry run mode; no modifications are made")
+          .build();
+  private static Options options =
+      new Options().addOption(fcBaseUrlOpt).addOption(billingProjectPrefixOpt).addOption(dryRunOpt);
+
+  private static final String[] FC_SCOPES =
+      new String[] {
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "https://www.googleapis.com/auth/userinfo.email"
+      };
+  private static final Logger log = Logger.getLogger(BackfillCanCompute.class.getName());
+  private static final Set<String> CAN_COMPUTE_ROLES =
+      ImmutableSet.of("PROJECT_OWNER", "OWNER", "WRITER");
+
+  private static WorkspacesApi newWorkspacesApi(String apiUrl) throws IOException {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(apiUrl);
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault().createScoped(Arrays.asList(FC_SCOPES));
+    credential.refreshToken();
+    apiClient.setAccessToken(credential.getAccessToken());
+    WorkspacesApi api = new WorkspacesApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  private static void dryLog(boolean dryRun, String msg) {
+    String prefix = "";
+    if (dryRun) {
+      prefix = "[DRY RUN] Would have... ";
+    }
+    log.info(prefix + msg);
+  }
+
+  /**
+   * Swagger Java codegen does not handle the WorkspaceACL model correctly; it returns a GSON map
+   * instead. Run this through a typed Gson conversion process to coerce it into the desired type.
+   */
+  private static Map<String, WorkspaceAccessEntry> extractAclResponse(WorkspaceACL aclResp) {
+    Type accessEntryType = new TypeToken<Map<String, WorkspaceAccessEntry>>() {}.getType();
+    Gson gson = new Gson();
+    return gson.fromJson(gson.toJson(aclResp.getAcl(), accessEntryType), accessEntryType);
+  }
+
+  private static void backfill(
+      WorkspacesApi workspacesApi, String billingProjectPrefix, boolean dryRun)
+      throws ApiException {
+    int userUpgrades = 0;
+    int workspaceUpdates = 0;
+    for (WorkspaceResponse resp : workspacesApi.listWorkspaces()) {
+      Workspace w = resp.getWorkspace();
+      if (!w.getNamespace().startsWith(billingProjectPrefix)) {
+        continue;
+      }
+
+      String id = w.getNamespace() + "/" + w.getName();
+      if (!"PROJECT_OWNER".equals(resp.getAccessLevel())) {
+        log.warning(
+            String.format(
+                "service account has '%s' access to workspace '%s'; skipping",
+                resp.getAccessLevel(), id));
+        continue;
+      }
+
+      List<WorkspaceACLUpdate> updates = new ArrayList<>();
+      Map<String, WorkspaceAccessEntry> acl =
+          extractAclResponse(workspacesApi.getWorkspaceAcl(w.getNamespace(), w.getName()));
+      for (String user : acl.keySet()) {
+        WorkspaceAccessEntry entry = acl.get(user);
+        if (!CAN_COMPUTE_ROLES.contains(entry.getAccessLevel()) || entry.getCanCompute()) {
+          continue;
+        }
+        dryLog(
+            dryRun,
+            String.format("upgrading user '%s' (%s) to canCompute", user, entry.getAccessLevel()));
+        userUpgrades++;
+        updates.add(
+            new WorkspaceACLUpdate()
+                .email(user)
+                .canCompute(true)
+                .canShare(entry.getCanShare())
+                .accessLevel(entry.getAccessLevel()));
+      }
+
+      if (!updates.isEmpty()) {
+        dryLog(dryRun, String.format("applying upgrades to workspace '%s'", id));
+        workspaceUpdates++;
+        if (!dryRun) {
+          workspacesApi.updateWorkspaceACL(
+              w.getNamespace(), w.getName(), /* inviteUsersNotFound */ false, updates);
+        }
+      }
+    }
+
+    dryLog(
+        dryRun,
+        String.format("upgraded %d users in %d workspace updates", userUpgrades, workspaceUpdates));
+  }
+
+  @Bean
+  public CommandLineRunner run() {
+    return (args) -> {
+      CommandLine opts = new DefaultParser().parse(options, args);
+      backfill(
+          newWorkspacesApi(opts.getOptionValue(fcBaseUrlOpt.getLongOpt())),
+          opts.getOptionValue(billingProjectPrefixOpt.getLongOpt()),
+          opts.hasOption(dryRunOpt.getLongOpt()));
+    };
+  }
+
+  public static void main(String[] args) {
+    new SpringApplicationBuilder(BackfillCanCompute.class).web(false).run(args);
+  }
+}


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-2657

Acting as the GAE default SA for the given environment:
```
for each owned workspace:
  ensure writers and owners have canCompute
``` 

- Required pulling in the getWorkspaceACL Firecloud swagger
- Includes a billing project filter to avoid touching local/old workspaces
- There are surprisingly many workspaces for which the GAE SA has "NO ACCESS", this warrants some follow-up investigation.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
