### PR TITLE
Increase billingProjectBufferCapacity size to 100 in test env

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -11,7 +11,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",
     "billingRetryCount": 2,
-    "billingProjectBufferCapacity": 10,
+    "billingProjectBufferCapacity": 100,
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test"
   },


### PR DESCRIPTION
to allow Gatling perf tests to run in test. https://all-of-us-workbench-test.appspot.com/