### PR TITLE
[RW-2983] [risk=no] Load user roles before opening the workspace share modal.

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1050,7 +1050,12 @@ paths:
         - workspaces
       consumes:
         - application/json
-      description: Shares a workspace with users
+      description: >
+        Shares a workspace with the given users and permissions. Note that the entire ACL must
+        be provided to this method (including all existing users and roles), not just the additional
+        roles desired. Clients should first fetch existing ACLs via the getFirecloudWorkspaceUserRoles
+        method, make any changes desired, then pass the final list to this method.
+
       operationId: shareWorkspace
       parameters:
           - in: body

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -117,13 +117,17 @@ const computeStyle = ({style = {}, hover = {}, disabledStyle = {}}, {disabled}) 
 
 // Set data test id = '' in the child to prevent it from propegating to all children
 export const Clickable = ({as = 'div', disabled = false, onClick = null, ...props}) => {
+  // Don't propagate test IDs to the rendered child component.
+  delete props['data-test-id'];
   return <Interactive
-    as={as} {...props} data-test-id=''
+    as={as} {...props}
     onClick={(...args) => onClick && !disabled && onClick(...args)}
   />;
 };
 
 export const Button = ({type = 'primary', style = {}, disabled = false, ...props}) => {
+  // Don't propagate test IDs to the rendered child component.
+  delete props['data-test-id'];
   return <Clickable
     disabled={disabled} {...props}
     {...fp.merge(computeStyle(buttonVariants[type], {disabled}), {style})}

--- a/ui/src/app/components/icons.tsx
+++ b/ui/src/app/components/icons.tsx
@@ -24,6 +24,7 @@ export const styles = {
 };
 
 export const ClrIcon = ({className = '', ...props}) => {
+  delete props['data-test-id'];
   return React.createElement('clr-icon', {class: className, ...props});
 };
 

--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -26,11 +26,15 @@ const styles = {
   }
 };
 
+interface WithDynamicPositionProps {
+  target: string;
+}
+
 export const withDynamicPosition = () => WrappedComponent => {
-  const Wrapper = class extends React.Component {
+  const Wrapper = class WithDynamicPosition extends React.Component {
     static displayName = `withDynamicPosition()`;
 
-    props: any;
+    props: WithDynamicPositionProps;
     state: any;
     element: any;
     animation: number;
@@ -202,6 +206,8 @@ export const Popup = fp.flow(
   onClickOutside,
   withDynamicPosition()
 )(class PopupComponent extends React.Component {
+  static displayName = `Popup`;
+
   static readonly defaultProps = {
     side: 'right'
   };

--- a/ui/src/app/views/workspace-list.spec.tsx
+++ b/ui/src/app/views/workspace-list.spec.tsx
@@ -2,7 +2,6 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {
-  dataSetApi,
   registerApiClient, workspacesApi,
 } from 'app/services/swagger-fetch-clients';
 import {navigate, serverConfigStore, userProfileStore} from 'app/utils/navigation';
@@ -40,7 +39,7 @@ describe('WorkspaceList', () => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
 
     // mocking because we don't have access to the angular service
-    reload.mockImplementation(async() => {
+    reload.mockImplementation(async () => {
       const newProfile = await profileApi.getMe();
       userProfileStore.next({profile: newProfile as unknown as Profile, reload, updateCache});
     });
@@ -49,7 +48,7 @@ describe('WorkspaceList', () => {
     serverConfigStore.next({useBillingProjectBuffer: false, gsuiteDomain: 'abc'});
   });
 
-  it('displays the correct number of workspaces', async() => {
+  it('displays the correct number of workspaces', async () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     const cardNameList = wrapper.find('[data-test-id="workspace-card-name"]')
@@ -57,7 +56,7 @@ describe('WorkspaceList', () => {
     expect(cardNameList).toEqual(workspaceStubs.map(w => w.name));
   });
 
-  it('navigates when clicking on the workspace name', async() => {
+  it('navigates when clicking on the workspace name', async () => {
     const workspace = workspaceStubs[0];
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -65,7 +64,7 @@ describe('WorkspaceList', () => {
     expect(navigate).toHaveBeenCalledWith(['workspaces', workspace.namespace, workspace.id]);
   });
 
-  it('has the correct permissions classes', async() => {
+  it('has the correct permissions classes', async () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="workspace-card"]').first()
@@ -73,7 +72,7 @@ describe('WorkspaceList', () => {
       .toBe(WorkspaceStubVariables.DEFAULT_WORKSPACE_PERMISSION);
   });
 
-  it('fetches user roles before opening the share dialog', async() => {
+  it('fetches user roles before opening the share dialog', async () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     const userRolesSpy = jest.spyOn(workspacesApi(), 'getFirecloudWorkspaceUserRoles');
@@ -92,10 +91,5 @@ describe('WorkspaceList', () => {
     const shareModal = wrapper.find('[data-test-id="workspace-share-modal"]').first();
     expect(shareModal.prop('userRoles')).toEqual(userRolesStub);
   });
-
-  // TODO (RW-2625) Exercise a workspace share code path from the workspace list.
-
-  // Note: this spec is not testing the Popup menus on workspace cards due to an issue using
-  //    PopupTrigger in the test suite.
 
 });

--- a/ui/src/app/views/workspace-list.spec.tsx
+++ b/ui/src/app/views/workspace-list.spec.tsx
@@ -1,23 +1,27 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 
-import {WorkspaceList} from './workspace-list';
-import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import {
+  dataSetApi,
+  registerApiClient, workspacesApi,
+} from 'app/services/swagger-fetch-clients';
+import {navigate, serverConfigStore, userProfileStore} from 'app/utils/navigation';
 import {Profile} from 'generated';
 import {ProfileApi, WorkspacesApi} from 'generated/fetch';
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-service-stub';
-import {navigate, serverConfigStore, userProfileStore} from 'app/utils/navigation';
 import {
+  userRolesStub,
   WorkspacesApiStub,
   workspaceStubs,
   WorkspaceStubVariables
 } from 'testing/stubs/workspaces-api-stub';
-import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {WorkspaceList} from './workspace-list';
 
 // Mock the navigate function but not userProfileStore
 jest.mock('app/utils/navigation', () => ({
-    ...(require.requireActual('app/utils/navigation')),
+  ...(require.requireActual('app/utils/navigation')),
   navigate: jest.fn()
 }));
 
@@ -28,7 +32,7 @@ describe('WorkspaceList', () => {
   const updateCache = jest.fn();
 
   const component = () => {
-    return mount(<WorkspaceList/>);
+    return mount(<WorkspaceList/>, {attachTo: document.getElementById('root')});
   };
 
   beforeEach(() => {
@@ -36,16 +40,16 @@ describe('WorkspaceList', () => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
 
     // mocking because we don't have access to the angular service
-    reload.mockImplementation(async () => {
+    reload.mockImplementation(async() => {
       const newProfile = await profileApi.getMe();
       userProfileStore.next({profile: newProfile as unknown as Profile, reload, updateCache});
     });
 
     userProfileStore.next({profile, reload, updateCache});
-    serverConfigStore.next({useBillingProjectBuffer: false, gsuiteDomain: "abc"});
+    serverConfigStore.next({useBillingProjectBuffer: false, gsuiteDomain: 'abc'});
   });
 
-  it('displays the correct number of workspaces', async () => {
+  it('displays the correct number of workspaces', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     const cardNameList = wrapper.find('[data-test-id="workspace-card-name"]')
@@ -53,7 +57,7 @@ describe('WorkspaceList', () => {
     expect(cardNameList).toEqual(workspaceStubs.map(w => w.name));
   });
 
-  it('enables editing workspaces', async () => {
+  it('navigates when clicking on the workspace name', async() => {
     const workspace = workspaceStubs[0];
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -61,12 +65,32 @@ describe('WorkspaceList', () => {
     expect(navigate).toHaveBeenCalledWith(['workspaces', workspace.namespace, workspace.id]);
   });
 
-  it('has the correct permissions classes', async () => {
+  it('has the correct permissions classes', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="workspace-card"]').first()
       .find('[data-test-id="workspace-access-level"]').text())
       .toBe(WorkspaceStubVariables.DEFAULT_WORKSPACE_PERMISSION);
+  });
+
+  it('fetches user roles before opening the share dialog', async() => {
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    const userRolesSpy = jest.spyOn(workspacesApi(), 'getFirecloudWorkspaceUserRoles');
+
+    // Click the snowman menu
+    wrapper.find('[data-test-id="workspace-card-menu"]').first().simulate('click');
+    // Click the share menu item
+    wrapper.find('[data-test-id="share-workspace"]').first()
+      .simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    // We should have called the userRoles API before opening the share modal.
+    expect(userRolesSpy).toHaveBeenCalledTimes(1);
+
+    // The share modal should have been opened w/ the correct props.
+    const shareModal = wrapper.find('[data-test-id="workspace-share-modal"]').first();
+    expect(shareModal.prop('userRoles')).toEqual(userRolesStub);
   });
 
   // TODO (RW-2625) Exercise a workspace share code path from the workspace list.

--- a/ui/src/app/views/workspace-list.tsx
+++ b/ui/src/app/views/workspace-list.tsx
@@ -195,6 +195,8 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
       workspaceDeletionError: false});
   }
 
+  // Reloads data by calling the callback from the owning component. This
+  // currently causes the workspace-list to reload the entire list of workspaces.
   async reloadData() {
     await this.props.reload();
   }

--- a/ui/src/app/views/workspace-share.tsx
+++ b/ui/src/app/views/workspace-share.tsx
@@ -157,6 +157,8 @@ export interface Props {
   accessLevel: WorkspaceAccessLevel;
   userEmail: string;
   onClose: Function;
+  // The userRoles to pre-populate the share dialog. Must be filled with all
+  // pre-existing roles on the workspace for this dialog to work correctly.
   userRoles: UserRole[];
 }
 


### PR DESCRIPTION
See the bug description with some add'l info on the breakage.

With this PR, users will see a brief spinner on the workspace card itself while we're loading the user roles:

<img width="400" alt="Screen Shot 2019-07-05 at 3 41 26 PM" src="https://user-images.githubusercontent.com/51842/60742450-6c472700-9f3b-11e9-93b6-432d79fa10c7.png">

I tried to add a minimal unit test that checks that we're correctly loading data and populating the workspace-share props. And some add'l docs on the API to clarify that you need to include the full desired ACL, not just newly-shared users.