### PR TITLE
[RW-2708][Risk=no] Srubenst/notebook locking ux

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -724,7 +724,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
         cloudStorageService.getMetadata(bucketName, "notebooks/" + notebookName);
 
     if (metadata != null) {
-      String lockExpirationTime = metadata.get("lockExpirationTime");
+      String lockExpirationTime = metadata.get("lockExpiresAt");
       if (lockExpirationTime != null) {
         response.lockExpirationTime(Long.valueOf(lockExpirationTime));
       }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2476,7 +2476,7 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpiresA0t", lockExpirationTime.toString())
+            .put("lockExpiresAt", lockExpirationTime.toString())
             // store directly in plaintext, to show that this does not work
             .put("lastLockedBy", lastLockedUser)
             .put("extraMetadata", "is not a problem")

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2386,7 +2386,7 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpirationTime", lockExpirationTime.toString())
+            .put("lockExpiresAt", lockExpirationTime.toString())
             .put(
                 "lastLockedBy",
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
@@ -2428,7 +2428,7 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpirationTime", lockExpirationTime.toString())
+            .put("lockExpiresAt", lockExpirationTime.toString())
             .put(
                 "lastLockedBy",
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
@@ -2452,7 +2452,7 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpirationTime", lockExpirationTime.toString())
+            .put("lockExpiresAt", lockExpirationTime.toString())
             .put(
                 "lastLockedBy",
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
@@ -2476,7 +2476,7 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpirationTime", lockExpirationTime.toString())
+            .put("lockExpiresA0t", lockExpirationTime.toString())
             // store directly in plaintext, to show that this does not work
             .put("lastLockedBy", lastLockedUser)
             .put("extraMetadata", "is not a problem")

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -151,6 +151,8 @@ public class WorkspacesControllerTest {
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
   private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
   private static final String BUCKET_NAME = "workspace-bucket";
+  private static final String LOCK_EXPIRE_TIME_KEY = "lockExpiresAt";
+  private static final String LAST_LOCKING_USER_KEY = "lastLockedBy";
 
   private static final Concept CLIENT_CONCEPT_1 =
       new Concept()
@@ -2386,9 +2388,9 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpiresAt", lockExpirationTime.toString())
+            .put(LOCK_EXPIRE_TIME_KEY, lockExpirationTime.toString())
             .put(
-                "lastLockedBy",
+                LAST_LOCKING_USER_KEY,
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
             .put("extraMetadata", "is not a problem")
             .build();
@@ -2428,9 +2430,9 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpiresAt", lockExpirationTime.toString())
+            .put(LOCK_EXPIRE_TIME_KEY, lockExpirationTime.toString())
             .put(
-                "lastLockedBy",
+                LAST_LOCKING_USER_KEY,
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
             .put("extraMetadata", "is not a problem")
             .build();
@@ -2452,9 +2454,9 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpiresAt", lockExpirationTime.toString())
+            .put(LOCK_EXPIRE_TIME_KEY, lockExpirationTime.toString())
             .put(
-                "lastLockedBy",
+                LAST_LOCKING_USER_KEY,
                 WorkspacesController.notebookLockingEmailHash(BUCKET_NAME, lastLockedUser))
             .put("extraMetadata", "is not a problem")
             .build();
@@ -2476,9 +2478,9 @@ public class WorkspacesControllerTest {
 
     final Map<String, String> gcsMetadata =
         new ImmutableMap.Builder<String, String>()
-            .put("lockExpiresAt", lockExpirationTime.toString())
+            .put(LOCK_EXPIRE_TIME_KEY, lockExpirationTime.toString())
             // store directly in plaintext, to show that this does not work
-            .put("lastLockedBy", lastLockedUser)
+            .put(LAST_LOCKING_USER_KEY, lastLockedUser)
             .put("extraMetadata", "is not a problem")
             .build();
 

--- a/ui/src/app/views/interactive-notebook.tsx
+++ b/ui/src/app/views/interactive-notebook.tsx
@@ -11,7 +11,7 @@ import {notebooksClusterApi} from 'app/services/notebooks-swagger-fetch-clients'
 import {clusterApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams} from 'app/utils';
-import {navigate, navigateByUrl, userProfileStore} from 'app/utils/navigation';
+import {navigate, userProfileStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {ConfirmPlaygroundModeModal} from 'app/views/confirm-playground-mode-modal';

--- a/ui/src/app/views/interactive-notebook.tsx
+++ b/ui/src/app/views/interactive-notebook.tsx
@@ -193,16 +193,14 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
 
     private cloneNotebook() {
       const {ns, wsid, nbName} = this.props.urlParams;
-      workspacesApi().cloneNotebook(
-        ns, wsid, nbName).then((notebook) => {
-          navigateByUrl(
-            `/workspaces/${ns}/${wsid}/notebooks/${encodeURIComponent(notebook.name)}`);
-        });
+      workspacesApi().cloneNotebook(ns, wsid, nbName).then((notebook) => {
+        navigate(['workspaces', ns, wsid, 'notebooks', encodeURIComponent(notebook.name)]);
+      });
     }
 
     private get notebookInUse() {
       const {lastLockedBy, lockExpirationTime} = this.state;
-      return lastLockedBy !== null && lockExpirationTime - new Date().getTime() >= 0
+      return lastLockedBy !== null && new Date().getTime()  < lockExpirationTime
         && lastLockedBy !== userProfileStore.getValue().profile.username;
     }
 

--- a/ui/src/app/views/interactive-notebook.tsx
+++ b/ui/src/app/views/interactive-notebook.tsx
@@ -4,7 +4,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {ClrIcon} from 'app/components/icons';
-import {Spinner, SpinnerOverlay} from 'app/components/spinners';
+import {SpinnerOverlay} from 'app/components/spinners';
 import {EditComponentReact} from 'app/icons/edit';
 import {PlaygroundModeIcon} from 'app/icons/playground-mode-icon';
 import {notebooksClusterApi} from 'app/services/notebooks-swagger-fetch-clients';
@@ -107,11 +107,11 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
         });
       workspacesApi().getNotebookLockingMetadata(this.props.urlParams.ns,
         this.props.urlParams.wsid, this.props.urlParams.nbName).then((resp) => {
-        this.setState({
-          lastLockedBy: resp.lastLockedBy,
-          lockExpirationTime: resp.lockExpirationTime
+          this.setState({
+            lastLockedBy: resp.lastLockedBy,
+            lockExpirationTime: resp.lockExpirationTime
+          });
         });
-      })
     }
 
     private runCluster(onClusterReady: Function): void {
@@ -141,7 +141,6 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
     }
 
     private startEditMode() {
-      const time = new Date().getTime();
       if (this.canWrite()) {
         if (!this.notebookInUse) {
           this.setState({userRequestedExecutableNotebook: true});

--- a/ui/src/app/views/notebook-in-use-modal.tsx
+++ b/ui/src/app/views/notebook-in-use-modal.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import colors from 'app/styles/colors';
-import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {Button} from 'app/components/buttons';
+import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {Spinner} from 'app/components/spinners';
+import colors from 'app/styles/colors';
+import * as React from 'react';
 
 
 export interface Props {

--- a/ui/src/app/views/notebook-in-use-modal.tsx
+++ b/ui/src/app/views/notebook-in-use-modal.tsx
@@ -46,7 +46,10 @@ export class NotebookInUseModal extends React.Component<Props, State> {
         </Button>
         <Button type='secondary'
                 style={{width: '8rem', margin: '0 10px'}}
-                onClick={() => { this.setState({copyLoading: true}); this.props.onCopy(); }}>
+                onClick={() => {
+                  this.setState({copyLoading: true});
+                  this.props.onCopy();
+                }}>
           Make a copy {this.state.copyLoading && <Spinner
           style={{marginLeft: '0.3rem', height: '21px', width: '21px'}} />}
         </Button>

--- a/ui/src/app/views/notebook-in-use-modal.tsx
+++ b/ui/src/app/views/notebook-in-use-modal.tsx
@@ -1,30 +1,37 @@
 import * as React from 'react';
 import colors from 'app/styles/colors';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
-import {Button} from 'app/components/buttons'
+import {Button} from 'app/components/buttons';
+import {Spinner} from 'app/components/spinners';
 
 
 export interface Props {
-  email: string
+  email: string;
   onCancel: Function;
+  onCopy: Function;
+  onPlaygroundMode: Function;
 }
 
 interface State {
+  copyLoading: boolean;
 }
 
 export class NotebookInUseModal extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+    this.state = {
+      copyLoading: false
+    };
   }
 
   render() {
-    return <Modal onRequestClose={() => { this.props.onCancel(); }}>
+    return <Modal onRequestClose={() => { this.props.onCancel(); }} width={600}>
       <ModalTitle>File is in use</ModalTitle>
       <ModalBody>
         <p style={{color: colors.primary}}>
           This file is currently being edited by
-          <span style={{color: colors.accent}}>{this.props.email}</span>.
+          <span style={{color: colors.accent}}> {this.props.email}</span>.
         </p>
         <p style={{color: colors.primary}}>
           You can make a copy, or run it in playground mode to explore
@@ -33,9 +40,19 @@ export class NotebookInUseModal extends React.Component<Props, State> {
       </ModalBody>
       <ModalFooter style={{alignItems: 'center'}}>
         <Button type='secondary'
-                style={{margin: '0 10px'}}
+                style={{width: '6rem', margin: '0 10px'}}
                 onClick={() => { this.props.onCancel(); }}>
           Cancel
+        </Button>
+        <Button type='secondary'
+                style={{width: '8rem', margin: '0 10px'}}
+                onClick={() => { this.setState({copyLoading: true}); this.props.onCopy(); }}>
+          Make a copy {this.state.copyLoading && <Spinner
+          style={{marginLeft: '0.3rem', height: '21px', width: '21px'}} />}
+        </Button>
+        <Button style={{width: '10rem', margin: '0 10px'}}
+                onClick={() => { this.props.onPlaygroundMode(); }}>
+          Run Playground Mode
         </Button>
       </ModalFooter>
     </Modal>;

--- a/ui/src/app/views/notebook-in-use-modal.tsx
+++ b/ui/src/app/views/notebook-in-use-modal.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import colors from 'app/styles/colors';
+import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
+import {Button} from 'app/components/buttons'
+
+
+export interface Props {
+  email: string
+  onCancel: Function;
+}
+
+interface State {
+}
+
+export class NotebookInUseModal extends React.Component<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return <Modal onRequestClose={() => { this.props.onCancel(); }}>
+      <ModalTitle>File is in use</ModalTitle>
+      <ModalBody>
+        <p style={{color: colors.primary}}>
+          This file is currently being edited by
+          <span style={{color: colors.accent}}>{this.props.email}</span>.
+        </p>
+        <p style={{color: colors.primary}}>
+          You can make a copy, or run it in playground mode to explore
+          and execute its contents without saving any changes.
+        </p>
+      </ModalBody>
+      <ModalFooter style={{alignItems: 'center'}}>
+        <Button type='secondary'
+                style={{margin: '0 10px'}}
+                onClick={() => { this.props.onCancel(); }}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>;
+  }
+
+}


### PR DESCRIPTION
This does not tackle the jupyter extension around locking. That I am going to do in a separate PR. Also fixes a key mismatch in the API with the gcs metadata.
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
