### PR TITLE
[RW-3146] [risk=no] Create analytics module for event tracking

### DIFF
--- a/ui/src/app/pages/workspace/workspace-list.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.tsx
@@ -21,7 +21,6 @@ import {ClrIcon} from 'app/components/icons';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
-import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
@@ -31,6 +30,7 @@ import {
   ReactWrapperBase,
   withUserProfile
 } from 'app/utils';
+import {triggerEvent} from 'app/utils/analytics';
 import {
   BillingProjectStatus,
   ErrorResponse,

--- a/ui/src/app/pages/workspace/workspace-list.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.tsx
@@ -21,6 +21,7 @@ import {ClrIcon} from 'app/components/icons';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
+import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
@@ -37,6 +38,8 @@ import {
 } from 'generated/fetch';
 import * as React from 'react';
 import RSelect from 'react-select';
+
+const EVENT_CATEGORY = 'Workspace list';
 
 const styles = reactStyles({
   fadeBox: {
@@ -215,14 +218,23 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
           <div style={{display: 'flex', flexDirection: 'column'}}>
             <div style={{ display: 'flex', alignItems: 'flex-start', flexDirection: 'row'}}>
               <WorkspaceCardMenu wp={wp}
-                                 onDelete={() => {this.setState({confirmDeleting: true}); }}
-                                 onShare={() => this.handleShareAction()}
+                                 onDelete={() => {
+                                   triggerEvent(
+                                     EVENT_CATEGORY, 'delete', 'Card menu - click delete');
+                                   this.setState({confirmDeleting: true});
+                                 }}
+                                 onShare={() => {
+                                   triggerEvent(EVENT_CATEGORY, 'share', 'Card menu - click share');
+                                   this.handleShareAction();
+                                 }}
                                  disabled={false}/>
               <Clickable>
                 <div style={styles.workspaceName}
                      data-test-id='workspace-card-name'
-                     onClick={() => navigate(
-                         ['workspaces', wp.workspace.namespace, wp.workspace.id, 'data'])}>
+                     onClick={() => {
+                       triggerEvent(EVENT_CATEGORY, 'navigate', 'Click on workspace name');
+                       navigate(['workspaces', wp.workspace.namespace, wp.workspace.id, 'data']);
+                     }}>
                   {wp.workspace.name}</div>
               </Clickable>
             </div>

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -1,0 +1,22 @@
+declare let gtag: Function;
+
+/**
+ * Triggers a Google Analytics event.
+ *
+ * For guidance on how to use action names, categories, and labels effectively,
+ * see https://support.google.com/analytics/answer/1033068#Anatomy.
+ */
+export function triggerEvent(
+  category: string, action: string, label?: string, value?: number,
+  nonInteraction: Boolean = false) {
+  if (window['gtag']) {
+    gtag('event', action, {
+      'event_category': category,
+      'event_label': label,
+      'event_value': value,
+      'non_interaction': nonInteraction
+    });
+  } else {
+    console.error('Google Analytics gtag.js has not been loaded');
+  }
+}


### PR DESCRIPTION
This PR creates a somewhat-trivial analytics module to house centrally-defined event tracking code.

I would imagine this module may be extended over time, e.g. to hold any more opinionated analytics-related functions (e.g. Ajax event timing, page-view tracking, etc.).

I also included a couple examples of usage from the workspace-list component. I ran this locally and verified with the Analytics debugger extension that the events were getting fired:

<img width="500" alt="Screen Shot 2019-08-14 at 8 57 24 PM" src="https://user-images.githubusercontent.com/51842/63092912-514fd580-bf31-11e9-80d6-a5812bd863ef.png">

If we wanted to be more "type-safe" with our analytics categories, we could consider creating a string-valued enum to store those within the analytics module. Possibly useful for follow-up work as we start to scale up the event reporting throughout our codebase.