### PR TITLE
[RW-1960][risk=no] Enforce CSP on non-index.html resources

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -12,7 +12,7 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
-    Content-Security-Policy-Report-Only: "default-src 'none'; report-uri /content-security-report"
+    Content-Security-Policy: "default-src 'none'; report-uri /content-security-report"
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html


### PR DESCRIPTION
We haven't gotten any reports on this policy, and this is the original cause of the security ticket. Wrapping up this ticket here and filing another story to finish the primary policy.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
