### PR TITLE
[RW-2817][P1] fix null pointer bugs on ws edit 

### DIFF
--- a/ui/src/app/views/workspace-edit.tsx
+++ b/ui/src/app/views/workspace-edit.tsx
@@ -461,7 +461,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
     get noSpecificPopulationSelected() {
       return this.state.workspace.researchPurpose.population &&
-        this.state.workspace.researchPurpose.populationDetails.length === 0;
+        (!this.state.workspace.researchPurpose.populationDetails ||
+          this.state.workspace.researchPurpose.populationDetails.length === 0);
     }
 
     get noDiseaseOfFocusSpecified() {
@@ -740,8 +741,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                    disabled={!this.state.workspace.researchPurpose.population}/>
                 <TextInput type='text' autoFocus placeholder='Please specify'
                            value={this.state.workspace.researchPurpose.otherPopulationDetails}
-                           disabled={!this.state.workspace.researchPurpose.populationDetails
-                             .includes(SpecificPopulationEnum.OTHER)}
+                           disabled={!fp.includes(SpecificPopulationEnum.OTHER,
+                             this.state.workspace.researchPurpose.populationDetails)}
                            onChange={v => this.setState(fp.set(
                              ['workspace', 'researchPurpose', 'otherPopulationDetails'], v))}/>
               </div>


### PR DESCRIPTION
fixed two null pointer errors on workspace edit page:
* running "includes" on null object when checking if the "other population" was selected
* checking if we have any specific populations selected when verifying all fields filled for the save button.  (this one happened when we had "no" selected in the initial ws then tried to edit it to say "yes"; see below comment)

note that these happened on duplicate and edit because we are fetching a ws object that has already been created, and when these fields are left empty on initial create they are returned as null.  