### PR TITLE
[RW-1960][RW-1961][RW-1962][risk=low] Add security headers, CSP in report only mode for now

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -10,12 +10,20 @@ handlers:
   secure: always
   http_headers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+    X-XSS-Protection: 1
+    X-Content-Type-Options: "nosniff"
+    # Reevaluate after deployment and remove "-Report-Only" if possible.
+    Content-Security-Policy-Report-Only: default-src 'self'
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html
   secure: always
   http_headers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+    X-XSS-Protection: 1
+    X-Content-Type-Options: "nosniff"
+    # Reevaluate after deployment and remove "-Report-Only" if possible.
+    Content-Security-Policy-Report-Only: default-src 'self'
 
 # If a file (relative path under ui/) matches this regex, do not upload it.
 # Skip everything not starting with "dist".


### PR DESCRIPTION
I'm unclear from the documentation whether this content security policy will fail, so enable in report-only mode for now.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
