### PR TITLE
[RW-3403][risk=low] Copy all GCS objects from the workspace bucket on clone

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
@@ -18,7 +18,9 @@ public interface CloudStorageService {
 
   String getImageUrl(String image_name);
 
-  List<Blob> getBlobList(String bucketName, String directory);
+  List<Blob> getBlobList(String bucketName);
+
+  List<Blob> getBlobListForPrefix(String bucketName, String directory);
 
   Set<BlobId> blobsExist(List<BlobId> id);
 

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -59,8 +59,7 @@ public class CloudStorageServiceImpl implements CloudStorageService {
   @Override
   public List<Blob> getBlobList(String bucketName) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
-    Iterable<Blob> blobList =
-        storage.get(bucketName).list(Storage.BlobListOption.prefix(directory)).getValues();
+    Iterable<Blob> blobList = storage.get(bucketName).list().getValues();
     return ImmutableList.copyOf(blobList);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -57,7 +57,15 @@ public class CloudStorageServiceImpl implements CloudStorageService {
   }
 
   @Override
-  public List<Blob> getBlobList(String bucketName, String directory) {
+  public List<Blob> getBlobList(String bucketName) {
+    Storage storage = StorageOptions.getDefaultInstance().getService();
+    Iterable<Blob> blobList =
+        storage.get(bucketName).list(Storage.BlobListOption.prefix(directory)).getValues();
+    return ImmutableList.copyOf(blobList);
+  }
+
+  @Override
+  public List<Blob> getBlobListForPrefix(String bucketName, String directory) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
     Iterable<Blob> blobList =
         storage.get(bucketName).list(Storage.BlobListOption.prefix(directory)).getValues();

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -79,7 +79,8 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getWorkspace()
             .getBucketName();
 
-    return cloudStorageService.getBlobList(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY).stream()
+    return cloudStorageService.getBlobListForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
+        .stream()
         .filter(blob -> NOTEBOOK_PATTERN.matcher(blob.getName()).matches())
         .map(blob -> blobToFileDetail(blob, bucketName))
         .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.annotations.AuthorityRequired;
@@ -87,13 +86,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   private static final String RANDOM_CHARS = "abcdefghijklmnopqrstuvwxyz";
   private static final int NUM_RANDOM_CHARS = 20;
-  private static final int MAX_FC_CREATION_ATTEMPT_VALUES = 6;
   // If we later decide to tune this value, consider moving to the WorkbenchConfig.
   private static final int MAX_CLONE_FILE_SIZE_MB = 100;
-  // "directory" for notebooks, within the workspace cloud storage bucket.
-  private static final String NOTEBOOKS_WORKSPACE_DIRECTORY =
-      NotebooksService.NOTEBOOKS_WORKSPACE_DIRECTORY;
-  private static final Pattern NOTEBOOK_PATTERN = NotebooksService.NOTEBOOK_PATTERN;
 
   private Retryer<Boolean> retryer =
       RetryerBuilder.<Boolean>newBuilder()
@@ -388,9 +382,9 @@ public class WorkspacesController implements WorkspacesApiDelegate {
                 toFcWorkspaceId.getWorkspaceNamespace(), toFcWorkspaceId.getWorkspaceName())
             .getWorkspace();
 
-    // In the future, we may want to allow callers to specify whether notebooks
+    // In the future, we may want to allow callers to specify whether files
     // should be cloned at all (by default, yes), else they are currently stuck
-    // if someone accidentally adds a large notebook or if there are too many to
+    // if someone accidentally adds a large file or if there are too many to
     // feasibly copy within a single API request.
     for (Blob b : cloudStorageService.getBlobList(fromBucket)) {
       if (b.getSize() != null && b.getSize() / 1e6 > MAX_CLONE_FILE_SIZE_MB) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -89,7 +89,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   private static final int NUM_RANDOM_CHARS = 20;
   private static final int MAX_FC_CREATION_ATTEMPT_VALUES = 6;
   // If we later decide to tune this value, consider moving to the WorkbenchConfig.
-  private static final int MAX_NOTEBOOK_SIZE_MB = 100;
+  private static final int MAX_CLONE_FILE_SIZE_MB = 100;
   // "directory" for notebooks, within the workspace cloud storage bucket.
   private static final String NOTEBOOKS_WORKSPACE_DIRECTORY =
       NotebooksService.NOTEBOOKS_WORKSPACE_DIRECTORY;
@@ -392,16 +392,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // should be cloned at all (by default, yes), else they are currently stuck
     // if someone accidentally adds a large notebook or if there are too many to
     // feasibly copy within a single API request.
-    for (Blob b : cloudStorageService.getBlobList(fromBucket, NOTEBOOKS_WORKSPACE_DIRECTORY)) {
-      if (!NOTEBOOK_PATTERN.matcher(b.getName()).matches()) {
-        continue;
-      }
-      if (b.getSize() != null && b.getSize() / 1e6 > MAX_NOTEBOOK_SIZE_MB) {
+    for (Blob b : cloudStorageService.getBlobList(fromBucket)) {
+      if (b.getSize() != null && b.getSize() / 1e6 > MAX_CLONE_FILE_SIZE_MB) {
         throw new FailedPreconditionException(
             String.format(
-                "workspace %s/%s contains a notebook larger than %dMB: '%s'; cannot clone - please "
-                    + "remove this notebook, reduce its size, or contact the workspace owner",
-                fromWorkspaceNamespace, fromWorkspaceId, MAX_NOTEBOOK_SIZE_MB, b.getName()));
+                "workspace %s/%s contains a file larger than %dMB: '%s'; cannot clone - please "
+                    + "remove this file, reduce its size, or contact the workspace owner",
+                fromWorkspaceNamespace, fromWorkspaceId, MAX_CLONE_FILE_SIZE_MB, b.getName()));
       }
 
       try {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1298,12 +1298,12 @@ public class WorkspacesControllerTest {
     stubGetWorkspace(fcWorkspace, WorkspaceAccessLevel.OWNER);
     String f1 = NotebooksService.withNotebookExtension("notebooks/f1");
     String f2 = NotebooksService.withNotebookExtension("notebooks/f2 with spaces");
-    String f3 = "notebooks/f3.vcf";
+    String f3 = "foo/f3.vcf";
     // Note: mockBlob cannot be inlined into thenReturn() due to Mockito nuances.
     List<Blob> blobs =
         ImmutableList.of(
             mockBlob(BUCKET_NAME, f1), mockBlob(BUCKET_NAME, f2), mockBlob(BUCKET_NAME, f3));
-    when(cloudStorageService.getBlobListForPrefix(BUCKET_NAME, "notebooks")).thenReturn(blobs);
+    when(cloudStorageService.getBlobList(BUCKET_NAME)).thenReturn(blobs);
     mockBillingProjectBuffer("cloned-ns");
     workspacesController
         .cloneWorkspace(workspace.getNamespace(), workspace.getId(), req)
@@ -1311,8 +1311,7 @@ public class WorkspacesControllerTest {
         .getWorkspace();
     verify(cloudStorageService).copyBlob(BlobId.of(BUCKET_NAME, f1), BlobId.of("bucket2", f1));
     verify(cloudStorageService).copyBlob(BlobId.of(BUCKET_NAME, f2), BlobId.of("bucket2", f2));
-    verify(cloudStorageService, never())
-        .copyBlob(BlobId.of(BUCKET_NAME, f3), BlobId.of("bucket2", f3));
+    verify(cloudStorageService).copyBlob(BlobId.of(BUCKET_NAME, f3), BlobId.of("bucket2", f3));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1559,8 +1559,7 @@ public class WorkspacesControllerTest {
     Blob bigNotebook =
         mockBlob(BUCKET_NAME, NotebooksService.withNotebookExtension("notebooks/nb"));
     when(bigNotebook.getSize()).thenReturn(5_000_000_000L); // 5 GB.
-    when(cloudStorageService.getBlobListForPrefix(BUCKET_NAME, "notebooks"))
-        .thenReturn(ImmutableList.of(bigNotebook));
+    when(cloudStorageService.getBlobList(BUCKET_NAME)).thenReturn(ImmutableList.of(bigNotebook));
     mockBillingProjectBuffer("cloned-ns");
     workspacesController
         .cloneWorkspace(workspace.getNamespace(), workspace.getId(), req)

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1303,7 +1303,7 @@ public class WorkspacesControllerTest {
     List<Blob> blobs =
         ImmutableList.of(
             mockBlob(BUCKET_NAME, f1), mockBlob(BUCKET_NAME, f2), mockBlob(BUCKET_NAME, f3));
-    when(cloudStorageService.getBlobList(BUCKET_NAME, "notebooks")).thenReturn(blobs);
+    when(cloudStorageService.getBlobListForPrefix(BUCKET_NAME, "notebooks")).thenReturn(blobs);
     mockBillingProjectBuffer("cloned-ns");
     workspacesController
         .cloneWorkspace(workspace.getNamespace(), workspace.getId(), req)
@@ -1560,7 +1560,7 @@ public class WorkspacesControllerTest {
     Blob bigNotebook =
         mockBlob(BUCKET_NAME, NotebooksService.withNotebookExtension("notebooks/nb"));
     when(bigNotebook.getSize()).thenReturn(5_000_000_000L); // 5 GB.
-    when(cloudStorageService.getBlobList(BUCKET_NAME, "notebooks"))
+    when(cloudStorageService.getBlobListForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(bigNotebook));
     mockBillingProjectBuffer("cloned-ns");
     workspacesController
@@ -1903,7 +1903,7 @@ public class WorkspacesControllerTest {
     when(mockBlob2.getName()).thenReturn("notebooks/mockFile.text");
     when(mockBlob3.getName())
         .thenReturn(NotebooksService.withNotebookExtension("notebooks/two words"));
-    when(cloudStorageService.getBlobList("bucket", "notebooks"))
+    when(cloudStorageService.getBlobListForPrefix("bucket", "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2, mockBlob3));
 
     // Will return 1 entry as only python files in notebook folder are return
@@ -1930,7 +1930,7 @@ public class WorkspacesControllerTest {
     when(mockBlob1.getName())
         .thenReturn(NotebooksService.withNotebookExtension("notebooks/extra/nope"));
     when(mockBlob2.getName()).thenReturn(NotebooksService.withNotebookExtension("notebooks/foo"));
-    when(cloudStorageService.getBlobList("bucket", "notebooks"))
+    when(cloudStorageService.getBlobListForPrefix("bucket", "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
 
     List<String> gotNames =


### PR DESCRIPTION
This may be revisited in the future, but for now this is needed for the migration so we don't drop non-notebook user data.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
