### PR TITLE
[RW-1960][risk=no] Fix CSP syntax

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -70,7 +70,7 @@ handlers:
       child-src
         https://accounts.google.com
         https://leonardo.dsde-dev.broadinstitute.org
-        https://notebooks.firecloud.org
+        https://notebooks.firecloud.org;
       report-uri /content-security-index-report"
 
 # If a file (relative path under ui/) matches this regex, do not upload it.


### PR DESCRIPTION
Apologies, I guess I failed to manual test the `report-uri` which was a late addition. Verified this fixes the issue by a manual demo server deploy: https://calbach-dot-all-of-us-workbench-test.appspot.com

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
