### PR TITLE
[RW-3042][risk=no] Don't block "create workspace" on free tier billing project

### DIFF
--- a/ui/src/app/views/signed-in/component.html
+++ b/ui/src/app/views/signed-in/component.html
@@ -62,7 +62,7 @@
       <button class="btn btn-primary nav-link"
           [class.active]="createWorkspaceActive"
           routerLink="/workspaces/build"
-          [disabled]="(hasDataAccess ? null : true) || !billingProjectInitialized"
+          [disabled]="(hasDataAccess ? null : true)"
           (click)="sidenavToggle = false">Create Workspace</button>
       <button class="btn btn-primary nav-link"
           [class.active]="workspacesActive"

--- a/ui/src/app/views/signed-in/component.ts
+++ b/ui/src/app/views/signed-in/component.ts
@@ -10,7 +10,7 @@ import {hasRegisteredAccess} from 'app/utils';
 import {routeConfigDataStore} from 'app/utils/navigation';
 import {initializeZendeskWidget, openZendeskWidget} from 'app/utils/zendesk';
 import {environment} from 'environments/environment';
-import {Authority, BillingProjectStatus} from 'generated';
+import {Authority} from 'generated';
 
 @Component({
   selector: 'app-signed-in',
@@ -41,10 +41,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
   // True if the user tried to open the Zendesk support widget and an error
   // occurred.
   zendeskLoadError = false;
-  billingProjectInitialized = false;
-  billingProjectQuery: NodeJS.Timer;
   private profileLoadingSub: Subscription;
-  private profileBlockingSub: Subscription;
   private subscriptions = [];
 
   @ViewChild('sidenavToggleElement') sidenavToggleElement: ElementRef;
@@ -98,17 +95,6 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
       }
     });
 
-    this.profileBlockingSub = this.profileStorageService.profile$.subscribe((profile) => {
-      // This will block workspace creation until the billing project is initialized
-      if (profile.freeTierBillingProjectStatus === BillingProjectStatus.Ready) {
-        this.billingProjectInitialized = true;
-      } else {
-        this.billingProjectQuery = setTimeout(() => {
-          this.profileStorageService.reload();
-        }, 10000);
-      }
-    });
-
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.minimizeChrome = minimizeChrome;
     }));
@@ -123,9 +109,6 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
   ngOnDestroy() {
     if (this.profileLoadingSub) {
       this.profileLoadingSub.unsubscribe();
-    }
-    if (this.profileBlockingSub) {
-      this.profileBlockingSub.unsubscribe();
     }
     for (const s of this.subscriptions) {
       s.unsubscribe();


### PR DESCRIPTION
The per user free tier project goes away with 1ppw, and this was only really relevant in local/test, so should be fine to remove the guard entirely.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
