### PR TITLE
[RW-2796][risk=no] Add support footer to help sidebar

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -101,7 +101,7 @@ const styles = reactStyles({
   footer: {
     position: 'absolute',
     bottom: 0,
-    padding: '1rem 1.5rem 1.5rem 1rem',
+    padding: '1.25rem 0.75rem',
     background: colorWithWhiteness(colors.primary, .8),
   },
   link: {
@@ -144,7 +144,7 @@ export const HelpSidebar = withUserProfile()(
         activeIcon: undefined,
         filteredContent: undefined,
         sidebarOpen: false,
-        searchTerm: undefined
+        searchTerm: ''
       };
     }
 
@@ -231,7 +231,7 @@ export const HelpSidebar = withUserProfile()(
         display: activeIcon === tab ? 'block' : 'none',
         height: 'calc(100% - 1rem)',
         overflow: 'auto',
-        padding: '0.5rem 0.5rem 6.5rem',
+        padding: '0.5rem 0.5rem 5.5rem',
       });
       return <React.Fragment>
         <div style={styles.iconContainer}>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -97,10 +97,11 @@ const styles = reactStyles({
     backgroundColor: 'transparent',
     outline: 'none',
   },
-  highlighted: {
-    color: colorWithWhiteness(colors.success, -0.4),
-    backgroundColor: colorWithWhiteness(colors.success, 0.7),
-    display: 'inline-block'
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    padding: '1.5rem',
+    background: colorWithWhiteness(colors.primary, .8),
   }
 });
 
@@ -273,6 +274,14 @@ export class HelpSidebar extends React.Component<Props, State> {
             {!!participant &&
               <SidebarContent participant={participant} setParticipant={(p) => setParticipant(p)} />
             }
+          </div>
+          <div style={styles.footer}>
+            <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
+            <p style={styles.contentItem}>
+              Visit the
+              <a href='https://www.researchallofus.org/frequently-asked-questions/' target='_blank'>FAQs here</a>
+              or <a href='' target='_blank'>contact us</a>.
+            </p>
           </div>
         </div>
       </div>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -146,7 +146,6 @@ export const HelpSidebar = withUserProfile()(
         sidebarOpen: false,
         searchTerm: undefined
       };
-      console.log(props);
     }
 
     debounceInput = fp.debounce(300, (input: string) => {
@@ -238,7 +237,7 @@ export const HelpSidebar = withUserProfile()(
         <div style={styles.iconContainer}>
           <div style={activeIcon === 'help' ? iconStyles.active : styles.icon}>
             <ClrIcon className='is-solid' shape='info-standard' size={28}
-                     onClick={() => this.onIconClick('help')} />
+              onClick={() => this.onIconClick('help')} />
           </div>
           <div style={iconStyles.disabled}>
             <ClrIcon className='is-solid' shape='book' size={32} />
@@ -246,7 +245,7 @@ export const HelpSidebar = withUserProfile()(
           {location === 'reviewParticipantDetail' &&
             <div style={activeIcon === 'annotations' ? iconStyles.active : styles.icon}>
               <ClrIcon shape='note' size={32}
-                       onClick={() => this.onIconClick('annotations')} />
+                onClick={() => this.onIconClick('annotations')} />
             </div>
           }
         </div>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -5,7 +5,8 @@ import * as React from 'react';
 import {ClrIcon} from 'app/components/icons';
 import {SidebarContent} from 'app/pages/data/cohort-review/sidebar-content.component';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {highlightSearchTerm, reactStyles, ReactWrapperBase} from 'app/utils';
+import {highlightSearchTerm, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {openZendeskWidget} from 'app/utils/zendesk';
 
 const sidebarContent = require('assets/json/help-sidebar.json');
 
@@ -100,8 +101,13 @@ const styles = reactStyles({
   footer: {
     position: 'absolute',
     bottom: 0,
-    padding: '1.5rem',
+    padding: '1rem 1.5rem 1.5rem 1rem',
     background: colorWithWhiteness(colors.primary, .8),
+  },
+  link: {
+    color: colors.accent,
+    cursor: 'pointer',
+    textDecoration: 'none'
   }
 });
 
@@ -119,6 +125,7 @@ const iconStyles = {
 
 interface Props {
   location: string;
+  profileState: any;
   participant?: any;
   setParticipant?: Function;
 }
@@ -129,165 +136,176 @@ interface State {
   sidebarOpen: boolean;
   searchTerm: string;
 }
-export class HelpSidebar extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      activeIcon: undefined,
-      filteredContent: undefined,
-      sidebarOpen: false,
-      searchTerm: ''
-    };
-  }
-
-  debounceInput = fp.debounce(300, (input: string) => {
-    if (input.length < 3) {
-      this.setState({filteredContent: undefined});
-    } else {
-      this.searchHelpTips(input.trim().toLowerCase());
+export const HelpSidebar = withUserProfile()(
+  class extends React.Component<Props, State> {
+    constructor(props: Props) {
+      super(props);
+      this.state = {
+        activeIcon: undefined,
+        filteredContent: undefined,
+        sidebarOpen: false,
+        searchTerm: undefined
+      };
+      console.log(props);
     }
-  });
 
-  searchHelpTips(input: string) {
-    // For each object, we check the title first. If it matches, we return the entire content array.
-    // If the title doesn't match, we check each element of the content array for matches
-    const filteredContent = fp.values(JSON.parse(JSON.stringify(sidebarContent))).reduce((acc, section) => {
-      const inputMatch = (text: string) => text.toLowerCase().includes(input);
-      const content = section.reduce((ac, item) => {
-        if (!inputMatch(item.title)) {
-          item.content = item.content.reduce((a, ic) => {
-            if (typeof ic === 'string') {
-              if (inputMatch(ic)) {
-                a.push(ic);
-              }
-            } else if (inputMatch(ic.title)) {
-              a.push(ic);
-            } else {
-              ic.content = ic.content.filter(inputMatch);
-              if (ic.content.length) {
-                a.push(ic);
-              }
-            }
-            return a;
-          }, []);
-        }
-        return item.content.length ? [...ac, item] : ac;
-      }, []);
-      return [...acc, ...content];
-    }, []);
-    this.setState({filteredContent});
-  }
-
-  onIconClick(icon: string) {
-    const {activeIcon, sidebarOpen} = this.state;
-    const newSidebarOpen = !(icon === activeIcon && sidebarOpen);
-    if (newSidebarOpen) {
-      this.setState({activeIcon: icon, sidebarOpen: newSidebarOpen});
-    } else {
-      this.hideSidebar();
-    }
-  }
-
-  onInputChange(value: string) {
-    this.setState({searchTerm: value});
-    this.debounceInput(value);
-  }
-
-  hideSidebar() {
-    this.setState({sidebarOpen: false});
-    // keep activeIcon set while the sidebar transition completes
-    setTimeout(() => {
-      const {sidebarOpen} = this.state;
-      // check if the sidebar has been opened again before resetting activeIcon
-      if (!sidebarOpen) {
-        this.setState({activeIcon: undefined});
+    debounceInput = fp.debounce(300, (input: string) => {
+      if (input.length < 3) {
+        this.setState({filteredContent: undefined});
+      } else {
+        this.searchHelpTips(input.trim().toLowerCase());
       }
-    }, 300);
-  }
-
-  highlightMatches(content: string) {
-    const {searchTerm} = this.state;
-    return highlightSearchTerm(searchTerm, content, colors.success);
-  }
-
-  render() {
-    const {location, participant, setParticipant} = this.props;
-    const {activeIcon, filteredContent, searchTerm, sidebarOpen} = this.state;
-    const displayContent = filteredContent !== undefined ? filteredContent : sidebarContent[location];
-    const contentStyle = (tab: string) => ({
-      display: activeIcon === tab ? 'block' : 'none',
-      height: 'calc(100% - 1rem)',
-      overflow: 'auto',
-      padding: '0.5rem',
     });
-    return <React.Fragment>
-      <div style={styles.iconContainer}>
-        <div style={activeIcon === 'help' ? iconStyles.active : styles.icon}>
-          <ClrIcon className='is-solid' shape='info-standard' size={28}
-                   onClick={() => this.onIconClick('help')} />
-        </div>
-        <div style={iconStyles.disabled}>
-          <ClrIcon className='is-solid' shape='book' size={32} />
-        </div>
-        {location === 'reviewParticipantDetail' &&
-          <div style={activeIcon === 'annotations' ? iconStyles.active : styles.icon}>
-            <ClrIcon shape='note' size={32}
-                     onClick={() => this.onIconClick('annotations')} />
-          </div>
+
+    searchHelpTips(input: string) {
+      // For each object, we check the title first. If it matches, we return the entire content array.
+      // If the title doesn't match, we check each element of the content array for matches
+      const filteredContent = fp.values(JSON.parse(JSON.stringify(sidebarContent))).reduce((acc, section) => {
+        const inputMatch = (text: string) => text.toLowerCase().includes(input);
+        const content = section.reduce((ac, item) => {
+          if (!inputMatch(item.title)) {
+            item.content = item.content.reduce((a, ic) => {
+              if (typeof ic === 'string') {
+                if (inputMatch(ic)) {
+                  a.push(ic);
+                }
+              } else if (inputMatch(ic.title)) {
+                a.push(ic);
+              } else {
+                ic.content = ic.content.filter(inputMatch);
+                if (ic.content.length) {
+                  a.push(ic);
+                }
+              }
+              return a;
+            }, []);
+          }
+          return item.content.length ? [...ac, item] : ac;
+        }, []);
+        return [...acc, ...content];
+      }, []);
+      this.setState({filteredContent});
+    }
+
+    onIconClick(icon: string) {
+      const {activeIcon, sidebarOpen} = this.state;
+      const newSidebarOpen = !(icon === activeIcon && sidebarOpen);
+      if (newSidebarOpen) {
+        this.setState({activeIcon: icon, sidebarOpen: newSidebarOpen});
+      } else {
+        this.hideSidebar();
+      }
+    }
+
+    onInputChange(value: string) {
+      this.setState({searchTerm: value});
+      this.debounceInput(value);
+    }
+
+    openContactWidget() {
+      const {profileState: {profile: {contactEmail, familyName, givenName, username}}} = this.props;
+      openZendeskWidget(givenName, familyName, username, contactEmail);
+    }
+
+    hideSidebar() {
+      this.setState({sidebarOpen: false});
+      // keep activeIcon set while the sidebar transition completes
+      setTimeout(() => {
+        const {sidebarOpen} = this.state;
+        // check if the sidebar has been opened again before resetting activeIcon
+        if (!sidebarOpen) {
+          this.setState({activeIcon: undefined});
         }
-      </div>
-      <div style={activeIcon ? {...styles.sidebarContainer, ...styles.sidebarContainerActive} : styles.sidebarContainer}>
-        <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar}>
-          <div style={styles.topBar}>
-            <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
-              onClick={() => this.hideSidebar()} />
+      }, 300);
+    }
+
+    highlightMatches(content: string) {
+      const {searchTerm} = this.state;
+      return highlightSearchTerm(searchTerm, content, colors.success);
+    }
+
+    render() {
+      const {location, participant, setParticipant} = this.props;
+      const {activeIcon, filteredContent, searchTerm, sidebarOpen} = this.state;
+      const displayContent = filteredContent !== undefined ? filteredContent : sidebarContent[location];
+      const contentStyle = (tab: string) => ({
+        display: activeIcon === tab ? 'block' : 'none',
+        height: 'calc(100% - 1rem)',
+        overflow: 'auto',
+        padding: '0.5rem 0.5rem 6.5rem',
+      });
+      return <React.Fragment>
+        <div style={styles.iconContainer}>
+          <div style={activeIcon === 'help' ? iconStyles.active : styles.icon}>
+            <ClrIcon className='is-solid' shape='info-standard' size={28}
+                     onClick={() => this.onIconClick('help')} />
           </div>
-          <div style={contentStyle('help')}>
-            <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
-            <div style={styles.textSearch}>
-              <ClrIcon style={{color: colors.primary, margin: '0 0.25rem'}} shape='search' size={16} />
-              <input
-                type='text'
-                style={styles.textInput}
-                value={searchTerm}
-                onChange={(e) => this.onInputChange(e.target.value)}
-                placeholder={'Search'} />
+          <div style={iconStyles.disabled}>
+            <ClrIcon className='is-solid' shape='book' size={32} />
+          </div>
+          {location === 'reviewParticipantDetail' &&
+            <div style={activeIcon === 'annotations' ? iconStyles.active : styles.icon}>
+              <ClrIcon shape='note' size={32}
+                       onClick={() => this.onIconClick('annotations')} />
             </div>
-            {displayContent.length > 0
-              ? displayContent.map((section, s) => <div key={s}>
-                <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
-                {section.content.map((content, c) => {
-                  return typeof content === 'string'
-                    ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>
-                    : <div key={c}>
-                      <h4 style={styles.contentTitle}>{this.highlightMatches(content.title)}</h4>
-                      {content.content.map((item, i) =>
-                        <p key={i} style={styles.contentItem}>{this.highlightMatches(item)}</p>)
-                      }
-                    </div>;
-                })}
-              </div>)
-              : <div style={{marginTop: '0.5rem'}}><em>No results found</em></div>
-            }
-          </div>
-          <div style={contentStyle('annotations')}>
-            {!!participant &&
-              <SidebarContent participant={participant} setParticipant={(p) => setParticipant(p)} />
-            }
-          </div>
-          <div style={styles.footer}>
-            <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
-            <p style={styles.contentItem}>
-              Visit the
-              <a href='https://www.researchallofus.org/frequently-asked-questions/' target='_blank'>FAQs here</a>
-              or <a href='' target='_blank'>contact us</a>.
-            </p>
+          }
+        </div>
+        <div style={activeIcon ? {...styles.sidebarContainer, ...styles.sidebarContainerActive} : styles.sidebarContainer}>
+          <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar}>
+            <div style={styles.topBar}>
+              <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
+                onClick={() => this.hideSidebar()} />
+            </div>
+            <div style={contentStyle('help')}>
+              <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
+              <div style={styles.textSearch}>
+                <ClrIcon style={{color: colors.primary, margin: '0 0.25rem'}} shape='search' size={16} />
+                <input
+                  type='text'
+                  style={styles.textInput}
+                  value={searchTerm}
+                  onChange={(e) => this.onInputChange(e.target.value)}
+                  placeholder={'Search'} />
+              </div>
+              {displayContent.length > 0
+                ? displayContent.map((section, s) => <div key={s}>
+                  <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
+                  {section.content.map((content, c) => {
+                    return typeof content === 'string'
+                      ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>
+                      : <div key={c}>
+                        <h4 style={styles.contentTitle}>{this.highlightMatches(content.title)}</h4>
+                        {content.content.map((item, i) =>
+                          <p key={i} style={styles.contentItem}>{this.highlightMatches(item)}</p>)
+                        }
+                      </div>;
+                  })}
+                </div>)
+                : <div style={{marginTop: '0.5rem'}}><em>No results found</em></div>
+              }
+            </div>
+            <div style={contentStyle('annotations')}>
+              {!!participant &&
+                <SidebarContent participant={participant} setParticipant={() => setParticipant(participant)} />
+              }
+            </div>
+            <div style={styles.footer}>
+              <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
+              <p style={styles.contentItem}>
+                Visit the
+                <a style={styles.link}
+                  href='https://www.researchallofus.org/frequently-asked-questions/'
+                  target='_blank'> FAQs here </a>
+                or <span style={styles.link}
+                  onClick={() => this.openContactWidget()}> contact us</span>.
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-    </React.Fragment>;
+      </React.Fragment>;
+    }
   }
-}
+);
 
 @Component({
   selector: 'app-help-sidebar',

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -431,7 +431,7 @@ export function resettableTimeout(f, timeoutInSeconds) {
 }
 
 export function highlightSearchTerm(searchTerm: string, stringToHighlight: string, highlightColor: string) {
-  if (searchTerm === '' || searchTerm.length < 3) {
+  if (searchTerm.length < 3) {
     return stringToHighlight;
   }
   const words: string[] = [];


### PR DESCRIPTION
Last ticket for the help tip sidebar! Positioned at the bottom of the sidebar container, gives the user two options for support:
- FAQs - opens a new tab to the [Research Hub FAQ page](https://www.researchallofus.org/frequently-asked-questions/)
- Contact us - opens the Zendesk widget

![Screen Shot 2019-09-19 at 12 46 20 PM](https://user-images.githubusercontent.com/40036095/65267964-bc19a100-dadb-11e9-93c4-8df12fe49013.png)
