### PR TITLE
[RW-3491][Risk=low] Parameterize get workspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -64,6 +64,10 @@ public interface FireCloudService {
   WorkspaceACLUpdateResponseList updateWorkspaceACL(
       String projectName, String workspaceName, List<WorkspaceACLUpdate> aclUpdates);
 
+  /**
+   * Requested field options specified here:
+   * https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#heading=h.xgjl2srtytjt
+   */
   WorkspaceResponse getWorkspace(String projectName, String workspaceName);
 
   List<WorkspaceResponse> getWorkspaces();

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -4,7 +4,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -70,7 +70,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   // The set of Google OAuth scopes required for access to FireCloud APIs. If FireCloud ever changes
   // its API scopes (see https://api.firecloud.org/api-docs.yaml), we'll need to update this list.
   public static final List<String> FIRECLOUD_API_OAUTH_SCOPES =
-      Arrays.asList(
+      ImmutableList.of(
           "openid",
           "https://www.googleapis.com/auth/userinfo.profile",
           "https://www.googleapis.com/auth/userinfo.email",
@@ -79,7 +79,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   // All options are defined in this document:
   // https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#
   public static final List<String> FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS =
-      Arrays.asList(
+      ImmutableList.of(
           "accessLevel",
           "workspace.workspaceId",
           "workspace.name",

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -76,6 +76,17 @@ public class FireCloudServiceImpl implements FireCloudService {
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-billing");
 
+  // All options are defined in this document:
+  // https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#
+  public static final List<String> FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS =
+      Arrays.asList(
+          "accessLevel",
+          "workspace.workspaceId",
+          "workspace.name",
+          "workspace.namespace",
+          "workspace.bucketName",
+          "workspace.createdBy");
+
   @Autowired
   public FireCloudServiceImpl(
       Provider<WorkbenchConfig> configProvider,
@@ -302,7 +313,10 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public WorkspaceResponse getWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
-    return retryHandler.run((context) -> workspacesApi.getWorkspace(projectName, workspaceName));
+    return retryHandler.run(
+        (context) ->
+            workspacesApi.getWorkspace(
+                projectName, workspaceName, FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -10,7 +10,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -10,6 +10,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -371,6 +371,21 @@ paths:
       parameters:
         - $ref: '#/parameters/workspaceNamespaceParam'
         - $ref: '#/parameters/workspaceNameParam'
+        - name: fields
+          description: >
+            When specified, include only these keys in the response payload and exclude other keys.
+            Accepts a comma-delimited list of values. To include a nested key, specify the key's path
+            using a dot delimiter; for example, to include {"workspace": {"attributes": {}}}, specify
+            "workspace.attributes". Legal values are any first-level key in the response, any first-level key
+            inside the {"workspace": {}} object, and any first-level key inside the {"workspace": {"attributes": {}}}
+            object.
+            If omitted, will return the full response payload.
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+          in: query
       responses:
         200:
           description: Successful Request


### PR DESCRIPTION
This change specifies specific parameters to fetch when we call `getWorkspace` from FireCloud. This is intended to be a performance upgrade from what happens right now. From analysis of the code base, these are the only fields we need, and they are used basically everywhere.