### PR TITLE
[RW-2847][risk=no]Open Notebook from Data set in a "new tab" by default

### DIFF
--- a/ui/src/app/views/export-data-set-modal.tsx
+++ b/ui/src/app/views/export-data-set-modal.tsx
@@ -126,9 +126,11 @@ class ExportDataSetModal extends React.Component<
         newNotebook: this.state.newNotebook,
         kernelType: this.state.kernelType
       });
-    navigate(['workspaces',
-      workspaceNamespace,
-      workspaceFirecloudName, 'notebooks', this.state.notebookName + '.ipynb']);
+    // Open notebook in a new tab and close the modal
+    const notebookUrl = '\\workspaces\\' + workspaceNamespace + '\\' + workspaceFirecloudName +
+        '\\notebooks\\' + this.state.notebookName + '.ipynb';
+    window.open(notebookUrl);
+    this.props.closeFunction();
   }
 
   render() {

--- a/ui/src/app/views/export-data-set-modal.tsx
+++ b/ui/src/app/views/export-data-set-modal.tsx
@@ -9,7 +9,6 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {dataSetApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import {summarizeErrors} from 'app/utils';
-import {navigate} from 'app/utils/navigation';
 
 
 import {DataSet, DataSetRequest, FileDetail, KernelTypeEnum} from 'generated/fetch';

--- a/ui/src/app/views/new-dataset-modal.tsx
+++ b/ui/src/app/views/new-dataset-modal.tsx
@@ -149,9 +149,7 @@ class NewDataSetModal extends React.Component<Props, State> {
       } else {
         await dataSetApi().createDataSet(workspaceNamespace, workspaceId, request);
       }
-      if (!this.state.exportToNotebook) {
-        window.history.back();
-      } else {
+      if (this.state.exportToNotebook) {
         await dataSetApi().exportToNotebook(
           workspaceNamespace, workspaceId,
           {
@@ -163,9 +161,9 @@ class NewDataSetModal extends React.Component<Props, State> {
         // Open notebook in a new tab and return back to the Data tab
         const notebookUrl = '\\workspaces\\' + workspaceNamespace + '\\' + workspaceId +
           '\\notebooks\\' + this.state.notebookName + '.ipynb';
-        window.history.back();
         window.open(notebookUrl);
       }
+      window.history.back();
     } catch (e) {
       if (e.status === 409) {
         this.setState({conflictDataSetName: true, loading: false});

--- a/ui/src/app/views/new-dataset-modal.tsx
+++ b/ui/src/app/views/new-dataset-modal.tsx
@@ -161,9 +161,11 @@ class NewDataSetModal extends React.Component<Props, State> {
             notebookName: this.state.notebookName,
             newNotebook: this.state.newNotebook
           });
-        navigate(['workspaces',
-          workspaceNamespace,
-          workspaceId, 'notebooks', this.state.notebookName + '.ipynb']);
+        // Open notebook in a new tab and return back to the Data tab
+        const notebookUrl = '\\workspaces\\' + workspaceNamespace + '\\' + workspaceId +
+          '\\notebooks\\' + this.state.notebookName + '.ipynb';
+        window.history.back();
+        window.open(notebookUrl);
       }
     } catch (e) {
       if (e.status === 409) {

--- a/ui/src/app/views/new-dataset-modal.tsx
+++ b/ui/src/app/views/new-dataset-modal.tsx
@@ -19,7 +19,6 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import colors from 'app/styles/colors';
 import {summarizeErrors} from 'app/utils';
-import {navigate} from 'app/utils/navigation';
 import {
   DataSet,
   DataSetRequest,


### PR DESCRIPTION
Export data set via snowman : opens the notebook in a new tab and returns back to Data tab

Update/save data set: opens notebook in a new tab and then closes the save modal and return back to data tab