### PR TITLE
[risk=no, ticket=no] Bump set-value to 2.0.1 per dependabot recommendation

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -145,6 +145,7 @@
     "lolex": "^3.0.0",
     "protractor": "~5.4.1",
     "react-test-renderer": "^16.6.3",
+    "set-value": "^2.0.1",
     "ts-node": "~3.0.4",
     "tslint": "^5.9.1",
     "tslint-eslint-rules": "^5.4.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7445,6 +7445,16 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"


### PR DESCRIPTION
PR-ing myself because it could not be done automatically.

Here's the security alert: https://github.com/all-of-us/workbench/network/alert/ui/yarn.lock/set-value/open
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
