### PR TITLE
fixes for VS Code editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .classpath
 .project
 .externalToolBuilders
+.vscode
 .settings
 cron-emulator.log
 /api/?/

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -14,12 +14,17 @@
     "typeRoots": [
       "node_modules/@types"
     ],
+    "jsx": "react",
     "lib": [
       "es2016",
       "es2018.promise",
       "dom"
     ],
     "module": "es2015",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "paths": {
+      "app/*": ["./src/app/*"],
+      "generated/*": ["./src/generated/*"]
+    }
   }
 }


### PR DESCRIPTION
When editing/viewing the UI code in Visual Studio Code, I noticed that paths weren't resolving correctly. It looks like this is because we're using webpack implied roots (like `app`). Adding paths for `app` and `generated` to `.tsconfig` fixed that.

Additionally, I want to ignore the `.vscode` directory this editor creates.

An open question is whether this can go in a shared `.editorconfig`.