### PR TITLE
[RW-3462][risk=no] changing flaky test case.

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
@@ -6,6 +6,8 @@ import javax.sql.DataSource;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -26,6 +28,16 @@ public class TestJpaConfig {
     dataSource.setPassword("sa");
 
     return dataSource;
+  }
+
+  @Bean
+  public JdbcTemplate getJdbcTemplate() {
+    return new JdbcTemplate(dataSource());
+  }
+
+  @Bean
+  public NamedParameterJdbcTemplate getNamedParameterJdbcTemplate() {
+    return new NamedParameterJdbcTemplate(dataSource());
   }
 
   @Bean


### PR DESCRIPTION
**Background**
ParticipantCohortStatusDao is a custom jpa crud implementation. This evolved out of the need to manually create batched insert statements. For unknown reasons Spring JPA nor JDBC batching works in appengine running in the cloud. It's old school but it solves our batching issue by using JdbcTemplate/NamedParameterJdbcTemplate. 

In the test case ParticipantCohortStatusDaoTest there is some funkiness with using ParticipantCohortStatusDao and JdbcTemplate in the same test. Seems that neither was using the same datasource/transaction. I'm using TestJpaConfig to override these issues and allows for everything in test to use the same datasource. Also, noticed that the test wasn't using the @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)