### PR TITLE
[RW-3481][risk=no] Don't pin ubuntu package deps

### DIFF
--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -6,25 +6,25 @@ FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-     openjdk-8-jdk=8u222-b10-1ubuntu1~18.04.1 \
-     curl=7.58.0-2ubuntu3.7 \
-     python=2.7.15~rc1-1 \
-     gcc=4:7.4.0-1ubuntu2.3 \
-     python-dev=2.7.15~rc1-1 \
-     python-setuptools=39.0.1-2 \
-     bash=4.4.18-2ubuntu1.2 \
-     libc6-i386=2.27-3ubuntu1 \
-     openssh-client=1:7.6p1-4ubuntu0.3 \
-     git=1:2.17.1-1ubuntu0.4 \
-     gettext=0.19.8.1-6ubuntu0.3 \
-     mysql-server=5.7.27-0ubuntu0.18.04.1 \
-     mysql-client=5.7.27-0ubuntu0.18.04.1 \
-     ruby=1:2.5.1 \
-     ruby-dev=1:2.5.1 \
-     ruby-json=2.1.0+dfsg-2 \
-     make=4.1-9.1ubuntu1 \
-     unzip=6.0-21ubuntu1 \
-     wait-for-it=0.0~git20170723-1 \
+     openjdk-8-jdk \
+     curl \
+     python \
+     gcc \
+     python-dev \
+     python-setuptools \
+     bash \
+     libc6-i386 \
+     openssh-client \
+     git \
+     gettext \
+     mysql-server \
+     mysql-client \
+     ruby \
+     ruby-dev \
+     ruby-json \
+     make \
+     unzip \
+     wait-for-it \
      && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
One of these versions went out of date and is no longer available (curl package). This was probably overly specific - if we really want to lock in specific versions, we can periodically push a local dev docker image rather than building locally. I don't know that these versions were intentional, this was a carry-over from the original alpine image.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
