### PR TITLE
[RW-1960][risk=no] Relax the content security policy to allow for Incapsula script shenanigans

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -21,20 +21,14 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
-    # The script-src sha-256 hash whitelists the inline Google Analytics script
-    # found in index.html. If that Javascript is updated, we need to
-    # simultaneously update this hash. The new hash can be computed online, e.g.
-    # https://report-uri.com/home/hash or will be included in the console error
-    # output if you fail to update this. Failing to update this causes Google
-    # Analytics setup to fail, and may break the app entirely.
-    # Note: Once we're fully on React and have finer grained control over asset
-    # deployment, this inline script and hash could be removed in favor of
-    # adding this to another included JS file.
+    # unsafe-inline is unfortunately required as the Incapsula WAF injects a
+    # script onto the page when we're serving in production, for which we'd be
+    # unable to precompute a hash.
     Content-Security-Policy-Report-Only: "
       default-src 'none';
       script-src
         'self'
-        'sha256-WRcvuKF/fyz1ZMEquk5/ItKxTEyg/UFUSfLnSSG5Dcc='
+        'unsafe-inline'
         https://apis.google.com
         https://*.googleapis.com
         https://static.zdassets.com

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -13,7 +13,6 @@
     <script src="https://apis.google.com/js/platform.js"></script>
     <!-- Google Analytics setup -->
     <script async type="text/javascript" src="https://www.googletagmanager.com/gtag/js"></script>
-    <!-- Important: any changes to the following script must be reflected in app.yaml -->
     <script type="text/javascript">
       window.dataLayer=window.dataLayer||[];
       function gtag() {window.dataLayer.push(arguments)}


### PR DESCRIPTION
Incapsula apparently injects a script onto the pages it returns. We can't precompute a hash of this script, so our only option for now is to allow unsafe-inline, if we don't want to break whatever Incapsula is doing.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
