### PR TITLE
[RW-3492][risk=no] Fix main background to adjust to size of content 

### DIFF
--- a/ui/src/app/pages/signed-in/component.css
+++ b/ui/src/app/pages/signed-in/component.css
@@ -6,6 +6,7 @@ body {
   display: flex;
   /*View height minus top bar.*/
   min-height: calc(100vh - 4rem);
+  position: relative;
 }
 
 .app-container {


### PR DESCRIPTION
Background div is not adjusting to the size of the content. 

Cuts of on longer pages (Data page):
<img width="1313" alt="Screen Shot 2019-09-17 at 10 56 37 AM" src="https://user-images.githubusercontent.com/40036095/65058531-0400c280-d93a-11e9-87d5-c52ae09c005f.png">

Overflows on shorter pages:
<img width="1336" alt="Screen Shot 2019-09-17 at 10 57 01 AM" src="https://user-images.githubusercontent.com/40036095/65058554-11b64800-d93a-11e9-9f69-640ef996d9dd.png">
