### PR TITLE
[RW-2872][risk=no] Add value_source_concept_id to elastic index for ppi data

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -47,7 +47,7 @@ public class ElasticDocument {
           .put("visit_concept_id", 4)
           .put("value_as_number", 5)
           .put("value_as_concept_id", 6)
-          .put("value_source_concept_id", 7)
+          .put("value_as_source_concept_id", 7)
           .build();
 
   private static final Map<String, Object> NESTED_FOREIGN_SCHEMA =
@@ -63,7 +63,7 @@ public class ElasticDocument {
                   .put("visit_concept_id", esType(ElasticType.KEYWORD))
                   .put("value_as_number", esType(ElasticType.FLOAT))
                   .put("value_as_concept_id", esType(ElasticType.KEYWORD))
-                  .put("value_source_concept_id", esType(ElasticType.KEYWORD))
+                  .put("value_as_source_concept_id", esType(ElasticType.KEYWORD))
                   .build());
 
   public static final Map<String, Object> PERSON_SCHEMA =

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -47,6 +47,7 @@ public class ElasticDocument {
           .put("visit_concept_id", 4)
           .put("value_as_number", 5)
           .put("value_as_concept_id", 6)
+          .put("value_source_concept_id", 7)
           .build();
 
   private static final Map<String, Object> NESTED_FOREIGN_SCHEMA =
@@ -62,6 +63,7 @@ public class ElasticDocument {
                   .put("visit_concept_id", esType(ElasticType.KEYWORD))
                   .put("value_as_number", esType(ElasticType.FLOAT))
                   .put("value_as_concept_id", esType(ElasticType.KEYWORD))
+                  .put("value_source_concept_id", esType(ElasticType.KEYWORD))
                   .build());
 
   public static final Map<String, Object> PERSON_SCHEMA =

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -157,7 +157,7 @@ public final class ElasticFilters {
     if (AttrName.CAT.equals(attr.getName())) {
       // Currently the UI only uses the In operator for CAT which fits the terms query
       String name =
-          isSourceConceptId ? "events.value_source_concept_id" : "events.value_as_concept_id";
+          isSourceConceptId ? "events.value_as_source_concept_id" : "events.value_as_concept_id";
       return QueryBuilders.termsQuery(name, attr.getOperands());
     }
     Object left = null, right = null;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -126,7 +126,7 @@ public final class ElasticFilters {
           b.filter(QueryBuilders.termsQuery(conceptField, leafConceptIds));
         }
         for (Attribute attr : param.getAttributes()) {
-          b.filter(attributeToQuery(attr, param));
+          b.filter(attributeToQuery(attr, DomainType.SURVEY.toString().equals(param.getDomain())));
         }
         for (QueryBuilder f : modFilters) {
           b.filter(f);
@@ -152,14 +152,12 @@ public final class ElasticFilters {
     return filter;
   }
 
-  private static QueryBuilder attributeToQuery(Attribute attr, SearchParameter parameter) {
+  private static QueryBuilder attributeToQuery(Attribute attr, boolean isSourceConceptId) {
     // Attributes with a name of CAT map to the value_as_concept_id column
     if (AttrName.CAT.equals(attr.getName())) {
       // Currently the UI only uses the In operator for CAT which fits the terms query
       String name =
-          DomainType.SURVEY.toString().equals(parameter.getDomain())
-              ? "events.value_source_concept_id"
-              : "events.value_as_concept_id";
+          isSourceConceptId ? "events.value_source_concept_id" : "events.value_as_concept_id";
       return QueryBuilders.termsQuery(name, attr.getOperands());
     }
     Object left = null, right = null;

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -126,7 +126,7 @@ public final class ElasticFilters {
           b.filter(QueryBuilders.termsQuery(conceptField, leafConceptIds));
         }
         for (Attribute attr : param.getAttributes()) {
-          b.filter(attributeToQuery(attr));
+          b.filter(attributeToQuery(attr, param));
         }
         for (QueryBuilder f : modFilters) {
           b.filter(f);
@@ -152,11 +152,15 @@ public final class ElasticFilters {
     return filter;
   }
 
-  private static QueryBuilder attributeToQuery(Attribute attr) {
+  private static QueryBuilder attributeToQuery(Attribute attr, SearchParameter parameter) {
     // Attributes with a name of CAT map to the value_as_concept_id column
     if (AttrName.CAT.equals(attr.getName())) {
       // Currently the UI only uses the In operator for CAT which fits the terms query
-      return QueryBuilders.termsQuery("events.value_as_concept_id", attr.getOperands());
+      String name =
+          DomainType.SURVEY.toString().equals(parameter.getDomain())
+              ? "events.value_source_concept_id"
+              : "events.value_as_concept_id";
+      return QueryBuilders.termsQuery(name, attr.getOperands());
     }
     Object left = null, right = null;
     RangeQueryBuilder rq;

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,7 +81,6 @@ public class ElasticFiltersTest {
   private SearchParameter leafParam2;
 
   @Before
-  @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
   public void setUp() {
     // Generate a simple test criteria tree
     // 1
@@ -400,7 +398,7 @@ public class ElasticFiltersTest {
     Attribute attr = new Attribute().name(AttrName.CAT).operator(Operator.IN).addOperandsItem("1");
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(
-            criteriaDao,
+            cbCriteriaDao,
             new SearchRequest()
                 .addIncludesItem(
                     new SearchGroup()
@@ -409,10 +407,12 @@ public class ElasticFiltersTest {
                                 .addSearchParametersItem(
                                     new SearchParameter()
                                         .domain(DomainType.SURVEY.toString())
-                                        .type(TreeType.PPI.toString())
-                                        .subtype(TreeSubType.BASICS.toString())
+                                        .type(CriteriaType.PPI.toString())
+                                        .subtype(CriteriaSubType.BASICS.toString())
                                         .conceptId(777L)
-                                        .group(true)
+                                        .group(false)
+                                        .ancestorData(false)
+                                        .standard(false)
                                         .addAttributesItem(attr)))));
     assertThat(resp)
         .isEqualTo(

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -396,6 +396,33 @@ public class ElasticFiltersTest {
   }
 
   @Test
+  public void testPPIAnswerQueryCat() {
+    Attribute attr = new Attribute().name(AttrName.CAT).operator(Operator.IN).addOperandsItem("1");
+    QueryBuilder resp =
+        ElasticFilters.fromCohortSearch(
+            criteriaDao,
+            new SearchRequest()
+                .addIncludesItem(
+                    new SearchGroup()
+                        .addItemsItem(
+                            new SearchGroupItem()
+                                .addSearchParametersItem(
+                                    new SearchParameter()
+                                        .domain(DomainType.SURVEY.toString())
+                                        .type(TreeType.PPI.toString())
+                                        .subtype(TreeSubType.BASICS.toString())
+                                        .conceptId(777L)
+                                        .group(true)
+                                        .addAttributesItem(attr)))));
+    assertThat(resp)
+        .isEqualTo(
+            singleNestedQuery(
+                QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("777")),
+                QueryBuilders.termsQuery(
+                    "events.value_as_source_concept_id", ImmutableList.of("1"))));
+  }
+
+  @Test
   public void testAgeAtEventModifierQuery() {
     QueryBuilder resp =
         ElasticFilters.fromCohortSearch(

--- a/api/tools/src/main/resources/bigquery/es_person.sql
+++ b/api/tools/src/main/resources/bigquery/es_person.sql
@@ -33,7 +33,7 @@ LEFT JOIN (
         v.visit_concept_id,
         value_as_number,
         value_as_concept_id,
-        value_source_concept_id)) observations
+        value_source_concept_id as value_as_source_concept_id)) observations
   FROM
     `{BQ_DATASET}.observation` ob
   LEFT JOIN
@@ -62,7 +62,7 @@ LEFT JOIN (
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id,
-        CAST(NULL as INT64) as value_source_concept_id)) conditions
+        CAST(NULL as INT64) as value_as_source_concept_id)) conditions
   FROM
     `{BQ_DATASET}.condition_occurrence` co
   LEFT JOIN
@@ -91,7 +91,7 @@ LEFT JOIN (
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id,
-        CAST(NULL as INT64) as value_source_concept_id)) drugs
+        CAST(NULL as INT64) as value_as_source_concept_id)) drugs
   FROM
     `{BQ_DATASET}.drug_exposure` d
   LEFT JOIN
@@ -120,7 +120,7 @@ LEFT JOIN (
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
         CAST(NULL as INT64) as value_as_concept_id,
-        CAST(NULL as INT64) as value_source_concept_id)) procedures
+        CAST(NULL as INT64) as value_as_source_concept_id)) procedures
   FROM
     `{BQ_DATASET}.procedure_occurrence` pr
   LEFT JOIN
@@ -149,7 +149,7 @@ LEFT JOIN (
         v.visit_concept_id,
         value_as_number,
         value_as_concept_id,
-        CAST(NULL as INT64) as value_source_concept_id)) measurements
+        CAST(NULL as INT64) as value_as_source_concept_id)) measurements
   FROM
     `{BQ_DATASET}.measurement` m
   LEFT JOIN

--- a/api/tools/src/main/resources/bigquery/es_person.sql
+++ b/api/tools/src/main/resources/bigquery/es_person.sql
@@ -31,8 +31,9 @@ LEFT JOIN (
         observation_date AS start_date,
         DATE_DIFF(observation_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
-        CAST(NULL as FLOAT64) as value_as_number,
-        CAST(NULL as INT64) as value_as_concept_id)) observations
+        value_as_number,
+        value_as_concept_id,
+        value_source_concept_id)) observations
   FROM
     `{BQ_DATASET}.observation` ob
   LEFT JOIN
@@ -60,7 +61,8 @@ LEFT JOIN (
         DATE_DIFF(condition_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
-        CAST(NULL as INT64) as value_as_concept_id)) conditions
+        CAST(NULL as INT64) as value_as_concept_id,
+        CAST(NULL as INT64) as value_source_concept_id)) conditions
   FROM
     `{BQ_DATASET}.condition_occurrence` co
   LEFT JOIN
@@ -88,7 +90,8 @@ LEFT JOIN (
         DATE_DIFF(drug_exposure_start_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
-        CAST(NULL as INT64) as value_as_concept_id)) drugs
+        CAST(NULL as INT64) as value_as_concept_id,
+        CAST(NULL as INT64) as value_source_concept_id)) drugs
   FROM
     `{BQ_DATASET}.drug_exposure` d
   LEFT JOIN
@@ -116,7 +119,8 @@ LEFT JOIN (
         DATE_DIFF(procedure_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         CAST(NULL as FLOAT64) as value_as_number,
-        CAST(NULL as INT64) as value_as_concept_id)) procedures
+        CAST(NULL as INT64) as value_as_concept_id,
+        CAST(NULL as INT64) as value_source_concept_id)) procedures
   FROM
     `{BQ_DATASET}.procedure_occurrence` pr
   LEFT JOIN
@@ -144,7 +148,8 @@ LEFT JOIN (
         DATE_DIFF(measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), YEAR) AS age_at_start,
         v.visit_concept_id,
         value_as_number,
-        value_as_concept_id)) measurements
+        value_as_concept_id,
+        CAST(NULL as INT64) as value_source_concept_id)) measurements
   FROM
     `{BQ_DATASET}.measurement` m
   LEFT JOIN


### PR DESCRIPTION
Add value_source_concept_id to elastic index for ppi data from the observation OMOP table. When CB searches for any categorical data for surveys data(PPI) we now need to match against value_source_concept_id instead of value_as_concept_id. 