### PR TITLE
[RW-1605][risk=no] Fix cluster load messaging on notebooks redirect

### DIFF
--- a/ui/src/app/views/notebook-redirect/component.html
+++ b/ui/src/app/views/notebook-redirect/component.html
@@ -9,8 +9,8 @@
       <div id="initializing" class="progress-card" [class.progress-card-current]="[Progress.Initializing, Progress.Resuming, Progress.Unknown].includes(progress)">
         <span *ngIf="[Progress.Initializing, Progress.Resuming, Progress.Unknown].includes(progress)" class="spinner spinner-sm"></span>
         <app-notebook-icon *ngIf="![Progress.Initializing, Progress.Resuming, Progress.Unknown].includes(progress)"></app-notebook-icon>
-        <span *ngIf="progress === Progress.Unknown" class="progress-text">Connecting to notebook server...</span>
-        <span *ngIf="(progress === Progress.Initializing || progressComplete[Progress.Initializing]) && !progressComplete[Progress.Resuming]" class="progress-text">Initializing notebook server, may take up to 10 minutes</span>
+        <span *ngIf="progress === Progress.Unknown || progressComplete[Progress.Unknown]" class="progress-text">Connecting to the notebook server</span>
+        <span *ngIf="progress === Progress.Initializing || progressComplete[Progress.Initializing]" class="progress-text">Initializing notebook server, may take up to 10 minutes</span>
         <span *ngIf="progress === Progress.Resuming || progressComplete[Progress.Resuming]" class="progress-text">Resuming notebook server, may take up to 1 minute</span>
       </div>
       <div id="authenticating" class="progress-card" [class.progress-card-current]="progress === Progress.Authenticating">

--- a/ui/src/app/views/notebook-redirect/component.spec.ts
+++ b/ui/src/app/views/notebook-redirect/component.spec.ts
@@ -158,6 +158,20 @@ describe('NotebookRedirectComponent', () => {
     expect(fixture.debugElement.queryAll(By.css('.i-frame')).length).toBe(1);
   }));
 
+  it('should display "Connecting" after initially finding a RUNNING cluster', fakeAsync(() => {
+    blockingClusterStub.cluster.status = ClusterStatus.Running;
+
+    updateAndTick(fixture);
+    fixture.detectChanges();
+
+    const initBox = fixture.debugElement.queryAll(By.css('#initializing'))[0];
+    expect(initBox.children[1].nativeElement.innerText)
+      .toContain('Connecting');
+
+    tick(10000);
+    fixture.detectChanges();
+  }));
+
   it('should display resuming message until resumed', fakeAsync(() => {
     blockingClusterStub.cluster.status = ClusterStatus.Stopped;
     updateAndTick(fixture);

--- a/ui/src/app/views/notebook-redirect/component.spec.ts
+++ b/ui/src/app/views/notebook-redirect/component.spec.ts
@@ -168,8 +168,8 @@ describe('NotebookRedirectComponent', () => {
     expect(initBox.children[1].nativeElement.innerText)
       .toContain('Connecting');
 
+    // Clear lingering timers.
     tick(10000);
-    fixture.detectChanges();
   }));
 
   it('should display resuming message until resumed', fakeAsync(() => {


### PR DESCRIPTION
When cluster is already running, don't show the "may take 10 minutes" language. Some minor cleanup so that we only set `progressComplete` on one of Unknown, Initializing, Resuming.

![image](https://user-images.githubusercontent.com/822298/60206130-b592ca80-9807-11e9-9d9c-78d97239f2f7.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
