### PR TITLE
[RW-1960][risk=low] Include Google Analytics in content-security-policy

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -66,7 +66,8 @@ handlers:
         https://api.firecloud.org
         https://*.googleapis.com
         https://*.zdassets.com
-        https://aousupporthelp.zendesk.com;
+        https://aousupporthelp.zendesk.com
+        https://www.google-analytics.com;
       child-src
         https://accounts.google.com
         https://leonardo.dsde-dev.broadinstitute.org


### PR DESCRIPTION
Seeing this URL reported in prod, though it seems only in certain scenarios does it make XHRs

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
