### PR TITLE
[RW-2875][risk=no] refactor ElasticFilters to use CriteriaLookupUtil

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -128,7 +128,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     when(configProvider.get()).thenReturn(testConfig);
 
     ElasticSearchService elasticSearchService =
-        new ElasticSearchService(criteriaDao, cloudStorageService, configProvider);
+        new ElasticSearchService(cbCriteriaDao, cloudStorageService, configProvider);
 
     controller =
         new CohortBuilderController(
@@ -1187,9 +1187,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
-            Arrays.asList(icd9Child, icd9Parent),
-            new ArrayList<>());
+            DomainType.CONDITION.toString(), Arrays.asList(icd9Parent), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1218,7 +1216,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .group(true)
             .selectable(true)
             .ancestorData(false)
-            .conceptId("2");
+            .conceptId("2")
+            .synonyms("[CONDITION_rank1]");
     saveCriteriaWithPath("0", criteriaParent);
     CBCriteria criteriaChild =
         new CBCriteria()
@@ -1446,7 +1445,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .group(true)
             .standard(false)
             .ancestorData(false)
-            .conceptId(1L)
+            .conceptId(2L)
             .value("001");
 
     CBCriteria criteriaParent =
@@ -1461,7 +1460,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .group(true)
             .selectable(true)
             .ancestorData(false)
-            .conceptId("2");
+            .conceptId("2")
+            .synonyms("[CONDITION_rank1]");
     saveCriteriaWithPath("0", criteriaParent);
     CBCriteria criteriaChild =
         new CBCriteria()

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -137,14 +137,12 @@ public final class ElasticFilters {
           filter.should(b);
         } else {
           // "should" gives us "OR" behavior so long as we're in a filter context, which we are.
-          // This
-          // translates to N occurrences of criteria 1 OR N occurrences of criteria 2, etc.
+          // This translates to N occurrences of criteria 1 OR N occurrences of criteria 2, etc.
           filter.should(
               QueryBuilders.functionScoreQuery(
                       QueryBuilders.nestedQuery(
                           // We sum a constant score for each matching document, yielding the total
-                          // number
-                          // of matching nested documents (events).
+                          // number of matching nested documents (events).
                           "events", QueryBuilders.constantScoreQuery(b), ScoreMode.Total))
                   .setMinScore(occurredAtLeast));
         }

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -22,14 +22,13 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AttrName;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.CriteriaType;
+import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
-import org.pmiops.workbench.model.TreeSubType;
-import org.pmiops.workbench.model.TreeType;
 
 /**
  * Utility for conversion of Cohort Builder request into Elasticsearch filters. Instances of this
@@ -47,9 +46,9 @@ public final class ElasticFilters {
 
   private static Map<String, String> NON_NESTED_FIELDS =
       ImmutableMap.of(
-          TreeSubType.GEN.toString(), "gender_concept_id",
-          TreeSubType.RACE.toString(), "race_concept_id",
-          TreeSubType.ETH.toString(), "ethnicity_concept_id");
+          CriteriaType.GENDER.toString(), "gender_concept_id",
+          CriteriaType.RACE.toString(), "race_concept_id",
+          CriteriaType.ETHNICITY.toString(), "ethnicity_concept_id");
 
   private final CriteriaLookupUtil criteriaLookupUtil;
 
@@ -119,7 +118,7 @@ public final class ElasticFilters {
         String conceptField =
             "events." + (param.getStandard() ? "concept_id" : "source_concept_id");
         if (isNonNestedSchema(param)) {
-          conceptField = NON_NESTED_FIELDS.get(param.getSubtype());
+          conceptField = NON_NESTED_FIELDS.get(param.getType());
         }
         Set<String> leafConceptIds = toleafConceptIds(ImmutableList.of(param));
         BoolQueryBuilder b = QueryBuilders.boolQuery();
@@ -255,8 +254,8 @@ public final class ElasticFilters {
   }
 
   private static boolean isNonNestedSchema(SearchParameter param) {
-    CriteriaType paramType = CriteriaType.valueOf(param.getType());
-    return TreeType.DEMO.equals(paramType);
+    DomainType domainType = DomainType.valueOf(param.getDomain());
+    return DomainType.PERSON.equals(domainType);
   }
 
   private Set<String> toleafConceptIds(List<SearchParameter> params) {

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -266,7 +266,8 @@ public final class ElasticFilters {
             childrenByCriteriaGroup.get(param).stream()
                 .map(id -> Long.toString(id))
                 .collect(Collectors.toSet()));
-      } else if (param.getConceptId() != null) {
+      }
+      if (param.getConceptId() != null) {
         // not all SearchParameter have a concept id, so attributes/modifiers
         // are used to find matches in those scenarios.
         out.add(Long.toString(param.getConceptId()));

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticSearchService.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticSearchService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.json.JSONObject;
 import org.pmiops.workbench.cdr.CdrVersionContext;
-import org.pmiops.workbench.cdr.dao.CriteriaDao;
+import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.ElasticsearchConfig;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -41,16 +41,16 @@ public class ElasticSearchService {
 
   private static final Logger log = Logger.getLogger(ElasticSearchService.class.getName());
   private RestHighLevelClient client;
-  private CriteriaDao criteriaDao;
+  private CBCriteriaDao cbCriteriaDao;
   private CloudStorageService cloudStorageService;
   private Provider<WorkbenchConfig> configProvider;
 
   @Autowired
   public ElasticSearchService(
-      CriteriaDao criteriaDao,
+      CBCriteriaDao cbCriteriaDao,
       CloudStorageService cloudStorageService,
       Provider<WorkbenchConfig> configProvider) {
-    this.criteriaDao = criteriaDao;
+    this.cbCriteriaDao = cbCriteriaDao;
     this.cloudStorageService = cloudStorageService;
     this.configProvider = configProvider;
   }
@@ -59,7 +59,7 @@ public class ElasticSearchService {
   public Long count(SearchRequest req) throws IOException {
     String personIndex =
         ElasticUtils.personIndexName(CdrVersionContext.getCdrVersion().getElasticIndexBaseName());
-    QueryBuilder filter = ElasticFilters.fromCohortSearch(criteriaDao, req);
+    QueryBuilder filter = ElasticFilters.fromCohortSearch(cbCriteriaDao, req);
     log.info("Elastic filter: " + filter.toString());
     long count =
         client()
@@ -75,7 +75,7 @@ public class ElasticSearchService {
   public List<DemoChartInfo> demoChartInfo(SearchRequest req) throws IOException {
     String personIndex =
         ElasticUtils.personIndexName(CdrVersionContext.getCdrVersion().getElasticIndexBaseName());
-    QueryBuilder filter = ElasticFilters.fromCohortSearch(criteriaDao, req);
+    QueryBuilder filter = ElasticFilters.fromCohortSearch(cbCriteriaDao, req);
     log.info("Elastic filter: " + filter.toString());
     SearchResponse searchResponse =
         client()

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -96,7 +96,7 @@ public class CohortBuilderControllerTest {
     when(configProvider.get()).thenReturn(testConfig);
 
     ElasticSearchService elasticSearchService =
-        new ElasticSearchService(criteriaDao, cloudStorageService, configProvider);
+        new ElasticSearchService(cbCriteriaDao, cloudStorageService, configProvider);
 
     controller =
         new CohortBuilderController(

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/util/CriteriaLookupUtilTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/querybuilder/util/CriteriaLookupUtilTest.java
@@ -125,6 +125,7 @@ public class CriteriaLookupUtilTest {
     assertEquals(
         ImmutableMap.of(searchParameter, new HashSet<>(childConceptIds)),
         lookupUtil.buildCriteriaLookupMap(searchRequest));
+    jdbcTemplate.execute("drop table cb_criteria_ancestor");
   }
 
   @Test
@@ -211,7 +212,7 @@ public class CriteriaLookupUtilTest {
             .group(false)
             .standard(false)
             .ancestorData(false)
-            .conceptId(1586135L);
+            .conceptId(5L);
     searchRequest =
         new SearchRequest()
             .addIncludesItem(

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -764,6 +764,7 @@ public class ElasticFiltersTest {
             .type(CriteriaType.AGE.toString())
             .group(false)
             .ancestorData(false)
+            .standard(true)
             .addAttributesItem(
                 new Attribute()
                     .name(AttrName.AGE)
@@ -786,15 +787,17 @@ public class ElasticFiltersTest {
   }
 
   @Test
-  public void testAgeAndVisitQuery() {
+  public void testAgeAndEthnicityQuery() {
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
     Object left = now.minusYears(34).minusYears(1).toLocalDate();
     Object right = now.minusYears(20).toLocalDate();
     SearchParameter ageParam =
         new SearchParameter()
-            .type(TreeType.DEMO.toString())
-            .subtype(TreeSubType.AGE.toString())
+            .domain(DomainType.PERSON.toString())
+            .type(CriteriaType.AGE.toString())
             .group(false)
+            .ancestorData(false)
+            .standard(true)
             .addAttributesItem(
                 new Attribute()
                     .name(AttrName.AGE)
@@ -804,9 +807,11 @@ public class ElasticFiltersTest {
     SearchParameter ethParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .type(TreeType.DEMO.toString())
-            .subtype(TreeSubType.ETH.toString())
+            .domain(DomainType.PERSON.toString())
+            .type(CriteriaType.ETHNICITY.toString())
             .group(false)
+            .ancestorData(false)
+            .standard(true)
             .conceptId(Long.parseLong(conceptId));
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -275,7 +275,8 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                QueryBuilders.termsQuery("events.concept_id", ImmutableList.of("21600009"))));
+                QueryBuilders.termsQuery(
+                    "events.concept_id", ImmutableList.of("21600002", "21600009"))));
   }
 
   @Test
@@ -351,7 +352,7 @@ public class ElasticFiltersTest {
         .isEqualTo(
             singleNestedQuery(
                 QueryBuilders.termsQuery(
-                    "events.source_concept_id", ImmutableList.of("777", "7771"))));
+                    "events.source_concept_id", ImmutableList.of("7771", "777"))));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -82,48 +82,43 @@ public class ElasticFiltersTest {
     // Generate a simple test criteria tree
     // 1
     // | - 2
-    // | - 3 - 4
-    cbCriteriaDao.save(
+    // | - 3
+    CBCriteria icd9Parent =
         icd9Criteria()
-            .id(1)
             .code("001")
             .conceptId("771")
             .group(true)
             .selectable(false)
+            .standard(false)
             .parentId(0)
-            .path(""));
+            .path("")
+            .synonyms("[CONDITION_rank1]");
+    cbCriteriaDao.save(icd9Parent);
+
     cbCriteriaDao.save(
         icd9Criteria()
-            .id(2)
             .code("001.002")
             .conceptId("772")
             .group(false)
             .selectable(true)
-            .parentId(1)
-            .path("1"));
+            .standard(false)
+            .parentId(icd9Parent.getId())
+            .path(String.valueOf(icd9Parent.getId()))
+            .synonyms("[CONDITION_rank1]"));
     cbCriteriaDao.save(
         icd9Criteria()
-            .id(3)
             .code("001.003")
             .conceptId("773")
             .group(true)
             .selectable(true)
-            .parentId(1)
-            .path("1"));
-    cbCriteriaDao.save(
-        icd9Criteria()
-            .id(4)
-            .code("001.003.004")
-            .conceptId("774")
-            .group(false)
-            .selectable(true)
-            .parentId(3)
-            .path("1.3"));
+            .standard(false)
+            .parentId(icd9Parent.getId())
+            .path(String.valueOf(icd9Parent.getId()))
+            .synonyms("[CONDITION_rank1]"));
 
     // Singleton SNOMED code.
     cbCriteriaDao.save(
         new CBCriteria()
-            .id(5)
             .code("005")
             .conceptId("775")
             .domainId(DomainType.CONDITION.toString())
@@ -134,10 +129,9 @@ public class ElasticFiltersTest {
             .parentId(0)
             .path(""));
 
-    // Four node PPI tree, survey, question, 2 answers.
-    cbCriteriaDao.save(
+    // Four node PPI tree, survey, question, 1 answer.
+    CBCriteria survey =
         basicsCriteria()
-            .id(6)
             .code("006")
             .group(true)
             .domainId(DomainType.SURVEY.toString())
@@ -147,10 +141,10 @@ public class ElasticFiltersTest {
             .selectable(true)
             .parentId(0)
             .path("")
-            .synonyms("+[SURVEY_rank1]"));
-    cbCriteriaDao.save(
+            .synonyms("+[SURVEY_rank1]");
+    cbCriteriaDao.save(survey);
+    CBCriteria question =
         basicsCriteria()
-            .id(7)
             .code("007")
             .conceptId("777")
             .domainId(DomainType.SURVEY.toString())
@@ -159,12 +153,12 @@ public class ElasticFiltersTest {
             .standard(false)
             .group(true)
             .selectable(true)
-            .parentId(6)
-            .path("6.7")
-            .synonyms("+[SURVEY_rank1]"));
+            .parentId(survey.getId())
+            .path(String.valueOf(survey.getId()))
+            .synonyms("+[SURVEY_rank1]");
+    cbCriteriaDao.save(question);
     cbCriteriaDao.save(
         basicsCriteria()
-            .id(8)
             .code("008")
             // Concept ID matches the question.
             .conceptId("7771")
@@ -174,8 +168,8 @@ public class ElasticFiltersTest {
             .standard(false)
             .group(false)
             .selectable(true)
-            .parentId(7)
-            .path("6.7")
+            .parentId(question.getId())
+            .path(String.valueOf(survey.getId()))
             .synonyms("+[SURVEY_rank1]"));
 
     // drug tree
@@ -185,9 +179,8 @@ public class ElasticFiltersTest {
         "create table cb_criteria_ancestor(ancestor_id integer, descendant_id integer)");
     jdbcTemplate.execute(
         "insert into cb_criteria_ancestor(ancestor_id, descendant_id) values (19069022, 21600009)");
-    cbCriteriaDao.save(
+    CBCriteria drugParent =
         drugCriteria()
-            .id(10)
             .code("A")
             .conceptId("21600001")
             .group(true)
@@ -195,49 +188,56 @@ public class ElasticFiltersTest {
             .parentId(0)
             .path("")
             .domainId(DomainType.DRUG.toString())
-            .type(CriteriaType.ATC.toString()));
-    cbCriteriaDao.save(
+            .type(CriteriaType.ATC.toString());
+    cbCriteriaDao.save(drugParent);
+    CBCriteria drug1 =
         drugCriteria()
-            .id(11)
             .code("A01")
             .conceptId("21600002")
             .group(true)
             .selectable(true)
-            .parentId(10)
-            .path("10")
+            .parentId(drugParent.getId())
+            .path(String.valueOf(drugParent.getId()))
             .domainId(DomainType.DRUG.toString())
-            .type(CriteriaType.ATC.toString()));
-    cbCriteriaDao.save(
+            .type(CriteriaType.ATC.toString());
+    cbCriteriaDao.save(drug1);
+    CBCriteria drug2 =
         drugCriteria()
-            .id(12)
             .code("A01A")
             .conceptId("21600003")
             .group(true)
             .selectable(true)
-            .parentId(11)
-            .path("10.11")
+            .parentId(drug1.getId())
+            .path(drugParent.getId() + "." + drug1.getId())
             .domainId(DomainType.DRUG.toString())
-            .type(CriteriaType.ATC.toString()));
+            .type(CriteriaType.ATC.toString());
+    cbCriteriaDao.save(drug2);
+    CBCriteria drug3 =
+        cbCriteriaDao.save(
+            drugCriteria()
+                .code("A01AA")
+                .conceptId("21600004")
+                .group(true)
+                .selectable(true)
+                .parentId(drug2.getId())
+                .path(drugParent.getId() + "." + drug1.getId() + "." + drug2.getId())
+                .domainId(DomainType.DRUG.toString())
+                .type(CriteriaType.ATC.toString()));
     cbCriteriaDao.save(
         drugCriteria()
-            .id(13)
-            .code("A01AA")
-            .conceptId("21600004")
-            .group(true)
-            .selectable(true)
-            .parentId(12)
-            .path("10.11.12")
-            .domainId(DomainType.DRUG.toString())
-            .type(CriteriaType.ATC.toString()));
-    cbCriteriaDao.save(
-        drugCriteria()
-            .id(14)
             .code("9873")
             .conceptId("19069022")
             .group(false)
             .selectable(true)
-            .parentId(13)
-            .path("10.11.12.13")
+            .parentId(drug3.getId())
+            .path(
+                drugParent.getId()
+                    + "."
+                    + drug1.getId()
+                    + "."
+                    + drug2.getId()
+                    + "."
+                    + drug3.getId())
             .domainId(DomainType.DRUG.toString())
             .type(CriteriaType.RXNORM.toString()));
 
@@ -345,14 +345,17 @@ public class ElasticFiltersTest {
                                 .addSearchParametersItem(
                                     new SearchParameter()
                                         .value("001")
-                                        .type(TreeType.ICD9.toString())
-                                        .subtype(TreeSubType.CM.toString())
-                                        .group(true)))));
+                                        .conceptId(771L)
+                                        .domain(DomainType.CONDITION.toString())
+                                        .type(CriteriaType.ICD9CM.toString())
+                                        .group(true)
+                                        .ancestorData(false)
+                                        .standard(false)))));
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
                 QueryBuilders.termsQuery(
-                    "events.source_concept_id", ImmutableList.of("772", "774"))));
+                    "events.source_concept_id", ImmutableList.of("772", "773"))));
   }
 
   @Test
@@ -525,8 +528,10 @@ public class ElasticFiltersTest {
     SearchParameter heightAnyParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .type(TreeType.PM.toString())
-            .subtype(TreeSubType.HEIGHT.toString())
+            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .type(CriteriaType.PPI.toString())
+            .standard(false)
+            .ancestorData(false)
             .group(false);
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(
@@ -552,9 +557,11 @@ public class ElasticFiltersTest {
     SearchParameter heightParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .type(TreeType.PM.toString())
-            .subtype(TreeSubType.HEIGHT.toString())
+            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .type(CriteriaType.PPI.toString())
             .group(false)
+            .ancestorData(false)
+            .standard(false)
             .addAttributesItem(attr);
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(
@@ -583,8 +590,10 @@ public class ElasticFiltersTest {
     SearchParameter weightParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .type(TreeType.PM.toString())
-            .subtype(TreeSubType.HEIGHT.toString())
+            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .type(CriteriaType.PPI.toString())
+            .standard(false)
+            .ancestorData(false)
             .group(false)
             .addAttributesItem(attr);
     QueryBuilder resp =
@@ -607,8 +616,10 @@ public class ElasticFiltersTest {
     SearchParameter genderParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .type(TreeType.DEMO.toString())
-            .subtype(TreeSubType.GEN.toString())
+            .domain(DomainType.PERSON.toString())
+            .type(CriteriaType.GENDER.toString())
+            .standard(true)
+            .ancestorData(false)
             .group(false);
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -68,7 +68,7 @@ public interface CBCriteriaDao extends CrudRepository<CBCriteria, Long> {
               + " has_ancestor_data,a.path,synonyms "
               + "  from cb_criteria a "
               + "  where domain_id = :domain "
-              + "   and type = :type "
+              + "   and type = :type"
               + "   and concept_id in (:parentConceptIds)",
       nativeQuery = true)
   List<CBCriteria> findCriteriaAncestors(

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -68,7 +68,7 @@ public interface CBCriteriaDao extends CrudRepository<CBCriteria, Long> {
               + " has_ancestor_data,a.path,synonyms "
               + "  from cb_criteria a "
               + "  where domain_id = :domain "
-              + "   and type = :type"
+              + "   and type = :type "
               + "   and concept_id in (:parentConceptIds)",
       nativeQuery = true)
   List<CBCriteria> findCriteriaAncestors(


### PR DESCRIPTION
This PR addresses updating the ElasticFilters to use the CriteriaLookupUtil. 
CriteriaLookupUtil was created to consolidate criteria lookup logic between BQ and Elastic.