### PR TITLE
[RW-3354] [risk=low] Scope all BigQuery service instances to the current CDR project

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
@@ -41,10 +41,12 @@ public class BigQueryService {
 
   private BigQuery getBigQueryService() {
     CdrVersion cdrVersion = CdrVersionContext.getCdrVersion();
-    return BigQueryOptions.newBuilder().setProjectId(
-        cdrVersion.getBigqueryProject()).build().getService();
+    return BigQueryOptions.newBuilder()
+        .setProjectId(cdrVersion.getBigqueryProject())
+        .build()
+        .getService();
   }
-  
+
   /** Execute the provided query using bigquery. */
   public TableResult executeQuery(QueryJobConfiguration query) {
     return executeQuery(query, 60000L);


### PR DESCRIPTION
This fixes an issue we encountered when trying to turn on VPC-SC BigQuery enforcement in test. By default, the BigQuery client library executes queries in the context of the current default project (in our case, the App Engine project, e.g. all-of-us-workbench-test).

With VPC-SC BigQuery enforcement enabled, a query that's executed in the context of a project outside of the perimeter is considered "cross-perimeter", even if the query itself only accesses resources within the perimeter and the acting service account is whitelisted for access.

This PR should allow us to turn on BigQuery enforcement in the test environment. We may want to prepare a cherry-pick onto the current release in order to gain business & security approval to push it out next week. This will be required to enable enforcement on staging, stable and prod.