### PR TITLE
[RW-2484][risk=no] Create help tips sidebar component

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -24,7 +24,6 @@ import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {BugReportComponent} from './components/bug-report';
 import {ErrorHandlerComponent} from './components/error-handler/component';
-import {HelpSidebarComponent} from './components/help-sidebar';
 import {RoutingSpinnerComponent} from './components/routing-spinner/component';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AdminUserComponent} from './pages/admin/admin-user';
@@ -137,7 +136,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     DataSetPageComponent,
     DataUseAgreementComponent,
     ErrorHandlerComponent,
-    HelpSidebarComponent,
     InitialErrorComponent,
     InteractiveNotebookComponent,
     NotebookListComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -24,6 +24,7 @@ import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {BugReportComponent} from './components/bug-report';
 import {ErrorHandlerComponent} from './components/error-handler/component';
+import {HelpSidebarComponent} from './components/help-sidebar';
 import {RoutingSpinnerComponent} from './components/routing-spinner/component';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AdminUserComponent} from './pages/admin/admin-user';
@@ -136,6 +137,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     DataSetPageComponent,
     DataUseAgreementComponent,
     ErrorHandlerComponent,
+    HelpSidebarComponent,
     InitialErrorComponent,
     InteractiveNotebookComponent,
     NotebookListComponent,

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -29,7 +29,6 @@ export const DetailPage = withCurrentWorkspace()(
     constructor(props: any) {
       super(props);
       this.state = {participant: null};
-      this.setParticipant = this.setParticipant.bind(this);
     }
 
     componentDidMount() {
@@ -62,14 +61,17 @@ export const DetailPage = withCurrentWorkspace()(
     render() {
       const {participant} = this.state;
       return <React.Fragment>
-        {!participant ? <SpinnerOverlay /> : <React.Fragment>
-          <div className='detail-page '>
-            <DetailHeader participant={participant} />
-            <DetailTabs />
-          </div>
-          <HelpSidebar location='reviewParticipantDetail' participant={participant}
-            setParticipant={this.setParticipant} />
-        </React.Fragment>}
+        {!!participant
+          ? <React.Fragment>
+            <div className='detail-page '>
+              <DetailHeader participant={participant} />
+              <DetailTabs />
+            </div>
+            <HelpSidebar location='reviewParticipantDetail' participant={participant}
+              setParticipant={() => this.setParticipant} />
+          </React.Fragment>
+          : <SpinnerOverlay />
+        }
       </React.Fragment>;
     }
   }

--- a/ui/src/app/cohort-review/detail-page/detail-page.tsx
+++ b/ui/src/app/cohort-review/detail-page/detail-page.tsx
@@ -7,69 +7,19 @@ import {DetailHeader} from 'app/cohort-review/detail-header/detail-header.compon
 import {DetailTabs} from 'app/cohort-review/detail-tabs/detail-tabs.component';
 import {Participant} from 'app/cohort-review/participant.model';
 import {cohortReviewStore, getVocabOptions, vocabOptions} from 'app/cohort-review/review-state.service';
-import {SidebarContent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
-import {ClrIcon} from 'app/components/icons';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
-import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
+import {ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 
-const styles = reactStyles({
-  detailSidebar: {
-    position: 'absolute',
-    top: '1px',
-    right: '0px',
-    borderRadius: '2px',
-    height: '100%',
-    backgroundColor: '#E2E2EA',
-    display: 'flex',
-  },
-  sidebarHandle: {
-    backgroundColor: '#728FA3',
-    padding: '0.6rem',
-    position: 'absolute',
-    borderRadius: '0.2rem 0 0 0.2rem',
-    marginLeft: '-2.4rem',
-    top: '3rem',
-    cursor: 'pointer'
-  },
-  detailPage: {
-    transition: 'margin 0.5s',
-    marginRight: '1rem',
-  },
-  detailPageOpen: {
-    marginRight: '324px',
-    paddingRight: '1rem',
-  },
-  sidebarContent: {
-    width: 0,
-    transition: '0.5s',
-    overflowX: 'hidden',
-    flex: 1,
-    paddingTop: '0.35rem',
-    paddingBottom: '0.35rem',
-    color: colors.primary,
-  },
-  sidebarContentOpen: {
-    width: '370px',
-    borderLeft: '1rem solid #728FA3',
-    paddingLeft: '0.5rem',
-    paddingRight: '0.5rem',
-  },
-  sidebarHandleOpen: {
-    marginLeft: '0.25rem',
-    width: '359px',
-  },
-});
 
 interface Props {
   workspace: WorkspaceData;
 }
 
 interface State {
-  sidebarOpen: boolean;
   participant: Participant;
 }
 
@@ -78,7 +28,7 @@ export const DetailPage = withCurrentWorkspace()(
     private subscription;
     constructor(props: any) {
       super(props);
-      this.state = {sidebarOpen: true, participant: null};
+      this.state = {participant: null};
       this.setParticipant = this.setParticipant.bind(this);
     }
 
@@ -105,42 +55,20 @@ export const DetailPage = withCurrentWorkspace()(
       this.subscription.unsubscribe();
     }
 
-    get angleDir() {
-      return this.state.sidebarOpen ? 'right' : 'left';
-    }
-
-    toggleSidebar() {
-      const sidebarOpen = !this.state.sidebarOpen;
-      this.setState({sidebarOpen});
-    }
-
     setParticipant(v) {
       this.setState({participant: v});
     }
 
     render() {
-      const {participant, sidebarOpen} = this.state;
+      const {participant} = this.state;
       return <React.Fragment>
         {!participant ? <SpinnerOverlay /> : <React.Fragment>
-          <div className={'detail-page ' + (sidebarOpen ? 'sidebar-open' : '')}
-               style={{...styles.detailPage, ...(sidebarOpen ? styles.detailPageOpen : {})}}>
-            <DetailHeader participant={participant}>
-            </DetailHeader>
-            <DetailTabs>
-            </DetailTabs>
+          <div className='detail-page '>
+            <DetailHeader participant={participant} />
+            <DetailTabs />
           </div>
-          <div style={styles.detailSidebar}>
-            <div style={styles.sidebarHandle} onClick={() => this.toggleSidebar()}>
-              <ClrIcon style={{color: 'white'}} shape='angle-double' dir={this.angleDir} size='29'/>
-            </div>
-            <div id='review-sidebar-content'
-              style={{...styles.sidebarContent, ...(sidebarOpen ? styles.sidebarContentOpen : {})}}>
-              <SidebarContent
-                participant={participant}
-                setParticipant={this.setParticipant}>
-              </SidebarContent>
-            </div>
-          </div>
+          <HelpSidebar location='reviewParticipantDetail' participant={participant}
+            setParticipant={this.setParticipant} />
         </React.Fragment>}
       </React.Fragment>;
     }

--- a/ui/src/app/cohort-review/page-layout/page-layout.css
+++ b/ui/src/app/cohort-review/page-layout/page-layout.css
@@ -6,5 +6,5 @@
   min-height: calc(100vh - calc(4rem + 60px));
   padding: 1rem;
   position: relative;
-  width: calc(100% + 0.6rem);
+  width: calc(100% + 0.6rem - 45px);
 }

--- a/ui/src/app/cohort-review/page-layout/page-layout.css
+++ b/ui/src/app/cohort-review/page-layout/page-layout.css
@@ -6,5 +6,5 @@
   min-height: calc(100vh - calc(4rem + 60px));
   padding: 1rem;
   position: relative;
-  width: calc(100% + 0.6rem - 45px);
+  margin-right: 45px;
 }

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.spec.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.spec.tsx
@@ -1,13 +1,20 @@
+import {cohortReviewStore} from 'app/cohort-review/review-state.service';
+import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {mount} from 'enzyme';
+import {CohortAnnotationDefinitionApi, CohortReviewApi} from 'generated/fetch';
 import * as React from 'react';
+import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
+import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
-
 import {SidebarContent} from './sidebar-content.component';
 
 describe('SidebarContent', () => {
   beforeEach(() => {
+    registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
+    registerApiClient(CohortAnnotationDefinitionApi, new CohortAnnotationDefinitionServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
+    cohortReviewStore.next(cohortReviewStubs[0]);
   });
 
   it('should render', () => {

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as moment from 'moment';
 import * as React from 'react';
 
+import {AddAnnotationDefinitionModal, EditAnnotationDefinitionsModal} from 'app/cohort-review/annotation-definition-modals/annotation-definition-modals.component';
 import {Participant} from 'app/cohort-review/participant.model';
 import {cohortReviewStore} from 'app/cohort-review/review-state.service';
 import {Button} from 'app/components/buttons';
@@ -9,7 +10,7 @@ import {styles as headerStyles} from 'app/components/headers';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox, DatePicker, NumberInput, Select, TextArea} from 'app/components/inputs';
 import {Spinner} from 'app/components/spinners';
-import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
+import {cohortAnnotationDefinitionApi, cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {withCurrentWorkspace, withUrlParams} from 'app/utils';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -252,22 +253,41 @@ export const SidebarContent = fp.flow(
   {
     participant: Participant,
     setParticipant: Function,
-    annotations: ParticipantCohortAnnotation[],
-    annotationDefinitions: CohortAnnotationDefinition[],
-    annotationDeleted: boolean,
-    setAnnotations: Function,
-    openCreateDefinitionModal: Function,
-    openEditDefinitionsModal: Function,
     urlParams: any,
     workspace: WorkspaceData,
   },
-  {savingStatus: CohortStatus}
+  {
+    savingStatus: CohortStatus,
+    creatingDefinition: boolean,
+    editingDefinitions: boolean,
+    annotations: ParticipantCohortAnnotation[],
+    annotationDefinitions: CohortAnnotationDefinition[],
+    annotationDeleted: boolean,
+  }
 > {
   constructor(props) {
     super(props);
     this.state = {
       savingStatus: undefined,
+      creatingDefinition: false,
+      editingDefinitions: false,
+      annotations: null,
+      annotationDefinitions: null,
+      annotationDeleted: false
     };
+  }
+
+  componentDidMount(): void {
+    const {urlParams: {ns, wsid, pid, cid}} = this.props;
+    cohortReviewApi()
+      .getParticipantCohortAnnotations(ns, wsid, cohortReviewStore.getValue().cohortReviewId, +pid)
+      .then(({items}) => {
+        this.setState({annotations: items});
+      });
+    cohortAnnotationDefinitionApi().getCohortAnnotationDefinitions(ns, wsid, +cid)
+      .then(({items}) => {
+        this.setState({annotationDefinitions: items});
+      });
   }
 
   async saveStatus(v) {
@@ -291,15 +311,28 @@ export const SidebarContent = fp.flow(
     }
   }
 
+  closeEditDefinitionsModal = (deleted: boolean = false) => {
+    this.setState({editingDefinitions: false, annotationDeleted: deleted});
+    if (deleted) {
+      setTimeout(() => this.setState({annotationDeleted: false}), 5000);
+    }
+  }
+
+  definitionCreated = (ad) => {
+    const annotationDefinitions = this.state.annotationDefinitions.concat([ad]);
+    this.setState({annotationDefinitions, creatingDefinition: false});
+  }
+
   render() {
     const {
       participant: {participantId, birthDate, gender, race, ethnicity, deceased, status},
-      annotations, setAnnotations, annotationDefinitions, annotationDeleted,
-      openCreateDefinitionModal, openEditDefinitionsModal, workspace: {accessLevel}
+      workspace: {accessLevel}
     } = this.props;
-    const {savingStatus} = this.state;
+    const {annotations, annotationDefinitions, annotationDeleted, savingStatus, creatingDefinition,
+      editingDefinitions} = this.state;
     const disabled = accessLevel === WorkspaceAccessLevel.NOACCESS ||
       accessLevel === WorkspaceAccessLevel.READER;
+    const annotationsExist = annotationDefinitions && annotationDefinitions.length > 0;
     return <div>
       <div style={styles.header}>Participant {participantId}</div>
       <div><span style={{fontWeight: 'bold'}}>DOB:</span> {birthDate}</div>
@@ -334,15 +367,15 @@ export const SidebarContent = fp.flow(
         <div style={styles.header}>Annotations</div>
         <Button
           type='link' style={{...styles.button, ...(disabled ? {cursor: 'not-allowed'} : {})}}
-          onClick={openCreateDefinitionModal} disabled={disabled}>
+          onClick={() => this.setState({creatingDefinition: true})} disabled={disabled}>
           <ClrIcon shape='plus-circle' size={21} />
         </Button>
-        {!!annotationDefinitions.length && <Button
+        {annotationsExist && <Button
           type='link' style={{...styles.button, ...(disabled ? {cursor: 'not-allowed'} : {})}}
-          onClick={openEditDefinitionsModal} disabled={disabled}
+          onClick={() => this.setState({editingDefinitions: true})} disabled={disabled}
         >Edit</Button>}
       </div>
-      {annotationDefinitions.map(def => {
+      {annotationsExist && annotationDefinitions.map(def => {
         const {cohortAnnotationDefinitionId} = def;
         const annotation = fp.find({cohortAnnotationDefinitionId}, annotations);
         return <AnnotationItem
@@ -351,11 +384,21 @@ export const SidebarContent = fp.flow(
             // make sure we're still on the same page before updating
             if (participantId === +this.props.urlParams.pid) {
               const filtered = fp.remove({cohortAnnotationDefinitionId}, annotations);
-              setAnnotations(filtered.concat(update.annotationId ? [update] : []));
+              this.setState({annotations: filtered.concat(update.annotationId ? [update] : [])});
             }
           }}
         />;
       })}
+      {editingDefinitions && <EditAnnotationDefinitionsModal
+          onClose={this.closeEditDefinitionsModal}
+          annotationDefinitions={annotationDefinitions}
+          setAnnotationDefinitions={(v) => this.setState({annotationDefinitions: v})}>
+      </EditAnnotationDefinitionsModal>}
+      {creatingDefinition && <AddAnnotationDefinitionModal
+          annotationDefinitions={annotationDefinitions}
+          onCancel={() => this.setState({creatingDefinition: false})}
+          onCreate={this.definitionCreated}>
+      </AddAnnotationDefinitionModal>}
     </div>;
   }
 });

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -333,7 +333,7 @@ export const SidebarContent = fp.flow(
     const disabled = accessLevel === WorkspaceAccessLevel.NOACCESS ||
       accessLevel === WorkspaceAccessLevel.READER;
     const annotationsExist = annotationDefinitions && annotationDefinitions.length > 0;
-    return <div>
+    return <React.Fragment>
       <div style={styles.header}>Participant {participantId}</div>
       <div><span style={{fontWeight: 'bold'}}>DOB:</span> {birthDate}</div>
       <div><span style={{fontWeight: 'bold'}}>Gender:</span> {gender}</div>
@@ -399,6 +399,6 @@ export const SidebarContent = fp.flow(
           onCancel={() => this.setState({creatingDefinition: false})}
           onCreate={this.definitionCreated}>
       </AddAnnotationDefinitionModal>}
-    </div>;
+    </React.Fragment>;
   }
 });

--- a/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
+++ b/ui/src/app/cohort-review/sidebar-content/sidebar-content.component.tsx
@@ -311,14 +311,14 @@ export const SidebarContent = fp.flow(
     }
   }
 
-  closeEditDefinitionsModal = (deleted: boolean = false) => {
+  closeEditDefinitionsModal(deleted: boolean = false) {
     this.setState({editingDefinitions: false, annotationDeleted: deleted});
     if (deleted) {
       setTimeout(() => this.setState({annotationDeleted: false}), 5000);
     }
   }
 
-  definitionCreated = (ad) => {
+  definitionCreated(ad) {
     const annotationDefinitions = this.state.annotationDefinitions.concat([ad]);
     this.setState({annotationDefinitions, creatingDefinition: false});
   }
@@ -390,14 +390,14 @@ export const SidebarContent = fp.flow(
         />;
       })}
       {editingDefinitions && <EditAnnotationDefinitionsModal
-          onClose={this.closeEditDefinitionsModal}
+          onClose={() => this.closeEditDefinitionsModal}
           annotationDefinitions={annotationDefinitions}
           setAnnotationDefinitions={(v) => this.setState({annotationDefinitions: v})}>
       </EditAnnotationDefinitionsModal>}
       {creatingDefinition && <AddAnnotationDefinitionModal
           annotationDefinitions={annotationDefinitions}
           onCancel={() => this.setState({creatingDefinition: false})}
-          onCreate={this.definitionCreated}>
+          onCreate={() => this.definitionCreated}>
       </AddAnnotationDefinitionModal>}
     </React.Fragment>;
   }

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -10,6 +10,7 @@ import {
 } from 'app/cohort-review/review-state.service';
 import {datatableStyles} from 'app/cohort-review/review-utils/primeReactCss.utils';
 import {Button} from 'app/components/buttons';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortBuilderApi, cohortReviewApi} from 'app/services/swagger-fetch-clients';
@@ -660,6 +661,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
           </DataTable>
         </React.Fragment>
         {loading && <SpinnerOverlay />}
+        <HelpSidebar location='review' />
       </div>;
     }
   }

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -661,7 +661,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
           </DataTable>
         </React.Fragment>
         {loading && <SpinnerOverlay />}
-        <HelpSidebar location='review' />
+        <HelpSidebar location='cohortBuilder' />
       </div>;
     }
   }

--- a/ui/src/app/cohort-review/table-page/table-page.tsx
+++ b/ui/src/app/cohort-review/table-page/table-page.tsx
@@ -661,7 +661,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
           </DataTable>
         </React.Fragment>
         {loading && <SpinnerOverlay />}
-        <HelpSidebar location='cohortBuilder' />
+        <HelpSidebar location='reviewParticipants' />
       </div>;
     }
   }

--- a/ui/src/app/cohort-search/cohort-search.module.ts
+++ b/ui/src/app/cohort-search/cohort-search.module.ts
@@ -7,6 +7,7 @@ import {NouisliderModule} from 'ng2-nouislider';
 import {NgxPopperModule} from 'ngx-popper';
 
 /* Components */
+import {HelpSidebarComponent} from 'app/components/help-sidebar';
 import {AttributesPageComponent} from './attributes-page/attributes-page.component';
 import {CohortSearchComponent} from './cohort-search/cohort-search.component';
 import {DemographicsComponent} from './demographics/demographics.component';
@@ -62,6 +63,7 @@ const routes: Routes = [{
     CohortSearchComponent,
     GenderChartComponent,
     DemographicsComponent,
+    HelpSidebarComponent,
     ModalComponent,
     ModifierPageComponent,
     NodeComponent,

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.css
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.css
@@ -1,6 +1,6 @@
 .cohort-search-wrapper {
-  padding: 1rem;
-  margin-bottom: 1rem;
+  padding: 1rem 1rem 2rem;
+  margin-right: 45px;
   position: relative;
 }
 .cohort-name {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
@@ -34,6 +34,7 @@
       Loading...
     </div>
   </div>
+  <app-help-sidebar location="cohortBuilder"></app-help-sidebar>
 </div>
 <app-list-modal></app-list-modal>
 <clr-modal [(clrModalOpen)]="modalOpen" [clrModalClosable]="false">

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.ts
@@ -24,6 +24,7 @@ import {wizardStore} from 'app/cohort-search/search-state.service';
 import {SelectionInfoComponent} from 'app/cohort-search/selection-info/selection-info.component';
 import {TreeComponent} from 'app/cohort-search/tree/tree.component';
 import {ConfirmDeleteModalComponent} from 'app/components/confirm-delete-modal';
+import {HelpSidebarComponent} from 'app/components/help-sidebar';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, queryParamsStore} from 'app/utils/navigation';
 import {CohortBuilderService, CohortsService, DomainType} from 'generated';
@@ -50,6 +51,7 @@ describe('CohortSearchComponent', () => {
         ConfirmDeleteModalComponent,
         GenderChartComponent,
         DemographicsComponent,
+        HelpSidebarComponent,
         ModalComponent,
         ModifierPageComponent,
         NodeInfoComponent,

--- a/ui/src/app/cohort-search/modal/modal.component.css
+++ b/ui/src/app/cohort-search/modal/modal.component.css
@@ -9,6 +9,7 @@
   visibility: hidden;
   transform: scale(1.1);
   transition: visibility 0.25s linear, opacity 0.25s 0s, transform 0.25s;
+  z-index: 102;
 }
 
 .crit-modal-container.show {

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -24,7 +24,7 @@ export const styles = reactStyles({
     boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
     position: 'fixed',
     bottom: '1rem',
-    right: '1rem',
+    right: '2.9rem',
     borderRadius: '3rem',
     backgroundColor: colors.accent,
     height: '1.8rem',

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+import {mount} from 'enzyme';
+import {HelpSidebar} from './help-sidebar';
+
+describe('SidebarContent', () => {
+  it('should render', () => {
+    const wrapper = mount(<HelpSidebar location='data' />);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+});

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -75,9 +75,16 @@ const styles = reactStyles({
   }
 });
 
-const activeIconStyle = {
-  ...styles.icon,
-  background: colorWithWhiteness(colors.primary, 0.55)
+const iconStyles = {
+  active: {
+    ...styles.icon,
+    background: colorWithWhiteness(colors.primary, 0.55)
+  },
+  disabled: {
+    ...styles.icon,
+    opacity: 0.4,
+    cursor: 'not-allowed'
+  }
 };
 
 interface Props {
@@ -136,16 +143,15 @@ export class HelpSidebar extends React.Component<Props, State> {
     });
     return <React.Fragment>
       <div style={styles.iconContainer}>
-        <div style={activeIcon === 'help' ? activeIconStyle : styles.icon}>
+        <div style={activeIcon === 'help' ? iconStyles.active : styles.icon}>
           <ClrIcon className='is-solid' shape='info-standard' size={28}
                    onClick={() => this.onIconClick('help')} />
         </div>
-        <div style={activeIcon === 'book' ? activeIconStyle : styles.icon}>
-          <ClrIcon className='is-solid' shape='book' size={32}
-                   onClick={() => this.onIconClick('book')} />
+        <div style={iconStyles.disabled}>
+          <ClrIcon className='is-solid' shape='book' size={32} />
         </div>
         {location === 'reviewParticipantDetail' &&
-          <div style={activeIcon === 'annotations' ? activeIconStyle : styles.icon}>
+          <div style={activeIcon === 'annotations' ? iconStyles.active : styles.icon}>
             <ClrIcon shape='note' size={32}
                      onClick={() => this.onIconClick('annotations')} />
           </div>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -14,6 +14,7 @@ const styles = reactStyles({
     top: 0,
     right: 'calc(-0.6rem - 45px)',
     height: '100%',
+    minHeight: 'calc(100vh - 156px)',
     width: 'calc(14rem + 45px)',
     overflow: 'hidden',
     color: colors.primary,
@@ -33,6 +34,7 @@ const styles = reactStyles({
     top: 0,
     right: 'calc(-0.6rem - 45px)',
     height: '100%',
+    minHeight: 'calc(100vh - 156px)',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),
     zIndex: 101

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -14,7 +14,7 @@ const styles = reactStyles({
     top: 0,
     right: '-45px',
     height: '100%',
-    width: 'calc(14rem + 85px)',
+    width: 'calc(14rem + 45px)',
     overflow: 'hidden',
     color: colors.primary,
     zIndex: 1000
@@ -25,7 +25,7 @@ const styles = reactStyles({
     right: '45px',
     height: '100%',
     width: '14rem',
-    padding: '0.5rem',
+    overflow: 'auto',
     background: colorWithWhiteness(colors.primary, .87),
     transition: 'margin-right 0.5s ease-out'
   },
@@ -36,6 +36,7 @@ const styles = reactStyles({
     height: '100%',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),
+    zIndex: 2
   },
   icon: {
     color: colors.white,
@@ -44,14 +45,17 @@ const styles = reactStyles({
     cursor: 'pointer',
     textAlign: 'center',
   },
-  closeIcon: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    width: '100%',
+  topBar: {
+    position: 'fixed',
+    width: '14rem',
     background: colorWithWhiteness(colors.primary, 0.4),
     color: colors.white,
     height: '1rem',
+    zIndex: 1
+  },
+  closeIcon: {
+    cursor: 'pointer',
+    verticalAlign: 'top'
   },
   sectionTitle: {
     marginTop: '0.5rem',
@@ -110,9 +114,24 @@ export class HelpSidebar extends React.Component<Props, State> {
 
   onIconClick = (icon: string) => {
     let {activeIcon, sidebarOpen} = this.state;
-    sidebarOpen = icon === activeIcon ? !sidebarOpen : true;
-    activeIcon = sidebarOpen ? icon : undefined;
-    this.setState({activeIcon, sidebarOpen});
+    sidebarOpen = !(icon === activeIcon && sidebarOpen);
+    if (sidebarOpen) {
+      this.setState({activeIcon: icon, sidebarOpen});
+    } else {
+      this.hideSidebar();
+    }
+  }
+
+  hideSidebar = () => {
+    this.setState({sidebarOpen: false});
+    // keep activeIcon set while the sidebar transition completes
+    setTimeout(() => {
+      const {sidebarOpen} = this.state;
+      // check if the sidebar has been opened again before resetting activeIcon
+      if (!sidebarOpen) {
+        this.setState({activeIcon: undefined});
+      }
+    }, 300);
   }
 
   render() {
@@ -121,13 +140,14 @@ export class HelpSidebar extends React.Component<Props, State> {
     const contentStyle = (tab: string) => ({
       display: activeIcon === tab ? 'block' : 'none',
       overflow: 'auto',
-      marginTop: '1rem'
+      marginTop: '1rem',
+      padding: '0.5rem',
     });
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
-        <div style={styles.closeIcon}
-             onClick={() => this.setState({activeIcon: undefined, sidebarOpen: false})}>
-          <ClrIcon shape='caret right' size={24} style={{cursor: 'pointer', verticalAlign: 'none'}}/>
+        <div style={styles.topBar}>
+          <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
+            onClick={() => this.hideSidebar()} />
         </div>
         <div style={contentStyle('help')}>
           <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
@@ -146,7 +166,9 @@ export class HelpSidebar extends React.Component<Props, State> {
           </div>)}
         </div>
         <div style={contentStyle('annotations')}>
-          <SidebarContent participant={participant} setParticipant={setParticipant} />
+          {!!participant &&
+            <SidebarContent participant={participant} setParticipant={setParticipant} />
+          }
         </div>
       </div>
       <div style={styles.iconContainer}>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -25,6 +25,7 @@ const styles = reactStyles({
     height: '100%',
     width: '14rem',
     padding: '0.5rem',
+    overflow: 'auto',
     background: colorWithWhiteness(colors.primary, .87),
     transition: 'margin-right 0.5s ease-out'
   },
@@ -42,6 +43,21 @@ const styles = reactStyles({
     color: colors.white,
     marginTop: '1.25rem',
     cursor: 'pointer'
+  },
+  sectionTitle: {
+    marginTop: '0.5rem',
+    fontWeight: 600,
+    color: colors.primary
+  },
+  contentTitle: {
+    marginTop: '0.25rem',
+    fontSize: '14px',
+    fontWeight: 600,
+    color: colors.primary
+  },
+  contentItem: {
+    marginTop: 0,
+    color: colors.primary
   }
 });
 
@@ -81,14 +97,14 @@ export class HelpSidebar extends React.Component<Props, State> {
     const {activeIcon, sidebarOpen} = this.state;
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
-        <h3 style={{fontWeight: 600, margin: 0}}>Help Tips</h3>
+        <h3 style={{...styles.sectionTitle, margin: 0}}>Help Tips</h3>
         {sidebarContent[location].map((section, s) => <div key={s}>
-          <h4>{section.title}</h4>
+          <h3 style={styles.sectionTitle}>{section.title}</h3>
           {section.content.map((content, c) => {
-            return typeof content === 'string' ? <p key={c}>{content}</p> :
-              <div>
-                <h5>{content.title}</h5>
-                {content.content.map((item, i) => <p key={i}>{item}</p>)}
+            return typeof content === 'string' ? <p key={c} style={styles.contentItem}>{content}</p>
+              : <div>
+                <h4 style={styles.contentTitle}>{content.title}</h4>
+                {content.content.map((item, i) => <p key={i} style={styles.contentItem}>{item}</p>)}
               </div>;
           })}
         </div>)}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -2,7 +2,7 @@ import {Component, Input} from '@angular/core';
 import * as React from 'react';
 
 import {ClrIcon} from 'app/components/icons';
-import colors from 'app/styles/colors';
+import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 
 const styles = reactStyles({
@@ -11,34 +11,81 @@ const styles = reactStyles({
     top: 0,
     right: 0,
     height: '100%',
-    background: colors.secondary,
-    padding: '0.25rem'
+    marginRight: '-45px',
+  },
+  content: {
+    position: 'absolute',
+    top: 0,
+    right: '45px',
+    height: '100%',
+    overflow: 'hidden',
+    background: colors.light,
+    transition: 'width 0.5s ease-out'
+  },
+  iconContainer: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    textAlign: 'center',
+    height: '100%',
+    width: '45px',
+    background: colorWithWhiteness(colors.primary, 0.4),
+    zIndex: 10010
   },
   icon: {
-    color: colors.white
+    color: colors.white,
+    marginTop: '1.25rem',
+    cursor: 'pointer'
   }
 });
+
+const contentStyles = {
+  closed: {
+    ...styles.content,
+    width: 0
+  },
+  open: {
+    ...styles.content,
+    width: '10rem'
+  },
+};
 
 interface Props {
   location: string;
 }
 
 interface State {
-  open: boolean;
+  activeIcon: string;
+  sidebarOpen: boolean;
   searchTerm: string;
 }
 export class HelpSidebar extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      open: false,
+      activeIcon: undefined,
+      sidebarOpen: false,
       searchTerm: undefined
     };
   }
 
   render() {
+    const {location} = this.props;
+    const {activeIcon, sidebarOpen} = this.state;
     return <div style={styles.sidebar}>
-      <div><ClrIcon className='is-solid' shape='info-standard' size={22} style={styles.icon}/></div>
+      <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
+        <h3>Sidebar Content</h3>
+      </div>
+      <div style={styles.iconContainer}>
+        <ClrIcon className='is-solid' shape='info-standard' size={28} style={styles.icon}
+          onClick={() => this.setState({activeIcon: 'info', sidebarOpen: !sidebarOpen})} />
+        <ClrIcon className='is-solid' shape='book' size={32} style={styles.icon}
+          onClick={() => this.setState({activeIcon: 'book', sidebarOpen: !sidebarOpen})} />
+        {location === 'review' &&
+          <ClrIcon shape='note' size={32} style={styles.icon}
+            onClick={() => this.setState({activeIcon: 'annotations', sidebarOpen: !sidebarOpen})} />
+        }
+      </div>
     </div>;
   }
 }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -18,6 +18,10 @@ const styles = reactStyles({
     width: 'calc(14rem + 45px)',
     overflow: 'hidden',
     color: colors.primary,
+    zIndex: -1,
+  },
+  sidebarContainerActive: {
+    zIndex: 100,
   },
   sidebar: {
     position: 'absolute',
@@ -26,8 +30,12 @@ const styles = reactStyles({
     height: '100%',
     width: '14rem',
     overflow: 'auto',
+    marginRight: 'calc(-14rem - 40px)',
     background: colorWithWhiteness(colors.primary, .87),
     transition: 'margin-right 0.5s ease-out'
+  },
+  sidebarOpen: {
+    marginRight: 0,
   },
   iconContainer: {
     position: 'absolute',
@@ -109,10 +117,10 @@ export class HelpSidebar extends React.Component<Props, State> {
   }
 
   onIconClick(icon: string) {
-    let {activeIcon, sidebarOpen} = this.state;
-    sidebarOpen = !(icon === activeIcon && sidebarOpen);
-    if (sidebarOpen) {
-      this.setState({activeIcon: icon, sidebarOpen});
+    const {activeIcon, sidebarOpen} = this.state;
+    const newSidebarOpen = !(icon === activeIcon && sidebarOpen);
+    if (newSidebarOpen) {
+      this.setState({activeIcon: icon, sidebarOpen: newSidebarOpen});
     } else {
       this.hideSidebar();
     }
@@ -133,8 +141,6 @@ export class HelpSidebar extends React.Component<Props, State> {
   render() {
     const {location, participant, setParticipant} = this.props;
     const {activeIcon, sidebarOpen} = this.state;
-    const sidebarContainerStyles = {...styles.sidebarContainer, zIndex: activeIcon ? 100 : -1};
-    const sidebarStyles = {...styles.sidebar, marginRight: sidebarOpen ? 0 : 'calc(-14rem - 40px)'};
     const contentStyle = (tab: string) => ({
       display: activeIcon === tab ? 'block' : 'none',
       height: 'calc(100% - 1rem)',
@@ -157,8 +163,8 @@ export class HelpSidebar extends React.Component<Props, State> {
           </div>
         }
       </div>
-      <div style={sidebarContainerStyles}>
-        <div style={sidebarStyles}>
+      <div style={activeIcon ? {...styles.sidebarContainer, ...styles.sidebarContainerActive} : styles.sidebarContainer}>
+        <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar}>
           <div style={styles.topBar}>
             <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
               onClick={() => this.hideSidebar()} />

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -1,6 +1,7 @@
 import {Component, Input} from '@angular/core';
 import * as React from 'react';
 
+import {SidebarContent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
@@ -16,6 +17,7 @@ const styles = reactStyles({
     width: 'calc(14rem + 85px)',
     overflow: 'hidden',
     color: colors.primary,
+    zIndex: 1000
   },
   content: {
     position: 'absolute',
@@ -34,26 +36,22 @@ const styles = reactStyles({
     height: '100%',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),
-    zIndex: 10010
   },
   icon: {
     color: colors.white,
-    marginTop: '0.75rem',
+    marginTop: '1rem',
     padding: '0.25rem 0',
     cursor: 'pointer',
     textAlign: 'center',
   },
   closeIcon: {
-    cursor: 'pointer',
     position: 'absolute',
-    margin: '-10px 0 0 -52px',
-    width: '40px',
-    borderBottomLeftRadius: '10px',
-    borderTopLeftRadius: '10px',
+    top: 0,
+    right: 0,
+    width: '100%',
     background: colorWithWhiteness(colors.primary, 0.4),
     color: colors.white,
-    height: '40px',
-    textAlign: 'center',
+    height: '1rem',
   },
   sectionTitle: {
     marginTop: '0.5rem',
@@ -90,6 +88,8 @@ const activeIconStyle = {
 
 interface Props {
   location: string;
+  participant?: any;
+  setParticipant?: Function;
 }
 
 interface State {
@@ -116,25 +116,38 @@ export class HelpSidebar extends React.Component<Props, State> {
   }
 
   render() {
-    const {location} = this.props;
+    const {location, participant, setParticipant} = this.props;
     const {activeIcon, sidebarOpen} = this.state;
+    const contentStyle = (tab: string) => ({
+      display: activeIcon === tab ? 'block' : 'none',
+      overflow: 'auto',
+      marginTop: '1rem'
+    });
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
         <div style={styles.closeIcon}
              onClick={() => this.setState({activeIcon: undefined, sidebarOpen: false})}>
-          <ClrIcon shape='caret right' size={32} style={{marginTop: '3px'}}/>
+          <ClrIcon shape='caret right' size={24} style={{cursor: 'pointer', verticalAlign: 'none'}}/>
         </div>
-        <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
-        {sidebarContent[location].map((section, s) => <div key={s}>
-          <h3 style={styles.sectionTitle}>{section.title}</h3>
-          {section.content.map((content, c) => {
-            return typeof content === 'string' ? <p key={c} style={styles.contentItem}>{content}</p>
-              : <div>
-                <h4 style={styles.contentTitle}>{content.title}</h4>
-                {content.content.map((item, i) => <p key={i} style={styles.contentItem}>{item}</p>)}
-              </div>;
-          })}
-        </div>)}
+        <div style={contentStyle('help')}>
+          <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
+          {sidebarContent[location].map((section, s) => <div key={s}>
+            <h3 style={styles.sectionTitle}>{section.title}</h3>
+            {section.content.map((content, c) => {
+              return typeof content === 'string'
+                ? <p key={c} style={styles.contentItem}>{content}</p>
+                : <div>
+                  <h4 style={styles.contentTitle}>{content.title}</h4>
+                  {content.content.map((item, i) =>
+                    <p key={i} style={styles.contentItem}>{item}</p>)
+                  }
+                </div>;
+            })}
+          </div>)}
+        </div>
+        <div style={contentStyle('annotations')}>
+          <SidebarContent participant={participant} setParticipant={setParticipant} />
+        </div>
       </div>
       <div style={styles.iconContainer}>
         <div style={activeIcon === 'help' ? activeIconStyle : styles.icon}>
@@ -145,7 +158,7 @@ export class HelpSidebar extends React.Component<Props, State> {
           <ClrIcon className='is-solid' shape='book' size={32}
             onClick={() => this.onIconClick('book')} />
         </div>
-        {location === 'review' &&
+        {location === 'reviewParticipantDetail' &&
           <div style={activeIcon === 'annotations' ? activeIconStyle : styles.icon}>
             <ClrIcon shape='note' size={32}
               onClick={() => this.onIconClick('annotations')} />
@@ -162,8 +175,10 @@ export class HelpSidebar extends React.Component<Props, State> {
 })
 export class HelpSidebarComponent extends ReactWrapperBase {
   @Input('location') location: Props['location'];
+  @Input('participant') participant: Props['participant'];
+  @Input('setParticipant') setParticipant: Props['setParticipant'];
 
   constructor() {
-    super(HelpSidebar, ['location']);
+    super(HelpSidebar, ['location', 'participant', 'setParticipant']);
   }
 }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -99,7 +99,6 @@ export class HelpSidebar extends React.Component<Props, State> {
       sidebarOpen: false,
       searchTerm: undefined
     };
-    console.log(sidebarContent);
   }
 
   onIconClick = (icon: string) => {

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -9,18 +9,21 @@ const styles = reactStyles({
   sidebar: {
     position: 'absolute',
     top: 0,
-    right: 0,
+    right: '-45px',
     height: '100%',
-    marginRight: '-45px',
+    width: 'calc(14rem + 45px)',
+    overflow: 'hidden',
+    color: colors.primary,
   },
   content: {
     position: 'absolute',
     top: 0,
     right: '45px',
     height: '100%',
-    overflow: 'hidden',
-    background: colors.light,
-    transition: 'width 0.5s ease-out'
+    width: '14rem',
+    padding: '0.5rem',
+    background: colorWithWhiteness(colors.primary, .87),
+    transition: 'margin-right 0.5s ease-out'
   },
   iconContainer: {
     position: 'absolute',
@@ -42,11 +45,11 @@ const styles = reactStyles({
 const contentStyles = {
   closed: {
     ...styles.content,
-    width: 0
+    marginRight: '-14rem',
   },
   open: {
     ...styles.content,
-    width: '10rem'
+    marginRight: 0,
   },
 };
 
@@ -74,7 +77,7 @@ export class HelpSidebar extends React.Component<Props, State> {
     const {activeIcon, sidebarOpen} = this.state;
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
-        <h3>Sidebar Content</h3>
+        <h3 style={{fontWeight: 600, margin: 0}}>Help Tips</h3>
       </div>
       <div style={styles.iconContainer}>
         <ClrIcon className='is-solid' shape='info-standard' size={28} style={styles.icon}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -6,13 +6,13 @@ import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 
-const sidebarContent = require('assets/json/help-sidebar.json')
+const sidebarContent = require('assets/json/help-sidebar.json');
 
 const styles = reactStyles({
   sidebar: {
     position: 'absolute',
     top: 0,
-    right: '-45px',
+    right: 'calc(-0.6rem - 45px)',
     height: '100%',
     width: 'calc(14rem + 45px)',
     overflow: 'hidden',
@@ -46,7 +46,6 @@ const styles = reactStyles({
     textAlign: 'center',
   },
   topBar: {
-    position: 'fixed',
     width: '14rem',
     background: colorWithWhiteness(colors.primary, 0.4),
     color: colors.white,
@@ -139,8 +138,8 @@ export class HelpSidebar extends React.Component<Props, State> {
     const {activeIcon, sidebarOpen} = this.state;
     const contentStyle = (tab: string) => ({
       display: activeIcon === tab ? 'block' : 'none',
+      height: 'calc(100% - 1rem)',
       overflow: 'auto',
-      marginTop: '1rem',
       padding: '0.5rem',
     });
     return <div style={styles.sidebar}>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -9,7 +9,7 @@ import {reactStyles, ReactWrapperBase} from 'app/utils';
 const sidebarContent = require('assets/json/help-sidebar.json');
 
 const styles = reactStyles({
-  sidebar: {
+  sidebarContainer: {
     position: 'absolute',
     top: 0,
     right: 'calc(-0.6rem - 45px)',
@@ -17,9 +17,8 @@ const styles = reactStyles({
     width: 'calc(14rem + 45px)',
     overflow: 'hidden',
     color: colors.primary,
-    zIndex: 1000
   },
-  content: {
+  sidebar: {
     position: 'absolute',
     top: 0,
     right: '45px',
@@ -32,11 +31,11 @@ const styles = reactStyles({
   iconContainer: {
     position: 'absolute',
     top: 0,
-    right: 0,
+    right: 'calc(-0.6rem - 45px)',
     height: '100%',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),
-    zIndex: 2
+    zIndex: 101
   },
   icon: {
     color: colors.white,
@@ -44,6 +43,7 @@ const styles = reactStyles({
     padding: '0.25rem 0',
     cursor: 'pointer',
     textAlign: 'center',
+    transition: 'background 0.2s linear'
   },
   topBar: {
     width: '14rem',
@@ -72,17 +72,6 @@ const styles = reactStyles({
     color: colors.primary
   }
 });
-
-const contentStyles = {
-  closed: {
-    ...styles.content,
-    marginRight: 'calc(-14rem - 40px)',
-  },
-  open: {
-    ...styles.content,
-    marginRight: 0,
-  },
-};
 
 const activeIconStyle = {
   ...styles.icon,
@@ -136,57 +125,61 @@ export class HelpSidebar extends React.Component<Props, State> {
   render() {
     const {location, participant, setParticipant} = this.props;
     const {activeIcon, sidebarOpen} = this.state;
+    const sidebarContainerStyles = {...styles.sidebarContainer, zIndex: activeIcon ? 100 : -1};
+    const sidebarStyles = {...styles.sidebar, marginRight: sidebarOpen ? 0 : 'calc(-14rem - 40px)'};
     const contentStyle = (tab: string) => ({
       display: activeIcon === tab ? 'block' : 'none',
       height: 'calc(100% - 1rem)',
       overflow: 'auto',
       padding: '0.5rem',
     });
-    return <div style={styles.sidebar}>
-      <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
-        <div style={styles.topBar}>
-          <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
-            onClick={() => this.hideSidebar()} />
-        </div>
-        <div style={contentStyle('help')}>
-          <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
-          {sidebarContent[location].map((section, s) => <div key={s}>
-            <h3 style={styles.sectionTitle}>{section.title}</h3>
-            {section.content.map((content, c) => {
-              return typeof content === 'string'
-                ? <p key={c} style={styles.contentItem}>{content}</p>
-                : <div>
-                  <h4 style={styles.contentTitle}>{content.title}</h4>
-                  {content.content.map((item, i) =>
-                    <p key={i} style={styles.contentItem}>{item}</p>)
-                  }
-                </div>;
-            })}
-          </div>)}
-        </div>
-        <div style={contentStyle('annotations')}>
-          {!!participant &&
-            <SidebarContent participant={participant} setParticipant={setParticipant} />
-          }
-        </div>
-      </div>
+    return <React.Fragment>
       <div style={styles.iconContainer}>
         <div style={activeIcon === 'help' ? activeIconStyle : styles.icon}>
           <ClrIcon className='is-solid' shape='info-standard' size={28}
-            onClick={() => this.onIconClick('help')} />
+                   onClick={() => this.onIconClick('help')} />
         </div>
         <div style={activeIcon === 'book' ? activeIconStyle : styles.icon}>
           <ClrIcon className='is-solid' shape='book' size={32}
-            onClick={() => this.onIconClick('book')} />
+                   onClick={() => this.onIconClick('book')} />
         </div>
         {location === 'reviewParticipantDetail' &&
           <div style={activeIcon === 'annotations' ? activeIconStyle : styles.icon}>
             <ClrIcon shape='note' size={32}
-              onClick={() => this.onIconClick('annotations')} />
+                     onClick={() => this.onIconClick('annotations')} />
           </div>
         }
       </div>
-    </div>;
+      <div style={sidebarContainerStyles}>
+        <div style={sidebarStyles}>
+          <div style={styles.topBar}>
+            <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
+              onClick={() => this.hideSidebar()} />
+          </div>
+          <div style={contentStyle('help')}>
+            <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
+            {sidebarContent[location].map((section, s) => <div key={s}>
+              <h3 style={styles.sectionTitle}>{section.title}</h3>
+              {section.content.map((content, c) => {
+                return typeof content === 'string'
+                  ? <p key={c} style={styles.contentItem}>{content}</p>
+                  : <div>
+                    <h4 style={styles.contentTitle}>{content.title}</h4>
+                    {content.content.map((item, i) =>
+                      <p key={i} style={styles.contentItem}>{item}</p>)
+                    }
+                  </div>;
+              })}
+            </div>)}
+          </div>
+          <div style={contentStyle('annotations')}>
+            {!!participant &&
+              <SidebarContent participant={participant} setParticipant={setParticipant} />
+            }
+          </div>
+        </div>
+      </div>
+    </React.Fragment>;
   }
 }
 

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -4,6 +4,9 @@ import * as React from 'react';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {k} from '@angular/core/src/render3';
+
+const sidebarContent = require('assets/json/help-sidebar.json')
 
 const styles = reactStyles({
   sidebar: {
@@ -70,6 +73,7 @@ export class HelpSidebar extends React.Component<Props, State> {
       sidebarOpen: false,
       searchTerm: undefined
     };
+    console.log(sidebarContent);
   }
 
   render() {
@@ -78,6 +82,16 @@ export class HelpSidebar extends React.Component<Props, State> {
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
         <h3 style={{fontWeight: 600, margin: 0}}>Help Tips</h3>
+        {sidebarContent[location].map((section, s) => <div key={s}>
+          <h4>{section.title}</h4>
+          {section.content.map((content, c) => {
+            return typeof content === 'string' ? <p key={c}>{content}</p> :
+              <div>
+                <h5>{content.title}</h5>
+                {content.content.map((item, i) => <p key={i}>{item}</p>)}
+              </div>;
+          })}
+        </div>)}
       </div>
       <div style={styles.iconContainer}>
         <ClrIcon className='is-solid' shape='info-standard' size={28} style={styles.icon}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -108,7 +108,7 @@ export class HelpSidebar extends React.Component<Props, State> {
     };
   }
 
-  onIconClick = (icon: string) => {
+  onIconClick(icon: string) {
     let {activeIcon, sidebarOpen} = this.state;
     sidebarOpen = !(icon === activeIcon && sidebarOpen);
     if (sidebarOpen) {
@@ -118,7 +118,7 @@ export class HelpSidebar extends React.Component<Props, State> {
     }
   }
 
-  hideSidebar = () => {
+  hideSidebar() {
     this.setState({sidebarOpen: false});
     // keep activeIcon set while the sidebar transition completes
     setTimeout(() => {
@@ -170,7 +170,7 @@ export class HelpSidebar extends React.Component<Props, State> {
               {section.content.map((content, c) => {
                 return typeof content === 'string'
                   ? <p key={c} style={styles.contentItem}>{content}</p>
-                  : <div>
+                  : <div key={c}>
                     <h4 style={styles.contentTitle}>{content.title}</h4>
                     {content.content.map((item, i) =>
                       <p key={i} style={styles.contentItem}>{item}</p>)
@@ -181,7 +181,7 @@ export class HelpSidebar extends React.Component<Props, State> {
           </div>
           <div style={contentStyle('annotations')}>
             {!!participant &&
-              <SidebarContent participant={participant} setParticipant={setParticipant} />
+              <SidebarContent participant={participant} setParticipant={() => setParticipant} />
             }
           </div>
         </div>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -1,0 +1,56 @@
+import {Component, Input} from '@angular/core';
+import * as React from 'react';
+
+import {ClrIcon} from 'app/components/icons';
+import colors from 'app/styles/colors';
+import {reactStyles, ReactWrapperBase} from 'app/utils';
+
+const styles = reactStyles({
+  sidebar: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    height: '100%',
+    background: colors.secondary,
+    padding: '0.25rem'
+  },
+  icon: {
+    color: colors.white
+  }
+});
+
+interface Props {
+  location: string;
+}
+
+interface State {
+  open: boolean;
+  searchTerm: string;
+}
+export class HelpSidebar extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      open: false,
+      searchTerm: undefined
+    };
+  }
+
+  render() {
+    return <div style={styles.sidebar}>
+      <div><ClrIcon className='is-solid' shape='info-standard' size={22} style={styles.icon}/></div>
+    </div>;
+  }
+}
+
+@Component({
+  selector: 'app-help-sidebar',
+  template: '<div #root></div>',
+})
+export class HelpSidebarComponent extends ReactWrapperBase {
+  @Input('location') location: Props['location'];
+
+  constructor() {
+    super(HelpSidebar, ['location']);
+  }
+}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
-import {k} from '@angular/core/src/render3';
 
 const sidebarContent = require('assets/json/help-sidebar.json')
 
@@ -14,7 +13,7 @@ const styles = reactStyles({
     top: 0,
     right: '-45px',
     height: '100%',
-    width: 'calc(14rem + 45px)',
+    width: 'calc(14rem + 85px)',
     overflow: 'hidden',
     color: colors.primary,
   },
@@ -25,7 +24,6 @@ const styles = reactStyles({
     height: '100%',
     width: '14rem',
     padding: '0.5rem',
-    overflow: 'auto',
     background: colorWithWhiteness(colors.primary, .87),
     transition: 'margin-right 0.5s ease-out'
   },
@@ -33,7 +31,6 @@ const styles = reactStyles({
     position: 'absolute',
     top: 0,
     right: 0,
-    textAlign: 'center',
     height: '100%',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),
@@ -41,8 +38,22 @@ const styles = reactStyles({
   },
   icon: {
     color: colors.white,
-    marginTop: '1.25rem',
-    cursor: 'pointer'
+    marginTop: '0.75rem',
+    padding: '0.25rem 0',
+    cursor: 'pointer',
+    textAlign: 'center',
+  },
+  closeIcon: {
+    cursor: 'pointer',
+    position: 'absolute',
+    margin: '-10px 0 0 -52px',
+    width: '40px',
+    borderBottomLeftRadius: '10px',
+    borderTopLeftRadius: '10px',
+    background: colorWithWhiteness(colors.primary, 0.4),
+    color: colors.white,
+    height: '40px',
+    textAlign: 'center',
   },
   sectionTitle: {
     marginTop: '0.5rem',
@@ -64,12 +75,17 @@ const styles = reactStyles({
 const contentStyles = {
   closed: {
     ...styles.content,
-    marginRight: '-14rem',
+    marginRight: 'calc(-14rem - 40px)',
   },
   open: {
     ...styles.content,
     marginRight: 0,
   },
+};
+
+const activeIconStyle = {
+  ...styles.icon,
+  background: colorWithWhiteness(colors.primary, 0.55)
 };
 
 interface Props {
@@ -92,12 +108,23 @@ export class HelpSidebar extends React.Component<Props, State> {
     console.log(sidebarContent);
   }
 
+  onIconClick = (icon: string) => {
+    let {activeIcon, sidebarOpen} = this.state;
+    sidebarOpen = icon === activeIcon ? !sidebarOpen : true;
+    activeIcon = sidebarOpen ? icon : undefined;
+    this.setState({activeIcon, sidebarOpen});
+  }
+
   render() {
     const {location} = this.props;
     const {activeIcon, sidebarOpen} = this.state;
     return <div style={styles.sidebar}>
       <div style={sidebarOpen ? contentStyles.open : contentStyles.closed}>
-        <h3 style={{...styles.sectionTitle, margin: 0}}>Help Tips</h3>
+        <div style={styles.closeIcon}
+             onClick={() => this.setState({activeIcon: undefined, sidebarOpen: false})}>
+          <ClrIcon shape='caret right' size={32} style={{marginTop: '3px'}}/>
+        </div>
+        <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
         {sidebarContent[location].map((section, s) => <div key={s}>
           <h3 style={styles.sectionTitle}>{section.title}</h3>
           {section.content.map((content, c) => {
@@ -110,13 +137,19 @@ export class HelpSidebar extends React.Component<Props, State> {
         </div>)}
       </div>
       <div style={styles.iconContainer}>
-        <ClrIcon className='is-solid' shape='info-standard' size={28} style={styles.icon}
-          onClick={() => this.setState({activeIcon: 'info', sidebarOpen: !sidebarOpen})} />
-        <ClrIcon className='is-solid' shape='book' size={32} style={styles.icon}
-          onClick={() => this.setState({activeIcon: 'book', sidebarOpen: !sidebarOpen})} />
+        <div style={activeIcon === 'help' ? activeIconStyle : styles.icon}>
+          <ClrIcon className='is-solid' shape='info-standard' size={28}
+            onClick={() => this.onIconClick('help')} />
+        </div>
+        <div style={activeIcon === 'book' ? activeIconStyle : styles.icon}>
+          <ClrIcon className='is-solid' shape='book' size={32}
+            onClick={() => this.onIconClick('book')} />
+        </div>
         {location === 'review' &&
-          <ClrIcon shape='note' size={32} style={styles.icon}
-            onClick={() => this.setState({activeIcon: 'annotations', sidebarOpen: !sidebarOpen})} />
+          <div style={activeIcon === 'annotations' ? activeIconStyle : styles.icon}>
+            <ClrIcon shape='note' size={32}
+              onClick={() => this.onIconClick('annotations')} />
+          </div>
         }
       </div>
     </div>;

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -7,6 +7,7 @@ import {SlidingFabReact} from 'app/components/buttons';
 import {WorkspaceCardBase} from 'app/components/card';
 import {FadeBox} from 'app/components/containers';
 import {Header} from 'app/components/headers';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox, TextInput} from 'app/components/inputs';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
@@ -467,94 +468,98 @@ export const ConceptHomepage = withCurrentWorkspace()(
         conceptsToAdd, currentSearchString, conceptsSavedText, selectedSurvey, surveyAddModalOpen,
         selectedSurveyQuestions} =
           this.state;
-      return <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
-        <Header style={{fontSize: '20px', marginTop: 0, fontWeight: 600}}>Search Concepts</Header>
-        <div style={{marginBottom: '6%', marginTop: '1.5%'}}>
-          <div style={{display: 'flex', alignItems: 'center'}}>
-            <ClrIcon shape='search' style={{position: 'absolute', height: '1rem', width: '1rem',
-              fill: colors.accent, left: 'calc(1rem + 4.5%)'}}/>
-            <TextInput style={styles.searchBar} data-test-id='concept-search-input'
-                       placeholder='Search concepts in domain'
-                       onKeyDown={e => {this.triggerSearch(e); }}/>
-            {currentSearchString !== '' && <Clickable onClick={() => this.clearSearch()}
-                                                      data-test-id='clear-search'>
-                <ClrIcon shape='times-circle' style={styles.clearSearchIcon}/>
-            </Clickable>}
-            <CheckBox checked={standardConceptsOnly}
-                      data-test-id='standardConceptsCheckBox'
-                      style={{marginLeft: '0.5rem', height: '16px', width: '16px'}}
-                      onChange={() => this.setState({
-                        standardConceptsOnly: !standardConceptsOnly
-                      })}/>
-            <label style={{marginLeft: '0.2rem'}}>
-              Standard concepts only
-            </label>
+      return <React.Fragment>
+        <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
+          <Header style={{fontSize: '20px', marginTop: 0, fontWeight: 600}}>Search Concepts</Header>
+          <div style={{marginBottom: '6%', marginTop: '1.5%'}}>
+            <div style={{display: 'flex', alignItems: 'center'}}>
+              <ClrIcon shape='search' style={{position: 'absolute', height: '1rem', width: '1rem',
+                fill: colors.accent, left: 'calc(1rem + 4.5%)'}}/>
+              <TextInput style={styles.searchBar} data-test-id='concept-search-input'
+                         placeholder='Search concepts in domain'
+                         onKeyDown={e => {this.triggerSearch(e); }}/>
+              {currentSearchString !== '' && <Clickable onClick={() => this.clearSearch()}
+                                                        data-test-id='clear-search'>
+                  <ClrIcon shape='times-circle' style={styles.clearSearchIcon}/>
+              </Clickable>}
+              <CheckBox checked={standardConceptsOnly}
+                        data-test-id='standardConceptsCheckBox'
+                        style={{marginLeft: '0.5rem', height: '16px', width: '16px'}}
+                        onChange={() => this.setState({
+                          standardConceptsOnly: !standardConceptsOnly
+                        })}/>
+              <label style={{marginLeft: '0.2rem'}}>
+                Standard concepts only
+              </label>
+            </div>
+            {showSearchError &&
+            <AlertDanger style={{width: '64.3%', marginLeft: '1%',
+              justifyContent: 'space-between'}}>
+                Minimum concept search length is three characters.
+                <AlertClose style={{width: 'unset'}}
+                            onClick={() => this.setState({showSearchError: false})}/>
+            </AlertDanger>}
+            <div style={{marginTop: '0.5rem'}}>{conceptsSavedText}</div>
           </div>
-          {showSearchError &&
-          <AlertDanger style={{width: '64.3%', marginLeft: '1%', justifyContent: 'space-between'}}>
-              Minimum concept search length is three characters.
-              <AlertClose style={{width: 'unset'}}
-                          onClick={() => this.setState({showSearchError: false})}/>
-          </AlertDanger>}
-          <div style={{marginTop: '0.5rem'}}>{conceptsSavedText}</div>
-        </div>
-        {browsingSurvey && <div><SurveyDetails surveyName={selectedSurvey}
-                                             surveySelected={(selectedQuestion) =>
-                                                 this.setState(
+          {browsingSurvey && <div><SurveyDetails surveyName={selectedSurvey}
+                                               surveySelected={(selectedQuestion) =>
+                                                   this.setState(
                                                      {selectedSurveyQuestions: selectedQuestion})}/>
-          <SlidingFabReact submitFunction={() => this.setState({surveyAddModalOpen: true})}
-                           iconShape='plus'
-                           tooltip={!this.state.workspacePermissions.canWrite}
-                           tooltipContent={<div>Requires Owner or Writer permission</div>}
-                           expanded={this.addSurveyToSetText}
-                           disable={selectedSurveyQuestions.length === 0}/>
-        </div>}
-        {!browsingSurvey && loadingDomains ? <SpinnerOverlay/> :
-          searching ?
-            this.renderConcepts() : !browsingSurvey &&
-                <div>
-                  <div style={styles.sectionHeader}>
-                    EHR Domain
-                  </div>
-                  <div style={styles.cardList}>
-                  {conceptDomainList.map((domain, i) => {
-                    return <DomainCard conceptDomainInfo={domain}
-                                         standardConceptsOnly={standardConceptsOnly}
-                                         browseInDomain={() => this.browseDomain(domain)}
-                                         key={i} data-test-id='domain-box'/>;
-                  })}
-                  </div>
-                  <div style={styles.sectionHeader}>
-                    Survey Questions
-                  </div>
-                  <div style={styles.cardList}>
-                    {conceptSurveysList.map((surveys) => {
-                      return <SurveyCard survey={surveys} key={surveys.orderNumber}
-                                         browseSurvey={() => {this.setState({
-                                           browsingSurvey: true,
-                                           selectedSurvey: surveys.name
-                                         }); }}/>;
+            <SlidingFabReact submitFunction={() => this.setState({surveyAddModalOpen: true})}
+                             iconShape='plus'
+                             tooltip={!this.state.workspacePermissions.canWrite}
+                             tooltipContent={<div>Requires Owner or Writer permission</div>}
+                             expanded={this.addSurveyToSetText}
+                             disable={selectedSurveyQuestions.length === 0}/>
+          </div>}
+          {!browsingSurvey && loadingDomains ? <SpinnerOverlay/> :
+            searching ?
+              this.renderConcepts() : !browsingSurvey &&
+                  <div>
+                    <div style={styles.sectionHeader}>
+                      EHR Domain
+                    </div>
+                    <div style={styles.cardList}>
+                    {conceptDomainList.map((domain, i) => {
+                      return <DomainCard conceptDomainInfo={domain}
+                                           standardConceptsOnly={standardConceptsOnly}
+                                           browseInDomain={() => this.browseDomain(domain)}
+                                           key={i} data-test-id='domain-box'/>;
                     })}
-                   </div>
-                </div>
-        }
-        {conceptAddModalOpen &&
-          <ConceptAddModal selectedDomain={selectedDomain}
-                           selectedConcepts={conceptsToAdd}
-                           onSave={(conceptSet) => this.afterConceptsSaved(conceptSet)}
-                           onClose={() => this.setState({conceptAddModalOpen: false})}/>}
-        {surveyAddModalOpen &&
-        <ConceptSurveyAddModal selectedSurvey={selectedSurveyQuestions}
-                               onClose={() => this.setState({surveyAddModalOpen: false})}
-                               onSave={() => this.setState({surveyAddModalOpen: false})}
-                               surveyName={selectedSurvey}/>}
-      </FadeBox>;
+                    </div>
+                    <div style={styles.sectionHeader}>
+                      Survey Questions
+                    </div>
+                    <div style={styles.cardList}>
+                      {conceptSurveysList.map((surveys) => {
+                        return <SurveyCard survey={surveys} key={surveys.orderNumber}
+                                           browseSurvey={() => {this.setState({
+                                             browsingSurvey: true,
+                                             selectedSurvey: surveys.name
+                                           }); }}/>;
+                      })}
+                     </div>
+                  </div>
+          }
+          {conceptAddModalOpen &&
+            <ConceptAddModal selectedDomain={selectedDomain}
+                             selectedConcepts={conceptsToAdd}
+                             onSave={(conceptSet) => this.afterConceptsSaved(conceptSet)}
+                             onClose={() => this.setState({conceptAddModalOpen: false})}/>}
+          {surveyAddModalOpen &&
+          <ConceptSurveyAddModal selectedSurvey={selectedSurveyQuestions}
+                                 onClose={() => this.setState({surveyAddModalOpen: false})}
+                                 onSave={() => this.setState({surveyAddModalOpen: false})}
+                                 surveyName={selectedSurvey}/>}
+        </FadeBox>
+        <HelpSidebar location='conceptSets' />
+      </React.Fragment>;
     }
   }
 );
 
 @Component({
-  template: '<div #root></div>'
+  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
 })
 export class ConceptHomepageComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -8,6 +8,7 @@ import {SlidingFabReact} from 'app/components/buttons';
 import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {FadeBox} from 'app/components/containers';
 import {CopyModal} from 'app/components/copy-modal';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon, SnowmanIcon} from 'app/components/icons';
 import {TextArea, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalFooter, ModalTitle} from 'app/components/modals';
@@ -247,93 +248,95 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
         presence: {allowEmpty: false}
       }});
 
-      return <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
-        {loading ? <SpinnerOverlay/> :
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-          <div style={styles.conceptSetHeader}>
-            <div style={{display: 'flex', flexDirection: 'row'}}>
-              <ConceptSetMenu canDelete={workspace.accessLevel === WorkspaceAccessLevel.OWNER}
-                              canEdit={WorkspacePermissionsUtil.canWrite(workspace.accessLevel)}
-                              onDelete={() => this.setState({deleting: true})}
-                              onEdit={() => this.setState({editing: true})}
-                              onCopy={() => this.setState({copying: true})}/>
-              <div style={styles.conceptSetMetadataWrapper}>
-              {editing ?
-                <div style={{display: 'flex', flexDirection: 'column'}}>
-                  <TextInput value={editName} disabled={editSaving}
-                             id='edit-name'
-                             style={{marginBottom: '0.5rem'}} data-test-id='edit-name'
-                             onChange={v => this.setState({editName: v})}/>
-                  {errors && <ValidationError>
-                    {summarizeErrors( errors && errors.editName)}
-                  </ValidationError>}
-                  <TextArea value={editDescription} disabled={editSaving}
-                            style={{marginBottom: '0.5rem'}} data-test-id='edit-description'
-                            onChange={v => this.setState({editDescription: v})}/>
-                  <div style={{marginBottom: '0.5rem'}}>
-                    <Button type='primary' style={{marginRight: '0.5rem'}}
-                            data-test-id='save-edit-concept-set'
-                            disabled={editSaving || errors}
-                            onClick={() => this.submitEdits()}>Save</Button>
-                    <Button type='secondary' disabled={editSaving}
-                            data-test-id='cancel-edit-concept-set'
-                            onClick={() => this.setState({
-                              editing: false,
-                              editName: conceptSet.name,
-                              editDescription: conceptSet.description
-                            })}>Cancel</Button>
+      return <React.Fragment>
+        <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
+          {loading ? <SpinnerOverlay/> :
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={styles.conceptSetHeader}>
+              <div style={{display: 'flex', flexDirection: 'row'}}>
+                <ConceptSetMenu canDelete={workspace.accessLevel === WorkspaceAccessLevel.OWNER}
+                                canEdit={WorkspacePermissionsUtil.canWrite(workspace.accessLevel)}
+                                onDelete={() => this.setState({deleting: true})}
+                                onEdit={() => this.setState({editing: true})}
+                                onCopy={() => this.setState({copying: true})}/>
+                <div style={styles.conceptSetMetadataWrapper}>
+                {editing ?
+                  <div style={{display: 'flex', flexDirection: 'column'}}>
+                    <TextInput value={editName} disabled={editSaving}
+                               id='edit-name'
+                               style={{marginBottom: '0.5rem'}} data-test-id='edit-name'
+                               onChange={v => this.setState({editName: v})}/>
+                    {errors && <ValidationError>
+                      {summarizeErrors( errors && errors.editName)}
+                    </ValidationError>}
+                    <TextArea value={editDescription} disabled={editSaving}
+                              style={{marginBottom: '0.5rem'}} data-test-id='edit-description'
+                              onChange={v => this.setState({editDescription: v})}/>
+                    <div style={{marginBottom: '0.5rem'}}>
+                      <Button type='primary' style={{marginRight: '0.5rem'}}
+                              data-test-id='save-edit-concept-set'
+                              disabled={editSaving || errors}
+                              onClick={() => this.submitEdits()}>Save</Button>
+                      <Button type='secondary' disabled={editSaving}
+                              data-test-id='cancel-edit-concept-set'
+                              onClick={() => this.setState({
+                                editing: false,
+                                editName: conceptSet.name,
+                                editDescription: conceptSet.description
+                              })}>Cancel</Button>
+                    </div>
+                  </div> :
+                  <React.Fragment>
+                    <div style={styles.conceptSetTitle} data-test-id='concept-set-title'>
+                      {conceptSet.name}
+                      <Clickable disabled={!WorkspacePermissionsUtil
+                                  .canWrite(workspace.accessLevel)}
+                                 data-test-id='edit-concept-set'
+                                 onClick={() => this.setState({editing: true})}>
+                        <EditComponentReact enableHoverEffect={true}
+                                            disabled={
+                                              !WorkspacePermissionsUtil.canWrite(
+                                                workspace.accessLevel
+                                              )
+                                            }
+                                            style={{marginTop: '0.1rem'}}/>
+                      </Clickable>
+                    </div>
+                    <div style={{marginBottom: '1.5rem', color: colors.primary}}
+                         data-test-id='concept-set-description'>
+                      {conceptSet.description}</div>
+                  </React.Fragment>}
+                  <div style={styles.conceptSetData}>
+                      <div data-test-id='participant-count'>
+                        Participant Count: {conceptSet.participantCount}</div>
+                      <div style={{marginLeft: '2rem'}} data-test-id='concept-set-domain'>
+                          Domain: {fp.capitalize(conceptSet.domain.toString())}</div>
                   </div>
-                </div> :
-                <React.Fragment>
-                  <div style={styles.conceptSetTitle} data-test-id='concept-set-title'>
-                    {conceptSet.name}
-                    <Clickable disabled={!WorkspacePermissionsUtil.canWrite(workspace.accessLevel)}
-                               data-test-id='edit-concept-set'
-                               onClick={() => this.setState({editing: true})}>
-                      <EditComponentReact enableHoverEffect={true}
-                                          disabled={
-                                            !WorkspacePermissionsUtil.canWrite(
-                                              workspace.accessLevel
-                                            )
-                                          }
-                                          style={{marginTop: '0.1rem'}}/>
-                    </Clickable>
-                  </div>
-                  <div style={{marginBottom: '1.5rem', color: colors.primary}}
-                       data-test-id='concept-set-description'>
-                    {conceptSet.description}</div>
-                </React.Fragment>}
-                <div style={styles.conceptSetData}>
-                    <div data-test-id='participant-count'>
-                      Participant Count: {conceptSet.participantCount}</div>
-                    <div style={{marginLeft: '2rem'}} data-test-id='concept-set-domain'>
-                        Domain: {fp.capitalize(conceptSet.domain.toString())}</div>
                 </div>
               </div>
+              <div style={{display: 'flex', flexDirection: 'column'}}>
+                <Button type='secondaryLight' style={styles.buttonBoxes}
+                        onClick={() => this.addToConceptSet()}>
+                  <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
+                </Button>
+              </div>
             </div>
-            <div style={{display: 'flex', flexDirection: 'column'}}>
-              <Button type='secondaryLight' style={styles.buttonBoxes}
-                      onClick={() => this.addToConceptSet()}>
-                <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
-              </Button>
-            </div>
-          </div>
-          {!!conceptSet.concepts ?
-          <ConceptTable concepts={conceptSet.concepts} loading={loading}
-                        reactKey={conceptSet.domain.toString()}
-                        onSelectConcepts={this.onSelectConcepts.bind(this)}
-                        placeholderValue={'No Concepts Found'}
-                        selectedConcepts={selectedConcepts} nextPage={(page) => {}}/> :
-          <Button type='secondaryLight' data-test-id='add-concepts'
-                  style={{...styles.buttonBoxes, marginLeft: '0.5rem', maxWidth: '22%'}}
-                  onClick={() => navigateByUrl('workspaces/' + ns + '/' +
-                    wsid + '/data/concepts' + conceptSet.survey ? ('?survey=' + conceptSet.survey) :
-                      ('?domain=' + conceptSet.domain))}>
-            <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
-          </Button>}
-          {WorkspacePermissionsUtil.canWrite(workspace.accessLevel) &&
-              this.selectedConceptsCount > 0 &&
-              <SlidingFabReact submitFunction={() => this.setState({removingConcepts: true})}
+            {!!conceptSet.concepts ?
+            <ConceptTable concepts={conceptSet.concepts} loading={loading}
+                          reactKey={conceptSet.domain.toString()}
+                          onSelectConcepts={this.onSelectConcepts.bind(this)}
+                          placeholderValue={'No Concepts Found'}
+                          selectedConcepts={selectedConcepts} nextPage={(page) => {}}/> :
+            <Button type='secondaryLight' data-test-id='add-concepts'
+                    style={{...styles.buttonBoxes, marginLeft: '0.5rem', maxWidth: '22%'}}
+                    onClick={() => navigateByUrl('workspaces/' + ns + '/' +
+                      wsid + '/data/concepts' + conceptSet.survey ?
+                        ('?survey=' + conceptSet.survey) : ('?domain=' + conceptSet.domain))}>
+              <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
+            </Button>}
+            {WorkspacePermissionsUtil.canWrite(workspace.accessLevel) &&
+                this.selectedConceptsCount > 0 &&
+                <SlidingFabReact submitFunction={() => this.setState({removingConcepts: true})}
                                iconShape='trash' expanded='Remove from set'
                                tooltip={this.conceptSetConceptsCount === this.selectedConceptsCount}
                                tooltipContent={
@@ -341,48 +344,50 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                                disable={!WorkspacePermissionsUtil.canWrite(workspace.accessLevel) ||
                                  this.selectedConceptsCount === 0 ||
                                this.conceptSetConceptsCount === this.selectedConceptsCount}/>}
-        </div>}
-        {!loading && deleting &&
-        <ConfirmDeleteModal closeFunction={() => this.setState({deleting: false})}
-                            receiveDelete={() => this.onDeleteConceptSet()}
-                            resourceName={conceptSet.name}
-                            resourceType={ResourceType.CONCEPT_SET}/>}
-        {error && <Modal>
-            <ModalTitle>Error: {errorMessage}</ModalTitle>
+          </div>}
+          {!loading && deleting &&
+          <ConfirmDeleteModal closeFunction={() => this.setState({deleting: false})}
+                              receiveDelete={() => this.onDeleteConceptSet()}
+                              resourceName={conceptSet.name}
+                              resourceType={ResourceType.CONCEPT_SET}/>}
+          {error && <Modal>
+              <ModalTitle>Error: {errorMessage}</ModalTitle>
+              <ModalFooter>
+                  <Button type='secondary'
+                          onClick={() =>
+                            this.setState({error: false})}>Close</Button>
+              </ModalFooter>
+          </Modal>}
+          {removingConcepts && <Modal>
+            <ModalTitle>Are you sure you want to remove {this.selectedConceptsCount}
+            {this.selectedConceptsCount > 1 ? ' concepts' : ' concept'} from this set?</ModalTitle>
             <ModalFooter>
-                <Button type='secondary'
-                        onClick={() =>
-                          this.setState({error: false})}>Close</Button>
+                <Button type='secondary' style={{marginRight: '0.5rem'}} disabled={removeSubmitting}
+                        onClick={() => this.setState({removingConcepts: false})}>
+                    Cancel</Button>
+                <Button type='primary' onClick={() => this.onRemoveConcepts()}
+                        disabled={removeSubmitting} data-test-id='confirm-remove-concept'>
+                    Remove concepts</Button>
             </ModalFooter>
-        </Modal>}
-        {removingConcepts && <Modal>
-          <ModalTitle>Are you sure you want to remove {this.selectedConceptsCount}
-          {this.selectedConceptsCount > 1 ? ' concepts' : ' concept'} from this set?</ModalTitle>
-          <ModalFooter>
-              <Button type='secondary' style={{marginRight: '0.5rem'}} disabled={removeSubmitting}
-                      onClick={() => this.setState({removingConcepts: false})}>
-                  Cancel</Button>
-              <Button type='primary' onClick={() => this.onRemoveConcepts()}
-                      disabled={removeSubmitting} data-test-id='confirm-remove-concept'>
-                  Remove concepts</Button>
-          </ModalFooter>
-        </Modal>}
-        {copying && <CopyModal
-          fromWorkspaceNamespace={workspace.namespace}
-          fromWorkspaceName={workspace.id}
-          fromResourceName={conceptSet.name}
-          resourceType={ResourceType.CONCEPT_SET}
-          onClose={() => this.setState({copying: false})}
-          onCopy={() => this.onCopy()}
-          saveFunction={(copyRequest: CopyRequest) => this.copyConceptSet(copyRequest)}/>
-        }
-      </FadeBox>;
+          </Modal>}
+          {copying && <CopyModal
+            fromWorkspaceNamespace={workspace.namespace}
+            fromWorkspaceName={workspace.id}
+            fromResourceName={conceptSet.name}
+            resourceType={ResourceType.CONCEPT_SET}
+            onClose={() => this.setState({copying: false})}
+            onCopy={() => this.onCopy()}
+            saveFunction={(copyRequest: CopyRequest) => this.copyConceptSet(copyRequest)}/>
+          }
+        </FadeBox>
+        <HelpSidebar location='conceptSets' />
+      </React.Fragment>;
     }
   });
 
 
 @Component({
-  template: '<div #root></div>'
+  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
 })
 export class ConceptSetDetailsComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/data-page.tsx
+++ b/ui/src/app/pages/data/data-page.tsx
@@ -287,12 +287,11 @@ export const DataPage = withCurrentWorkspace()(class extends React.Component<
         }}>
         </div>
         <div style={{
-          marginBottom: '1rem',
           display: 'flex',
           flexWrap: 'wrap',
           position: 'relative',
           minHeight: 247,
-          padding: '0 0.5rem'
+          padding: '0 0.5rem 1rem'
         }}>
           {filteredList.map((resource: RecentResource, index: number) => {
             return <div key={index}> {this.createResourceCard(resource)} </div>;

--- a/ui/src/app/pages/data/data-page.tsx
+++ b/ui/src/app/pages/data/data-page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {CardButton, TabButton} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {ResourceCard} from 'app/components/resource-card';
@@ -300,12 +301,13 @@ export const DataPage = withCurrentWorkspace()(class extends React.Component<
           {isLoading && <SpinnerOverlay></SpinnerOverlay>}
         </div>
       </FadeBox>
+      <HelpSidebar location='data' />
     </React.Fragment>;
   }
 });
 
 @Component({
-  template: '<div #root></div>'
+  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
 })
 export class DataPageComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {Button, Clickable} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
+import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
@@ -158,7 +159,7 @@ export const styles = reactStyles({
     backgroundColor: colors.white,
     borderTop: `1px solid ${colors.light}`,
     textAlign: 'right',
-    padding: '3px 10px 50px 20px',
+    padding: '3px 55px 50px 20px',
     position: 'fixed',
     left: '0',
     bottom: '0',
@@ -640,7 +641,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         valueSets
       } = this.state;
       return <React.Fragment>
-        <FadeBox style={{marginTop: '1rem'}}>
+        <FadeBox style={{paddingTop: '1rem'}}>
           <h2 style={{paddingTop: 0, marginTop: 0}}>Data Sets{this.editing &&
             dataSet !== undefined && ' - ' + dataSet.name}</h2>
           <div style={{color: colors.primary, fontSize: '14px'}}>Build a data set by selecting the
@@ -859,6 +860,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
             </Button>
           </ModalFooter>
         </Modal>}
+        <HelpSidebar location='datasetBuilder' />
       </React.Fragment>;
     }
   });
@@ -869,7 +871,7 @@ export {
 };
 
 @Component({
-  template: '<div #root></div>'
+  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
 })
 export class DataSetPageComponent extends ReactWrapperBase {
   constructor() {


### PR DESCRIPTION
Created `help-sidebar` component, designed to match this [Invision screen](https://projects.invisionapp.com/share/ZURSZVNW4RE#/screens/356269832). Used in the following pages/components:
- Data homepage
- Data Set page
- Cohort Builder
- Cohort Review Participants page
- Cohort Review Participant Detail page
- Concept homepage
- Concept Set Details page
<img width="1667" alt="Screen Shot 2019-09-06 at 11 08 13 AM" src="https://user-images.githubusercontent.com/40036095/64443034-abf2d200-d096-11e9-8de7-c0b3b5280545.png">

Also moved `sidebar-content` component from `detail-page` in cohort review to new `help-sidebar` component.
