### PR TITLE
[RW-3469][risk=no] Fix z-index for menu and tooltip

### DIFF
--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -8,7 +8,7 @@ const styles = {
   tooltip: {
     background: 'black', color: 'white',
     padding: '0.5rem',
-    position: 'fixed', top: 0, left: 0, pointerEvents: 'none',
+    position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 105,
     maxWidth: 400, borderRadius: 4
   },
   notch: {

--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -19,7 +19,7 @@ const styles = {
     transformOrigin: 'bottom'
   },
   popup: {
-    position: 'fixed', top: 0, left: 0,
+    position: 'fixed', top: 0, left: 0, zIndex: 105,
     backgroundColor: 'white',
     border: `1px solid #b7b7b7`, borderRadius: 4,
     boxShadow: '0 3px 2px 0 rgba(0,0,0,0.12)'


### PR DESCRIPTION
Prevent workspace navbar menu and modifier tooltip from being overlapped.