### PR TITLE
[RW-2899][risk=no] Fix resource card lastModified time handling

### DIFF
--- a/ui/src/app/utils/resourceActionsReact.ts
+++ b/ui/src/app/utils/resourceActionsReact.ts
@@ -35,7 +35,7 @@ export function convertToResource(resource: FileDetail | Cohort | ConceptSet | D
   if (!resource.lastModifiedTime) {
     modifiedTime = new Date().toDateString();
   } else {
-    modifiedTime = resource.lastModifiedTime.toString();
+    modifiedTime = new Date(resource.lastModifiedTime).toString();
   }
   const newResource: RecentResource = {
     workspaceNamespace: workspaceNamespace,

--- a/ui/src/app/views/resource-card.spec.tsx
+++ b/ui/src/app/views/resource-card.spec.tsx
@@ -1,4 +1,4 @@
-import {mount} from 'enzyme';
+import {mount, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 
 import {ResourceCard} from './resource-card';
@@ -13,7 +13,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     cohort: new CohortsServiceStub().cohorts[0],
-    modifiedTime: Date.now().toString()
+    modifiedTime: new Date().toISOString()
   },
   conceptSetCard: {
     workspaceId: 1,
@@ -21,7 +21,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     conceptSet: new ConceptSetsApiStub().conceptSets[0],
-    modifiedTime: Date.now().toString()
+    modifiedTime: new Date().toISOString()
   },
   notebookCard: {
     workspaceId: 1,
@@ -33,7 +33,7 @@ const ResourceCardWrapper = {
       'path': 'gs://bucket/notebooks/mockFile.ipynb',
       'lastModifiedTime': 100
     },
-    modifiedTime: Date.now().toString()
+    modifiedTime: new Date().toISOString()
   }
 };
 
@@ -45,6 +45,11 @@ describe('ResourceCardComponent', () => {
         onUpdate={() => {}}/>);
   };
 
+  const lastModifiedDate = (wrapper: ReactWrapper) => {
+    const txt = wrapper.find('[data-test-id="last-modified"]').text().replace('Last Modified: ', '');
+    return Date.parse(txt);
+  };
+
   it('should render', () => {
     const wrapper = component(ResourceCardWrapper.cohortCard);
     expect(wrapper).toBeTruthy();
@@ -53,16 +58,19 @@ describe('ResourceCardComponent', () => {
   it('should render a cohort if resource is cohort', () => {
     const wrapper = component(ResourceCardWrapper.cohortCard);
     expect(wrapper.find('[data-test-id="card-type"]').text()).toBe('Cohort');
+    expect(lastModifiedDate(wrapper)).toBeTruthy();
   });
 
   it('should render a concept set if resource is concept set', () => {
     const wrapper = component(ResourceCardWrapper.conceptSetCard);
     expect(wrapper.find('[data-test-id="card-type"]').text()).toBe('Concept Set');
+    expect(lastModifiedDate(wrapper)).toBeTruthy();
   });
 
   it('should render a notebook if the resource is a notebook', () => {
     const wrapper = component(ResourceCardWrapper.notebookCard);
     expect(wrapper.find('[data-test-id="card-type"]').text()).toBe('Notebook');
+    expect(lastModifiedDate(wrapper)).toBeTruthy();
   });
 
   // Note: this spec is not testing the Popup menus on resource cards due to an issue using

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -199,6 +199,9 @@ export class ResourceCard extends React.Component<Props, State> {
   }
 
   get displayDate(): string {
+    if (!this.props.resourceCard.modifiedTime) {
+      return '';
+    }
     const date = new Date(this.props.resourceCard.modifiedTime);
     // datetime formatting to slice off weekday from readable date string
     return date.toDateString().split(' ').slice(1).join(' ');

--- a/ui/src/app/views/resource-card.tsx
+++ b/ui/src/app/views/resource-card.tsx
@@ -199,7 +199,7 @@ export class ResourceCard extends React.Component<Props, State> {
   }
 
   get displayDate(): string {
-    const date = new Date(Number(this.props.resourceCard.modifiedTime));
+    const date = new Date(this.props.resourceCard.modifiedTime);
     // datetime formatting to slice off weekday from readable date string
     return date.toDateString().split(' ').slice(1).join(' ');
   }
@@ -582,7 +582,7 @@ export class ResourceCard extends React.Component<Props, State> {
           <div style={styles.cardDescription}>{this.description}</div>
         </div>
         <div style={styles.cardFooter}>
-          <div style={styles.lastModified}>
+          <div style={styles.lastModified} data-test-id='last-modified'>
             Last Modified: {this.displayDate}</div>
           <div style={{...styles.resourceType, ...resourceTypeStyles[this.resourceType]}}
                data-test-id='card-type'>


### PR DESCRIPTION
RecentResource uses a `string`; this was being coerced as a string number on the workspace page, while recent-work was broken.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
