### PR TITLE
[RW-2060] [risk=no] Enable VPC flow logs in higher envs.

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -68,6 +68,6 @@
     "enableLeoWelder": true,
     "useBillingProjectBuffer": true,
     "unsafeAllowDeleteUser": false,
-    "enableVpcFlowLogs": false
+    "enableVpcFlowLogs": true
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -68,6 +68,6 @@
     "enableLeoWelder": true,
     "useBillingProjectBuffer": true,
     "unsafeAllowDeleteUser": false,
-    "enableVpcFlowLogs": false
+    "enableVpcFlowLogs": true
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -68,6 +68,6 @@
     "enableLeoWelder": true,
     "useBillingProjectBuffer": true,
     "unsafeAllowDeleteUser": false,
-    "enableVpcFlowLogs": false
+    "enableVpcFlowLogs": true
   }
 }


### PR DESCRIPTION
This turns on the VPC flow logging functionality in all of our environments.

This has been enabled in test for ~1-2 weeks. I've confirmed that flow logs are enabled in newly-created workspaces in test, and we haven't encountered any issues or problems with users accessing notebooks as a result.