### PR TITLE
[RW-1960][risk=low] Refactor sketchy Google Analytics initialization

### DIFF
--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {
   ActivatedRoute,

--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -1,4 +1,3 @@
-import {DOCUMENT} from '@angular/common';
 import {Component, Inject, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {
@@ -17,6 +16,8 @@ import {environment} from 'environments/environment';
 
 import outdatedBrowserRework from 'outdated-browser-rework';
 
+declare let gtag: Function;
+
 export const overriddenUrlKey = 'allOfUsApiUrlOverride';
 
 @Component({
@@ -33,7 +34,6 @@ export class AppComponent implements OnInit {
   private baseTitle: string;
 
   constructor(
-    @Inject(DOCUMENT) private doc: any,
     private activatedRoute: ActivatedRoute,
     private serverConfigService: ServerConfigService,
     private router: Router,
@@ -121,30 +121,15 @@ export class AppComponent implements OnInit {
    * the global gtag function.
    */
   private setGTagManager() {
-    const s = this.doc.createElement('script');
-    s.type = 'text/javascript';
-    s.innerHTML =
-      '(function(w,d,s,l,i){' +
-        'w[l]=w[l]||[];' +
-        'var f=d.getElementsByTagName(s)[0];' +
-        'var j=d.createElement(s);' +
-        'var dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';' +
-        'j.async=true;' +
-        'j.src=\'https://www.googletagmanager.com/gtag/js?id=\'+i+dl;' +
-        'f.parentNode.insertBefore(j,f);' +
-      '})' +
-      '(window, document, \'script\', \'dataLayer\', \'' + environment.gaId + '\');' +
-      'window.dataLayer = window.dataLayer || [];' +
-      'function gtag(){dataLayer.push(arguments);}' +
-      'gtag(\'js\', new Date());' +
-      // There is some interpolation issues here that cause some useragents to be too long
-      // limit is 150. Slicing to 100 pretty much guarantees that even with the encoding
-      // it comes in under this limit -US 2/27/18
-      'gtag(\'set\', \'user_agent\', \'' + window.navigator.userAgent.slice(0, 100) + '\');' +
-      'gtag(\'config\', \'' + environment.gaId + '\', {\'custom_map\': ' +
-      '{\'' + environment.gaUserAgentDimension + '\': \'user_agent\'}});';
-    const head = this.doc.getElementsByTagName('head')[0];
-    head.appendChild(s);
+    gtag('config', environment.gaId, {
+      custom_map: {
+        [environment.gaUserAgentDimension]: 'user_agent'
+      }
+    });
+    // There is some interpolation issues here that cause some useragents to be too long
+    // limit is 150. Slicing to 100 pretty much guarantees that even with the encoding
+    // it comes in under this limit -US 2/27/18
+    gtag('set', 'user_agent', window.navigator.userAgent.slice(0, 100));
   }
 
   private checkBrowserSupport() {

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -11,10 +11,16 @@
       This puts `gapi` into the global namespace
     -->
     <script src="https://apis.google.com/js/platform.js"></script>
+    <!-- Google Analytics setup -->
+    <script async type="text/javascript" src="https://www.googletagmanager.com/gtag/js"></script>
+    <script type="text/javascript">
+      window.dataLayer=window.dataLayer||[];
+      function gtag() {window.dataLayer.push(arguments)}
+      gtag('js', new Date());
+    </script>
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   </head>
-  <!-- Push state routing -->
   <base href="/">
 
   <body id='body'>


### PR DESCRIPTION
Move GA initialization into `index.html`, rather than constructing a Javascript script string piecemeal at runtime.

This allows us to define a tighter Content Security Policy (RW-1960), i.e. disallowing unsafe-inline scripts. Tested via manual deploy to GAE.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
