### PR TITLE
[RW-3229] [risk=low] Enable copy notebook / concept set from readonly workspace

### DIFF
--- a/ui/src/app/components/resource-card-template.tsx
+++ b/ui/src/app/components/resource-card-template.tsx
@@ -57,6 +57,7 @@ export interface Action {
   icon: string;
   displayName: string;
   onClick: () => void;
+  disabled: boolean;
 }
 
 interface Props {
@@ -96,7 +97,8 @@ export class ResourceCardTemplate extends React.Component<Props, {}> {
                     return (<MenuItem
                       key={i}
                       icon={action.icon}
-                      onClick={() => action.onClick()}>
+                      onClick={() => action.onClick()}
+                      disabled={action.disabled}>
                       {action.displayName}
                     </MenuItem>);
                   })}

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -162,7 +162,7 @@ export class ResourceCard extends React.Component<Props, State> {
   }
 
   get actionsDisabled(): boolean {
-    return !this.writePermission && !this.isConceptSet
+    return !this.writePermission && !this.isConceptSet;
   }
 
   get writePermission(): boolean {

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -161,16 +161,12 @@ export class ResourceCard extends React.Component<Props, State> {
     return this.resourceType === ResourceType.DATA_SET;
   }
 
-  get actionsDisabled(): boolean {
-    return !this.writePermission && !this.isConceptSet;
-  }
-
-  get writePermission(): boolean {
+  get writerPermission(): boolean {
     return this.props.resourceCard.permission === 'OWNER'
       || this.props.resourceCard.permission === 'WRITER';
   }
 
-  get deletePermission(): boolean {
+  get ownerPermission(): boolean {
     return this.props.resourceCard.permission === 'OWNER';
   }
 
@@ -510,18 +506,18 @@ export class ResourceCard extends React.Component<Props, State> {
                         data-test-id='card'>
         <div style={{display: 'flex', flexDirection: 'column', alignItems: 'flex-start'}}>
           <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-start'}}>
-            <ResourceCardMenu disabled={this.actionsDisabled}
+            <ResourceCardMenu disabled={false}
                               resourceType={this.resourceType}
                               onCloneResource={() => this.cloneResource()}
                               onCopyConceptSet={() => this.setState({copyingConceptSet: true})}
-                              canDelete={this.deletePermission}
+                              canDelete={this.ownerPermission}
                               onDeleteResource={() => this.openConfirmDelete()}
                               onRenameResource={() => this.renameResource()}
-                              canEdit={this.writePermission}
+                              canEdit={this.writerPermission}
                               onEdit={() => this.edit()}
                               onExportDataSet={() => this.exportDataSet()}
                               onReviewCohort={() => this.reviewCohort()}/>
-            <Clickable disabled={this.actionsDisabled}>
+            <Clickable>
               <a style={styles.cardName}
                    data-test-id='card-name'
                  href={this.getResourceUrl()}

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -162,12 +162,16 @@ export class ResourceCard extends React.Component<Props, State> {
   }
 
   get actionsDisabled(): boolean {
-    return !this.writePermission;
+    return !this.writePermission && !this.isConceptSet
   }
 
   get writePermission(): boolean {
     return this.props.resourceCard.permission === 'OWNER'
       || this.props.resourceCard.permission === 'WRITER';
+  }
+
+  get deletePermission(): boolean {
+    return this.props.resourceCard.permission === 'OWNER';
   }
 
   get displayName(): string {
@@ -510,8 +514,10 @@ export class ResourceCard extends React.Component<Props, State> {
                               resourceType={this.resourceType}
                               onCloneResource={() => this.cloneResource()}
                               onCopyConceptSet={() => this.setState({copyingConceptSet: true})}
+                              canDelete={this.deletePermission}
                               onDeleteResource={() => this.openConfirmDelete()}
                               onRenameResource={() => this.renameResource()}
+                              canEdit={this.writePermission}
                               onEdit={() => this.edit()}
                               onExportDataSet={() => this.exportDataSet()}
                               onReviewCohort={() => this.reviewCohort()}/>

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -9,12 +9,12 @@ import {ResourceType} from 'app/utils/resourceActionsReact';
 
 export const ResourceCardMenu: React.FunctionComponent<{
   disabled: boolean, resourceType: ResourceType, onRenameResource?: Function,
-  onCloneResource?: Function, onCopyConceptSet?: Function, onDeleteResource?: Function,
-  onEdit?: Function, onExportDataSet: Function, onReviewCohort?: Function,
+  onCloneResource?: Function, onCopyConceptSet?: Function, canDelete: boolean, onDeleteResource?: Function,
+  canEdit: boolean, onEdit?: Function, onExportDataSet: Function, onReviewCohort?: Function,
 }> = ({
         disabled, resourceType, onRenameResource = () => {}, onCloneResource = () => {},
-        onCopyConceptSet = () => {}, onDeleteResource = () => {}, onEdit = () => {},
-        onExportDataSet = () => {}, onReviewCohort = () => {}
+        onCopyConceptSet = () => {}, canDelete, onDeleteResource = () => {},
+        canEdit, onEdit = () => {}, onExportDataSet = () => {}, onReviewCohort = () => {}
       }) => {
   return <PopupTrigger
     data-test-id='resource-card-menu'
@@ -39,9 +39,9 @@ export const ResourceCardMenu: React.FunctionComponent<{
         }],
         ['conceptSet', () => {
           return <React.Fragment>
-            <MenuItem icon='pencil' onClick={onEdit}>Rename</MenuItem>
+            <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Rename</MenuItem>
             <MenuItem icon='copy' onClick={onCopyConceptSet}>Copy to another workspace</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource}>Delete</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
           </React.Fragment>;
         }],
         ['dataSet', () => {
@@ -54,6 +54,7 @@ export const ResourceCardMenu: React.FunctionComponent<{
         }]
       )
     }
+    disabled={resourceType !== ResourceType.CONCEPT_SET || !canEdit}
   >
     <Clickable disabled={disabled} data-test-id='resource-menu'>
       <ClrIcon shape='ellipsis-vertical' size={21}

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -25,17 +25,17 @@ export const ResourceCardMenu: React.FunctionComponent<{
       switchCase(resourceType,
         ['cohort', () => {
           return <React.Fragment>
-            <MenuItem icon='note' onClick={onRenameResource}>Rename</MenuItem>
-            <MenuItem icon='copy' onClick={onCloneResource}>Duplicate</MenuItem>
-            <MenuItem icon='pencil' onClick={onEdit}>Edit</MenuItem>
-            <MenuItem icon='grid-view' onClick={onReviewCohort}>Review</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource}>Delete</MenuItem>
+            <MenuItem icon='note' onClick={onRenameResource} disabled={!canEdit}>Rename</MenuItem>
+            <MenuItem icon='copy' onClick={onCloneResource} disabled={!canEdit}>Duplicate</MenuItem>
+            <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Edit</MenuItem>
+            <MenuItem icon='grid-view' onClick={onReviewCohort} disabled={!canEdit}>Review</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
           </React.Fragment>;
         }],
         ['cohortReview', () => {
           return <React.Fragment>
-            <MenuItem icon='note' onClick={onRenameResource}>Rename</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource}>Delete</MenuItem>
+            <MenuItem icon='note' onClick={onRenameResource} disabled={!canEdit}>Rename</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
           </React.Fragment>;
         }],
         ['conceptSet', () => {
@@ -49,15 +49,14 @@ export const ResourceCardMenu: React.FunctionComponent<{
         }],
         ['dataSet', () => {
           return <React.Fragment>
-            <MenuItem icon='pencil' onClick={onRenameResource}>Rename Data Set</MenuItem>
-            <MenuItem icon='pencil' onClick={onEdit}>Edit</MenuItem>
-            <MenuItem icon='clipboard' onClick={onExportDataSet}>Export to Notebook</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource}>Delete</MenuItem>
+            <MenuItem icon='pencil' onClick={onRenameResource} disabled={!canEdit}>Rename Data Set</MenuItem>
+            <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Edit</MenuItem>
+            <MenuItem icon='clipboard' onClick={onExportDataSet} disabled={!canEdit}>Export to Notebook</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
           </React.Fragment>;
         }]
       )
     }
-    disabled={resourceType !== ResourceType.CONCEPT_SET || !canEdit}
   >
     <Clickable disabled={disabled} data-test-id='resource-menu'>
       <ClrIcon shape='ellipsis-vertical' size={21}

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -9,8 +9,9 @@ import {ResourceType} from 'app/utils/resourceActionsReact';
 
 export const ResourceCardMenu: React.FunctionComponent<{
   disabled: boolean, resourceType: ResourceType, onRenameResource?: Function,
-  onCloneResource?: Function, onCopyConceptSet?: Function, canDelete: boolean, onDeleteResource?: Function,
-  canEdit: boolean, onEdit?: Function, onExportDataSet: Function, onReviewCohort?: Function,
+  onCloneResource?: Function, onCopyConceptSet?: Function, canDelete: boolean,
+  onDeleteResource?: Function, canEdit: boolean, onEdit?: Function,
+  onExportDataSet: Function, onReviewCohort?: Function,
 }> = ({
         disabled, resourceType, onRenameResource = () => {}, onCloneResource = () => {},
         onCopyConceptSet = () => {}, canDelete, onDeleteResource = () => {},
@@ -41,7 +42,9 @@ export const ResourceCardMenu: React.FunctionComponent<{
           return <React.Fragment>
             <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Rename</MenuItem>
             <MenuItem icon='copy' onClick={onCopyConceptSet}>Copy to another workspace</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>
+              Delete
+            </MenuItem>
           </React.Fragment>;
         }],
         ['dataSet', () => {

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -26,16 +26,24 @@ export const ResourceCardMenu: React.FunctionComponent<{
         ['cohort', () => {
           return <React.Fragment>
             <MenuItem icon='note' onClick={onRenameResource} disabled={!canEdit}>Rename</MenuItem>
-            <MenuItem icon='copy' onClick={onCloneResource} disabled={!canEdit}>Duplicate</MenuItem>
+            <MenuItem icon='copy' onClick={onCloneResource} disabled={!canEdit}>
+              Duplicate
+            </MenuItem>
             <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Edit</MenuItem>
-            <MenuItem icon='grid-view' onClick={onReviewCohort} disabled={!canEdit}>Review</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
+            <MenuItem icon='grid-view' onClick={onReviewCohort} disabled={!canEdit}>
+              Review
+            </MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>
+              Delete
+            </MenuItem>
           </React.Fragment>;
         }],
         ['cohortReview', () => {
           return <React.Fragment>
             <MenuItem icon='note' onClick={onRenameResource} disabled={!canEdit}>Rename</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>
+              Delete
+            </MenuItem>
           </React.Fragment>;
         }],
         ['conceptSet', () => {
@@ -49,10 +57,16 @@ export const ResourceCardMenu: React.FunctionComponent<{
         }],
         ['dataSet', () => {
           return <React.Fragment>
-            <MenuItem icon='pencil' onClick={onRenameResource} disabled={!canEdit}>Rename Data Set</MenuItem>
+            <MenuItem icon='pencil' onClick={onRenameResource} disabled={!canEdit}>
+              Rename Data Set
+            </MenuItem>
             <MenuItem icon='pencil' onClick={onEdit} disabled={!canEdit}>Edit</MenuItem>
-            <MenuItem icon='clipboard' onClick={onExportDataSet} disabled={!canEdit}>Export to Notebook</MenuItem>
-            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>Delete</MenuItem>
+            <MenuItem icon='clipboard' onClick={onExportDataSet} disabled={!canEdit}>
+              Export to Notebook
+            </MenuItem>
+            <MenuItem icon='trash' onClick={onDeleteResource} disabled={!canDelete}>
+              Delete
+            </MenuItem>
           </React.Fragment>;
         }]
       )

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -59,6 +59,10 @@ export const NotebookResourceCard = fp.flow(
       || this.props.resource.permission === 'WRITER';
   }
 
+  get deletePermission(): boolean {
+    return this.props.resource.permission === 'OWNER';
+  }
+
   get actions(): Action[] {
     return [
       {
@@ -67,16 +71,19 @@ export const NotebookResourceCard = fp.flow(
         onClick: () => {
           this.setState({showRenameModal: true});
         },
+        disabled: !this.writePermission,
       },
       {
         icon: 'copy',
         displayName: 'Duplicate',
         onClick: () => this.duplicateNotebook(),
+        disabled: !this.writePermission,
       },
       {
         icon: 'copy',
         displayName: 'Copy to another Workspace',
         onClick: () => this.setState({showCopyNotebookModal: true}),
+        disabled: false,
       },
       {
         icon: 'trash',
@@ -85,6 +92,7 @@ export const NotebookResourceCard = fp.flow(
           this.props.showConfirmDeleteModal(this.displayName,
             this.resourceType, () => this.deleteNotebook());
         },
+        disabled: !this.deletePermission,
       }];
   }
 
@@ -169,7 +177,7 @@ export const NotebookResourceCard = fp.flow(
 
       <ResourceCardTemplate
         actions={this.actions}
-        actionsDisabled={!this.writePermission}
+        actionsDisabled={false}
         disabled={false} // Notebook Cards are always at least readable
         resourceUrl={this.resourceUrl}
         displayName={this.displayName}

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -94,12 +94,12 @@ const ConceptSetMenu: React.FunctionComponent<ConceptSetMenuProps> = (
   </PopupTrigger>;
 };
 
-export interface ConceptSetProps {
+export interface ConceptSetDetailsProps {
   urlParams: any;
   workspace: WorkspaceData;
 }
 
-export interface ConceptSetState {
+export interface ConceptSetDetailsState {
   copying: boolean;
   copySaving: boolean;
   conceptSet: ConceptSet;
@@ -117,7 +117,7 @@ export interface ConceptSetState {
 }
 
 export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace())(
-  class extends React.Component<ConceptSetProps, ConceptSetState> {
+  class extends React.Component<ConceptSetDetailsProps, ConceptSetDetailsState> {
     constructor(props) {
       super(props);
       this.state = {

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -48,7 +48,7 @@ const styles = reactStyles({
   }
 });
 
-export interface ConceptSetProps {
+export interface ConceptSetMenuProps {
   canDelete: boolean,
   canEdit: boolean,
   onEdit: Function,
@@ -56,7 +56,9 @@ export interface ConceptSetProps {
   onCopy: Function
 }
 
-const ConceptSetMenu: React.FunctionComponent<ConceptSetProps> = ({canDelete, canEdit, onEdit, onDelete, onCopy}) => {
+const ConceptSetMenu: React.FunctionComponent<ConceptSetMenuProps> = (
+  {canDelete, canEdit, onEdit, onDelete, onCopy}
+) => {
 
   return <PopupTrigger
     side='right'

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -48,9 +48,15 @@ const styles = reactStyles({
   }
 });
 
-const ConceptSetMenu: React.FunctionComponent<{
-  canDelete: boolean, canEdit: boolean, onEdit: Function, onDelete: Function, onCopy: Function
-}> = ({canDelete, canEdit, onEdit, onDelete, onCopy}) => {
+export interface ConceptSetProps {
+  canDelete: boolean,
+  canEdit: boolean,
+  onEdit: Function,
+  onDelete: Function,
+  onCopy: Function
+}
+
+const ConceptSetMenu: React.FunctionComponent<ConceptSetProps> = ({canDelete, canEdit, onEdit, onDelete, onCopy}) => {
 
   return <PopupTrigger
     side='right'
@@ -86,28 +92,43 @@ const ConceptSetMenu: React.FunctionComponent<{
   </PopupTrigger>;
 };
 
+export interface ConceptSetProps {
+  urlParams: any,
+  workspace: WorkspaceData
+}
+
+export interface ConceptSetState {
+  copying: boolean,
+  copySaving: boolean,
+  conceptSet: ConceptSet,
+  deleting: boolean,
+  editing: boolean,
+  editName: string,
+  editDescription: string,
+  editSaving: boolean,
+  error: boolean,
+  errorMessage: string,
+  loading: boolean,
+  removingConcepts: boolean,
+  removeSubmitting: boolean,
+  selectedConcepts: Concept[]
+}
+
 export const ConceptSetDetails =
-  fp.flow(withUrlParams(), withCurrentWorkspace())(class extends React.Component<{
-    urlParams: any, workspace: WorkspaceData
-  }, {
-    copying: boolean, copySaving: boolean, conceptSet: ConceptSet, deleting: boolean, editName: string,
-    editDescription: string, editSaving: boolean, error: boolean, errorMessage: string,
-    editing: boolean, loading: boolean, removingConcepts: boolean, removeSubmitting: boolean,
-    selectedConcepts: Concept[]
-  }> {
+  fp.flow(withUrlParams(), withCurrentWorkspace())(class extends React.Component<ConceptSetProps, ConceptSetState> {
     constructor(props) {
       super(props);
       this.state = {
         copying: false,
         copySaving: false,
         conceptSet: undefined,
+        editing: false,
         editName: '',
         editDescription: '',
         editSaving: false,
         error: false,
         errorMessage: '',
         deleting: false,
-        editing: false,
         loading: true,
         removingConcepts: false,
         removeSubmitting: false,

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -7,6 +7,7 @@ import {Button, Clickable, MenuItem} from 'app/components/buttons';
 import {SlidingFabReact} from 'app/components/buttons';
 import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {FadeBox} from 'app/components/containers';
+import {CopyModal} from 'app/components/copy-modal';
 import {ClrIcon} from 'app/components/icons';
 import {TextArea, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalFooter, ModalTitle} from 'app/components/modals';
@@ -27,7 +28,6 @@ import {ResourceType} from 'app/utils/resourceActionsReact';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {Concept, ConceptSet, CopyRequest, WorkspaceAccessLevel} from 'generated/fetch';
-import {CopyModal} from "app/components/copy-modal";
 
 const styles = reactStyles({
   conceptSetHeader: {
@@ -49,11 +49,11 @@ const styles = reactStyles({
 });
 
 export interface ConceptSetMenuProps {
-  canDelete: boolean,
-  canEdit: boolean,
-  onEdit: Function,
-  onDelete: Function,
-  onCopy: Function
+  canDelete: boolean;
+  canEdit: boolean;
+  onEdit: Function;
+  onDelete: Function;
+  onCopy: Function;
 }
 
 const ConceptSetMenu: React.FunctionComponent<ConceptSetMenuProps> = (
@@ -95,29 +95,29 @@ const ConceptSetMenu: React.FunctionComponent<ConceptSetMenuProps> = (
 };
 
 export interface ConceptSetProps {
-  urlParams: any,
-  workspace: WorkspaceData
+  urlParams: any;
+  workspace: WorkspaceData;
 }
 
 export interface ConceptSetState {
-  copying: boolean,
-  copySaving: boolean,
-  conceptSet: ConceptSet,
-  deleting: boolean,
-  editing: boolean,
-  editName: string,
-  editDescription: string,
-  editSaving: boolean,
-  error: boolean,
-  errorMessage: string,
-  loading: boolean,
-  removingConcepts: boolean,
-  removeSubmitting: boolean,
-  selectedConcepts: Concept[]
+  copying: boolean;
+  copySaving: boolean;
+  conceptSet: ConceptSet;
+  deleting: boolean;
+  editing: boolean;
+  editName: string;
+  editDescription: string;
+  editSaving: boolean;
+  error: boolean;
+  errorMessage: string;
+  loading: boolean;
+  removingConcepts: boolean;
+  removeSubmitting: boolean;
+  selectedConcepts: Concept[];
 }
 
-export const ConceptSetDetails =
-  fp.flow(withUrlParams(), withCurrentWorkspace())(class extends React.Component<ConceptSetProps, ConceptSetState> {
+export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace())(
+  class extends React.Component<ConceptSetProps, ConceptSetState> {
     constructor(props) {
       super(props);
       this.state = {
@@ -293,7 +293,11 @@ export const ConceptSetDetails =
                                data-test-id='edit-concept-set'
                                onClick={() => this.setState({editing: true})}>
                       <EditComponentReact enableHoverEffect={true}
-                                          disabled={!WorkspacePermissionsUtil.canWrite(workspace.accessLevel)}
+                                          disabled={
+                                            !WorkspacePermissionsUtil.canWrite(
+                                              workspace.accessLevel
+                                            )
+                                          }
                                           style={{marginTop: '0.1rem'}}/>
                     </Clickable>
                   </div>
@@ -329,7 +333,8 @@ export const ConceptSetDetails =
                       ('?domain=' + conceptSet.domain))}>
             <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
           </Button>}
-          {WorkspacePermissionsUtil.canWrite(workspace.accessLevel) && this.selectedConceptsCount > 0 &&
+          {WorkspacePermissionsUtil.canWrite(workspace.accessLevel) &&
+              this.selectedConceptsCount > 0 &&
               <SlidingFabReact submitFunction={() => this.setState({removingConcepts: true})}
                                iconShape='trash' expanded='Remove from set'
                                tooltip={this.conceptSetConceptsCount === this.selectedConceptsCount}


### PR DESCRIPTION
One can now copy notebooks and concept sets from a read-only workspace to another workspace without cloning the entire read-only workspace.