### PR TITLE
[risk=no] Refactor WorkspaceACL handling to avoid Java warning

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -135,20 +135,16 @@ public class WorkspaceServiceImpl implements WorkspaceService {
                 fcWorkspace -> fcWorkspace));
   }
 
-  /**
-   * Swagger Java codegen does not handle the WorkspaceACL model correctly; it returns a GSON map
-   * instead. Run this through a typed Gson conversion process to parse into the desired type.
-   */
-  private static Map<String, WorkspaceAccessEntry> extractAclResponse(WorkspaceACL aclResp) {
-    Type accessEntryType = new TypeToken<Map<String, WorkspaceAccessEntry>>() {}.getType();
-    Gson gson = new Gson();
-    return gson.fromJson(gson.toJson(aclResp.getAcl(), accessEntryType), accessEntryType);
-  }
-
   @Override
   public Map<String, WorkspaceAccessEntry> getFirecloudWorkspaceAcls(
       String workspaceNamespace, String firecloudName) {
-    return extractAclResponse(fireCloudService.getWorkspaceAcl(workspaceNamespace, firecloudName));
+    WorkspaceACL aclResp = fireCloudService.getWorkspaceAcl(workspaceNamespace, firecloudName);
+
+    // Swagger Java codegen does not handle the WorkspaceACL model correctly; it returns a GSON map
+    // instead. Run this through a typed Gson conversion process to parse into the desired type.
+    Type accessEntryType = new TypeToken<Map<String, WorkspaceAccessEntry>>() {}.getType();
+    Gson gson = new Gson();
+    return gson.fromJson(gson.toJson(aclResp.getAcl(), accessEntryType), accessEntryType);
   }
 
   /**

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -78,7 +78,10 @@ import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.*;
+import org.pmiops.workbench.firecloud.model.WorkspaceACL;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
+import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
+import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.CloneWorkspaceRequest;
@@ -343,13 +346,18 @@ public class WorkspacesControllerTest {
   }
 
   private WorkspaceACL createWorkspaceACL() {
-    WorkspaceACL fcAcl = new WorkspaceACL();
-    Map<String, Object> acl = new HashMap<>();
-    JSONObject accessEntry =
-        new JSONObject().put("accessLevel", "OWNER").put("canCompute", true).put("canShare", true);
-    acl.put(currentUser.getEmail(), accessEntry);
-    fcAcl.setAcl(acl);
-    return fcAcl;
+    return createWorkspaceACL(
+        new JSONObject()
+            .put(
+                currentUser.getEmail(),
+                new JSONObject()
+                    .put("accessLevel", "OWNER")
+                    .put("canCompute", true)
+                    .put("canShare", true)));
+  }
+
+  private WorkspaceACL createWorkspaceACL(JSONObject acl) {
+    return new Gson().fromJson(new JSONObject().put("acl", acl).toString(), WorkspaceACL.class);
   }
 
   private JSONObject createDemoCriteria() {
@@ -1434,37 +1442,43 @@ public class WorkspacesControllerTest {
                 new UserRole().email(writer.getEmail()).role(WorkspaceAccessLevel.WRITER)));
 
     stubFcUpdateWorkspaceACL();
-    WorkspaceACL workspaceAclsFromCloned = new WorkspaceACL();
-    Map<String, Object> aclsFromCloned = new HashMap<>();
-    aclsFromCloned.put(
-        "cloner@gmail.com",
-        new JSONObject().put("accessLevel", "OWNER").put("canCompute", true).put("canShare", true));
-    workspaceAclsFromCloned.setAcl(aclsFromCloned);
+    WorkspaceACL workspaceAclsFromCloned =
+        createWorkspaceACL(
+            new JSONObject()
+                .put(
+                    "cloner@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "OWNER")
+                        .put("canCompute", true)
+                        .put("canShare", true)));
 
-    WorkspaceACL workspaceAclsFromOriginal = new WorkspaceACL();
-    Map<String, Object> aclsFromOriginal = new HashMap<>();
-    aclsFromOriginal.put(
-        "cloner@gmail.com",
-        new JSONObject()
-            .put("accessLevel", "READER")
-            .put("canCompute", true)
-            .put("canShare", true));
-    aclsFromOriginal.put(
-        "reader@gmail.com",
-        new JSONObject()
-            .put("accessLevel", "READER")
-            .put("canCompute", false)
-            .put("canShare", false));
-    aclsFromOriginal.put(
-        "writer@gmail.com",
-        new JSONObject()
-            .put("accessLevel", "WRITER")
-            .put("canCompute", true)
-            .put("canShare", false));
-    aclsFromOriginal.put(
-        LOGGED_IN_USER_EMAIL,
-        new JSONObject().put("accessLevel", "OWNER").put("canCompute", true).put("canShare", true));
-    workspaceAclsFromOriginal.setAcl(aclsFromOriginal);
+    WorkspaceACL workspaceAclsFromOriginal =
+        createWorkspaceACL(
+            new JSONObject()
+                .put(
+                    "cloner@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "READER")
+                        .put("canCompute", true)
+                        .put("canShare", true))
+                .put(
+                    "reader@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "READER")
+                        .put("canCompute", false)
+                        .put("canShare", false))
+                .put(
+                    "writer@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "WRITER")
+                        .put("canCompute", true)
+                        .put("canShare", false))
+                .put(
+                    LOGGED_IN_USER_EMAIL,
+                    new JSONObject()
+                        .put("accessLevel", "OWNER")
+                        .put("canCompute", true)
+                        .put("canShare", true)));
 
     when(fireCloudService.getWorkspaceAcl("cloned-ns", "cloned"))
         .thenReturn(workspaceAclsFromCloned);
@@ -1691,24 +1705,27 @@ public class WorkspacesControllerTest {
     shareWorkspaceRequest.addItemsItem(reader);
 
     // Mock firecloud ACLs
-    WorkspaceACL workspaceACLs = new WorkspaceACL();
-    Map<String, Object> acls = new HashMap<>();
-    acls.put(
-        LOGGED_IN_USER_EMAIL,
-        new JSONObject().put("accessLevel", "OWNER").put("canCompute", true).put("canShare", true));
-    acls.put(
-        "writerfriend@gmail.com",
-        new JSONObject()
-            .put("accessLevel", "WRITER")
-            .put("canCompute", true)
-            .put("canShare", false));
-    acls.put(
-        "readerfriend@gmail.com",
-        new JSONObject()
-            .put("accessLevel", "READER")
-            .put("canCompute", false)
-            .put("canShare", false));
-    workspaceACLs.setAcl(acls);
+    WorkspaceACL workspaceACLs =
+        createWorkspaceACL(
+            new JSONObject()
+                .put(
+                    LOGGED_IN_USER_EMAIL,
+                    new JSONObject()
+                        .put("accessLevel", "OWNER")
+                        .put("canCompute", true)
+                        .put("canShare", true))
+                .put(
+                    "writerfriend@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "WRITER")
+                        .put("canCompute", true)
+                        .put("canShare", false))
+                .put(
+                    "readerfriend@gmail.com",
+                    new JSONObject()
+                        .put("accessLevel", "READER")
+                        .put("canCompute", false)
+                        .put("canShare", false)));
     when(fireCloudService.getWorkspaceAcl(any(), any())).thenReturn(workspaceACLs);
 
     CLOCK.increment(1000);


### PR DESCRIPTION
Slightly more automated parsing + gets rid of the unchecked Java warning.

Copied from my now deleted backfill script: https://github.com/all-of-us/workbench/pull/2221/files#diff-3e77476e30c3fda73b42c53d56c9f977R96

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
