### PR TITLE
[No ticket] [risk=no] Adds an 'opacity' prop to the spinner component

### DIFF
--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 const styles = reactStyles({
   overlay: {
-    backgroundColor: 'rgba(200, 200, 200, 0)',
+    backgroundColor: new Color(colors.light).alpha(0).toString(),
     position: 'absolute', top: 0, left: 0, bottom: 0, right: 0,
     display: 'flex', justifyContent: 'center', alignItems: 'center',
     zIndex: 1

--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -1,10 +1,11 @@
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils/index';
 import * as React from 'react';
+import * as Color from 'Color';
 
 const styles = reactStyles({
   overlay: {
-    backgroundColor: 'rgba(0, 0, 0, 0)',
+    backgroundColor: 'rgba(200, 200, 200, 0)',
     position: 'absolute', top: 0, left: 0, bottom: 0, right: 0,
     display: 'flex', justifyContent: 'center', alignItems: 'center',
     zIndex: 1
@@ -30,10 +31,20 @@ export const Spinner = ({dark = false, size = 72, style = {}, ...props}) => {
   </svg>;
 };
 
+interface SpinnerOverlayProps {
+  dark?: boolean,
+  opacity?: number,
+  overrideStylesOverlay?: React.CSSProperties,
+  overrideStylesSquare?: React.CSSProperties
+};
+
 export const SpinnerOverlay = ({dark = false,
-                                 overrideStylesOverlay = {},
-                                 overrideStylesSquare = {}}) => {
-  return <div style={{...styles.overlay, ...overrideStylesOverlay}}>
+                                 opacity = 0,
+                                 overrideStylesOverlay= {},
+                                 overrideStylesSquare = {}}: SpinnerOverlayProps) => {
+  return <div style={{...styles.overlay, ...overrideStylesOverlay,
+    backgroundColor: Color(overrideStylesOverlay.backgroundColor || styles.overlay.backgroundColor)
+      .alpha(opacity).toString()}}>
     <div style={{...styles.square, ...overrideStylesSquare}}><Spinner dark={dark} /></div>
   </div>;
 };

--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -32,11 +32,16 @@ export const Spinner = ({dark = false, size = 72, style = {}, ...props}) => {
 };
 
 interface SpinnerOverlayProps {
-  dark?: boolean,
-  opacity?: number,
-  overrideStylesOverlay?: React.CSSProperties,
-  overrideStylesSquare?: React.CSSProperties
-};
+  // Colors the spinner using darker colors.
+  dark?: boolean;
+  // Sets the background opacity on the spinner overlay. Defaults to 0, which creates a fully-
+  // transparent overlay that blocks mouse interactions.
+  opacity?: number;
+  // CSS styles to apply to the overlay element.
+  overrideStylesOverlay?: React.CSSProperties;
+  // CSS styles to apply to the "square" element directly surrounding the spinner.
+  overrideStylesSquare?: React.CSSProperties;
+}
 
 export const SpinnerOverlay = ({dark = false,
                                  opacity = 0,

--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -1,7 +1,7 @@
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils/index';
+import * as Color from 'color';
 import * as React from 'react';
-import * as Color from 'Color';
 
 const styles = reactStyles({
   overlay: {


### PR DESCRIPTION
While working on https://github.com/all-of-us/workbench/pull/2345, I found myself wishing I were able to make the spinner overlay semi-opaque to make it clearer to the user which part of the screen was currently "loading", by graying it out a little bit.

This PR adds a simple prop to our core Spinner component, which should allow that to happen. By default opacity is zero, which should make this change a no-op for all existing usage.