### PR TITLE
[risk=no] Fix datepicker input

### DIFF
--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -180,7 +180,7 @@ export class DatePicker extends React.Component<
           {...props}
           value={date}
           onChange={v => {
-            this.popup.current.closeFunction();
+            this.popup.current.close();
             onChange(v);
           }}
         />}


### PR DESCRIPTION
Currently all date pickers will break when selecting a date from the calendar popup. Breaking change occured in #2537 , seems likely it was unintentional.