### PR TITLE
[RW-2994] [risk=no] Update our version of the dependency-check plugin.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -183,7 +183,7 @@ buildscript {    // Configuration for building
     classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
     classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.12.0'
     classpath 'io.swagger:swagger-codegen:2.2.3'
-    classpath 'org.owasp:dependency-check-gradle:3.1.0'
+    classpath 'org.owasp:dependency-check-gradle:5.1.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.23.0'
   }
 }


### PR DESCRIPTION
I ran this locally and it seems to work fine:
```
./gradlew dependencyCheckAnalyze

...

> Task :dependencyCheckAnalyze
Generating report for project api
Found 216 vulnerabilities in project api

...

BUILD SUCCESSFUL in 6m 59s
1 actionable task: 1 executed
```

There's no evidence to suggest this will directly fix the connection flakiness we observed... but at least we won't be on a 1+-year old version of the plugin.