### PR TITLE
[RW-3219][risk=no] moving cloud cdr version.

### DIFF
--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -19,7 +19,7 @@
     "creationTime": "2018-11-13 15:09:27Z",
     "releaseNumber": 1,
     "numParticipants": 116157,
-    "cdrDbName": "r_2019q1_3"
+    "cdrDbName": "r_2019q1_4"
   },
   {
     "cdrVersionId": 3,
@@ -31,6 +31,6 @@
     "creationTime": "2019-06-25 00:00:00Z",
     "releaseNumber": 2,
     "numParticipants": 191037,
-    "cdrDbName": "r_2019q2_1"
+    "cdrDbName": "r_2019q2_2"
   }
 ]


### PR DESCRIPTION
incrementing cloud cdr versions below:
{
    "cdrVersionId": 2,
    "name": "All of Us Dataset v1",
    "dataAccessLevel": 1,
    "bigqueryProject": "aou-res-curation-output-prod",
    "bigqueryDataset": "R2018Q4R1",
    "creationTime": "2018-11-13 15:09:27Z",
    "releaseNumber": 1,
    "numParticipants": 116157,
    "cdrDbName": "r_2019q1_4"
  },
  {
    "cdrVersionId": 3,
    "isDefault": true,
    "name": "All of Us Dataset v2",
    "dataAccessLevel": 1,
    "bigqueryProject": "aou-res-curation-output-prod",
    "bigqueryDataset": "R2019Q2R1",
    "creationTime": "2019-06-25 00:00:00Z",
    "releaseNumber": 2,
    "numParticipants": 191037,
    "cdrDbName": "r_2019q2_2"
  }
