### PR TITLE
[risk=no] Fix ?jupyterLabMode=undefined in notebooks redirect URLs

### DIFF
--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -462,7 +462,7 @@ export class ResourceCard extends React.Component<Props, State> {
     }
   }
 
-  getResourceUrl(jupyterLab?: boolean): string {
+  getResourceUrl(jupyterLab = false): string {
     const {workspaceNamespace, workspaceFirecloudName, conceptSet, notebook, dataSet, cohort} =
       this.props.resourceCard;
     const workspacePrefix = `/workspaces/${workspaceNamespace}/${workspaceFirecloudName}`;


### PR DESCRIPTION
Now shows ?jupyterLabMode=false

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
