### PR TITLE
[RW-2726][risk=no] Fix unique key warning in workspace-edit

### DIFF
--- a/ui/src/app/views/workspace-edit.tsx
+++ b/ui/src/app/views/workspace-edit.tsx
@@ -110,26 +110,26 @@ export const toolTipText = {
 export const researchPurposeQuestions = [
   {
     header: '1. What is the primary purpose of your project?',
-    description: ['(Please select as many options below as describe your \
-      research purpose)']
+    description: <div>(Please select as many options below as describe your
+      research purpose)</div>
   }, {
     header: '2. Provide the reason for choosing All of Us data for your investigation',
-    description: ['(Free text; 500 Character limit)']
+    description: <div>(Free text; 500 Character limit)</div>
   }, {
     header: '3. What are the specific scientific question(s) you intend to study?',
-    description: ['If you are exploring the data at this stage to formalize a specific research \
-      question, please describe the reason for exploring the data, and the scientific \
-      question you hope to be able to answer using the data.', <br/>,
-      '(Free text; 500 Character limit)']
+    description: <div>If you are exploring the data at this stage to formalize a specific research
+      question, please describe the reason for exploring the data, and the scientific
+      question you hope to be able to answer using the data. <br/>
+      (Free text; 500 Character limit)</div>
   }, {
     header: '4. What are your anticipated findings from this study?',
-    description: ['(Layperson language; 2000 Character limit)']
+    description: <div>(Layperson language; 2000 Character limit)</div>
   }, {
     header: '5. Will your study or data analysis focus on specific population(s)? \
       Or do you intend to study your phenotype, disease, or condition of interest with \
       a focus on comparative analysis of a specific demographic group (for example \
       a group based on race/ethnicity, gender, or age)?',
-    description: ['']
+    description: <div/>
   }
 ];
 
@@ -614,13 +614,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         <WorkspaceEditSection header='Billing Account' subHeader='National Institutes of Health'
             tooltip={toolTipText.billingAccount}/>
         <WorkspaceEditSection header='Research Use Statement Questions'
-            description={[ResearchPurposeDescription, 'Therefore, please provide' +
-            ' sufficiently detailed responses at a 5th grade reading level.  Your responses' +
-            ' will not be used to make decisions about data access.', <br/>, <br/>,
+            description={<div> {ResearchPurposeDescription} Therefore, please provide
+              sufficiently detailed responses at a 5th grade reading level.  Your responses
+              will not be used to make decisions about data access. <br/> <br/>
               <i>Note that you are required to create separate Workspaces for each project
-              for which you access AoU data, hence the responses below are expected to be specific
-              to the project for which you are creating this particular Workspace.</i>
-            ]}/>
+                for which you access AoU data, hence the responses below are expected to be specific
+                to the project for which you are creating this particular Workspace.</i> </div>
+            }/>
         <WorkspaceEditSection header={researchPurposeQuestions[0].header}
             description={researchPurposeQuestions[0].description} required>
           <div style={{display: 'flex', flexDirection: 'row'}}>


### PR DESCRIPTION
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

This will remove this warning from the ui unit tests and from the UI page of workspace-edit (in the console) for users.

```
ERROR in src/app/views/export-data-set-modal.tsx(15,46): error TS2305: Module '"/Users/ajang/Firecloud/workbench/ui/src/generated/fetch/index"' has no exported member 'KernelTypeEnum'.
src/app/views/export-data-set-modal.tsx(93,18): error TS2339: Property 'generateCode' does not exist on type 'DataSetApi'.
src/app/views/export-data-set-modal.tsx(101,18): error TS2339: Property 'generateCode' does not exist on type 'DataSetApi'.
src/app/views/export-data-set-modal.tsx(127,9): error TS2345: Argument of type '{ dataSetRequest: { name: string; includesAllParticipants: boolean; description: string; conceptSetIds: number[]; cohortIds: number[]; values: DomainValuePair[]; }; notebookName: string; newNotebook: boolean; kernelType: any; }' is not assignable to parameter of type 'DataSetExportRequest'.
```


Figuring out how to make the error messaging better / easier to debug (adding line numbers and class name) will be tackled in the Wed tech talk.