### PR TITLE
[RW-3418][risk=no] Cleanup additional 1ppw leftover comment

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -23,7 +23,7 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.User.ClusterConfig;
-import org.pmiops.workbench.exceptions.FailedPreconditionException;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -117,12 +117,8 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterListResponse> listClusters(String billingProjectId) {
     if (billingProjectId == null) {
-      throw new FailedPreconditionException("Must specify billing project");
+      throw new BadRequestException("Must specify billing project");
     }
-
-    // future-proofing the transition from using free-tier projects to using the billing buffer:
-    // verify that the project has been properly initialized if it's the user's free tier project.
-    // billing buffer projects are guaranteed to be initialized at this point.
 
     User user = this.userProvider.get();
 

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -34,7 +34,7 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.Workspace;
-import org.pmiops.workbench.exceptions.FailedPreconditionException;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
@@ -238,7 +238,7 @@ public class ClusterControllerTest {
         .isEqualTo(ClusterStatus.UNKNOWN);
   }
 
-  @Test(expected = FailedPreconditionException.class)
+  @Test(expected = BadRequestException.class)
   public void testListClustersNullBillingProject() throws Exception {
     clusterController.listClusters(null);
   }


### PR DESCRIPTION
Also switch from FailedPrecondition to BadRequestException, which is now more appropriate for this situation.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
