### PR TITLE
[RW-3297][risk=no] Removing cohortId/cdrVersionId and replacing with cohortReviewId

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -42,7 +42,7 @@
     "projectId": "all-of-us-rw-perf",
     "shortName": "Perf",
     "oauthClientId": "63939010390-aj0r8hro7r8lkt7a45gissu3m73ietl2.apps.googleusercontent.com",
-    "traceAllRequests": false
+    "traceAllRequests": true
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-perf.appspot.com/login",

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -1519,12 +1519,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
     try {
       controller.getCohortChartData(
-          NAMESPACE,
-          NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
-          DomainType.CONDITION.name(),
-          -1);
+          NAMESPACE, NAME, review.getCohortReviewId(), DomainType.CONDITION.name(), -1);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // Success
@@ -1539,12 +1534,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
     try {
       controller.getCohortChartData(
-          NAMESPACE,
-          NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
-          DomainType.CONDITION.name(),
-          101);
+          NAMESPACE, NAME, review.getCohortReviewId(), DomainType.CONDITION.name(), 101);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // Success
@@ -1560,12 +1550,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                DomainType.LAB.name(),
-                10)
+                NAMESPACE, NAME, review.getCohortReviewId(), DomainType.LAB.name(), 10)
             .getBody();
     assertEquals(3, response.getItems().size());
     assertEquals(
@@ -1583,12 +1568,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                DomainType.DRUG.name(),
-                10)
+                NAMESPACE, NAME, review.getCohortReviewId(), DomainType.DRUG.name(), 10)
             .getBody();
     assertEquals(1, response.getItems().size());
     assertEquals(
@@ -1602,12 +1582,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                DomainType.CONDITION.name(),
-                10)
+                NAMESPACE, NAME, review.getCohortReviewId(), DomainType.CONDITION.name(), 10)
             .getBody();
     assertEquals(2, response.getItems().size());
     assertEquals(
@@ -1623,12 +1598,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                DomainType.PROCEDURE.name(),
-                10)
+                NAMESPACE, NAME, review.getCohortReviewId(), DomainType.PROCEDURE.name(), 10)
             .getBody();
     assertEquals(3, response.getItems().size());
     assertEquals(

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -30,7 +30,6 @@ import org.pmiops.workbench.cohortreview.ReviewQueryBuilder;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortFactory;
 import org.pmiops.workbench.conceptset.ConceptSetService;
-import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
@@ -143,8 +142,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   @Autowired private FireCloudService mockFireCloudService;
 
   @Autowired private UserDao userDao;
-
-  @Mock private Provider<WorkbenchConfig> configProvider;
 
   @Mock private Provider<User> userProvider;
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -643,8 +643,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantCohortStatus participantCohortStatus2 =
         new ParticipantCohortStatus().participantKey(key2);
     participantCohortStatusDao.save(participantCohortStatus2);
-
-    controller.setConfigProvider(configProvider);
   }
 
   @After

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -721,12 +721,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -741,12 +736,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -772,12 +762,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedCondition3), 3);
@@ -788,12 +773,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedCondition1), 3);
   }
@@ -812,12 +792,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -832,12 +807,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -863,12 +833,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedPhysicalMeasure1), 2);
@@ -879,12 +844,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedPhysicalMeasure2), 2);
   }
@@ -903,12 +863,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedLab1, expectedLab2), 2);
@@ -919,12 +874,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedLab2, expectedLab1), 2);
@@ -944,12 +894,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedVital1, expectedVital2), 2);
@@ -960,12 +905,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedVital2, expectedVital1), 2);
@@ -987,12 +927,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedLab1), 2);
@@ -1003,12 +938,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedLab2), 2);
   }
@@ -1027,12 +957,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -1044,12 +969,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -1072,12 +992,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedProcedure1), 2);
@@ -1088,12 +1003,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedProcedure2), 2);
@@ -1113,12 +1023,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -1133,12 +1038,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(
@@ -1164,12 +1064,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedObservation1), 2);
@@ -1180,12 +1075,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedObservation2), 2);
@@ -1205,12 +1095,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedDrug1, expectedDrug2), 2);
@@ -1221,12 +1106,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedDrug2, expectedDrug1), 2);
@@ -1248,12 +1128,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedDrug1), 2);
@@ -1264,12 +1139,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedDrug2), 2);
@@ -1291,12 +1161,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID2,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID2, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedAllEvents7), 8);
@@ -1307,12 +1172,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID2,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID2, testFilter)
             .getBody();
 
     assertResponse(response, expectedPageRequest, Arrays.asList(expectedAllEvents8), 8);
@@ -1332,12 +1192,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     ParticipantDataListResponse response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID2,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID2, testFilter)
             .getBody();
 
     assertResponse(
@@ -1360,12 +1215,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     response =
         controller
             .getParticipantData(
-                NAMESPACE,
-                NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
-                PARTICIPANT_ID2,
-                testFilter)
+                NAMESPACE, NAME, review.getCohortReviewId(), PARTICIPANT_ID2, testFilter)
             .getBody();
 
     assertResponse(
@@ -1566,9 +1416,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     stubMockFirecloudGetWorkspace();
 
     VocabularyListResponse response =
-        controller
-            .getVocabularies(NAMESPACE, NAME, cohort.getCohortId(), cdrVersion.getCdrVersionId())
-            .getBody();
+        controller.getVocabularies(NAMESPACE, NAME, review.getCohortReviewId()).getBody();
     assertEquals(27, response.getItems().size());
     assertEquals(
         new Vocabulary().type("Source").domain("ALL_EVENTS").vocabulary("CPT4"),

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -46,7 +46,6 @@ import org.pmiops.workbench.db.model.ParticipantCohortStatusKey;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
@@ -1393,8 +1392,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
             .getParticipantChartData(
                 NAMESPACE,
                 NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                review.getCohortReviewId(),
                 PARTICIPANT_ID,
                 DomainType.CONDITION.name(),
                 null)
@@ -1428,50 +1426,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void getParticipantChartDataBadCohortId() throws Exception {
-    stubMockFirecloudGetWorkspace();
-
-    try {
-      controller.getParticipantChartData(
-          NAMESPACE,
-          NAME,
-          99L,
-          cdrVersion.getCdrVersionId(),
-          PARTICIPANT_ID,
-          DomainType.CONDITION.name(),
-          null);
-      fail("Should have thrown a NotFoundException!");
-    } catch (NotFoundException nfe) {
-      // Success
-      assertThat(nfe.getMessage()).isEqualTo("Not Found: No Cohort exists for cohortId: 99");
-    }
-  }
-
-  @Test
-  public void getParticipantChartDataBadCdrVersionId() throws Exception {
-    stubMockFirecloudGetWorkspace();
-
-    try {
-      controller.getParticipantChartData(
-          NAMESPACE,
-          NAME,
-          cohort.getCohortId(),
-          99L,
-          PARTICIPANT_ID,
-          DomainType.CONDITION.name(),
-          null);
-      fail("Should have thrown a NotFoundException!");
-    } catch (NotFoundException nfe) {
-      // Success
-      assertThat(nfe.getMessage())
-          .isEqualTo(
-              "Not Found: Cohort Review does not exist for cohortId: "
-                  + cohort.getCohortId()
-                  + ", cdrVersionId: 99");
-    }
-  }
-
-  @Test
   public void getParticipantChartDataBadLimit() throws Exception {
     stubMockFirecloudGetWorkspace();
 
@@ -1479,8 +1433,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
       controller.getParticipantChartData(
           NAMESPACE,
           NAME,
-          cohort.getCohortId(),
-          99L,
+          review.getCohortReviewId(),
           PARTICIPANT_ID,
           DomainType.CONDITION.name(),
           -1);
@@ -1500,8 +1453,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
       controller.getParticipantChartData(
           NAMESPACE,
           NAME,
-          cohort.getCohortId(),
-          99L,
+          review.getCohortReviewId(),
           PARTICIPANT_ID,
           DomainType.CONDITION.name(),
           101);

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -497,8 +497,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   public ResponseEntity<ParticipantChartDataListResponse> getParticipantChartData(
       String workspaceNamespace,
       String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
+      Long cohortReviewId,
       Long participantId,
       String domain,
       Integer limit) {
@@ -509,8 +508,10 @@ public class CohortReviewController implements CohortReviewApiDelegate {
               "Bad Request: Please provide a chart limit between %d and %d.",
               MIN_LIMIT, MAX_LIMIT));
     }
-    validateRequestAndSetCdrVersion(
-        workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.READER);
+    CohortReview cohortReview = cohortReviewService.findCohortReview(cohortReviewId);
+    Cohort cohort = cohortReviewService.findCohort(cohortReview.getCohortId());
+    cohortReviewService.validateMatchingWorkspaceAndSetCdrVersion(
+        workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
 
     TableResult result =
         bigQueryService.executeQuery(

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -363,8 +363,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   public ResponseEntity<ParticipantCohortAnnotation> createParticipantCohortAnnotation(
       String workspaceNamespace,
       String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
+      Long cohortReviewId,
       Long participantId,
       ParticipantCohortAnnotation request) {
 
@@ -375,12 +374,16 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     if (request.getCohortReviewId() == null) {
       throw new BadRequestException("Bad Request: Please provide a valid cohort review id.");
     }
+    if (request.getCohortReviewId() != cohortReviewId) {
+      throw new BadRequestException(
+          "Bad Request: request cohort review id must equal path parameter cohort review id.");
+    }
     if (request.getParticipantId() == null) {
       throw new BadRequestException("Bad Request: Please provide a valid participant id.");
     }
 
-    validateRequestAndSetCdrVersion(
-        workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.WRITER);
+    cohortReviewService.enforceWorkspaceAccessLevel(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
     org.pmiops.workbench.db.model.ParticipantCohortAnnotation participantCohortAnnotation =
         FROM_CLIENT_PARTICIPANT_COHORT_ANNOTATION.apply(request);
@@ -531,18 +534,12 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
   @Override
   public ResponseEntity<ParticipantCohortAnnotationListResponse> getParticipantCohortAnnotations(
-      String workspaceNamespace,
-      String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
-      Long participantId) {
-    CohortReview review =
-        validateRequestAndSetCdrVersion(
-            workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.READER);
+      String workspaceNamespace, String workspaceId, Long cohortReviewId, Long participantId) {
+    cohortReviewService.enforceWorkspaceAccessLevel(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 
     List<org.pmiops.workbench.db.model.ParticipantCohortAnnotation> annotations =
-        cohortReviewService.findParticipantCohortAnnotations(
-            review.getCohortReviewId(), participantId);
+        cohortReviewService.findParticipantCohortAnnotations(cohortReviewId, participantId);
 
     ParticipantCohortAnnotationListResponse response =
         new ParticipantCohortAnnotationListResponse();

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -438,8 +438,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   public ResponseEntity<CohortChartDataListResponse> getCohortChartData(
       String workspaceNamespace,
       String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
+      Long cohortReviewId,
       String domain,
       Integer limit) {
     int chartLimit = Optional.ofNullable(limit).orElse(DEFAULT_LIMIT);
@@ -449,10 +448,11 @@ public class CohortReviewController implements CohortReviewApiDelegate {
               "Bad Request: Please provide a chart limit between %d and %d.",
               MIN_LIMIT, MAX_LIMIT));
     }
-    Cohort cohort = cohortReviewService.findCohort(cohortId);
-    CohortReview cohortReview =
-        validateRequestAndSetCdrVersion(
-            workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.READER);
+
+    CohortReview cohortReview = cohortReviewService.findCohortReview(cohortReviewId);
+    Cohort cohort = cohortReviewService.findCohort(cohortReview.getCohortId());
+    cohortReviewService.validateMatchingWorkspaceAndSetCdrVersion(
+        workspaceNamespace, workspaceId, cohort.getWorkspaceId(), WorkspaceAccessLevel.READER);
 
     SearchRequest searchRequest =
         new Gson().fromJson(getCohortDefinition(cohort), SearchRequest.class);

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -764,20 +764,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     return ResponseEntity.ok(TO_CLIENT_PARTICIPANT.apply(participantCohortStatus));
   }
 
-  private CohortReview validateRequestAndSetCdrVersion(
-      String workspaceNamespace,
-      String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
-      WorkspaceAccessLevel level) {
-    Cohort cohort = cohortReviewService.findCohort(cohortId);
-    // this validates that the user is in the proper workspace
-    cohortReviewService.validateMatchingWorkspaceAndSetCdrVersion(
-        workspaceNamespace, workspaceId, cohort.getWorkspaceId(), level);
-
-    return cohortReviewService.findCohortReview(cohort.getCohortId(), cdrVersionId);
-  }
-
   /**
    * Helper method to create a new {@link CohortReview}.
    *

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -106,7 +106,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   private UserRecentResourceService userRecentResourceService;
   private Provider<User> userProvider;
   private final Clock clock;
-  private Provider<WorkbenchConfig> configProvider;
   private static final Logger log = Logger.getLogger(CohortReviewController.class.getName());
 
   /**
@@ -265,17 +264,11 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     this.userRecentResourceService = userRecentResourceService;
     this.userProvider = userProvider;
     this.clock = clock;
-    this.configProvider = configProvider;
   }
 
   @VisibleForTesting
   public void setUserProvider(Provider<User> userProvider) {
     this.userProvider = userProvider;
-  }
-
-  @VisibleForTesting
-  public void setConfigProvider(Provider<WorkbenchConfig> configProvider) {
-    this.configProvider = configProvider;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -367,19 +367,9 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       Long participantId,
       ParticipantCohortAnnotation request) {
 
-    if (request.getCohortAnnotationDefinitionId() == null) {
-      throw new BadRequestException(
-          "Bad Request: Please provide a valid cohort annotation definition id.");
-    }
-    if (request.getCohortReviewId() == null) {
-      throw new BadRequestException("Bad Request: Please provide a valid cohort review id.");
-    }
     if (request.getCohortReviewId() != cohortReviewId) {
       throw new BadRequestException(
           "Bad Request: request cohort review id must equal path parameter cohort review id.");
-    }
-    if (request.getParticipantId() == null) {
-      throw new BadRequestException("Bad Request: Please provide a valid participant id.");
     }
 
     cohortReviewService.enforceWorkspaceAccessLevel(
@@ -415,14 +405,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       Long cohortReviewId,
       Long participantId,
       Long annotationId) {
-
-    if (annotationId == null) {
-      throw new BadRequestException(
-          "Bad Request: Please provide a valid cohort annotation definition id.");
-    }
-    if (participantId == null) {
-      throw new BadRequestException("Bad Request: Please provide a valid participant id.");
-    }
 
     cohortReviewService.enforceWorkspaceAccessLevel(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -412,8 +412,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   public ResponseEntity<EmptyResponse> deleteParticipantCohortAnnotation(
       String workspaceNamespace,
       String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
+      Long cohortReviewId,
       Long participantId,
       Long annotationId) {
 
@@ -425,17 +424,12 @@ public class CohortReviewController implements CohortReviewApiDelegate {
       throw new BadRequestException("Bad Request: Please provide a valid participant id.");
     }
 
-    CohortReview cohortReview =
-        validateRequestAndSetCdrVersion(
-            workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.WRITER);
-
-    // will throw a NotFoundException if participant does not exist
-    cohortReviewService.findParticipantCohortStatus(
-        cohortReview.getCohortReviewId(), participantId);
+    cohortReviewService.enforceWorkspaceAccessLevel(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
     // will throw a NotFoundException if participant cohort annotation does not exist
     cohortReviewService.deleteParticipantCohortAnnotation(
-        annotationId, cohortReview.getCohortReviewId(), participantId);
+        annotationId, cohortReviewId, participantId);
 
     return ResponseEntity.ok(new EmptyResponse());
   }
@@ -728,18 +722,16 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   public ResponseEntity<ParticipantCohortAnnotation> updateParticipantCohortAnnotation(
       String workspaceNamespace,
       String workspaceId,
-      Long cohortId,
-      Long cdrVersionId,
+      Long cohortReviewId,
       Long participantId,
       Long annotationId,
       ModifyParticipantCohortAnnotationRequest request) {
-    CohortReview cohortReview =
-        validateRequestAndSetCdrVersion(
-            workspaceNamespace, workspaceId, cohortId, cdrVersionId, WorkspaceAccessLevel.WRITER);
+    cohortReviewService.enforceWorkspaceAccessLevel(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
     org.pmiops.workbench.db.model.ParticipantCohortAnnotation participantCohortAnnotation =
         cohortReviewService.updateParticipantCohortAnnotation(
-            annotationId, cohortReview.getCohortReviewId(), participantId, request);
+            annotationId, cohortReviewId, participantId, request);
 
     return ResponseEntity.ok(
         TO_CLIENT_PARTICIPANT_COHORT_ANNOTATION.apply(participantCohortAnnotation));

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
@@ -49,6 +49,14 @@ public interface CohortReviewService {
   CohortReview findCohortReview(Long cohortId, Long cdrVersionId);
 
   /**
+   * Find the {@link CohortReview} for the specified cohortReviewId.
+   *
+   * @param cohortReviewId
+   * @return
+   */
+  CohortReview findCohortReview(Long cohortReviewId);
+
+  /**
    * Find the {@link CohortReview} for the specified ns, firecloudName and cohortReviewId
    *
    * @param ns

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -110,6 +110,18 @@ public class CohortReviewServiceImpl implements CohortReviewService {
   }
 
   @Override
+  public CohortReview findCohortReview(Long cohortReviewId) {
+    CohortReview cohortReview = cohortReviewDao.findCohortReviewByCohortReviewId(cohortReviewId);
+
+    if (cohortReview == null) {
+      throw new NotFoundException(
+          String.format(
+              "Not Found: Cohort Review does not exist for cohortReviewId: %s", cohortReviewId));
+    }
+    return cohortReview;
+  }
+
+  @Override
   public CohortReview findCohortReview(String ns, String firecloudName, Long cohortReviewId) {
     CohortReview cohortReview =
         cohortReviewDao.findByNamespaceAndFirecloudNameAndCohortReviewId(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
@@ -11,6 +11,8 @@ public interface CohortReviewDao extends JpaRepository<CohortReview, Long> {
   CohortReview findCohortReviewByCohortIdAndCdrVersionId(
       @Param("cohortId") long cohortId, @Param("cdrVersionId") long cdrVersionId);
 
+  CohortReview findCohortReviewByCohortReviewId(@Param("cohortReviewId") long cohortReviewId);
+
   @Query(
       value =
           "select * from cohort_review cr "

--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -219,12 +219,11 @@ paths:
           schema:
             $ref: "#/definitions/CohortChartDataListResponse"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants/{participantId}/annotations:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
       - $ref: '#/parameters/participantId'
     post:
       tags:

--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -126,12 +126,11 @@ paths:
           schema:
             $ref: "#/definitions/CohortReview"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants/{participantId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
       - $ref: '#/parameters/participantId'
     get:
       tags:
@@ -253,12 +252,11 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantCohortAnnotationListResponse"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants/{participantId}/data:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/data:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
       - $ref: '#/parameters/participantId'
     post:
       tags:
@@ -324,12 +322,11 @@ paths:
           schema:
             $ref: '#/definitions/EmptyResponse'
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/vocabularies:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/vocabularies:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
     get:
       tags:
         - cohortReview

--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -284,12 +284,11 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantDataListResponse"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants/{participantId}/annotations/{annotationId}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations/{annotationId}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
       - $ref: '#/parameters/participantId'
       - in: path
         name: annotationId

--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -191,12 +191,11 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantChartDataListResponse"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/charts/{domain}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/charts/{domain}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
     get:
       tags:
         - cohortReview

--- a/api/src/main/resources/cb_review_api.yaml
+++ b/api/src/main/resources/cb_review_api.yaml
@@ -162,12 +162,11 @@ paths:
           schema:
             $ref: "#/definitions/ParticipantCohortStatus"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants/{participantId}/charts/{domain}:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/charts/{domain}:
     parameters:
       - $ref: '#/parameters/workspaceNamespace'
       - $ref: '#/parameters/workspaceId'
-      - $ref: '#/parameters/cohortId'
-      - $ref: '#/parameters/cdrVersionId'
+      - $ref: '#/parameters/cohortReviewId'
       - $ref: '#/parameters/participantId'
     get:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -723,8 +723,7 @@ public class CohortReviewControllerTest {
     cohortReviewController.deleteParticipantCohortAnnotation(
         WORKSPACE_NAMESPACE,
         WORKSPACE_NAME,
-        cohort.getCohortId(),
-        cdrVersion.getCdrVersionId(),
+        cohortReview.getCohortReviewId(),
         participantCohortStatus1.getParticipantKey().getParticipantId(),
         annotation.getAnnotationId());
 
@@ -738,8 +737,7 @@ public class CohortReviewControllerTest {
       cohortReviewController.deleteParticipantCohortAnnotation(
           WORKSPACE_NAMESPACE,
           WORKSPACE_NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
+          cohortReview.getCohortReviewId(),
           participantCohortStatus1.getParticipantKey().getParticipantId(),
           null);
       fail("Should have thrown a BadRequestException!");
@@ -763,8 +761,7 @@ public class CohortReviewControllerTest {
       cohortReviewController.deleteParticipantCohortAnnotation(
           WORKSPACE_NAMESPACE,
           WORKSPACE_NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
+          cohortReview.getCohortReviewId(),
           participantId,
           annotationId);
       fail("Should have thrown a NotFoundException!");
@@ -789,44 +786,11 @@ public class CohortReviewControllerTest {
 
     try {
       cohortReviewController.deleteParticipantCohortAnnotation(
-          WORKSPACE_NAMESPACE,
-          WORKSPACE_NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
-          null,
-          1L);
+          WORKSPACE_NAMESPACE, WORKSPACE_NAME, cohortReview.getCohortReviewId(), null, 1L);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // Success
       assertThat(bre.getMessage()).isEqualTo("Bad Request: Please provide a valid participant id.");
-    }
-  }
-
-  @Test
-  public void deleteParticipantCohortAnnotationNoParticipant() throws Exception {
-    Long participantId = 9999L;
-
-    when(workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-            WORKSPACE_NAMESPACE, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER))
-        .thenReturn(workspace);
-
-    try {
-      cohortReviewController.deleteParticipantCohortAnnotation(
-          WORKSPACE_NAMESPACE,
-          WORKSPACE_NAME,
-          cohort.getCohortId(),
-          cdrVersion.getCdrVersionId(),
-          participantId,
-          1L);
-      fail("Should have thrown a NotFoundException!");
-    } catch (NotFoundException nfe) {
-      // Success
-      assertThat(nfe.getMessage())
-          .isEqualTo(
-              "Not Found: Participant Cohort Status does not exist for cohortReviewId: "
-                  + cohortReview.getCohortReviewId()
-                  + ", participantId: "
-                  + participantId);
     }
   }
 
@@ -949,8 +913,7 @@ public class CohortReviewControllerTest {
             .updateParticipantCohortAnnotation(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 participantAnnotation.getAnnotationId(),
                 new ModifyParticipantCohortAnnotationRequest().annotationValueString("test1"))
@@ -971,8 +934,7 @@ public class CohortReviewControllerTest {
           .updateParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantCohortStatus1.getParticipantKey().getParticipantId(),
               badAnnotationId,
               new ModifyParticipantCohortAnnotationRequest().annotationValueString("test1"))

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -340,8 +340,6 @@ public class CohortReviewControllerTest {
             .cohortAnnotationDefinitionId(
                 stringAnnotationDefinition.getCohortAnnotationDefinitionId());
     participantCohortAnnotationDao.save(participantAnnotation);
-
-    cohortReviewController.setConfigProvider(configProvider);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mock;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cdr.cache.GenderRaceEthnicityConcept;
-import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
@@ -141,8 +140,6 @@ public class CohortReviewControllerTest {
   @Autowired private BigQueryService bigQueryService;
 
   @Autowired private UserDao userDao;
-
-  @Mock private Provider<WorkbenchConfig> configProvider;
 
   @Mock private Provider<User> userProvider;
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -532,27 +532,6 @@ public class CohortReviewControllerTest {
   }
 
   @Test
-  public void createParticipantCohortAnnotationNoAnnotationDefinitionId() throws Exception {
-    Long participantId = participantCohortStatus1.getParticipantKey().getParticipantId();
-
-    try {
-      cohortReviewController
-          .createParticipantCohortAnnotation(
-              WORKSPACE_NAMESPACE,
-              WORKSPACE_NAME,
-              cohortReview.getCohortReviewId(),
-              participantId,
-              new ParticipantCohortAnnotation())
-          .getBody();
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: Please provide a valid cohort annotation definition id.");
-    }
-  }
-
-  @Test
   public void createParticipantCohortAnnotationNoAnnotationDefinitionFound() throws Exception {
     Long participantId = participantCohortStatus1.getParticipantKey().getParticipantId();
 
@@ -578,63 +557,6 @@ public class CohortReviewControllerTest {
       // Success
       assertThat(nfe.getMessage())
           .isEqualTo("Not Found: No cohort annotation definition found for id: 9999");
-    }
-  }
-
-  @Test
-  public void createParticipantCohortAnnotationNoParticipantId() throws Exception {
-    Long participantId = participantCohortStatus1.getParticipantKey().getParticipantId();
-
-    when(workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-            WORKSPACE_NAMESPACE, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER))
-        .thenReturn(workspace);
-
-    try {
-      cohortReviewController
-          .createParticipantCohortAnnotation(
-              WORKSPACE_NAMESPACE,
-              WORKSPACE_NAME,
-              cohortReview.getCohortReviewId(),
-              participantId,
-              new ParticipantCohortAnnotation()
-                  .cohortReviewId(cohortReview.getCohortReviewId())
-                  .annotationValueString("test")
-                  .cohortAnnotationDefinitionId(
-                      stringAnnotationDefinition.getCohortAnnotationDefinitionId()))
-          .getBody();
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: Please provide a valid participant id.");
-    }
-  }
-
-  @Test
-  public void createParticipantCohortAnnotationNoReviewId() throws Exception {
-    Long participantId = participantCohortStatus1.getParticipantKey().getParticipantId();
-
-    when(workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-            WORKSPACE_NAMESPACE, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER))
-        .thenReturn(workspace);
-
-    try {
-      cohortReviewController
-          .createParticipantCohortAnnotation(
-              WORKSPACE_NAMESPACE,
-              WORKSPACE_NAME,
-              cohortReview.getCohortReviewId(),
-              participantId,
-              new ParticipantCohortAnnotation()
-                  .participantId(participantId)
-                  .annotationValueString("test")
-                  .cohortAnnotationDefinitionId(
-                      stringAnnotationDefinition.getCohortAnnotationDefinitionId()))
-          .getBody();
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: Please provide a valid cohort review id.");
     }
   }
 
@@ -732,23 +654,6 @@ public class CohortReviewControllerTest {
   }
 
   @Test
-  public void deleteParticipantCohortAnnotationNullAnnotationId() throws Exception {
-    try {
-      cohortReviewController.deleteParticipantCohortAnnotation(
-          WORKSPACE_NAMESPACE,
-          WORKSPACE_NAME,
-          cohortReview.getCohortReviewId(),
-          participantCohortStatus1.getParticipantKey().getParticipantId(),
-          null);
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: Please provide a valid cohort annotation definition id.");
-    }
-  }
-
-  @Test
   public void deleteParticipantCohortAnnotationNoAnnotation() throws Exception {
     Long participantId = participantCohortStatus1.getParticipantKey().getParticipantId();
     Long annotationId = 9999L;
@@ -775,22 +680,6 @@ public class CohortReviewControllerTest {
                   + cohortReview.getCohortReviewId()
                   + ", participantId: "
                   + participantId);
-    }
-  }
-
-  @Test
-  public void deleteParticipantCohortAnnotationNullParticipantId() throws Exception {
-    when(workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-            WORKSPACE_NAMESPACE, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER))
-        .thenReturn(workspace);
-
-    try {
-      cohortReviewController.deleteParticipantCohortAnnotation(
-          WORKSPACE_NAMESPACE, WORKSPACE_NAME, cohortReview.getCohortReviewId(), null, 1L);
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: Please provide a valid participant id.");
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -827,8 +827,7 @@ public class CohortReviewControllerTest {
             .getParticipantCohortStatus(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId())
             .getBody();
 
@@ -962,8 +961,7 @@ public class CohortReviewControllerTest {
             .updateParticipantCohortStatus(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED))
             .getBody();

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -540,8 +540,7 @@ public class CohortReviewControllerTest {
           .createParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantId,
               new ParticipantCohortAnnotation())
           .getBody();
@@ -566,8 +565,7 @@ public class CohortReviewControllerTest {
           .createParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantId,
               new ParticipantCohortAnnotation()
                   .cohortReviewId(cohortReview.getCohortReviewId())
@@ -596,8 +594,7 @@ public class CohortReviewControllerTest {
           .createParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantId,
               new ParticipantCohortAnnotation()
                   .cohortReviewId(cohortReview.getCohortReviewId())
@@ -625,8 +622,7 @@ public class CohortReviewControllerTest {
           .createParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantId,
               new ParticipantCohortAnnotation()
                   .participantId(participantId)
@@ -845,8 +841,7 @@ public class CohortReviewControllerTest {
             .getParticipantCohortAnnotations(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId())
             .getBody();
 
@@ -1032,8 +1027,7 @@ public class CohortReviewControllerTest {
             .createParticipantCohortAnnotation(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_NAME,
-                cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
+                cohortReview.getCohortReviewId(),
                 participantId,
                 request)
             .getBody();
@@ -1067,8 +1061,7 @@ public class CohortReviewControllerTest {
           .createParticipantCohortAnnotation(
               WORKSPACE_NAMESPACE,
               WORKSPACE_NAME,
-              cohort.getCohortId(),
-              cdrVersion.getCdrVersionId(),
+              cohortReview.getCohortReviewId(),
               participantId,
               new ParticipantCohortAnnotation()
                   .cohortReviewId(cohortReview.getCohortReviewId())

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -311,7 +311,6 @@ public class WorkspacesControllerTest {
     testConfig.featureFlags.useBillingProjectBuffer = false;
     when(configProvider.get()).thenReturn(testConfig);
 
-    cohortReviewController.setConfigProvider(configProvider);
     workspacesController.setWorkbenchConfigProvider(configProvider);
     fcWorkspaceAcl = createWorkspaceACL();
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -916,8 +916,7 @@ public class WorkspacesControllerTest {
             .createParticipantCohortAnnotation(
                 workspace.getNamespace(),
                 workspace.getId(),
-                c1.getId(),
-                cdrVersion.getCdrVersionId(),
+                cr1.getCohortReviewId(),
                 participantId,
                 new ParticipantCohortAnnotation()
                     .cohortAnnotationDefinitionId(
@@ -942,8 +941,7 @@ public class WorkspacesControllerTest {
             .createParticipantCohortAnnotation(
                 workspace.getNamespace(),
                 workspace.getId(),
-                c1.getId(),
-                cdrVersion.getCdrVersionId(),
+                cr1.getCohortReviewId(),
                 participantId,
                 new ParticipantCohortAnnotation()
                     .cohortAnnotationDefinitionId(
@@ -980,15 +978,14 @@ public class WorkspacesControllerTest {
             .createParticipantCohortAnnotation(
                 workspace.getNamespace(),
                 workspace.getId(),
-                c2.getId(),
-                cdrVersion.getCdrVersionId(),
+                cr2.getCohortReviewId(),
                 participantId,
                 new ParticipantCohortAnnotation()
                     .cohortAnnotationDefinitionId(
                         cad2EnumResponse.getCohortAnnotationDefinitionId())
                     .annotationValueEnum("value")
                     .participantId(participantId)
-                    .cohortReviewId(cr1.getCohortReviewId()))
+                    .cohortReviewId(cr2.getCohortReviewId()))
             .getBody();
     CohortAnnotationDefinition cad2BooleanResponse =
         cohortAnnotationDefinitionController
@@ -1006,15 +1003,14 @@ public class WorkspacesControllerTest {
             .createParticipantCohortAnnotation(
                 workspace.getNamespace(),
                 workspace.getId(),
-                c2.getId(),
-                cdrVersion.getCdrVersionId(),
+                cr2.getCohortReviewId(),
                 participantId,
                 new ParticipantCohortAnnotation()
                     .cohortAnnotationDefinitionId(
                         cad2BooleanResponse.getCohortAnnotationDefinitionId())
                     .annotationValueBoolean(Boolean.TRUE)
                     .participantId(participantId)
-                    .cohortReviewId(cr1.getCohortReviewId()))
+                    .cohortReviewId(cr2.getCohortReviewId()))
             .getBody();
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
@@ -1113,11 +1109,7 @@ public class WorkspacesControllerTest {
     ParticipantCohortAnnotationListResponse clonedPca1List =
         cohortReviewController
             .getParticipantCohortAnnotations(
-                cloned.getNamespace(),
-                cloned.getId(),
-                cohortsByName.get("c1").getId(),
-                cdrVersion.getCdrVersionId(),
-                participantId)
+                cloned.getNamespace(), cloned.getId(), gotCr1.getCohortReviewId(), participantId)
             .getBody();
     assertParticipantCohortAnnotation(
         clonedPca1List,
@@ -1152,11 +1144,7 @@ public class WorkspacesControllerTest {
     ParticipantCohortAnnotationListResponse clonedPca2List =
         cohortReviewController
             .getParticipantCohortAnnotations(
-                cloned.getNamespace(),
-                cloned.getId(),
-                cohortsByName.get("c2").getId(),
-                cdrVersion.getCdrVersionId(),
-                participantId)
+                cloned.getNamespace(), cloned.getId(), gotCr2.getCohortReviewId(), participantId)
             .getBody();
     assertParticipantCohortAnnotation(
         clonedPca2List,

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -8,6 +8,7 @@ import {AddAnnotationDefinitionModal, EditAnnotationDefinitionsModal} from 'app/
 import {DetailHeader} from 'app/cohort-review/detail-header/detail-header.component';
 import {DetailTabs} from 'app/cohort-review/detail-tabs/detail-tabs.component';
 import {Participant} from 'app/cohort-review/participant.model';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {SidebarContent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {ClrIcon} from 'app/components/icons';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -17,7 +18,6 @@ import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {CohortAnnotationDefinition, ParticipantCohortAnnotation} from 'generated/fetch';
-import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 
 const styles = reactStyles({
   detailSidebar: {
@@ -104,7 +104,6 @@ export const DetailPage = withCurrentWorkspace()(
     }
 
     componentDidMount() {
-      const {cdrVersionId} = this.props.workspace;
       this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(params => !!params.pid)
         .switchMap(({ns, wsid, cid, pid}) => {

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -109,7 +109,8 @@ export const DetailPage = withCurrentWorkspace()(
         .switchMap(({ns, wsid, cid, pid}) => {
           return Observable.forkJoin(
             from(cohortReviewApi()
-              .getParticipantCohortStatus(ns, wsid, +cid, +cdrVersionId, +pid))
+              .getParticipantCohortStatus(ns, wsid,
+                cohortReviewStore.getValue().cohortReviewId, +pid))
               .do(ps => {
                 this.setState({participant: Participant.fromStatus(ps)});
               }),

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -17,7 +17,7 @@ import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {CohortAnnotationDefinition, ParticipantCohortAnnotation} from 'generated/fetch';
-import {cohortReviewStore} from '../review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 
 const styles = reactStyles({
   detailSidebar: {

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -17,6 +17,7 @@ import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {CohortAnnotationDefinition, ParticipantCohortAnnotation} from 'generated/fetch';
+import {cohortReviewStore} from '../review-state.service';
 
 const styles = reactStyles({
   detailSidebar: {
@@ -113,7 +114,8 @@ export const DetailPage = withCurrentWorkspace()(
                 this.setState({participant: Participant.fromStatus(ps)});
               }),
             from(cohortReviewApi()
-              .getParticipantCohortAnnotations(ns, wsid, +cid, +cdrVersionId, +pid))
+              .getParticipantCohortAnnotations(ns, wsid,
+                cohortReviewStore.getValue().cohortReviewId, +pid))
               .do(({items}) => {
                 this.setState({annotations: items});
               }),

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -82,6 +82,7 @@ interface State {
 
 export const DetailPage = withCurrentWorkspace()(
   class extends React.Component<Props, State> {
+    private subscription;
     constructor(props: any) {
       super(props);
       this.state = {
@@ -104,7 +105,7 @@ export const DetailPage = withCurrentWorkspace()(
 
     componentDidMount() {
       const {cdrVersionId} = this.props.workspace;
-      urlParamsStore.distinctUntilChanged(fp.isEqual)
+      this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(params => !!params.pid)
         .switchMap(({ns, wsid, cid, pid}) => {
           return Observable.forkJoin(
@@ -124,6 +125,10 @@ export const DetailPage = withCurrentWorkspace()(
           );
         })
         .subscribe();
+    }
+
+    componentWillUnmount() {
+      this.subscription.unsubscribe();
     }
 
     loadAnnotationDefinitions() {

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -1,5 +1,5 @@
 import {ReviewDomainChartsComponent} from 'app/cohort-review/review-domain-charts/review-domain-charts';
-import {vocabOptions} from 'app/cohort-review/review-state.service';
+import {cohortReviewStore, vocabOptions} from 'app/cohort-review/review-state.service';
 import {datatableStyles} from 'app/cohort-review/review-utils/primeReactCss.utils';
 import {ClrIcon} from 'app/components/icons';
 import {TextInput} from 'app/components/inputs';
@@ -273,8 +273,7 @@ export const DetailTabTable = withCurrentWorkspace()(
         cohortReviewApi().getParticipantData(
           namespace,
           id,
-          +cid,
-          +cdrVersionId,
+          cohortReviewStore.getValue().cohortReviewId,
           participantId,
           pageFilterRequest
         ).then(response => {

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -259,8 +259,7 @@ export const DetailTabTable = withCurrentWorkspace()(
     getParticipantData() {
       try {
         const {columns, domain, filterType, participantId,
-          workspace: {cdrVersionId, id, namespace}} = this.props;
-        const {cid} = urlParamsStore.getValue();
+          workspace: {id, namespace}} = this.props;
         const pageFilterRequest = {
           page: 0,
           pageSize: 10000,

--- a/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
+++ b/ui/src/app/cohort-review/detail-tab-table/detail-tab-table.component.tsx
@@ -7,7 +7,6 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
-import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {DomainType, PageFilterRequest, PageFilterType, SortOrder} from 'generated/fetch';
 import * as fp from 'lodash/fp';

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
@@ -308,7 +308,6 @@ export const DetailTabs = withCurrentWorkspace()(
     }
 
     componentDidMount() {
-      const {cdrVersionId} = this.props.workspace;
       this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(({pid}) => !!pid)
         .switchMap(({ns, wsid, cid, pid}) => {

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
@@ -294,6 +294,7 @@ interface State {
 
 export const DetailTabs = withCurrentWorkspace()(
   class extends React.Component<Props, State> {
+    private subscription;
     constructor(props: any) {
       super(props);
       this.state = {
@@ -308,7 +309,7 @@ export const DetailTabs = withCurrentWorkspace()(
 
     componentDidMount() {
       const {cdrVersionId} = this.props.workspace;
-      urlParamsStore.distinctUntilChanged(fp.isEqual)
+      this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(({pid}) => !!pid)
         .switchMap(({ns, wsid, cid, pid}) => {
           const chartData = {};
@@ -342,6 +343,10 @@ export const DetailTabs = withCurrentWorkspace()(
         updateState++;
         this.setState({filterState, updateState});
       });
+    }
+
+    componentWillUnmount() {
+      this.subscription.unsubscribe();
     }
 
     filteredData(_domain: string, checkedItems: any) {

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 
 import {DetailTabTable} from 'app/cohort-review/detail-tab-table/detail-tab-table.component';
 import {IndividualParticipantsCharts} from 'app/cohort-review/individual-participants-charts/individual-participants-charts';
-import {filterStateStore} from 'app/cohort-review/review-state.service';
-import {cohortReviewStore, domainToTitle} from 'app/cohort-search/utils';
+import {cohortReviewStore, filterStateStore} from 'app/cohort-review/review-state.service';
+import {domainToTitle} from 'app/cohort-search/utils';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';

--- a/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
+++ b/ui/src/app/cohort-review/detail-tabs/detail-tabs.component.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {DetailTabTable} from 'app/cohort-review/detail-tab-table/detail-tab-table.component';
 import {IndividualParticipantsCharts} from 'app/cohort-review/individual-participants-charts/individual-participants-charts';
 import {filterStateStore} from 'app/cohort-review/review-state.service';
-import {domainToTitle} from 'app/cohort-search/utils';
+import {cohortReviewStore, domainToTitle} from 'app/cohort-search/utils';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
@@ -321,7 +321,8 @@ export const DetailTabs = withCurrentWorkspace()(
               };
               this.setState({chartData, participantId: pid});
               return from(cohortReviewApi()
-                .getParticipantChartData(ns, wsid, cid, +cdrVersionId, pid, domainName, 10))
+                .getParticipantChartData(ns, wsid,
+                  cohortReviewStore.getValue().cohortReviewId, pid, domainName, 10))
                 .do(({items}) => {
                   chartData[domainName] = {
                     loading: false,

--- a/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
+++ b/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
@@ -6,7 +6,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {currentCohortStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import * as React from 'react';
-import {cohortReviewStore} from '../review-state.service';
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 
 const css = `
   .graph-border {

--- a/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
+++ b/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
@@ -6,6 +6,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {currentCohortStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import * as React from 'react';
+import {cohortReviewStore} from '../review-state.service';
 
 const css = `
   .graph-border {
@@ -125,7 +126,8 @@ export const ParticipantsCharts = withCurrentWorkspace()(
     componentDidMount() {
       const {domain, workspace: {cdrVersionId, id, namespace}} = this.props;
       const cohort = currentCohortStore.getValue();
-      cohortReviewApi().getCohortChartData(namespace, id, cohort.id, +cdrVersionId, domain, 10)
+      cohortReviewApi().getCohortChartData(namespace, id,
+        cohortReviewStore.getValue().cohortReviewId, domain, 10)
         .then(resp => {
           const data = resp.items.map(item => {
             this.nameRefs.push(React.createRef());

--- a/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
+++ b/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
@@ -1,3 +1,4 @@
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
@@ -6,7 +7,6 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {currentCohortStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import * as React from 'react';
-import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 
 const css = `
   .graph-border {
@@ -124,8 +124,7 @@ export const ParticipantsCharts = withCurrentWorkspace()(
     }
 
     componentDidMount() {
-      const {domain, workspace: {cdrVersionId, id, namespace}} = this.props;
-      const cohort = currentCohortStore.getValue();
+      const {domain, workspace: {id, namespace}} = this.props;
       cohortReviewApi().getCohortChartData(namespace, id,
         cohortReviewStore.getValue().cohortReviewId, domain, 10)
         .then(resp => {

--- a/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
+++ b/ui/src/app/cohort-review/participants-charts/participants-charts.tsx
@@ -4,7 +4,6 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
-import {currentCohortStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import * as React from 'react';
 

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -101,8 +101,7 @@ const AnnotationItem = fp.flow(
       const {
         annotation, setAnnotation,
         definition: {annotationType, cohortAnnotationDefinitionId},
-        urlParams: {ns, wsid, cid, pid},
-        workspace: {cdrVersionId},
+        urlParams: {ns, wsid, pid},
       } = this.props;
       const {timeout} = this.state;
       const aid = annotation ? annotation.annotationId : undefined;
@@ -266,8 +265,7 @@ export const SidebarContent = fp.flow(
     try {
       const {
         setParticipant,
-        urlParams: {ns, wsid, cid, pid},
-        workspace: {cdrVersionId},
+        urlParams: {ns, wsid, pid},
       } = this.props;
       this.setState({savingStatus: v});
       const data = await cohortReviewApi().updateParticipantCohortStatus(

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -125,7 +125,8 @@ const AnnotationItem = fp.flow(
         clearTimeout(timeout);
         this.setState({error: false, success: false, saving: true});
         await cohortReviewApi()
-          .createParticipantCohortAnnotation(ns, wsid, cid, +cdrVersionId, pid, {
+          .createParticipantCohortAnnotation(ns, wsid,
+            cohortReviewStore.getValue().cohortReviewId, pid, {
             cohortAnnotationDefinitionId,
             cohortReviewId: cohortReviewStore.getValue().cohortReviewId,
             participantId: pid,

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -271,7 +271,7 @@ export const SidebarContent = fp.flow(
       } = this.props;
       this.setState({savingStatus: v});
       const data = await cohortReviewApi().updateParticipantCohortStatus(
-        ns, wsid, cid, +cdrVersionId, pid, {status: v}
+        ns, wsid, cohortReviewStore.getValue().cohortReviewId, pid, {status: v}
       );
       // make sure we're still on the same page before updating
       if (data.participantId === +this.props.urlParams.pid) {

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -110,12 +110,14 @@ const AnnotationItem = fp.flow(
       this.setState({savingValue: newValue});
       if (aid && fp.includes(newValue, [null, ''])) {
         setAnnotation(await cohortReviewApi()
-          .deleteParticipantCohortAnnotation(ns, wsid, cid, +cdrVersionId, pid, aid));
+          .deleteParticipantCohortAnnotation(ns, wsid,
+            cohortReviewStore.getValue().cohortReviewId, pid, aid));
       } else if (aid && newValue !== value) {
         clearTimeout(timeout);
         this.setState({error: false, success: false, saving: true});
         await cohortReviewApi()
-          .updateParticipantCohortAnnotation(ns, wsid, cid, +cdrVersionId, pid, aid, {
+          .updateParticipantCohortAnnotation(ns, wsid,
+            cohortReviewStore.getValue().cohortReviewId, pid, aid, {
             ...writeValue(annotationType, newValue),
           }).then(res => {
             setAnnotation(res);

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -302,7 +302,8 @@ export const ParticipantsTable = withCurrentWorkspace()(
       if (!vocabOptions.getValue()) {
         const vocabFilters = {source: {}, standard: {}};
         try {
-          await cohortReviewApi().getVocabularies(namespace, id, cohortReviewStore.getValue().cohortReviewId)
+          await cohortReviewApi().getVocabularies(namespace, id,
+            cohortReviewStore.getValue().cohortReviewId)
             .then(response => {
               response.items.forEach(item => {
                 const type = item.type.toLowerCase();

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -302,7 +302,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
       if (!vocabOptions.getValue()) {
         const vocabFilters = {source: {}, standard: {}};
         try {
-          await cohortReviewApi().getVocabularies(namespace, id, cid, +cdrVersionId)
+          await cohortReviewApi().getVocabularies(namespace, id, cohortReviewStore.getValue().cohortReviewId)
             .then(response => {
               response.items.forEach(item => {
                 const type = item.type.toLowerCase();

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -149,7 +149,6 @@ export const ListOverview = withCurrentWorkspace()(
       if (currentCohortStore.getValue()) {
         this.setState({cohort: currentCohortStore.getValue()});
       }
-      this.getTotalCount();
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {


### PR DESCRIPTION
1. Removing cohortId/cdrVersionId and replacing with cohortReviewId in most review api calls.
2. Fix corresponding test cases.