### PR TITLE
[RW-3473][risk=no] make the registration dashboard headers readable on new background

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -345,7 +345,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
                 </FlexRow>
               </FlexRow>
               <SmallHeader style={{color: colors.primary, marginTop: '0.25rem'}}>
-                the secure analysis platform for All of Us data</SmallHeader>
+                The secure analysis platform for All of Us data</SmallHeader>
             </FlexColumn>
             <div></div>
           </FlexRow>

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -21,7 +21,7 @@ const styles = reactStyles({
     position: 'relative',
   },
   mainHeader: {
-    color: colors.white, fontSize: 28, fontWeight: 400,
+    color: colors.primary, fontSize: 28, fontWeight: 400,
     letterSpacing: 'normal', marginBottom: '0.2rem'
   },
   cardStyle: {
@@ -262,7 +262,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
       <div style={styles.mainHeader}>Researcher Workbench</div>
       <div style={{...styles.mainHeader, fontSize: '18px', marginBottom: '1rem'}}>
         <ClrIcon shape='warning-standard' class='is-solid'
-                 style={{color: colors.white, marginRight: '0.3rem'}}/>
+                 style={{color: colors.warning, marginRight: '0.3rem'}}/>
         In order to get access to data and tools please complete the following steps:
       </div>
       {canUnsafeSelfBypass &&

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -260,14 +260,14 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
                 data-test-id='registration-dashboard'>
       {bypassInProgress && <SpinnerOverlay />}
       <div style={styles.mainHeader}>Researcher Workbench</div>
-      <div style={{...styles.mainHeader, fontSize: '18px', marginBottom: '1rem'}}>
+      <div style={{...styles.mainHeader, fontSize: '18px', marginTop: '0.25rem'}}>
         <ClrIcon shape='warning-standard' class='is-solid'
                  style={{color: colors.warning, marginRight: '0.3rem'}}/>
         In order to get access to data and tools please complete the following steps:
       </div>
       {canUnsafeSelfBypass &&
         <div data-test-id='self-bypass'
-             style={{...baseStyles.card, ...styles.warningModal}}>
+             style={{...baseStyles.card, ...styles.warningModal, marginTop: '0.5rem'}}>
           {bypassActionComplete &&
             <span>Bypass action is complete. Reload the page to continue.</span>}
           {!bypassActionComplete && <span>


### PR DESCRIPTION
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

the homepage background change (from dark blue to grey) affected the registration-dashboard headers, which are nearly invisible here:
<img width="1481" alt="Screen Shot 2019-09-12 at 11 28 57 PM" src="https://user-images.githubusercontent.com/5375000/64836183-f7394300-d5b6-11e9-9999-2549a70cfd80.png">
<img width="1481" alt="Screen Shot 2019-09-12 at 11 28 59 PM" src="https://user-images.githubusercontent.com/5375000/64836184-f7394300-d5b6-11e9-96ef-9625e88f02dd.png">

I changed them to be the "primary" color and the warning sign to be the "warning" color:
<img width="1481" alt="Screen Shot 2019-09-12 at 11 32 47 PM" src="https://user-images.githubusercontent.com/5375000/64836198-fef8e780-d5b6-11e9-8b76-4b8f8983f116.png">

This is currently being reviewed by Lou (designer) before it is ready to be reviewed by another dev.

This can be tested by going to the url like: http://localhost:4200/?workbenchAccessTasks=true
