### PR TITLE
[RW-3115][risk=no] Don't copy blob metadata

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -89,7 +89,9 @@ public class CloudStorageServiceImpl implements CloudStorageService {
   @Override
   public void copyBlob(BlobId from, BlobId to) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
-    CopyWriter w = storage.copy(CopyRequest.newBuilder().setSource(from).setTarget(to).build());
+    // Clears user-defined metadata, e.g. locking information on notebooks.
+    BlobInfo toInfo = BlobInfo.newBuilder(to).build();
+    CopyWriter w = storage.copy(CopyRequest.newBuilder().setSource(from).setTarget(toInfo).build());
     while (!w.isDone()) {
       w.copyChunk();
     }


### PR DESCRIPTION
Verified via local manual testing. 

Specifically this avoids copying lock metadata when cloning a notebook. We currently have no other need to copy GCS metadata on any blob copy, so just turn it off everywhere.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
