### PR TITLE
[No ticket] [risk=no] Set default jsx compiler option in tsconfig

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -20,6 +20,7 @@
       "dom"
     ],
     "module": "es2015",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "jsx": "react"
   }
 }


### PR DESCRIPTION
When loading UI as a project in IntelliJ, the compiler threw a bunch of warnings that suggested something was wonky in the Angular configuration (i.e. `Cannot find module` for all modules, `--jsx is not set`). This change fixed all of the warnings.