### PR TITLE
[RW-3058][RISK=NO] Selecting Survey Concept set on dataset page results in exception while retrieving value

### DIFF
--- a/ui/src/app/views/dataset-page.spec.tsx
+++ b/ui/src/app/views/dataset-page.spec.tsx
@@ -46,8 +46,9 @@ describe('DataSet', () => {
   it ('should display all concepts sets in workspace', async() => {
     const wrapper = mount(<DataSetPage />);
     await waitOneTickAndUpdate(wrapper);
+    // Concept set list filters out surveys
     expect(wrapper.find('[data-test-id="concept-set-list-item"]').length)
-      .toBe(ConceptSetsApiStub.stubConceptSets().length);
+      .toBe(ConceptSetsApiStub.stubConceptSets().length - 3);
   });
 
   it('should display all cohorts in workspace', async() => {

--- a/ui/src/app/views/dataset-page.tsx
+++ b/ui/src/app/views/dataset-page.tsx
@@ -283,7 +283,8 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         const [conceptSets, cohorts] = await Promise.all([
           conceptSetsApi().getConceptSetsInWorkspace(namespace, id),
           cohortsApi().getCohortsInWorkspace(namespace, id)]);
-        this.setState({conceptSetList: conceptSets.items, cohortList: cohorts.items,
+        const conceptSetNoSurvey = conceptSets.items.filter((concept) => !concept.survey);
+        this.setState({conceptSetList: conceptSetNoSurvey, cohortList: cohorts.items,
           loadingResources: false});
         return Promise.resolve();
       } catch (error) {


### PR DESCRIPTION
If we select a survey in  data set it results in error while getting value for surveys. 
If we do end up showing the value , the big query will have to change to include ds_survey rather than observation. For bedford release i do not think its best to change the big query so close to release rather filter out survey in concept set for data set page.