### PR TITLE
[RW-3165][risk=low] Add ./project.rb command for publishing a CDR

### DIFF
--- a/api/db-cdr/generate-cdr/copy-bq-dataset.sh
+++ b/api/db-cdr/generate-cdr/copy-bq-dataset.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 
+set -ex
+
 # This command may be used to copy an entire BigQuery dataset from one location to
 # another. This is meant ONLY to be used when copying test / synthetic data between
 # cloud projects.
 #
-# Example usage (see RW-3112 for context):
-#
-# ./db-cdr/generate-cdr/copy-bq-dataset.sh all-of-us-ehr-dev:synthetic_cdr20180606 fc-aou-cdr-synthetic-test:synthetic_cdr20180606
+# Invoke via db-cdr/generate-cdr/project.rb publish-cdr
 #
 
 export SOURCE_DATASET=$1  # project1:dataset1
 export DEST_DATASET=$2  # project2:dataset2
+export JOB_PROJECT=$3 # project3
 
 for f in $(bq ls -n 1000 $SOURCE_DATASET | grep TABLE | awk '{print $1}')
 do
-  CP_COMMAND="bq cp -f $SOURCE_DATASET.$f $DEST_DATASET.$f"
-  echo $CP_COMMAND
-  echo $($CP_COMMAND)
+  bq --project_id="${JOB_PROJECT}" cp -f "${SOURCE_DATASET}.${f}" "${DEST_DATASET}.${f}"
 done

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -81,6 +81,15 @@ def publish_cdr(cmd_name, args)
     dest_dataset = "#{env.fetch(:dest_cdr_project)}:#{op.opts.bq_dataset}"
     common.status "Copying from '#{source_dataset}' to '#{dest_dataset}' as #{account}"
 
+    # If you receive an error from "bq" like "Invalid JWT Signature", you may
+    # need to delete cached BigQuery creds on your local machine. Try deleting
+    # files matching ~/.config/gcloud/legacy_credentials/*/singlestore_bq.json
+    # (verify the file location on your machine first).
+    # TODO: Find a better solution for Google credentials in docker.
+
+    # If you receive a prompt from "bq" for selecting a default project ID, just
+    # hit enter.
+    # TODO: Figure out how to prepopulate this value or disable interactivity.
     common.run_inline %W{bq mk -f --dataset #{dest_dataset}}
     common.run_inline %W{./copy-bq-dataset.sh #{source_dataset} #{dest_dataset} #{env.fetch(:source_cdr_project)}}
 

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -64,12 +64,8 @@ def publish_cdr(cmd_name, args)
     ->(opts, v) { opts.project = v},
     "The Google Cloud project associated with this environment."
   )
-  op.add_validator ->(opts) {
-    raise ArgumentError unless opts.bq_dataset and opts.project
-  }
-  op.add_validator ->(opts) {
-    raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project
-  }
+  op.add_validator ->(opts) { raise ArgumentError unless opts.bq_dataset and opts.project }
+  op.add_validator ->(opts) { raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project }
   op.parse.validate
 
   common = Common.new

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -71,6 +71,7 @@ def publish_cdr(cmd_name, args)
   common = Common.new
   env = ENVIRONMENTS[op.opts.project]
   account = env.fetch(:publisher_account)
+  # TODO(RW-3208): Investigate using a temporary / impersonated SA credential instead of a key.
   key_file = Tempfile.new(["#{account}-key", ".json"], "/tmp")
   ServiceAccountContext.new(
     op.opts.project, account, key_file.path).run do

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -1,69 +1,123 @@
+require_relative "../../../../aou-utils/serviceaccounts"
 require_relative "../../../../aou-utils/utils/common"
 require_relative "../../../libproject/wboptionsparser"
 require "json"
 require "set"
 require "tempfile"
 
-def update_bq_acl(cmd_name, args)
+ENVIRONMENTS = {
+  "all-of-us-workbench-test" => {
+    :publisher_account => "circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
+    :source_cdr_project => "all-of-us-ehr-dev",
+    :dest_cdr_project => "fc-aou-cdr-synth-test",
+    :config_json => "config_test.json"
+  },
+  "all-of-us-rw-staging" => {
+    :publisher_account => "circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
+    :source_cdr_project => "all-of-us-ehr-dev",
+    :dest_cdr_project => "fc-aou-cdr-synth-staging",
+    :config_json => "config_staging.json"
+  },
+  "all-of-us-rw-stable" => {
+    :publisher_account => "deploy@all-of-us-rw-stable.iam.gserviceaccount.com",
+    :source_cdr_project => "all-of-us-ehr-dev",
+    :dest_cdr_project => "fc-aou-cdr-synth-stable",
+    :config_json => "config_stable.json"
+  },
+  "all-of-us-rw-prod" => {
+    :publisher_account => "deploy@all-of-us-rw-prod.iam.gserviceaccount.com",
+    :source_cdr_project => "aou-res-curation-output-prod",
+    :dest_cdr_project => "fc-aou-cdr-prod",
+    :config_json => "config_prod.json"
+  }
+}
+
+def get_config(env)
+  unless ENVIRONMENTS.fetch(env, {}).has_key?(:config_json)
+    raise ArgumentError.new("env '#{env}' lacks a valid configuration")
+  end
+  return JSON.parse(File.read("../../config/" + ENVIRONMENTS[env][:config_json]))
+end
+
+def get_auth_domain_group(project)
+  return get_config(project)["firecloud"]["registeredDomainGroup"]
+end
+
+def ensure_docker(cmd_name, args=nil)
+  args = (args or [])
+  unless Workbench.in_docker?
+    exec(*(%W{docker-compose run --rm cdr-scripts ./generate-cdr/project.rb #{cmd_name}} + args))
+  end
+end
+
+def publish_cdr(cmd_name, args)
+  ensure_docker cmd_name, args
+
   op = WbOptionsParser.new(cmd_name, args)
-  op.add_option(
-   "--bq-project [project]",
-      ->(opts, v) { opts.bq_project = v},
-      "Project containing the CDR version. Required."
-    )
   op.add_option(
     "--bq-dataset [dataset]",
     ->(opts, v) { opts.bq_dataset = v},
     "Dataset for the CDR version. Required."
   )
-  op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
+  op.add_option(
+    "--project [project]",
+    ->(opts, v) { opts.project = v},
+    "The Google Cloud project associated with this environment."
+  )
+  op.add_validator ->(opts) {
+    raise ArgumentError unless opts.bq_dataset and opts.project
+  }
+  op.add_validator ->(opts) {
+    raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project
+  }
   op.parse.validate
 
-  # TODO: add controlled authorization domains here later; choose controlled vs. registered based
-  # on data access level of CDR version.
-  if op.opts.bq_project == "all-of-us-ehr-dev"
-    # We include prod in here for now since it uses synthetic data. We might remove this in future.
-    authorization_domains = ["all-of-us-registered-prod@firecloud.org",
-                             "GROUP_all-of-us-registered-stable@firecloud.org",
-                             "GROUP_all-of-us-registered-staging@firecloud.org",
-                             "GROUP_all-of-us-registered-test@dev.test.firecloud.org"]
-  elsif op.opts.bq_project == "aou-res-curation-prod"
-    authorization_domains = ["all-of-us-registered-prod@firecloud.org"]
-  else
-    raise ArgumentError.new("bq-project must be all-of-us-ehr-dev (synthetic) or aou-res-curation-prod (prod)")
-  end
-
   common = Common.new
-  config_file = Tempfile.new("#{op.opts.bq_dataset}-config.json")
-  begin
-    common.run_inline %{bq show --format=prettyjson #{op.opts.bq_project}:#{op.opts.bq_dataset} > #{config_file.path}}
-    json = JSON.parse(File.read(config_file.path))
-    existing_groups = Set[]
-    for entry in json["access"]
-      if entry.key?("groupByEmail")
-        existing_groups.add(entry["groupByEmail"])
+  env = ENVIRONMENTS[op.opts.project]
+  account = env.fetch(:publisher_account)
+  key_file = Tempfile.new(["#{account}-key", ".json"], "/tmp")
+  ServiceAccountContext.new(
+    op.opts.project, account, key_file.path).run do
+    common.run_inline %W{gcloud auth activate-service-account -q --key-file #{key_file.path}}
+
+    source_dataset = "#{env.fetch(:source_cdr_project)}:#{op.opts.bq_dataset}"
+    dest_dataset = "#{env.fetch(:dest_cdr_project)}:#{op.opts.bq_dataset}"
+    common.status "Copying from '#{source_dataset}' to '#{dest_dataset}' as #{account}"
+
+    common.run_inline %W{bq mk -f --dataset #{dest_dataset}}
+    common.run_inline %W{./copy-bq-dataset.sh #{source_dataset} #{dest_dataset} #{env.fetch(:source_cdr_project)}}
+
+    auth_domain_group = get_auth_domain_group(op.opts.project)
+
+    config_file = Tempfile.new("#{op.opts.bq_dataset}-config.json")
+    begin
+      json = JSON.parse(
+        common.capture_stdout %{bq show --format=prettyjson #{dest_dataset}})
+      existing_groups = Set[]
+      for entry in json["access"]
+        if entry.key?("groupByEmail")
+          existing_groups.add(entry["groupByEmail"])
+        end
       end
-    end
-    for domain in authorization_domains
-      if existing_groups.include?(domain)
-        puts "#{domain} already in ACL, skipping..."
+      if existing_groups.include?(auth_domain_group)
+        common.status "#{auth_domain_group} already in ACL, skipping..."
       else
-        puts "Adding #{domain} to ACL..."
-        new_entry = { "groupByEmail" => domain, "role" => "READER"}
+        common.status "Adding #{auth_domain_group} as a READER..."
+        new_entry = { "groupByEmail" => auth_domain_group, "role" => "READER"}
         json["access"].push(new_entry)
       end
+      File.open(config_file.path, "w") do |f|
+        f.write(JSON.pretty_generate(json))
+      end
+      common.run_inline %{bq update --source #{config_file.path} #{dest_dataset}}
+    ensure
+      config_file.unlink
     end
-    File.open(config_file.path, "w") do |f|
-      f.write(JSON.pretty_generate(json))
-    end
-    common.run_inline %{bq update --source #{config_file.path} #{op.opts.bq_project}:#{op.opts.bq_dataset}}
-  ensure
-    config_file.unlink
   end
 end
 
 Common.register_command({
-  :invocation => "update-bq-acl",
-  :description => "Updates the BigQuery dataset ACL for a CDR version to have the appropriate FireCloud groups on it.",
-  :fn => ->(*args) { update_bq_acl("update-bq-acl", args) }
+  :invocation => "publish-cdr",
+  :description => "Publishes a CDR dataset by copying it into a Firecloud CDR project and making it readable by registered users in the corresponding environment",
+  :fn => ->(*args) { publish_cdr("publish-cdr", args) }
 })

--- a/api/db-cdr/generate-cdr/project.rb
+++ b/api/db-cdr/generate-cdr/project.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../../../aou-utils/workbench"
+require_relative "libproject/devstart.rb"
+
+Workbench.handle_argv_or_die(__FILE__)

--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CLOUD_SDK_VERSION 215.0.0
+ENV CLOUD_SDK_VERSION 260.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 


### PR DESCRIPTION
Example invocation:
```
./project.rb publish-cdr --project all-of-us-rw-staging --bq-dataset synthetic_cdr20180606
```

This...
- Creates the dataset (if it doesn't exist)
- Copies all tables from the source dataset
- Adds the registered tier google group as a READER

Notes:
- gcloud upgrade needed due to `bq` error in docker: `SSLHandshakeError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)`
- JOB_PROJECT should be explicitly specified on copy, I'm not sure where it got this from without specification (possibly the gcloud default project)
- Switched script to `-ex` to fail on error and log all commands directly, rather then echo'ing
- There's some duplication with the base level ./project.rb. I can't import that without bringing in all the global commands, and the commands need to be slightly adjusted for the `generate-cdr` base dir

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
