### PR TITLE
[RW-2795][risk=no] Add search bar to help tip sidebar

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -134,7 +134,7 @@ export class HelpSidebar extends React.Component<Props, State> {
       searchTerm: ''
     };
     this.debounceInput = fp.debounce(300, (input: string) => {
-      if (input === '') {
+      if (input === '' || input.length < 3) {
         this.setState({filteredContent: undefined});
       } else {
         this.searchHelpTips(input.toLowerCase());
@@ -144,17 +144,18 @@ export class HelpSidebar extends React.Component<Props, State> {
 
   searchHelpTips(input: string) {
     const filteredContent = fp.values(JSON.parse(JSON.stringify(sidebarContent))).reduce((acc, section) => {
+      const inputMatch = (text: string) => text.toLowerCase().includes(input);
       const content = section.reduce((ac, item) => {
-        if (!item.title.toLowerCase().includes(input)) {
+        if (!inputMatch(item.title)) {
           item.content = item.content.reduce((a, ic) => {
             if (typeof ic === 'string') {
-              if (ic.toLowerCase().includes(input)) {
+              if (inputMatch(ic)) {
                 a.push(ic);
               }
-            } else if (ic.title.toLowerCase().includes(input)) {
+            } else if (inputMatch(ic.title)) {
               a.push(ic);
             } else {
-              ic.content = ic.content.filter(i => i.toLowerCase().includes(input));
+              ic.content = ic.content.filter(i => inputMatch(i));
               if (ic.content.length) {
                 a.push(ic);
               }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -129,7 +129,6 @@ interface State {
   searchTerm: string;
 }
 export class HelpSidebar extends React.Component<Props, State> {
-  debounceInput: Function;
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -138,14 +137,15 @@ export class HelpSidebar extends React.Component<Props, State> {
       sidebarOpen: false,
       searchTerm: ''
     };
-    this.debounceInput = fp.debounce(300, (input: string) => {
-      if (input === '' || input.length < 3) {
-        this.setState({filteredContent: undefined});
-      } else {
-        this.searchHelpTips(input.trim().toLowerCase());
-      }
-    });
   }
+
+  debounceInput = fp.debounce(300, (input: string) => {
+    if (input.length < 3) {
+      this.setState({filteredContent: undefined});
+    } else {
+      this.searchHelpTips(input.trim().toLowerCase());
+    }
+  });
 
   searchHelpTips(input: string) {
     // For each object, we check the title first. If it matches, we return the entire content array.

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import {SidebarContent} from 'app/cohort-review/sidebar-content/sidebar-content.component';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {highlightSearchTerm, reactStyles, ReactWrapperBase} from 'app/utils';
 
 const sidebarContent = require('assets/json/help-sidebar.json');
 
@@ -177,29 +177,6 @@ export class HelpSidebar extends React.Component<Props, State> {
     this.setState({filteredContent});
   }
 
-  highlightSearchTerm(stringToHighlight: string) {
-    const {searchTerm} = this.state;
-    if (searchTerm === '' || searchTerm.length < 3) {
-      return stringToHighlight;
-    }
-    const words: string[] = [];
-    const matchString = new RegExp(searchTerm.trim(), 'i');
-    const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
-    const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
-    if (matches) {
-      for (let i = 0; i < matches.length; i++) {
-        words.push(splits[i], matches[i]);
-      }
-      words.push(splits[splits.length - 1]);
-    } else {
-      words.push(splits[0]);
-    }
-    return words.map((word, w) => <span key={w}
-      style={matchString.test(word.toLowerCase()) ? styles.highlighted : {}}>
-        {word}
-      </span>);
-  }
-
   onIconClick(icon: string) {
     const {activeIcon, sidebarOpen} = this.state;
     const newSidebarOpen = !(icon === activeIcon && sidebarOpen);
@@ -272,14 +249,14 @@ export class HelpSidebar extends React.Component<Props, State> {
             </div>
             {displayContent.length > 0
               ? displayContent.map((section, s) => <div key={s}>
-                <h3 style={styles.sectionTitle}>{this.highlightSearchTerm(section.title)}</h3>
+                <h3 style={styles.sectionTitle}>{highlightSearchTerm(searchTerm, section.title)}</h3>
                 {section.content.map((content, c) => {
                   return typeof content === 'string'
-                    ? <p key={c} style={styles.contentItem}>{this.highlightSearchTerm(content)}</p>
+                    ? <p key={c} style={styles.contentItem}>{highlightSearchTerm(searchTerm, content)}</p>
                     : <div key={c}>
-                      <h4 style={styles.contentTitle}>{this.highlightSearchTerm(content.title)}</h4>
+                      <h4 style={styles.contentTitle}>{highlightSearchTerm(searchTerm, content.title)}</h4>
                       {content.content.map((item, i) =>
-                        <p key={i} style={styles.contentItem}>{this.highlightSearchTerm(item)}</p>)
+                        <p key={i} style={styles.contentItem}>{highlightSearchTerm(searchTerm, item)}</p>)
                       }
                     </div>;
                 })}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -204,6 +204,11 @@ export class HelpSidebar extends React.Component<Props, State> {
     }, 300);
   }
 
+  highlightMatches(content: string) {
+    const {searchTerm} = this.state;
+    return highlightSearchTerm(searchTerm, content, colors.success);
+  }
+
   render() {
     const {location, participant, setParticipant} = this.props;
     const {activeIcon, filteredContent, searchTerm, sidebarOpen} = this.state;
@@ -249,14 +254,14 @@ export class HelpSidebar extends React.Component<Props, State> {
             </div>
             {displayContent.length > 0
               ? displayContent.map((section, s) => <div key={s}>
-                <h3 style={styles.sectionTitle}>{highlightSearchTerm(searchTerm, section.title)}</h3>
+                <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
                 {section.content.map((content, c) => {
                   return typeof content === 'string'
-                    ? <p key={c} style={styles.contentItem}>{highlightSearchTerm(searchTerm, content)}</p>
+                    ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>
                     : <div key={c}>
-                      <h4 style={styles.contentTitle}>{highlightSearchTerm(searchTerm, content.title)}</h4>
+                      <h4 style={styles.contentTitle}>{this.highlightMatches(content.title)}</h4>
                       {content.content.map((item, i) =>
-                        <p key={i} style={styles.contentItem}>{highlightSearchTerm(searchTerm, item)}</p>)
+                        <p key={i} style={styles.contentItem}>{this.highlightMatches(item)}</p>)
                       }
                     </div>;
                 })}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -87,7 +87,7 @@ const styles = reactStyles({
     borderRadius: '4px',
     backgroundColor: colorWithWhiteness(colors.primary, .95),
     marginTop: '5px',
-    color: colorWithWhiteness(colors.primary, -1),
+    color: colors.primary,
   },
   textInput: {
     width: '90%',

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -181,11 +181,7 @@ export class HelpSidebar extends React.Component<Props, State> {
       return stringToHighlight;
     }
     const words: string[] = [];
-    let searchWords = searchTerm.split(new RegExp(',| '));
-    searchWords = searchWords
-    .filter(w => w.length > 0 )
-    .map(word => word.replace(/[&!^\/\\#,+()$~%.'":*?<>{}]/g, ''));
-    const matchString = new RegExp(searchWords.join('|'), 'i');
+    const matchString = new RegExp(searchTerm, 'i');
     const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
     const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
     if (matches) {
@@ -193,6 +189,8 @@ export class HelpSidebar extends React.Component<Props, State> {
         words.push(splits[i], matches[i]);
       }
       words.push(splits[splits.length - 1]);
+    } else {
+      words.push(splits[0]);
     }
     return words.map((word, w) => <span key={w}
       style={matchString.test(word.toLowerCase()) ? styles.highlighted : {}}>
@@ -270,19 +268,22 @@ export class HelpSidebar extends React.Component<Props, State> {
                 onChange={(e) => this.onInputChange(e.target.value)}
                 placeholder={'Search'} />
             </div>
-            {displayContent.map((section, s) => <div key={s}>
-              <h3 style={styles.sectionTitle}>{this.highlightSearchTerm(section.title)}</h3>
-              {section.content.map((content, c) => {
-                return typeof content === 'string'
-                  ? <p key={c} style={styles.contentItem}>{this.highlightSearchTerm(content)}</p>
-                  : <div key={c}>
-                    <h4 style={styles.contentTitle}>{this.highlightSearchTerm(content.title)}</h4>
-                    {content.content.map((item, i) =>
-                      <p key={i} style={styles.contentItem}>{this.highlightSearchTerm(item)}</p>)
-                    }
-                  </div>;
-              })}
-            </div>)}
+            {displayContent.length > 0
+              ? displayContent.map((section, s) => <div key={s}>
+                <h3 style={styles.sectionTitle}>{this.highlightSearchTerm(section.title)}</h3>
+                {section.content.map((content, c) => {
+                  return typeof content === 'string'
+                    ? <p key={c} style={styles.contentItem}>{this.highlightSearchTerm(content)}</p>
+                    : <div key={c}>
+                      <h4 style={styles.contentTitle}>{this.highlightSearchTerm(content.title)}</h4>
+                      {content.content.map((item, i) =>
+                        <p key={i} style={styles.contentItem}>{this.highlightSearchTerm(item)}</p>)
+                      }
+                    </div>;
+                })}
+              </div>)
+              : <div style={{marginTop: '0.5rem'}}><em>No results found</em></div>
+            }
           </div>
           <div style={contentStyle('annotations')}>
             {!!participant &&

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -142,12 +142,14 @@ export class HelpSidebar extends React.Component<Props, State> {
       if (input === '' || input.length < 3) {
         this.setState({filteredContent: undefined});
       } else {
-        this.searchHelpTips(input.toLowerCase());
+        this.searchHelpTips(input.trim().toLowerCase());
       }
     });
   }
 
   searchHelpTips(input: string) {
+    // For each object, we check the title first. If it matches, we return the entire content array.
+    // If the title doesn't match, we check each element of the content array for matches
     const filteredContent = fp.values(JSON.parse(JSON.stringify(sidebarContent))).reduce((acc, section) => {
       const inputMatch = (text: string) => text.toLowerCase().includes(input);
       const content = section.reduce((ac, item) => {
@@ -160,7 +162,7 @@ export class HelpSidebar extends React.Component<Props, State> {
             } else if (inputMatch(ic.title)) {
               a.push(ic);
             } else {
-              ic.content = ic.content.filter(i => inputMatch(i));
+              ic.content = ic.content.filter(inputMatch);
               if (ic.content.length) {
                 a.push(ic);
               }
@@ -181,7 +183,7 @@ export class HelpSidebar extends React.Component<Props, State> {
       return stringToHighlight;
     }
     const words: string[] = [];
-    const matchString = new RegExp(searchTerm, 'i');
+    const matchString = new RegExp(searchTerm.trim(), 'i');
     const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
     const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
     if (matches) {

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -97,6 +97,11 @@ const styles = reactStyles({
     backgroundColor: 'transparent',
     outline: 'none',
   },
+  highlighted: {
+    color: colorWithWhiteness(colors.success, -0.4),
+    backgroundColor: colorWithWhiteness(colors.success, 0.7),
+    display: 'inline-block'
+  }
 });
 
 const iconStyles = {
@@ -170,6 +175,31 @@ export class HelpSidebar extends React.Component<Props, State> {
     this.setState({filteredContent});
   }
 
+  highlightSearchTerm(stringToHighlight: string) {
+    const {searchTerm} = this.state;
+    if (searchTerm === '' || searchTerm.length < 3) {
+      return stringToHighlight;
+    }
+    const words: string[] = [];
+    let searchWords = searchTerm.split(new RegExp(',| '));
+    searchWords = searchWords
+    .filter(w => w.length > 0 )
+    .map(word => word.replace(/[&!^\/\\#,+()$~%.'":*?<>{}]/g, ''));
+    const matchString = new RegExp(searchWords.join('|'), 'i');
+    const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
+    const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
+    if (matches) {
+      for (let i = 0; i < matches.length; i++) {
+        words.push(splits[i], matches[i]);
+      }
+      words.push(splits[splits.length - 1]);
+    }
+    return words.map((word, w) => <span key={w}
+      style={matchString.test(word.toLowerCase()) ? styles.highlighted : {}}>
+        {word}
+      </span>);
+  }
+
   onIconClick(icon: string) {
     const {activeIcon, sidebarOpen} = this.state;
     const newSidebarOpen = !(icon === activeIcon && sidebarOpen);
@@ -241,14 +271,14 @@ export class HelpSidebar extends React.Component<Props, State> {
                 placeholder={'Search'} />
             </div>
             {displayContent.map((section, s) => <div key={s}>
-              <h3 style={styles.sectionTitle}>{section.title}</h3>
+              <h3 style={styles.sectionTitle}>{this.highlightSearchTerm(section.title)}</h3>
               {section.content.map((content, c) => {
                 return typeof content === 'string'
-                  ? <p key={c} style={styles.contentItem}>{content}</p>
+                  ? <p key={c} style={styles.contentItem}>{this.highlightSearchTerm(content)}</p>
                   : <div key={c}>
-                    <h4 style={styles.contentTitle}>{content.title}</h4>
+                    <h4 style={styles.contentTitle}>{this.highlightSearchTerm(content.title)}</h4>
                     {content.content.map((item, i) =>
-                      <p key={i} style={styles.contentItem}>{item}</p>)
+                      <p key={i} style={styles.contentItem}>{this.highlightSearchTerm(item)}</p>)
                     }
                   </div>;
               })}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -80,7 +80,22 @@ const styles = reactStyles({
   contentItem: {
     marginTop: 0,
     color: colors.primary
-  }
+  },
+  textSearch: {
+    width: '100%',
+    borderRadius: '4px',
+    backgroundColor: colorWithWhiteness(colors.primary, .95),
+    marginTop: '5px',
+    color: colorWithWhiteness(colors.primary, -1),
+  },
+  textInput: {
+    width: '90%',
+    height: '1.5rem',
+    padding: '0 0 0 5px',
+    border: 0,
+    backgroundColor: 'transparent',
+    outline: 'none',
+  },
 });
 
 const iconStyles = {
@@ -112,7 +127,7 @@ export class HelpSidebar extends React.Component<Props, State> {
     this.state = {
       activeIcon: undefined,
       sidebarOpen: false,
-      searchTerm: undefined
+      searchTerm: ''
     };
   }
 
@@ -140,7 +155,7 @@ export class HelpSidebar extends React.Component<Props, State> {
 
   render() {
     const {location, participant, setParticipant} = this.props;
-    const {activeIcon, sidebarOpen} = this.state;
+    const {activeIcon, searchTerm, sidebarOpen} = this.state;
     const contentStyle = (tab: string) => ({
       display: activeIcon === tab ? 'block' : 'none',
       height: 'calc(100% - 1rem)',
@@ -171,6 +186,15 @@ export class HelpSidebar extends React.Component<Props, State> {
           </div>
           <div style={contentStyle('help')}>
             <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
+            <div style={styles.textSearch}>
+              <ClrIcon style={{color: colors.primary, margin: '0 0.3rem'}} shape='search' size={16} />
+              <input
+                type='text'
+                style={styles.textInput}
+                value={searchTerm}
+                onChange={(e) => this.setState({searchTerm: e.target.value})}
+                placeholder={'Search'} />
+            </div>
             {sidebarContent[location].map((section, s) => <div key={s}>
               <h3 style={styles.sectionTitle}>{section.title}</h3>
               {section.content.map((content, c) => {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -9,6 +9,7 @@ import * as ReactDOM from 'react-dom';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 export const WINDOW_REF = 'window-ref';
+import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   currentCohortStore,
   currentConceptSetStore,
@@ -386,4 +387,30 @@ export function resettableTimeout(f, timeoutInSeconds) {
     },
     getTimer: () => timeout
   };
+}
+
+export function highlightSearchTerm(searchTerm: string, stringToHighlight: string) {
+  if (searchTerm === '' || searchTerm.length < 3) {
+    return stringToHighlight;
+  }
+  const words: string[] = [];
+  const matchString = new RegExp(searchTerm.trim(), 'i');
+  const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
+  const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
+  if (matches) {
+    for (let i = 0; i < matches.length; i++) {
+      words.push(splits[i], matches[i]);
+    }
+    words.push(splits[splits.length - 1]);
+  } else {
+    words.push(splits[0]);
+  }
+  return words.map((word, w) => <span key={w}
+    style={matchString.test(word.toLowerCase()) ? {
+      color: colorWithWhiteness(colors.success, -0.4),
+      backgroundColor: colorWithWhiteness(colors.success, 0.7),
+      display: 'inline-block'
+    } : {}}>
+      {word}
+    </span>);
 }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -9,7 +9,7 @@ import * as ReactDOM from 'react-dom';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 export const WINDOW_REF = 'window-ref';
-import colors, {colorWithWhiteness} from 'app/styles/colors';
+import {colorWithWhiteness} from 'app/styles/colors';
 import {
   currentCohortStore,
   currentConceptSetStore,

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -389,7 +389,7 @@ export function resettableTimeout(f, timeoutInSeconds) {
   };
 }
 
-export function highlightSearchTerm(searchTerm: string, stringToHighlight: string) {
+export function highlightSearchTerm(searchTerm: string, stringToHighlight: string, highlightColor: string) {
   if (searchTerm === '' || searchTerm.length < 3) {
     return stringToHighlight;
   }
@@ -407,8 +407,8 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
   }
   return words.map((word, w) => <span key={w}
     style={matchString.test(word.toLowerCase()) ? {
-      color: colorWithWhiteness(colors.success, -0.4),
-      backgroundColor: colorWithWhiteness(colors.success, 0.7),
+      color: colorWithWhiteness(highlightColor, -0.4),
+      backgroundColor: colorWithWhiteness(highlightColor, 0.7),
       display: 'inline-block'
     } : {}}>
       {word}


### PR DESCRIPTION
Searches entire help tip content, not just from current page. Used modified version of highlighting function from concept set search.
<img width="530" alt="Screen Shot 2019-09-16 at 8 36 51 AM" src="https://user-images.githubusercontent.com/40036095/64962608-57e9a980-d85d-11e9-9377-3a703c5382f0.png">

