### PR TITLE
[RW-3188][risk=no] Minor backfill optimization - skip creators

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
@@ -130,6 +130,11 @@ public class BackfillBillingProjectUsers {
       Map<String, WorkspaceAccessEntry> acl =
           extractAclResponse(workspacesApi.getWorkspaceAcl(w.getNamespace(), w.getName()));
       for (String user : acl.keySet()) {
+        if (user.equals(w.getCreatedBy())) {
+          // Skip the common case, creators should already be billing project users. Any edge cases
+          // where this is not true will be fixed by the 1PPW migration (RW-2705).
+          continue;
+        }
         WorkspaceAccessEntry entry = acl.get(user);
         if (!"OWNER".equals(entry.getAccessLevel())) {
           // Only owners should be granted billing project user.


### PR DESCRIPTION
Very few workspaces are actually shared so this skips most of the work. The script was a no-op for creators.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
