### PR TITLE
[RW-3206][risk=moderate] Update CDR project locations

### DIFF
--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -1,7 +1,7 @@
 [
   {
     "cdrVersionId": 1,
-    "name": "Synthetic Dataset v1",
+    "name": "Synthetic Dataset v1 (Legacy)",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "synthetic_cdr20180606",
@@ -12,7 +12,7 @@
   },
   {
     "cdrVersionId": 2,
-    "name": "All of Us Dataset v1",
+    "name": "All of Us Dataset v1 (Legacy)",
     "dataAccessLevel": 1,
     "bigqueryProject": "aou-res-curation-output-prod",
     "bigqueryDataset": "R2018Q4R1",
@@ -23,10 +23,21 @@
   },
   {
     "cdrVersionId": 3,
+    "name": "All of Us Dataset v2 (Legacy)",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "aou-res-curation-output-prod",
+    "bigqueryDataset": "R2019Q2R1",
+    "creationTime": "2019-06-25 00:00:00Z",
+    "releaseNumber": 2,
+    "numParticipants": 191037,
+    "cdrDbName": "r_2019q2_2"
+  },
+  {
+    "cdrVersionId": 4,
     "isDefault": true,
     "name": "All of Us Dataset v2",
     "dataAccessLevel": 1,
-    "bigqueryProject": "aou-res-curation-output-prod",
+    "bigqueryProject": "fc-aou-cdr-prod",
     "bigqueryDataset": "R2019Q2R1",
     "creationTime": "2019-06-25 00:00:00Z",
     "releaseNumber": 2,

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -1,7 +1,7 @@
 [
   {
     "cdrVersionId": 1,
-    "name": "Synthetic Dataset v1",
+    "name": "Synthetic Dataset v1 (Legacy)",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "synthetic_cdr20180606",
@@ -13,8 +13,7 @@
   },
   {
     "cdrVersionId": 2,
-    "isDefault": true,
-    "name": "Synthetic Dataset v2",
+    "name": "Synthetic Dataset v2 (Legacy)",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "synthetic_cdr20180606",
@@ -23,5 +22,31 @@
     "numParticipants": 946237,
     "cdrDbName": "synth_r_2019q3_2",
     "elasticIndexBaseName": "synth_r_2019q1_1"
+  },
+  {
+    "cdrVersionId": 3,
+    "name": "Synthetic Dataset v1",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "fc-aou-cdr-synth-stable",
+    "bigqueryDataset": "synthetic_cdr20180606",
+    "creationTime": "2017-12-26 00:00:00Z",
+    "releaseNumber": 1,
+    "numParticipants": 946237,
+    "cdrDbName": "synth_r_2019q3_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1"
+  },
+  {
+    "cdrVersionId": 4,
+    "isDefault": true,
+    "name": "Synthetic Dataset v2",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "fc-aou-cdr-synth-stable",
+    "bigqueryDataset": "synthetic_cdr20180606",
+    "creationTime": "2017-12-26 00:00:00Z",
+    "releaseNumber": 1,
+    "numParticipants": 946237,
+    "cdrDbName": "synth_r_2019q3_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1"
   }
+
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -1,7 +1,7 @@
 [
   {
     "cdrVersionId": 1,
-    "name": "Synthetic Dataset v1",
+    "name": "Synthetic Dataset v1 (Legacy)",
     "dataAccessLevel": 1,
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "synthetic_cdr20180606",
@@ -13,10 +13,34 @@
   },
   {
     "cdrVersionId": 2,
+    "name": "Synthetic Dataset v2 (Legacy)",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "all-of-us-ehr-dev",
+    "bigqueryDataset": "synthetic_cdr20180606",
+    "creationTime": "2017-12-26 00:00:00Z",
+    "releaseNumber": 1,
+    "numParticipants": 946237,
+    "cdrDbName": "synth_r_2019q3_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1"
+  },
+  {
+    "cdrVersionId": 3,
+    "name": "Synthetic Dataset v1",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "fc-aou-cdr-synth-staging",
+    "bigqueryDataset": "synthetic_cdr20180606",
+    "creationTime": "2017-12-26 00:00:00Z",
+    "releaseNumber": 1,
+    "numParticipants": 946237,
+    "cdrDbName": "synth_r_2019q3_2",
+    "elasticIndexBaseName": "synth_r_2019q1_1"
+  },
+  {
+    "cdrVersionId": 4,
     "isDefault": true,
     "name": "Synthetic Dataset v2",
     "dataAccessLevel": 1,
-    "bigqueryProject": "all-of-us-ehr-dev",
+    "bigqueryProject": "fc-aou-cdr-synth-staging",
     "bigqueryDataset": "synthetic_cdr20180606",
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,


### PR DESCRIPTION
Rated this as moderate risk since it defines a new connection to the recently created firecloud.org prod CDR dataset (note: this is likely to be applied tomorrow, ahead of the next actual code release).

- I decided to proliferate the number of CDR versions in staging/stable, rather than upgrade in place, to minimize disruption to existing workspaces.
- Production now defaults to the new firecloud.org CDR project

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
