### PR TITLE
[RW-2501] [risk=no] Turn on enforceRegistered in test.

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -7,7 +7,7 @@
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
-    "enforceRegistered": false,
+    "enforceRegistered": true,
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -7,7 +7,7 @@
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
     "debugEndpoints": false,
-    "enforceRegistered": false,
+    "enforceRegistered": true,
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2,


### PR DESCRIPTION
This PR flips the test config to begin enforcing the registered state. We think this will help us catch regressions, and perform more realistic performance testing, in our push-on-green test environment.

There should be two main impacts:

(1) The UI should now force-redirect new users to the "registration tasks" page in test. Use the self-bypass button to allow yourself entry.

(2) New workspaces should be created with an authorization domain (https://github.com/all-of-us/workbench/blob/master/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java#L133).