### PR TITLE
[RW-3112] [risk=low] Add a one-off script to copy a synthetic CDR from one loc to another

### DIFF
--- a/api/db-cdr/generate-cdr/copy-bq-dataset.sh
+++ b/api/db-cdr/generate-cdr/copy-bq-dataset.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This command may be used to copy an entire BigQuery dataset from one location to
+# another. This is meant ONLY to be used when copying test / synthetic data between
+# cloud projects.
+#
+# Example usage (see RW-3112 for context):
+#
+# ./db-cdr/generate-cdr/copy-bq-dataset.sh all-of-us-ehr-dev:synthetic_cdr20180606 fc-aou-cdr-synthetic-test:synthetic_cdr20180606
+#
+
+export SOURCE_DATASET=$1  # project1:dataset1
+export DEST_DATASET=$2  # project2:dataset2
+
+for f in `bq ls -n 1000 $SOURCE_DATASET | grep TABLE | awk '{print $1}'`
+do
+  export CP_COMMAND="bq cp -f $SOURCE_DATASET.$f $DEST_DATASET.$f"
+  echo $CP_COMMAND
+  echo `$CP_COMMAND`
+done

--- a/api/db-cdr/generate-cdr/copy-bq-dataset.sh
+++ b/api/db-cdr/generate-cdr/copy-bq-dataset.sh
@@ -12,9 +12,9 @@
 export SOURCE_DATASET=$1  # project1:dataset1
 export DEST_DATASET=$2  # project2:dataset2
 
-for f in `bq ls -n 1000 $SOURCE_DATASET | grep TABLE | awk '{print $1}'`
+for f in $(bq ls -n 1000 $SOURCE_DATASET | grep TABLE | awk '{print $1}')
 do
-  export CP_COMMAND="bq cp -f $SOURCE_DATASET.$f $DEST_DATASET.$f"
+  CP_COMMAND="bq cp -f $SOURCE_DATASET.$f $DEST_DATASET.$f"
   echo $CP_COMMAND
-  echo `$CP_COMMAND`
+  echo $($CP_COMMAND)
 done


### PR DESCRIPTION
For lack of a better place to put this, I'm proposing tracking this "BigQuery dataset copy" script within the generate-cdr folder.

I used this script when wrapping up https://precisionmedicineinitiative.atlassian.net/browse/RW-3112 for copying a synthetic CDR from pmi-ops.org project into a test.firecloud.org project.

If there's a feeling that this is either risky or clutters up the generate-cdr folder, I'm happy to punt on merging this in.