### PR TITLE
[RW-2851][risk=no] Add Surveys and PM to CB list search

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -63,7 +63,7 @@
     "unsafeAllowSelfBypass": true
   },
   "cohortbuilder": {
-    "enableListSearch": true
+    "enableListSearch": false
   },
   "featureFlags": {
     "useBillingProjectBuffer": true,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -15,7 +15,9 @@
     "xAppIdValue": "local-AoU-RW"
   },
   "auth": {
-    "serviceAccountApiUsers": [ "all-of-us-workbench-test@appspot.gserviceaccount.com" ]
+    "serviceAccountApiUsers": [
+      "all-of-us-workbench-test@appspot.gserviceaccount.com"
+    ]
   },
   "cdr": {
     "debugQueries": false
@@ -61,7 +63,7 @@
     "unsafeAllowSelfBypass": true
   },
   "cohortbuilder": {
-    "enableListSearch": false
+    "enableListSearch": true
   },
   "featureFlags": {
     "useBillingProjectBuffer": true,

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -1,5 +1,5 @@
 import {AttrName, Operator, TreeSubType, TreeType} from 'generated';
-import {DomainType} from 'generated/fetch';
+import {CriteriaType, DomainType} from 'generated/fetch';
 
 export const PROGRAM_TYPES = [
   { name: 'Surveys', type: TreeType.PPI, subtype: null },
@@ -33,7 +33,14 @@ export const DOMAIN_TYPES = [
   {name: 'Visits', type: TreeType.VISIT, fullTree: true, subtype: null}
 ];
 
-export const LIST_PROGRAM_TYPES = [];
+export const LIST_PROGRAM_TYPES = [
+  {
+    name: 'Physical Measurements',
+    domain: DomainType.PHYSICALMEASUREMENT,
+    type: CriteriaType.PPI,
+    standard: false
+  }
+];
 
 export const LIST_DOMAIN_TYPES = [
   {name: 'Conditions', domain: DomainType.CONDITION},
@@ -52,6 +59,7 @@ export const PM_UNITS = {
   'HR-DETAIL': 'beats/min'
 };
 
+/* Systolic (conceptId: 903118) should always be the first element in the attributes array */
 export const PREDEFINED_ATTRIBUTES = {
   'Hypotensive': [
     {

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -35,6 +35,12 @@ export const DOMAIN_TYPES = [
 
 export const LIST_PROGRAM_TYPES = [
   {
+    name: 'Surveys',
+    domain: DomainType.SURVEY,
+    type: CriteriaType.PPI,
+    standard: false
+  },
+  {
     name: 'Physical Measurements',
     domain: DomainType.PHYSICALMEASUREMENT,
     type: CriteriaType.PPI,

--- a/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.html
+++ b/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.html
@@ -57,7 +57,7 @@
                 formControlName="valueA"
                 [(ngModel)]="attr.operands[0]"
                 (ngModelChange)="inputChange($event, i, 'valueA')">
-              <span *ngIf="hasUnits">{{units[node.get('subtype')]}}</span>
+              <span *ngIf="hasUnits">{{units[criterion.subtype]}}</span>
             </div>
             <div *ngIf="isBetween(i)" class="form-group and-text">
               <div>and</div>
@@ -71,7 +71,7 @@
                 formControlName="valueB"
                 [(ngModel)]="attr.operands[1]"
                 (ngModelChange)="inputChange($event, i, 'valueB')">
-              <span *ngIf="hasUnits">{{units[node.get('subtype')]}}</span>
+              <span *ngIf="hasUnits">{{units[criterion.subtype]}}</span>
             </div>
               <span class="range-padding" *ngIf="isMeasurement && showInput(i)">
               Range: {{attr.MIN}} - {{attr.MAX}}

--- a/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.ts
+++ b/ui/src/app/cohort-search/list-attributes-page/list-attributes-page.component.ts
@@ -2,9 +2,9 @@ import {ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 
 import {AttrName, Operator, TreeSubType, TreeType} from 'generated';
-import {DomainType} from 'generated/fetch';
+import {CriteriaSubType, DomainType} from 'generated/fetch';
 
-import {PM_UNITS} from 'app/cohort-search/constant';
+import {PM_UNITS, PREDEFINED_ATTRIBUTES} from 'app/cohort-search/constant';
 import {selectionsStore, wizardStore} from 'app/cohort-search/search-state.service';
 import {stripHtml} from 'app/cohort-search/utils';
 import {numberAndNegativeValidator, rangeValidator} from 'app/cohort-search/validators';
@@ -106,7 +106,15 @@ export class ListAttributesPageComponent implements OnInit {
         });
     } else {
       this.options.unshift({value: AttrName.ANY, name: 'Any', display: 'Any', code: 'Any'});
-      this.attrs.NUM = this.criterion.attributes;
+      this.attrs.NUM = this.criterion.subtype === CriteriaSubType[CriteriaSubType.BP]
+          ? JSON.parse(JSON.stringify(PREDEFINED_ATTRIBUTES.BP_DETAIL))
+          : [{
+            name: this.criterion.subtype,
+            operator: null,
+            operands: [null],
+            MIN: 0,
+            MAX: 10000
+          }];
       if (this.attrs.NUM) {
         const NUM = <FormGroup>this.form.controls.NUM;
         this.selectedCode = 'Any';

--- a/ui/src/app/cohort-search/list-modal/list-modal.component.ts
+++ b/ui/src/app/cohort-search/list-modal/list-modal.component.ts
@@ -9,7 +9,7 @@ import {
   subtreeSelectedStore,
   wizardStore
 } from 'app/cohort-search/search-state.service';
-import {stripHtml} from 'app/cohort-search/utils';
+import {domainToTitle, stripHtml} from 'app/cohort-search/utils';
 import {CriteriaType, DomainType} from 'generated/fetch';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -54,9 +54,20 @@ export class ListModalComponent implements OnInit, OnDestroy {
         this.selectionList = wizard.item.searchParameters;
         this.noSelection = this.selectionList.length === 0;
         if (!this.open) {
-          this.title = wizard.domain;
-          this.backMode = 'list';
-          this.mode = 'list';
+          this.title = domainToTitle(wizard.domain);
+          if (wizard.domain === DomainType.PHYSICALMEASUREMENT) {
+            this.hierarchyNode = {
+              domainId: wizard.domain,
+              type: wizard.type,
+              isStandard: wizard.standard,
+              id: 0,    // root parent ID is always 0
+            };
+            this.backMode = 'tree';
+            this.mode = 'tree';
+          } else {
+            this.backMode = 'list';
+            this.mode = 'list';
+          }
           this.open = true;
         }
       });

--- a/ui/src/app/cohort-search/list-modal/list-modal.component.ts
+++ b/ui/src/app/cohort-search/list-modal/list-modal.component.ts
@@ -133,7 +133,7 @@ export class ListModalComponent implements OnInit, OnDestroy {
     const groupIndex = searchRequest[role].findIndex(grp => grp.id === groupId);
     const itemIndex = searchRequest[role][groupIndex].items.findIndex(it => it.id === item.id);
     if (itemIndex > -1) {
-      searchRequest[role][groupIndex][itemIndex] = item;
+      searchRequest[role][groupIndex].items[itemIndex] = item;
     } else {
       searchRequest[role][groupIndex].items.push(item);
     }

--- a/ui/src/app/cohort-search/list-modal/list-modal.component.ts
+++ b/ui/src/app/cohort-search/list-modal/list-modal.component.ts
@@ -55,7 +55,7 @@ export class ListModalComponent implements OnInit, OnDestroy {
         this.noSelection = this.selectionList.length === 0;
         if (!this.open) {
           this.title = domainToTitle(wizard.domain);
-          if (wizard.domain === DomainType.PHYSICALMEASUREMENT) {
+          if (this.initTree) {
             this.hierarchyNode = {
               domainId: wizard.domain,
               type: wizard.type,
@@ -152,6 +152,11 @@ export class ListModalComponent implements OnInit, OnDestroy {
     return this.wizard.domain !== DomainType.PHYSICALMEASUREMENT &&
       this.wizard.domain !== DomainType.PERSON &&
       this.wizard.domain !== DomainType.SURVEY;
+  }
+
+  get initTree() {
+    return this.wizard.domain === DomainType.PHYSICALMEASUREMENT
+      || this.wizard.domain === DomainType.SURVEY;
   }
 
   get showNext() {

--- a/ui/src/app/cohort-search/list-node-info/list-node-info.component.html
+++ b/ui/src/app/cohort-search/list-node-info/list-node-info.component.html
@@ -1,12 +1,12 @@
 <div class="item">
   <!-- SELECT BTN -->
   <button
-          *ngIf="selectable"
-          type="button"
-          class="btn btn-sm btn-link selection-button"
-          [class.pm]="isPM"
-          [disabled]="isDisabled && !hasAttributes"
-          (click)="select($event)">
+    *ngIf="selectable"
+    type="button"
+    class="btn btn-sm btn-link selection-button"
+    [class.pm]="isPM"
+    [disabled]="isDisabled && !hasAttributes"
+    (click)="select($event)">
     <clr-icon *ngIf="isDisabled && !hasAttributes" shape="check-circle" size="20" class="selection-icon"></clr-icon>
     <clr-icon *ngIf="!isDisabled && !hasAttributes" shape="plus-circle" size="20" class="selection-icon"></clr-icon>
     <clr-icon *ngIf="hasAttributes" shape="slider" dir="right" size="20" class="selection-icon-blue is-solid"></clr-icon>

--- a/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
+++ b/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
@@ -179,26 +179,26 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   get showCount() {
     return this.node.count > -1
       && (this.node.selectable
-      || (this.node.subtype === CriteriaSubType[CriteriaSubType.LAB]
+      || (this.node.subtype === CriteriaSubType.LAB
       && this.node.group
       && this.node.code !== null )
-      || this.node.type === CriteriaType[CriteriaType.CPT4]);
+      || this.node.type === CriteriaType.CPT4);
   }
 
   get isPM() {
-    return this.node.domainId === DomainType[DomainType.PHYSICALMEASUREMENT];
+    return this.node.domainId === DomainType.PHYSICALMEASUREMENT;
   }
 
   get isDrug() {
-    return this.node.domainId === DomainType[DomainType.DRUG];
+    return this.node.domainId === DomainType.DRUG;
   }
 
   get isPPI() {
-    return this.node.domainId === DomainType[DomainType.SURVEY];
+    return this.node.domainId === DomainType.SURVEY;
   }
 
   get isSNOMED() {
-    return this.node.type === CriteriaType[CriteriaType.SNOMED];
+    return this.node.type === CriteriaType.SNOMED;
   }
 
   get hasAttributes() {
@@ -210,9 +210,9 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get isPMCat() {
-    return this.node.subtype === CriteriaSubType[CriteriaSubType.WHEEL] ||
-      this.node.subtype === CriteriaSubType[CriteriaSubType.PREG] ||
-      this.node.subtype === CriteriaSubType[CriteriaSubType.HRIRR] ||
-      this.node.subtype === CriteriaSubType[CriteriaSubType.HRNOIRR];
+    return this.node.subtype === CriteriaSubType.WHEEL ||
+      this.node.subtype === CriteriaSubType.PREG ||
+      this.node.subtype === CriteriaSubType.HRIRR ||
+      this.node.subtype === CriteriaSubType.HRNOIRR;
   }
 }

--- a/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
+++ b/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
@@ -14,7 +14,7 @@ import {
   CohortSearchState,
   ppiAnswers,
 } from 'app/cohort-search/redux';
-import {attributesStore, groupSelectionsStore, selectionsStore, subtreeSelectedStore, wizardStore} from 'app/cohort-search/search-state.service';
+import {attributesStore, groupSelectionsStore, ppiQuestions, selectionsStore, subtreeSelectedStore, wizardStore} from 'app/cohort-search/search-state.service';
 import {stripHtml} from 'app/cohort-search/utils';
 import {AttrName, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 import {Subscription} from 'rxjs/Subscription';
@@ -81,7 +81,7 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get paramId() {
-    return `param${this.node.conceptId ?
+    return `param${this.node.conceptId && !this.isPPI ?
         (this.node.conceptId + this.node.code) : this.node.id}`;
   }
 
@@ -128,9 +128,11 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
         }
         let modifiedName = this.node.name;
         if (this.isPPI) {
-          // TODO need an alternative to pulling from redux store here
-          const parent = ppiAnswers(this.node.path)(this.ngRedux.getState()).toJS();
-          modifiedName = parent.name + ' - ' + modifiedName;
+          // get PPI question from store
+          const question = ppiQuestions.getValue()[this.node.parentId];
+          if (question) {
+            modifiedName = question + ' - ' + modifiedName;
+          }
         }
         let attributes = [];
         if (this.node.subtype === CriteriaSubType[CriteriaSubType.BP]) {

--- a/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
+++ b/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
@@ -194,7 +194,7 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get isPPI() {
-    return this.node.type === CriteriaType[CriteriaType.PPI];
+    return this.node.domainId === DomainType[DomainType.SURVEY];
   }
 
   get isSNOMED() {

--- a/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
+++ b/ui/src/app/cohort-search/list-node-info/list-node-info.component.ts
@@ -1,4 +1,3 @@
-import {NgRedux} from '@angular-redux/store';
 import {
   AfterViewInit,
   Component,
@@ -10,10 +9,6 @@ import {
   ViewChild
 } from '@angular/core';
 import {PREDEFINED_ATTRIBUTES} from 'app/cohort-search/constant';
-import {
-  CohortSearchState,
-  ppiAnswers,
-} from 'app/cohort-search/redux';
 import {attributesStore, groupSelectionsStore, ppiQuestions, selectionsStore, subtreeSelectedStore, wizardStore} from 'app/cohort-search/search-state.service';
 import {stripHtml} from 'app/cohort-search/utils';
 import {AttrName, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
@@ -32,10 +27,6 @@ export class ListNodeInfoComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('name') name: ElementRef;
   isTruncated = false;
   matched = false;
-
-  constructor(
-    private ngRedux: NgRedux<CohortSearchState>
-  ) {}
 
   ngOnInit() {
     this.subscription = selectionsStore.subscribe(selections => {

--- a/ui/src/app/cohort-search/list-node/list-node.component.ts
+++ b/ui/src/app/cohort-search/list-node/list-node.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {scrollStore, subtreePathStore, subtreeSelectedStore} from 'app/cohort-search/search-state.service';
+import {ppiQuestions, scrollStore, subtreePathStore, subtreeSelectedStore} from 'app/cohort-search/search-state.service';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {CriteriaType, DomainType} from 'generated/fetch';
@@ -53,7 +53,7 @@ export class ListNodeComponent implements OnInit, OnDestroy {
     if (!event || !!this.children) { return ; }
     this.loading = true;
     const cdrId = +(currentWorkspaceStore.getValue().cdrVersionId);
-    const {domainId, id, isStandard} = this.node;
+    const {domainId, id, isStandard, name} = this.node;
     const type = domainId === DomainType.DRUG ? CriteriaType[CriteriaType.ATC] : this.node.type;
     cohortBuilderApi().getCriteriaBy(cdrId, domainId, type, isStandard, id)
       .then(resp => {
@@ -69,6 +69,12 @@ export class ListNodeComponent implements OnInit, OnDestroy {
           this.empty = resp.items.length === 0;
           this.children = resp.items;
           this.loading = false;
+          if (!this.empty && domainId === DomainType.SURVEY && !resp.items[0].group) {
+            // save questions in the store so we can display them along with answers if selected
+            const questions = ppiQuestions.getValue();
+            questions[id] = name;
+            ppiQuestions.next(questions);
+          }
         }
       }, () => this.error = true);
   }

--- a/ui/src/app/cohort-search/list-search-group-item/list-search-group-item.component.ts
+++ b/ui/src/app/cohort-search/list-search-group-item/list-search-group-item.component.ts
@@ -46,13 +46,13 @@ export class ListSearchGroupItemComponent {
     const _type = this.item.type;
     const formatter = (param) => {
       let funcs = [listTypeDisplay, listAttributeDisplay];
-      if (_type === DomainType[DomainType.PERSON]) {
+      if (_type === DomainType.PERSON) {
         funcs = [listTypeDisplay, listNameDisplay, listAttributeDisplay];
-      } else if (_type === DomainType[DomainType.PHYSICALMEASUREMENT]
-        || _type === DomainType[DomainType.VISIT]
-        || _type === DomainType[DomainType.DRUG]
-        || _type === DomainType[DomainType.MEASUREMENT]
-        || _type === DomainType[DomainType.SURVEY]) {
+      } else if (_type === DomainType.PHYSICALMEASUREMENT
+        || _type === DomainType.VISIT
+        || _type === DomainType.DRUG
+        || _type === DomainType.MEASUREMENT
+        || _type === DomainType.SURVEY) {
         funcs = [listNameDisplay];
       }
       return funcs.map(f => f(param)).join(' ').trim();

--- a/ui/src/app/cohort-search/list-search-group-item/list-search-group-item.component.ts
+++ b/ui/src/app/cohort-search/list-search-group-item/list-search-group-item.component.ts
@@ -77,24 +77,30 @@ export class ListSearchGroupItemComponent {
     this.setStatus('active');
   }
 
-  get itemSubtype() {
-    if (this.item.type === DomainType.PERSON) {
-      const subtype = this.parameters[0].subtype;
-      return subtype === TreeSubType.DEC ? TreeSubType.AGE : subtype;
+  get typeAndStandard() {
+    switch (this.item.type) {
+      case DomainType.PERSON:
+        const type = this.parameters[0].subtype === TreeSubType.DEC
+          ? TreeSubType.AGE : this.parameters[0].subtype;
+        return {type, standard: false};
+      case DomainType.PHYSICALMEASUREMENT:
+        return {type: this.parameters[0].type, standard: false};
+      default:
+        return {type: null, standard: null};
     }
-    return null;
   }
 
   launchWizard() {
-    const selections = this.item.searchParameters.map(sp => sp.paramId);
+    const selections = this.item.searchParameters.map(sp => sp.parameterId);
     selectionsStore.next(selections);
     const codes = getCodeOptions(this.item.type);
     const fullTree = this.item.fullTree;
     const {role, groupId} = this;
+    const item = JSON.parse(JSON.stringify(this.item));
     const itemId = this.item.id;
     const domain = this.item.type;
-    const type = this.itemSubtype;
-    const context = {item: this.item, domain, type, role, groupId, itemId, fullTree, codes};
+    const {type, standard} = this.typeAndStandard;
+    const context = {item, domain, type, standard, role, groupId, itemId, fullTree, codes};
     wizardStore.next(context);
   }
 }

--- a/ui/src/app/cohort-search/list-search-group/list-search-group.component.ts
+++ b/ui/src/app/cohort-search/list-search-group/list-search-group.component.ts
@@ -194,14 +194,16 @@ export class ListSearchGroupComponent implements AfterViewInit, OnInit {
   }
 
   launchWizard(criteria: any, tempGroup?: number) {
-    const {domain, type} = criteria;
+    const {domain, type, standard} = criteria;
     const itemId = generateId('items');
-    const item = this.initItem(itemId, criteria.type);
+    const item = this.initItem(itemId, domain);
     const fullTree = criteria.fullTree || false;
     const codes = criteria.codes || false;
     const role = this.role;
     const groupId = this.group.id;
-    const context = {item, domain, type, role, groupId, itemId, fullTree, codes, tempGroup};
+    const context = {
+      item, domain, type, standard, role, groupId, itemId, fullTree, codes, tempGroup
+    };
     wizardStore.next(context);
   }
 

--- a/ui/src/app/cohort-search/list-tree/list-tree.component.css
+++ b/ui/src/app/cohort-search/list-tree/list-tree.component.css
@@ -40,6 +40,9 @@
 .tree-container {
   margin: 3rem 0 1rem;
   width: 99%;
+}
+
+.tree-container.border {
   border: 1px solid #cccccc;
   border-radius: 3px;
 }

--- a/ui/src/app/cohort-search/list-tree/list-tree.component.html
+++ b/ui/src/app/cohort-search/list-tree/list-tree.component.html
@@ -22,8 +22,8 @@
   </div>
 </div>
 
-<div class="tree-container">
-  <div class="tree-header">
+<div class="tree-container" [class.border]="showHeader">
+  <div *ngIf="showHeader" class="tree-header">
     <button class="btn btn-link" (click)="back()">Return to list</button>
   </div>
   <crit-list-node *ngFor="let item of children" [node]="item"></crit-list-node>

--- a/ui/src/app/cohort-search/list-tree/list-tree.component.ts
+++ b/ui/src/app/cohort-search/list-tree/list-tree.component.ts
@@ -30,7 +30,6 @@ export class ListTreeComponent extends ListNodeComponent implements OnInit, OnCh
     super.ngOnInit();
     setTimeout(() => super.loadChildren(true));
     this._type = this.node.domainId;
-    console.log(this.node);
   }
 
   get showSearch() {

--- a/ui/src/app/cohort-search/list-tree/list-tree.component.ts
+++ b/ui/src/app/cohort-search/list-tree/list-tree.component.ts
@@ -30,10 +30,16 @@ export class ListTreeComponent extends ListNodeComponent implements OnInit, OnCh
     super.ngOnInit();
     setTimeout(() => super.loadChildren(true));
     this._type = this.node.domainId;
+    console.log(this.node);
   }
 
   get showSearch() {
     return !this.isEmpty && this.node.domainId !== DomainType[DomainType.PERSON];
+  }
+
+  get showHeader() {
+    return this.node.domainId !== DomainType.PHYSICALMEASUREMENT
+      && this.node.domainId !== DomainType.SURVEY;
   }
 
   get showDropDown() {

--- a/ui/src/app/cohort-search/search-group-select/search-group-select.component.ts
+++ b/ui/src/app/cohort-search/search-group-select/search-group-select.component.ts
@@ -50,13 +50,13 @@ export class SearchGroupSelectComponent implements AfterViewInit {
     if (environment.enableCBListSearch) {
       const itemId = generateId('items');
       const groupId = generateId(this.role);
-      const {domain, type} = criteria;
+      const {domain, type, standard} = criteria;
       const searchRequest = searchRequestStore.getValue();
       const group = this.initGroup(groupId);
       const item = this.initItem(itemId, criteria.domain);
       searchRequest[this.role].push(group);
       searchRequestStore.next(searchRequest);
-      context = {item, domain, type, role, groupId, itemId, fullTree, codes};
+      context = {item, domain, type, standard, role, groupId, itemId, fullTree, codes};
       wizardStore.next(context);
     } else {
       const itemId = this.actions.generateId('items');

--- a/ui/src/app/cohort-search/search-state.service.ts
+++ b/ui/src/app/cohort-search/search-state.service.ts
@@ -12,3 +12,4 @@ export const scrollStore = new BehaviorSubject<any>(undefined);
 export const attributesStore = new BehaviorSubject<any>(undefined);
 export const autocompleteStore = new BehaviorSubject<any>('');
 export const idsInUse = new BehaviorSubject<any>(new Set());
+export const ppiQuestions = new BehaviorSubject<any>({});

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -98,30 +98,30 @@ export function listAttributeDisplay(parameter): string {
   }
 }
 
-export function domainToTitle(domain: string): string {
+export function domainToTitle(domain: any): string {
   switch (domain) {
-    case DomainType[DomainType.PERSON]:
+    case DomainType.PERSON:
       domain = 'Demographics';
       break;
-    case DomainType[DomainType.MEASUREMENT]:
+    case DomainType.MEASUREMENT:
       domain = 'Measurements';
       break;
-    case DomainType[DomainType.PHYSICALMEASUREMENT]:
+    case DomainType.PHYSICALMEASUREMENT:
       domain = 'Physical Measurements';
       break;
-    case DomainType[DomainType.VISIT]:
+    case DomainType.VISIT:
       domain = 'Visit';
       break;
-    case DomainType[DomainType.DRUG]:
+    case DomainType.DRUG:
       domain = 'Drugs';
       break;
-    case DomainType[DomainType.CONDITION]:
+    case DomainType.CONDITION:
       domain = 'Conditions';
       break;
-    case DomainType[DomainType.PROCEDURE]:
+    case DomainType.PROCEDURE:
       domain = 'Procedures';
       break;
-    case DomainType[DomainType.LAB]:
+    case DomainType.LAB:
       domain = 'Labs';
       break;
   }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -18,5 +18,5 @@ export const environment: Environment = {
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   enableJupyterLab: true,
   enableDatasetBuilder: true,
-  enableCBListSearch: false,
+  enableCBListSearch: true,
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -18,5 +18,5 @@ export const environment: Environment = {
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   enableJupyterLab: true,
   enableDatasetBuilder: true,
-  enableCBListSearch: true,
+  enableCBListSearch: false,
 };


### PR DESCRIPTION
**These feature flags need to be enabled to test this PR:
-`enableListSearch` in [/api/config/config_local.json](https://github.com/all-of-us/workbench/blob/master/api/config/config_local.json#L64)
-`enableCBListSearch ` in [/ui/src/environments/environment.local.ts](https://github.com/all-of-us/workbench/blob/master/ui/src/environments/environment.local.ts#L21)

Adds Surveys and Physical Measurements options in the criteria dropdown for new list search UI. These do not use the new list search workflow and will open the wizard directly to the tree view. No design or functionality changes, these should work the same as the current wizards.