### PR TITLE
[RW-3350][Risk=no] Add request type to trace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
@@ -17,7 +17,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.firecloud.FirecloudApiClientTracer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 // Interceptor to create a trace of the lifecycle of api calls.
@@ -49,7 +48,10 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
 
     SpanBuilder requestSpanBuilder =
         tracer.spanBuilder(
-            workbenchConfigProvider.get().server.shortName + request.getRequestURI());
+            workbenchConfigProvider.get().server.shortName
+                + "/"
+                + request.getMethod()
+                + request.getRequestURI());
 
     if (workbenchConfigProvider.get().server.traceAllRequests) {
       requestSpanBuilder.setSampler(Samplers.alwaysSample());
@@ -61,11 +63,8 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
   }
 
   @Override
-  public void postHandle(
-      HttpServletRequest request,
-      HttpServletResponse response,
-      Object handler,
-      ModelAndView modelAndView)
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {
     ((Scope) request.getAttribute(TRACE_ATTRIBUTE_KEY)).close();
   }


### PR DESCRIPTION
The change to `afterCompletion` from `postHandle` should also give us more accurate numbers, but also I am hoping it can fix https://precisionmedicineinitiative.atlassian.net/secure/RapidBoard.jspa?rapidView=30&view=planning&selectedIssue=RW-3240&epics=visible&selectedEpic=RW-1801

Not marking that as in progress though, since I don't know for sure that will fix it.