### PR TITLE
[RW-2998][risk=low] Use an API token rather than a password for Jira auth

### DIFF
--- a/deploy/libproject/jirarelease.rb
+++ b/deploy/libproject/jirarelease.rb
@@ -75,6 +75,7 @@ def format_jira_error(e)
 end
 
 class JiraReleaseClient
+
   def initialize(username, password)
     # Set :http_debug => true to see outgoing JIRA requests
     @client = JIRA::Client.new({
@@ -93,7 +94,7 @@ class JiraReleaseClient
       raise RuntimeError.new "failed to read JIRA login from '#{gcs_uri}'"
     end
     jira_json = JSON.parse(jira_creds)
-    return JiraReleaseClient.new(jira_json['username'], jira_json['password'])
+    return JiraReleaseClient.new(jira_json['username'], jira_json['apiToken'])
   end
 
   def ticket_summary(tag)

--- a/deploy/libproject/jirarelease.rb
+++ b/deploy/libproject/jirarelease.rb
@@ -75,7 +75,6 @@ def format_jira_error(e)
 end
 
 class JiraReleaseClient
-
   def initialize(username, password)
     # Set :http_debug => true to see outgoing JIRA requests
     @client = JIRA::Client.new({


### PR DESCRIPTION
Already generated API token per https://confluence.atlassian.com/cloud/api-tokens-938839638.html and pushed to all `jira-login.json` files. After the next release, will update these JSON files to omit the password.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
