### PR TITLE
RW-3417 [risk=no] workspace library changes

### DIFF
--- a/api/config/featured_workspaces_test.json
+++ b/api/config/featured_workspaces_test.json
@@ -1,3 +1,9 @@
 {
-  "featuredWorkspaces": []
+  "featuredWorkspaces": [
+    {
+      "name": "wharrgarbl",
+      "namespace": "aou-rw-test-ebb1d76d",
+      "id": "wharrgarbl"
+    }
+  ]
 }

--- a/ui/src/app/pages/workspace/workspace-library.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.spec.tsx
@@ -8,7 +8,7 @@ import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {FeaturedWorkspacesConfigApiStub} from 'testing/stubs/featured-workspaces-config-api-stub';
 import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
-import {WorkspacesApiStub, workspaceStubs} from 'testing/stubs/workspaces-api-stub';
+import {WorkspacesApiStub, buildWorkspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {WorkspaceLibrary} from './workspace-library';
 
 // Mock the navigate function but not userProfileStore
@@ -19,12 +19,15 @@ jest.mock('app/utils/navigation', () => ({
 
 describe('WorkspaceLibrary', () => {
   const profile = ProfileStubVariables.PROFILE_STUB as unknown as Profile;
+  const suffixes = ["", "_1"];
   let profileApi: ProfileApiStub;
   const reload = jest.fn();
   const updateCache = jest.fn();
 
   const component = () => {
-    return mount(<WorkspaceLibrary/>);
+    return mount(<WorkspaceLibrary
+      enablePublishedWorkspaces={true}
+    />);
   };
 
   beforeEach(() => {
@@ -47,13 +50,16 @@ describe('WorkspaceLibrary', () => {
   });
 
   it('should display featured workspaces', async () => {
-    const publishedWorkspaceStubs = workspaceStubs.map(w => ({...w, published: true}));
+    const publishedWorkspaceStubs = buildWorkspaceStubs(suffixes).map(w => ({
+      ...w,
+      published: true
+    }));
     registerApiClient(WorkspacesApi, new WorkspacesApiStub(publishedWorkspaceStubs));
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     const cardNameList = wrapper.find('[data-test-id="workspace-card-name"]')
       .map(c => c.text());
-    expect(cardNameList).toEqual(workspaceStubs.map(w => w.name));
+    expect(cardNameList).toEqual([publishedWorkspaceStubs[0].name]);
   });
 
   it('should not display unpublished workspaces', async () => {
@@ -65,7 +71,10 @@ describe('WorkspaceLibrary', () => {
   });
 
   it('should display published workspaces', async () => {
-    const publishedWorkspaceStubs = workspaceStubs.map(w => ({...w, published: true}));
+    const publishedWorkspaceStubs = buildWorkspaceStubs(suffixes).map(w => ({
+      ...w,
+      published: true,
+    }));
     registerApiClient(WorkspacesApi, new WorkspacesApiStub(publishedWorkspaceStubs));
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -73,7 +82,7 @@ describe('WorkspaceLibrary', () => {
     await waitOneTickAndUpdate(wrapper);
     const cardNameList = wrapper.find('[data-test-id="workspace-card-name"]')
       .map(c => c.text());
-    expect(cardNameList).toEqual(workspaceStubs.map(w => w.name));
+    expect(cardNameList).toEqual([publishedWorkspaceStubs[1].name]);
   });
 
 });

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -112,23 +112,24 @@ export const WorkspaceLibrary = withUserProfile()
     ];
 
   async componentDidMount() {
-    this.updateListedWorkspaces();
+    this.updateWorkspaces();
   }
 
   componentDidUpdate(prevProps, prevState) {
     // Reload libraries when switching tabs
     if (this.state.currentTab !== prevState.currentTab) {
-      this.updateListedWorkspaces();
+      this.updateWorkspaces();
     }
   }
 
-  async updateListedWorkspaces() {
-    const workspaceListLoaded = await this.loadWorkspaceList();
-    const featuredWorkspacesLoaded = await this.loadFeaturedWorkspaces(workspaceListLoaded);
-    this.updatePublishedWorkspaces(featuredWorkspacesLoaded);
+  async updateWorkspaces() {
+    const workspaceListLoaded = await this.getAllPublishedWorkspaces();
+    const featuredWorkspacesLoaded = await this.getFeaturedWorkspaces(workspaceListLoaded);
+    this.filterPublishedWorkspaces(featuredWorkspacesLoaded);
   }
 
-  async loadWorkspaceList() {
+  // Gets all published workspaces, including those configured as 'featured'
+  async getAllPublishedWorkspaces() {
     try {
       const workspacesReceived = await workspacesApi().getPublishedWorkspaces();
       workspacesReceived.items.sort(
@@ -144,8 +145,9 @@ export const WorkspaceLibrary = withUserProfile()
     }
   }
 
-
-  async loadFeaturedWorkspaces(workspaceListLoadedPromise) {
+  // Gets the 'featured workspaces' config and filters the list of published workspaces to
+  // find the 'featured' ones
+  async getFeaturedWorkspaces(workspaceListLoadedPromise) {
     try {
       const resp = await featuredWorkspacesConfigApi().getFeaturedWorkspacesConfig();
       const idToNamespace = new Map();
@@ -162,7 +164,8 @@ export const WorkspaceLibrary = withUserProfile()
     }
   }
 
-  updatePublishedWorkspaces(featuredWorkspacesLoadedPromise) {
+  // Filter the list of published workspaces to find the ones that are not configured as 'featured'
+  filterPublishedWorkspaces(featuredWorkspacesLoadedPromise) {
     const publishedWorkspaces = this.state.workspaceList.filter(ws =>
       !fp.contains(ws, this.state.featuredWorkspaces)
     );
@@ -219,7 +222,7 @@ export const WorkspaceLibrary = withUserProfile()
                   return <WorkspaceCard key={wp.workspace.name}
                                         wp={wp}
                                         userEmail={username}
-                                        reload={() => this.updateListedWorkspaces()}/>;
+                                        reload={() => this.updateWorkspaces()}/>;
                 })}
               </div>)}
           </div>}
@@ -233,7 +236,7 @@ export const WorkspaceLibrary = withUserProfile()
                     return <WorkspaceCard key={wp.workspace.name}
                                           wp={wp}
                                           userEmail={username}
-                                          reload={() => this.updateListedWorkspaces()}/>;
+                                          reload={() => this.updateWorkspaces()}/>;
                   })}
               </div>)}
           </div>}

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -102,6 +102,11 @@ export const WorkspaceLibrary = withUserProfile()
     };
   }
 
+  // Defaulting to the environment variable value here, but allowing it to be overridden by props.
+  // This is to make our testing easier. We don't use environment variable injection anywhere in
+  // our unit testing framework, so we have to pass it in via props. We also don't create this
+  // component in any way except for legacy Angular magic, so we have to get this information via
+  // environment variable.
   libraryTabs = (this.props.enablePublishedWorkspaces || environment.enablePublishedWorkspaces)
     ? [
       libraryTabEnums.FEATURED_WORKSPACES,

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -13,8 +13,8 @@ import {featuredWorkspacesConfigApi, workspacesApi} from 'app/services/swagger-f
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {WorkspacePermissions} from 'app/utils/workspace-permissions';
+import {environment} from 'environments/environment';
 import {ErrorResponse, Profile} from 'generated/fetch';
-import {environment} from "environments/environment";
 
 const styles = reactStyles({
   navPanel: {
@@ -168,7 +168,7 @@ export const WorkspaceLibrary = withUserProfile()
     );
     this.setState({
       publishedWorkspaces: publishedWorkspaces
-    })
+    });
   }
 
   render() {

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -128,9 +128,9 @@ export const WorkspaceLibrary = withUserProfile()
   }
 
   async updateWorkspaces() {
-    const workspaceListLoaded = await this.getAllPublishedWorkspaces();
-    const featuredWorkspacesLoaded = await this.getFeaturedWorkspaces(workspaceListLoaded);
-    this.filterPublishedWorkspaces(featuredWorkspacesLoaded);
+    await this.getAllPublishedWorkspaces();
+    await this.getFeaturedWorkspaces();
+    this.filterPublishedWorkspaces();
   }
 
   // Gets all published workspaces, including those configured as 'featured'
@@ -152,7 +152,7 @@ export const WorkspaceLibrary = withUserProfile()
 
   // Gets the 'featured workspaces' config and filters the list of published workspaces to
   // find the 'featured' ones
-  async getFeaturedWorkspaces(workspaceListLoadedPromise) {
+  async getFeaturedWorkspaces() {
     try {
       const resp = await featuredWorkspacesConfigApi().getFeaturedWorkspacesConfig();
       const idToNamespace = new Map();
@@ -170,7 +170,7 @@ export const WorkspaceLibrary = withUserProfile()
   }
 
   // Filter the list of published workspaces to find the ones that are not configured as 'featured'
-  filterPublishedWorkspaces(featuredWorkspacesLoadedPromise) {
+  filterPublishedWorkspaces() {
     const publishedWorkspaces = this.state.workspaceList.filter(ws =>
       !fp.contains(ws, this.state.featuredWorkspaces)
     );

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -53,15 +53,6 @@ const libraryTabEnums = {
   }
 };
 
-const libraryTabs = environment.enablePublishedWorkspaces
-  ? [
-  libraryTabEnums.FEATURED_WORKSPACES,
-  libraryTabEnums.PUBLISHED_WORKSPACES
-  ]
-  : [
-    libraryTabEnums.FEATURED_WORKSPACES
-  ];
-
 const LibraryTab: React.FunctionComponent<{
   title: string, icon: string, onClick: Function, selected: boolean}> =
   ({title, icon, onClick, selected}) => {
@@ -85,6 +76,7 @@ class CurrentTab {
 
 class Props {
   profileState: ProfileState;
+  enablePublishedWorkspaces: boolean;
 }
 
 class State {
@@ -109,6 +101,15 @@ export const WorkspaceLibrary = withUserProfile()
       workspacesLoading: true
     };
   }
+
+  libraryTabs = (this.props.enablePublishedWorkspaces || environment.enablePublishedWorkspaces)
+    ? [
+      libraryTabEnums.FEATURED_WORKSPACES,
+      libraryTabEnums.PUBLISHED_WORKSPACES
+    ]
+    : [
+      libraryTabEnums.FEATURED_WORKSPACES
+    ];
 
   async componentDidMount() {
     this.updateListedWorkspaces();
@@ -183,12 +184,12 @@ export const WorkspaceLibrary = withUserProfile()
     return <div style={{display: 'flex', flexDirection: 'row', height: '100%'}}>
       <div style={styles.navPanel}>
         <div style={{display: 'flex', flexDirection: 'column'}}>
-          {libraryTabs.map((tab, i) => {
+          {this.libraryTabs.map((tab, i) => {
             return <React.Fragment key={i}>
               <LibraryTab icon={tab.icon} title={tab.title} selected={currentTab === tab}
                           onClick={() => this.setState({currentTab: tab})}
                           data-test-id={tab.title}/>
-                {i !== libraryTabs.length - 1 &&
+                {i !== this.libraryTabs.length - 1 &&
                 <hr style={{width: '100%', margin: '0.5rem 0'}}/>}
             </React.Fragment>;
           })}

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -64,18 +64,18 @@ const LibraryTab: React.FunctionComponent<{
     </Clickable>;
   };
 
-class ProfileState {
+interface ReloadableProfile {
   profile: Profile;
   reload: Function;
 }
 
-class CurrentTab {
+interface CurrentTab {
   title: string;
   icon: string;
 }
 
 class Props {
-  profileState: ProfileState;
+  profileState: ReloadableProfile;
   enablePublishedWorkspaces: boolean;
 }
 
@@ -178,7 +178,6 @@ export const WorkspaceLibrary = withUserProfile()
       errorText,
       featuredWorkspaces,
       publishedWorkspaces,
-      workspaceList,
       workspacesLoading
     } = this.state;
     return <div style={{display: 'flex', flexDirection: 'row', height: '100%'}}>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -24,7 +24,7 @@ import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-s
 import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 import {UserServiceStub} from 'testing/stubs/user-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
-import {WorkspacesApiStub, workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
+import {WorkspacesApiStub, buildWorkspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
 
 import {findElements} from 'testing/react-testing-utility';
 import {setupModals, updateAndTick} from 'testing/test-helpers';
@@ -36,7 +36,7 @@ import {setupModals, updateAndTick} from 'testing/test-helpers';
 class FakeAppComponent {}
 
 const workspace = {
-  ...workspaceStubs[0],
+  ...buildWorkspaceStubs[0],
   accessLevel: FetchWorkspaceAccessLevel.OWNER,
 };
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -24,7 +24,7 @@ import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-s
 import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 import {UserServiceStub} from 'testing/stubs/user-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
-import {WorkspacesApiStub, buildWorkspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
+import {WorkspacesApiStub, workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
 
 import {findElements} from 'testing/react-testing-utility';
 import {setupModals, updateAndTick} from 'testing/test-helpers';
@@ -36,7 +36,7 @@ import {setupModals, updateAndTick} from 'testing/test-helpers';
 class FakeAppComponent {}
 
 const workspace = {
-  ...buildWorkspaceStubs[0],
+  ...workspaceStubs[0],
   accessLevel: FetchWorkspaceAccessLevel.OWNER,
 };
 

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -49,4 +49,7 @@ export interface Environment {
   // See RW-3275
   // Exit criteria: once the epic is completed and fully reviewed
   enableHomepageRestyle: boolean;
+  // Whether users should be able to see the Published Workspaces
+  // tab in the Workspace Library.
+  enablePublishedWorkspaces: boolean;
 }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -16,5 +16,6 @@ export const environment: Environment = {
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true
+  enableHomepageRestyle: true,
+  enablePublishedWorkspaces: true,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -16,5 +16,6 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-perf.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: false
+  enableHomepageRestyle: false,
+  enablePublishedWorkspaces: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -19,5 +19,7 @@ export const environment: Environment = {
   //
   // See environment-type.ts for more details on transient flags, including
   // exit criteria and Jira ticket links.
-  enableHomepageRestyle: false
+  enableHomepageRestyle: false,
+  enablePublishedWorkspaces: false,
+
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -15,5 +15,6 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: false
+  enableHomepageRestyle: false,
+  enablePublishedWorkspaces: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -15,5 +15,6 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: false
+  enableHomepageRestyle: false,
+  enablePublishedWorkspaces: false,
 };

--- a/ui/src/environments/environment.test.ts
+++ b/ui/src/environments/environment.test.ts
@@ -4,5 +4,6 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 export const environment: Environment = {
   ...testEnvironmentBase,
   displayTag: 'Test',
-  debug: false
+  debug: false,
+  enablePublishedWorkspaces: true,
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -4,5 +4,6 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 export const environment: Environment = {
   ...testEnvironmentBase,
   displayTag: 'Local->Test',
-  debug: true
+  debug: true,
+  enablePublishedWorkspaces: false,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -12,6 +12,7 @@ export const testEnvironmentBase = {
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   shouldShowDisplayTag: true,
+  enablePublishedWorkspaces: false,
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   enableHomepageRestyle: true

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -12,7 +12,7 @@ export const testEnvironmentBase = {
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   shouldShowDisplayTag: true,
-  enablePublishedWorkspaces: false,
+  enablePublishedWorkspaces: true,
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   enableHomepageRestyle: true

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -94,7 +94,7 @@ export class WorkspacesApiStub extends WorkspacesApi {
 
   constructor(workspaces?: Workspace[], workspaceUserRoles?: UserRole[]) {
     super(undefined, undefined, (..._: any[]) => { throw Error('cannot fetch in tests'); });
-    this.workspaces = fp.defaultTo(buildWorkspaceStubs([""]), workspaces);
+    this.workspaces = fp.defaultTo(workspaceStubs, workspaces);
     this.workspaceAccess = new Map<string, WorkspaceAccessLevel>();
     this.notebookList = WorkspacesApiStub.stubNotebookList();
     this.workspaceUserRoles = new Map<string, UserRole[]>();

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -58,7 +58,7 @@ export function buildWorkspaceStubs(suffixes: string[]) {
 }
 
 
-export const workspaceStubs = buildWorkspaceStubs([""]);
+export const workspaceStubs = buildWorkspaceStubs(['']);
 
 export const userRolesStub = [
   {

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -82,7 +82,7 @@ export const userRolesStub = [
 ];
 
 export const workspaceDataStub = {
-  ...buildWorkspaceStubs[0],
+  ...workspaceStubs[0],
   accessLevel: WorkspaceAccessLevel.OWNER,
 };
 

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -21,12 +21,12 @@ export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_PERMISSION = WorkspaceAccessLevel.OWNER;
 }
 
-export const workspaceStubs = [
-  {
-    name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
-    id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
-    namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+function buildWorkspaceStub(suffix) {
+  return {
+    name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME + suffix,
+    id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + suffix,
+    namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS + suffix,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID + suffix,
     creationTime: new Date().getTime(),
     lastModifiedTime: new Date().getTime(),
     researchPurpose: {
@@ -50,8 +50,12 @@ export const workspaceStubs = [
     },
     published: false,
     dataAccessLevel: DataAccessLevel.Registered
-  }
-];
+  };
+}
+
+export function buildWorkspaceStubs(suffixes: string[]) {
+  return suffixes.map(suffix => buildWorkspaceStub(suffix));
+}
 
 export const userRolesStub = [
   {
@@ -75,7 +79,7 @@ export const userRolesStub = [
 ];
 
 export const workspaceDataStub = {
-  ...workspaceStubs[0],
+  ...buildWorkspaceStubs[0],
   accessLevel: WorkspaceAccessLevel.OWNER,
 };
 
@@ -87,7 +91,7 @@ export class WorkspacesApiStub extends WorkspacesApi {
 
   constructor(workspaces?: Workspace[], workspaceUserRoles?: UserRole[]) {
     super(undefined, undefined, (..._: any[]) => { throw Error('cannot fetch in tests'); });
-    this.workspaces = fp.defaultTo(workspaceStubs, workspaces);
+    this.workspaces = fp.defaultTo(buildWorkspaceStubs([""]), workspaces);
     this.workspaceAccess = new Map<string, WorkspaceAccessLevel>();
     this.notebookList = WorkspacesApiStub.stubNotebookList();
     this.workspaceUserRoles = new Map<string, UserRole[]>();

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -21,7 +21,7 @@ export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_PERMISSION = WorkspaceAccessLevel.OWNER;
 }
 
-function buildWorkspaceStub(suffix) {
+function buildWorkspaceStub(suffix): Workspace {
   return {
     name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME + suffix,
     id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + suffix,
@@ -53,7 +53,7 @@ function buildWorkspaceStub(suffix) {
   };
 }
 
-export function buildWorkspaceStubs(suffixes: string[]) {
+export function buildWorkspaceStubs(suffixes: string[]): Workspace[] {
   return suffixes.map(suffix => buildWorkspaceStub(suffix));
 }
 

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -57,6 +57,9 @@ export function buildWorkspaceStubs(suffixes: string[]) {
   return suffixes.map(suffix => buildWorkspaceStub(suffix));
 }
 
+
+export const workspaceStubs = buildWorkspaceStubs([""]);
+
 export const userRolesStub = [
   {
     email: 'sampleuser1@fake-research-aou.org',


### PR DESCRIPTION
- Split out `workspaceList` into distinct lists of `publishedWorkspaces` and `featuredWorkspaces`.
- Hide the `Published Workspaces` tab behind a feature flag.
- Take `WorkspaceLibrary` props and state definitions out of the type parameter...