### PR TITLE
[RW-2736][risk=no]Convert cards and breadcrumbs to anchor links

### DIFF
--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -58,6 +58,15 @@ export const navigateByUrl = (...args) => {
   return NavStore.navigateByUrl(...args);
 };
 
+// if modifier keys are pressed (like shift or cmd) use the href
+// if no keys are pressed, prevent default behavior and route using navigateByUrl
+export const navigateAndPreventDefaultIfNoKeysPressed = (e: React.MouseEvent, url: string) => {
+  if (!(e.shiftKey || e.altKey || e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    navigateByUrl(url);
+  }
+};
+
 export enum BreadcrumbType {
   Workspaces = 'Workspaces',
   Workspace = 'Workspace',

--- a/ui/src/app/views/breadcrumb.tsx
+++ b/ui/src/app/views/breadcrumb.tsx
@@ -10,7 +10,7 @@ import {
   withRouteConfigData,
   withUrlParams
 } from 'app/utils';
-import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed, navigateByUrl} from 'app/utils/navigation';
+import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 
 const styles = {
   firstLink: {

--- a/ui/src/app/views/breadcrumb.tsx
+++ b/ui/src/app/views/breadcrumb.tsx
@@ -10,7 +10,7 @@ import {
   withRouteConfigData,
   withUrlParams
 } from 'app/utils';
-import {BreadcrumbType, navigateByUrl} from 'app/utils/navigation';
+import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed, navigateByUrl} from 'app/utils/navigation';
 
 const styles = {
   firstLink: {
@@ -93,8 +93,7 @@ const BreadcrumbLink = ({href, ...props}) => {
   return <a
     href={href}
     onClick={e => {
-      e.preventDefault();
-      navigateByUrl(href);
+      navigateAndPreventDefaultIfNoKeysPressed(e, href);
     }}
     {...props}
   />;

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -30,7 +30,7 @@ const styles = reactStyles({
     fontSize: '18px', fontWeight: 500, lineHeight: '22px', color: colors.blue[0],
     cursor: 'pointer', wordBreak: 'break-all', textOverflow: 'ellipsis',
     overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3,
-    WebkitBoxOrient: 'vertical'
+    WebkitBoxOrient: 'vertical', textDecoration: 'none'
   },
   cardDescription: {
     textOverflow: 'ellipsis', overflow: 'hidden', display: '-webkit-box',

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -446,15 +446,17 @@ export class ResourceCard extends React.Component<Props, State> {
         return `${workspacePrefix}/concepts/sets/${conceptSet.id}`;
       }
       case ResourceType.NOTEBOOK: {
-        const queryParams = {
-          playgroundMode: false,
-          jupyterLabMode: jupyterLab,
-        };
+        const queryParams = new URLSearchParams([
+          ['playgroundMode', 'false'],
+          ['jupyterLabMode', (jupyterLab || false).toString()]
+        ]);
+
         if (this.notebookReadOnly) {
-          queryParams.playgroundMode = true;
+          queryParams.set('jupyterLabMode', 'true');
         }
+
         return `${workspacePrefix}/notebooks/${encodeURIComponent(notebook.name)}?` +
-          fp.toPairs(queryParams).map(kvp => `${kvp[0]}=${kvp[1]}`).join('&');
+          queryParams.toString();
       }
       case ResourceType.DATA_SET: {
         return `${workspacePrefix}/data/data-sets/${dataSet.id}`;

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -1,7 +1,7 @@
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
-import {Clickable, Link} from 'app/components/buttons';
+import {Clickable} from 'app/components/buttons';
 import {ResourceCardBase} from 'app/components/card';
 import {ResourceCardMenu} from 'app/components/resources';
 import {TextModal} from 'app/components/text-modal';

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -448,7 +448,7 @@ export class ResourceCard extends React.Component<Props, State> {
       case ResourceType.NOTEBOOK: {
         const queryParams = new URLSearchParams([
           ['playgroundMode', 'false'],
-          ['jupyterLabMode', (jupyterLab || false).toString()]
+          ['jupyterLabMode', String(jupyterLab)]
         ]);
 
         if (this.notebookReadOnly) {


### PR DESCRIPTION
With this change, cards (like notebooks, data sets, cohorts) and breadcrumbs are now anchor links.  This enables user behavior like right-click, middle-click, shift-click, and command-click.  

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
