### PR TITLE
[RW-3217][risk=no] moving synth cloud cdr version.

### DIFF
--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1"
+    "cdrDbName": "synth_r_2019q3_2"
   },
   {
     "cdrVersionId": 2,

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,8 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]
+git

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,7 @@
     "creationTime": "2018-09-20 00:00:01Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_1",
+    "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]


### PR DESCRIPTION
moving synth cloud cdr version from synth_r_2019q3_1 -> synth_r_2019q3_2 in test/staging/stable