### PR TITLE
[RW-3304][risk=low] Add fallback snippets behavior for large notebooks

### DIFF
--- a/api/cluster-resources/README.md
+++ b/api/cluster-resources/README.md
@@ -58,6 +58,15 @@ Jupyter UI extension for playground mode. Passed via GCS at cluster creation tim
 Tweak the above instructions for testing the user script to push a modified
 extension and modify the cluster controller to use it.
 
+Alternatively, on a live version of a Leo cluster, use Chrome local overrides to
+plug in your locally modified Javascript.
+
+- Follow these instructions to setup local overrides: https://developers.google.com/web/updates/2018/01/devtools#overrides
+- Search the scripts tab to find the extension Javascript and save an override
+- Find the path to that override on disk
+- Copy your local Javascript to this path to push updates
+- Reload the browser, ensuring devtools are open and "enable local overrides" is on
+
 # Snippets Menu
 
 AoU Clusters enable the [Snippets Menu extension](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/snippets_menu/readme.html)

--- a/api/cluster-resources/aou-snippets-menu.js.template
+++ b/api/cluster-resources/aou-snippets-menu.js.template
@@ -1,7 +1,9 @@
 define([
+  'jquery',
   'base/js/namespace',
+  'base/js/events',
   'nbextensions/snippets_menu/main'
-], (Jupyter, snippets_menu) => {
+], ($, Jupyter, events, snippets_menu) => {
   // Jupyter UI extension to customize the "Snippets Menu" extension with AoU
   // specific code snippets. See
   // https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/snippets_menu/readme.html
@@ -9,30 +11,48 @@ define([
     const pyMenu = {{PY_MENU_JSON}};
     const rMenu = {{R_MENU_JSON}};
 
-    const kernelName = Jupyter.notebook.session.kernel_model.name;
+    const handleKernel = (kernelName) => {
+      // Show the menu which is relevant to the current kernel. Show both as a fallback.
+      let customMenus = [pyMenu, rMenu];
+      if (kernelName.startsWith("python")) {
+        customMenus = [pyMenu];
+      } else if (kernelName === "ir") {
+        customMenus = [rMenu];
+      }
+      snippets_menu.options['menus'] = snippets_menu.default_menus;
+      snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, ...customMenus);
 
-    // Show the menu which is relevant to the current kernel. Show both as a fallback.
-    let customMenus = [pyMenu, rMenu];
-    if (kernelName.startsWith("python")) {
-      customMenus = [pyMenu];
-    } else if (kernelName === "ir") {
-      customMenus = [rMenu];
+      // Include custom menu content from the nbconfigurator UI extension, if any.
+      // We primarily expect this to be used for manual testing of
+      // workbench-snippets code, so prefix it to differentiate from the menus
+      // installed by this extension.
+      const snippetsConfig = Jupyter.notebook.config.data.snippets || {};
+      if (snippetsConfig.include_custom_menu) {
+        const customExtMenu = JSON.parse(snippetsConfig.custom_menu_content);
+        customExtMenu['name'] = '[Custom] ' + customExtMenu['name'];
+        snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, customExtMenu);
+      }
+    };
+
+    // Session may be null at this point, e.g. for large notebooks, while the
+    // Jupyter UI is still doing initial rendering.
+    if (Jupyter.notebook.session && Jupyter.notebook.session.kernel_model) {
+      handleKernel(Jupyter.notebook.session.kernel_model.name);
+      console.log('loaded AoU snippets on initial load');
+    } else {
+      console.log('session data not yet available, listening for notebook load');
+      events.on('notebook_loaded.Notebook', () => {
+        // We can't avoid the initial Snippets menu insertion, so remove it here and render again.
+        $('.dropdown:contains("Snippets")').remove();
+
+        // Kernel name should now be available.
+        handleKernel(Jupyter.notebook.session.kernel_model.name);
+        snippets_menu.menu_setup(
+            snippets_menu.options.menus, snippets_menu.options.sibling, /* insertBeforeSibling */ false);
+        console.log('loaded AoU snippets on event');
+      });
     }
-    snippets_menu.options['menus'] = snippets_menu.default_menus;
-    snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, ...customMenus);
-
-    // Include custom menu content from the nbconfigurator UI extension, if any.
-    // We primarily expect this to be used for manual testing of
-    // workbench-snippets code, so prefix it to differentiate from the menus
-    // installed by this extension.
-    const snippetsConfig = Jupyter.notebook.config.data.snippets || {};
-    if (snippetsConfig.include_custom_menu) {
-      const customExtMenu = JSON.parse(snippetsConfig.custom_menu_content);
-      customExtMenu['name'] = '[Custom] ' + customExtMenu['name'];
-      snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, customExtMenu);
-    }
-
-    console.log('loaded custom AoU snippet-menus');
+    console.log('loaded custom AoU snippet-menus extension');
   };
 
   return {

--- a/api/cluster-resources/aou-snippets-menu.js.template
+++ b/api/cluster-resources/aou-snippets-menu.js.template
@@ -19,8 +19,14 @@ define([
       } else if (kernelName === "ir") {
         customMenus = [rMenu];
       }
-      snippets_menu.options['menus'] = snippets_menu.default_menus;
-      snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, ...customMenus);
+
+      // Avoid mutating the original default_menus to reduce side-effects.
+      snippets_menu.options['menus'] = [...snippets_menu.default_menus];
+      const menus = snippets_menu.options['menus'];
+      menus[0] = {
+         ...menus[0],
+         'sub-menu': [...customMenus, ...menus[0]['sub-menu']]
+      };
 
       // Include custom menu content from the nbconfigurator UI extension, if any.
       // We primarily expect this to be used for manual testing of
@@ -30,7 +36,10 @@ define([
       if (snippetsConfig.include_custom_menu) {
         const customExtMenu = JSON.parse(snippetsConfig.custom_menu_content);
         customExtMenu['name'] = '[Custom] ' + customExtMenu['name'];
-        snippets_menu.options['menus'][0]['sub-menu'].splice(0, 0, customExtMenu);
+        menus[0] = {
+           ...menus[0],
+           'sub-menu': [customExtMenu, ...menus[0]['sub-menu']]
+        };
       }
     };
 
@@ -40,10 +49,26 @@ define([
       handleKernel(Jupyter.notebook.session.kernel_model.name);
       console.log('loaded AoU snippets on initial load');
     } else {
+      // Initialize the menu with an empty kernel name for now, resulting in
+      // rendering of both language menus. Once the notebook loads we'll try to
+      // re-render the menu with only the proper language.
       console.log('session data not yet available, listening for notebook load');
+      handleKernel(/* kernelName */ "");
+
       events.on('notebook_loaded.Notebook', () => {
-        // We can't avoid the initial Snippets menu insertion, so remove it here and render again.
-        $('.dropdown:contains("Snippets")').remove();
+        // We can't avoid the initial Snippets menu insertion, so remove it here
+        // and render again. The snippets menu unfortunately does not attach any
+        // classes/IDs for selection so we use the display text. This is brittle
+        // so we ensure robust fallback behavior.
+        const snippetsEl = $('.dropdown:contains("Snippets")');
+        if (snippetsEl.length != 1) {
+          console.error(
+              'failed to locate snippets menu element, snippets are either ' +
+              'not being shown, or both language AoU snippet menus are being ' +
+              'shown');
+          return;
+        }
+        snippetsEl.remove();
 
         // Kernel name should now be available.
         handleKernel(Jupyter.notebook.session.kernel_model.name);


### PR DESCRIPTION
The session data I was depending on was null for large notebooks, i.e. while Jupyter UI was still initializing. Fallback to listening for notebook load.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
