### PR TITLE
[RW-3084][risk=no] Allow pre tags in notebook HTML

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -42,7 +42,9 @@ public class NotebooksServiceImpl implements NotebooksService {
                   // vulnerable to injection if vulnerabilities in nbconvert allow for custom style
                   // tag injection.
                   .allowTextIn("style")
-                  .allowElements("style")
+                  // <pre> is not included in the prebuilt sanitizers; it is used for monospace code
+                  // block formatting
+                  .allowElements("style", "pre")
                   // Allow id/class in order to interact with the style tag.
                   .allowAttributes("id", "class")
                   .globally()


### PR DESCRIPTION
My original manual testing notebook did not include non-trivial multiline code blocks - oops.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
