### PR TITLE
[RW-1960][risk=no] Add a content security policy in report-only mode

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -12,6 +12,7 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
+    Content-Security-Policy-Report-Only: "default-src 'none'; report-uri /content-security-report"
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html
@@ -20,6 +21,57 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
+    # The script-src sha-256 hash whitelists the inline Google Analytics script
+    # found in index.html. If that Javascript is updated, we need to
+    # simultaneously update this hash. The new hash can be computed online, e.g.
+    # https://report-uri.com/home/hash or will be included in the console error
+    # output if you fail to update this. Failing to update this causes Google
+    # Analytics setup to fail, and may break the app entirely.
+    # Note: Once we're fully on React and have finer grained control over asset
+    # deployment, this inline script and hash could be removed in favor of
+    # adding this to another included JS file.
+    Content-Security-Policy-Report-Only: "
+      default-src 'none';
+      script-src
+        'self'
+        'sha256-WRcvuKF/fyz1ZMEquk5/ItKxTEyg/UFUSfLnSSG5Dcc='
+        https://apis.google.com
+        https://*.googleapis.com
+        https://static.zdassets.com
+        https://www.googletagmanager.com
+        https://www.google-analytics.com;
+      style-src
+        'self'
+        'unsafe-inline'
+        https://fonts.googleapis.com;
+      img-src
+        'self'
+        data:
+        https://*.googleusercontent.com
+        https://www.google-analytics.com;
+      font-src
+        'self'
+        data:
+        https://fonts.gstatic.com;
+      connect-src
+        'self'
+        https://api-dot-all-of-us-workbench-test.appspot.com
+        https://api-dot-all-of-us-rw-staging.appspot.com
+        https://api-dot-all-of-us-rw-stable.appspot.com
+        https://api.stable.fake-research-aou.org
+        https://api.workbench.researchallofus.org
+        https://leonardo.dsde-dev.broadinstitute.org
+        https://notebooks.firecloud.org
+        https://firecloud-orchestration.dsde-dev.broadinstitute.org
+        https://api.firecloud.org
+        https://*.googleapis.com
+        https://*.zdassets.com
+        https://aousupporthelp.zendesk.com;
+      child-src
+        https://accounts.google.com
+        https://leonardo.dsde-dev.broadinstitute.org
+        https://notebooks.firecloud.org
+      report-uri /content-security-index-report"
 
 # If a file (relative path under ui/) matches this regex, do not upload it.
 # Skip everything not starting with "dist".

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -13,6 +13,7 @@
     <script src="https://apis.google.com/js/platform.js"></script>
     <!-- Google Analytics setup -->
     <script async type="text/javascript" src="https://www.googletagmanager.com/gtag/js"></script>
+    <!-- Important: any changes to the following script must be reflected in app.yaml -->
     <script type="text/javascript">
       window.dataLayer=window.dataLayer||[];
       function gtag() {window.dataLayer.push(arguments)}


### PR DESCRIPTION
CSP primer: https://developers.google.com/web/fundamentals/security/csp/
Spec: https://content-security-policy.com
tl;dr: this protects against XSS and injection of unexpected content on our site

- Enables a content security policy in report-only mode; this will log violations to a UI endpoint - we won't log the JSON report content, but we can track instances of violations via GAE logs
- Policy generated via the [CSP tester extension](https://chrome.google.com/webstore/detail/csp-tester/ehmipebdmhlmikaopdfoinmcjhhfadlf).
- A single policy is used for both dev and prod. This seems simplest to keep configuration understandable - there is not much risk in allowing connections across environment backends.
- This policy whitelists our exact inline script contents in `index.html`, this will need to be kept in sync manually. See comment in app.yaml - in the future this could instead be included in another JS file we load, for now while we're on a mixture of React/Angular this is non-trivial throwaway work and/or an extra browser request for another JS file.

Once enabled fully, this means that any requests from the Workbench to connect to sources that are not whitelisted will fail. This means we'll need to be diligent about updating this policy as we add/remove dependencies.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
