### PR TITLE
[RW-3140][risk=low] Makes compliance data load async and only when th…

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -172,7 +172,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
       });
     }).catch(err => {
       this.setState({trainingCompleted: false});
-      console.error('error fetching moodle training status');
+      console.error('error fetching moodle training status:', err);
     });
     const twoFactorAuthStatus = profileApi().syncTwoFactorAuthStatus().then(result => {
       this.setState({
@@ -180,7 +180,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
       });
     }).catch(err => {
       this.setState({twoFactorAuthCompleted: false});
-      console.error('error fetching two factor auth status');
+      console.error('error fetching two factor auth status:', err);
     });
     return Promise.all([complianceStatus, twoFactorAuthStatus]);
   }

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -217,7 +217,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
       const {workbenchAccessTasks} = queryParamsStore.getValue();
       const hasRegisteredAccess = hasRegisteredAccessFetch(profile.dataAccessLevel);
-      if (!hasRegisteredAccess || parseInt(workbenchAccessTasks, 2) === 1) {
+      if (!hasRegisteredAccess || workbenchAccessTasks) {
         await this.syncCompliance();
       }
       if (workbenchAccessTasks) {

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -217,7 +217,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
       const {workbenchAccessTasks} = queryParamsStore.getValue();
       const hasRegisteredAccess = hasRegisteredAccessFetch(profile.dataAccessLevel);
-      if (!hasRegisteredAccess || workbenchAccessTasks == 1) {
+      if (!hasRegisteredAccess || parseInt(workbenchAccessTasks, 2) === 1) {
         await this.syncCompliance();
       }
       if (workbenchAccessTasks) {


### PR DESCRIPTION
…e user lacks registered access.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
