### PR TITLE
[risk=no][ticket=no]Use fullNotebookName to localize

### DIFF
--- a/ui/src/app/pages/analysis/notebook-redirect/component.ts
+++ b/ui/src/app/pages/analysis/notebook-redirect/component.ts
@@ -191,9 +191,9 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
         // This will contain the Jupyter-local path to the localized notebook.
         if (!this.creating) {
           this.incrementProgress(Progress.Copying);
-          localizeObs = this.localizeNotebooks([this.notebookName],
+          localizeObs = this.localizeNotebooks([this.fullNotebookName],
             this.playground)
-            .map(localDir => `${localDir}/${this.notebookName}`);
+            .map(localDir => `${localDir}/${this.fullNotebookName}`);
         } else {
           this.incrementProgress(Progress.Creating);
           localizeObs = this.newNotebook();


### PR DESCRIPTION
Resolves a notebook localization issue, possibly from #2327 

1. Create a notebook and save it
2. Return to notebooks list page
3. Open the notebook -> directs user to readonly preview
4. Edit the notebook being previewed.

Problem behavior:
* was attempting to localize the notebook without the `.ipynb` suffix
* call to API /localize resulted in 404
* UI displayed "503 server busy" with infinite spinner

A more thorough fix would be to audit our use of "full" network name (with suffix) vs. "display" name (without) vs. simply "notebook name" in the UI.

But this quick fix should immediately unblock dev work.