### PR TITLE
[RW-3029][risk=no] Actually open exported dataset notebooks in a new tab

### DIFF
--- a/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
@@ -129,7 +129,7 @@ class ExportDataSetModal extends React.Component<
     // Open notebook in a new tab and close the modal
     const notebookUrl = '/workspaces/' + workspaceNamespace + '/' + workspaceFirecloudName +
         '/notebooks/' + appendNotebookFileSuffix(encodeURIComponent(this.state.notebookName));
-    window.open(notebookUrl);
+    window.open(notebookUrl, '_blank');
     this.props.closeFunction();
   }
 

--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -162,7 +162,7 @@ class NewDataSetModal extends React.Component<Props, State> {
         // Open notebook in a new tab and return back to the Data tab
         const notebookUrl = '/workspaces/' + workspaceNamespace + '/' + workspaceId +
             '/notebooks/' + appendNotebookFileSuffix(encodeURIComponent(this.state.notebookName));
-        window.open(notebookUrl);
+        window.open(notebookUrl, '_blank');
       }
       window.history.back();
     } catch (e) {


### PR DESCRIPTION
`window.open()` and `window.history.back()` calls previously created a race condition.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
