### PR TITLE
[risk=no] Fix firecloud.yaml bugs on removeUserFromBillingProject

### DIFF
--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -172,7 +172,7 @@ paths:
             type: string
           - in: path
             description: role of user for project
-            name: workbenchRole
+            name: role
             required: true
             type: string
             enum: ["user", "owner"]
@@ -186,7 +186,7 @@ paths:
         summary: remove user or group from billing project the caller owns
         operationId: removeUserFromBillingProject
         security:
-          - authorization:
+          - googleoauth:
               - openid
               - email
               - profile


### PR DESCRIPTION
I don't know how this happened - the source api-docs.yaml is correct (and has been for at least 3y), but it cost me ~1h of debugging to find. Also some weirdness around `workbenchRole` vs `role`; I don't know whether that was originally an issue in the docs or that was a problem of our own design - this endpoint never worked and the only place we call this, we're suppressing exceptions.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
