### PR TITLE
[RW-3375]Workspaces with concept sets cannot be duplicated

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.conceptset;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
@@ -41,5 +42,10 @@ public class ConceptSetService {
     // Allows for fetching concept sets for a workspace once its collection is no longer
     // bound to a session.
     return conceptSetDao.findByWorkspaceId(workspace.getWorkspaceId());
+  }
+
+  @VisibleForTesting
+  public void setConceptSetDao(ConceptSetDao conceptSetDao) {
+    this.conceptSetDao = conceptSetDao;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -34,7 +34,6 @@ public class ConceptSetService {
     c.setCreationTime(targetWorkspace.getCreationTime());
     c.setVersion(1);
     ConceptSet saved = conceptSetDao.save(c);
-    conceptSetDao.bulkCopyConceptIds(conceptSet.getConceptSetId(), saved.getConceptSetId());
     return saved;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -5,10 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import org.pmiops.workbench.db.model.ConceptSet;
 import org.pmiops.workbench.model.Domain;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 
 public interface ConceptSetDao extends CrudRepository<ConceptSet, Long> {
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -33,16 +33,5 @@ public interface ConceptSetDao extends CrudRepository<ConceptSet, Long> {
   /** Returns the concept set in the workspace with the specified name, or null if there is none. */
   ConceptSet findConceptSetByNameAndWorkspaceId(String name, long workspaceId);
 
-  @Modifying
-  @Query(
-      value =
-          "INSERT INTO concept_set_concept_id(concept_set_id, concept_id) "
-              + " SELECT (:toCsId), concept_id "
-              + " FROM concept_set_concept_id "
-              + " WHERE concept_set_id = (:fromCsId)",
-      nativeQuery = true)
-  void bulkCopyConceptIds(
-      @Param("fromCsId") long fromConceptSetId, @Param("toCsId") long toConceptSetId);
-
   List<ConceptSet> findAllByConceptSetIdIn(Collection<Long> conceptSetIds);
 }

--- a/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
@@ -1,0 +1,75 @@
+package org.pmiops.workbench.conceptset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.ConceptSet;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.model.Domain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Import(LiquibaseAutoConfiguration.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ConceptSetServiceTest {
+
+  @Autowired private ConceptSetDao conceptSetDao;
+
+  @Autowired private WorkspaceDao workspaceDao;
+
+  private ConceptSetService conceptSetService;
+  private Workspace workspace;
+
+  @Before
+  public void setUp() {
+    conceptSetService = new ConceptSetService();
+    conceptSetService.setConceptSetDao(conceptSetDao);
+    workspace = mockWorkspace();
+  }
+
+  @Test
+  public void testCloneConceptSetWithNoCdrVersionChange() {
+    ConceptSet fromConceptSet = mockConceptSet();
+    ConceptSet copiedConceptSet =
+        conceptSetService.cloneConceptSetAndConceptIds(fromConceptSet, workspace, false);
+    assertNotNull(copiedConceptSet);
+    assertEquals(copiedConceptSet.getConceptIds().size(), 5);
+    assertEquals(copiedConceptSet.getWorkspaceId(), workspace.getWorkspaceId());
+  }
+
+  private ConceptSet mockConceptSet() {
+    Set conceptIdsSet = Stream.of(1, 2, 3, 4, 5).collect(Collectors.toCollection(HashSet::new));
+
+    ConceptSet conceptSet = new ConceptSet();
+    conceptSet.setConceptIds(conceptIdsSet);
+    conceptSet.setConceptSetId(1);
+    conceptSet.setName("Mock Concept Set");
+    conceptSet.setDomainEnum(Domain.CONDITION);
+    return conceptSet;
+  }
+
+  private Workspace mockWorkspace() {
+    Workspace workspace = new Workspace();
+    workspace.setName("Target Workspace");
+    workspace.setWorkspaceId(2);
+    workspace = workspaceDao.save(workspace);
+    return workspace;
+  }
+}


### PR DESCRIPTION
Concept set constructor being called at the start of method 'cloneConceptSetAndConceptIds' was already taking care of concepts for new concept set, hence the extra call to bulkcopy was causing sql constraint exceptions