### PR TITLE
Revert "fixes for VS Code editor (#2442)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .classpath
 .project
 .externalToolBuilders
-.vscode
 .settings
 cron-emulator.log
 /api/?/

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -14,17 +14,12 @@
     "typeRoots": [
       "node_modules/@types"
     ],
-    "jsx": "react",
     "lib": [
       "es2016",
       "es2018.promise",
       "dom"
     ],
     "module": "es2015",
-    "baseUrl": "./",
-    "paths": {
-      "app/*": ["./src/app/*"],
-      "generated/*": ["./src/generated/*"]
-    }
+    "baseUrl": "./"
   }
 }


### PR DESCRIPTION
This reverts commit 2ba9f8406e59022d0cc1108827d3cab6d5d31a20.

We had some (all) yarn test failures due to components under `app` not being found.
