### PR TITLE
[risk=low][RW-3455] Fix double log in bug

### DIFF
--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -20,8 +20,6 @@ import {
 } from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 
-import {INACTIVITY_CONFIG} from 'app/pages/signed-in/component';
-import {SignInService} from 'app/services/sign-in.service';
 import outdatedBrowserRework from 'outdated-browser-rework';
 
 declare let gtag: Function;
@@ -44,7 +42,6 @@ export class AppComponent implements OnInit {
   constructor(
     private activatedRoute: ActivatedRoute,
     private serverConfigService: ServerConfigService,
-    private signInService: SignInService,
     private router: Router,
     private titleService: Title
   ) {}
@@ -73,16 +70,6 @@ export class AppComponent implements OnInit {
         };
         console.log('To override the API URLs, try:\n' +
           'setAllOfUsApiUrl(\'https://host.example.com:1234\')');
-
-        this.signInService.isSignedIn$.subscribe(signedIn => {
-          if (signedIn) {
-            const lastActive = window.localStorage.getItem(INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE);
-            if (lastActive !== null && Date.now() - parseInt(lastActive, 10) > environment.inactivityTimeoutSeconds * 1000) {
-              localStorage.setItem(INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE, Date.now().toString());
-              navigateSignOut();
-            }
-          }
-        });
       } catch (err) {
         console.log('Error setting urls: ' + err);
       }

--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -12,7 +12,6 @@ import {
 import {ServerConfigService} from 'app/services/server-config.service';
 import {cookiesEnabled} from 'app/utils';
 import {
-  navigateSignOut,
   queryParamsStore,
   routeConfigDataStore,
   serverConfigStore,

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -114,11 +114,18 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
       this.minimizeChrome = minimizeChrome;
     }));
 
+    const lastActive = window.localStorage.getItem(INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE);
+    if (lastActive !== null && Date.now() - parseInt(lastActive, 10) > environment.inactivityTimeoutSeconds * 1000) {
+      localStorage.setItem(INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE, Date.now().toString());
+      this.signOut();
+    }
+
     this.startUserActivityTracker();
     this.startInactivityTimers();
   }
 
   signOut(): void {
+    window.localStorage.setItem(INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE, null);
     this.signInService.signOut();
     navigateSignOut();
   }


### PR DESCRIPTION
This addresses a bug where a user needs to sign in twice when they’ve been automatically logged out by our system.

The problem seems to be that there is no way to definitively know if the user had just signed in. This is because we use Google oAuth for authentication. From our systems POV, we send them to a Google auth link and the user returns at some later point with a valid token. When we send them off for Google authentication, we do not know if the authentication flow will be successful. When the user comes back, we do not know if this was their first sign in or not.

This distinction is necessary because we consider a user to be signed out if they have been inactive for 30 minutes. At the moment, it doesn’t seem like there is a way to know that a user had just signed in so we proceed to check their last active timestamp as recorded in localStorage.  If they had been automatically logged out by our system, their last active timestamp will be beyond the expiration date so we log them out - resulting in the double sign in bug.  If they had signed out manually, their last active timestamp should be set to whenever they signed out. This results in two scenarios.
1. The expected single sign in flow if they sign back in within the expiration period. 
2. The double sign in like above if they sign back in past the expiration period.

The logic related to this bug executes when the user first hits the AoU application. At this time, the application needs to make a decision on if it should log out the user in the case that the user is returning after the expiration window has passed but NOT log out the user if they had just signed in.

I was able to add this distinction by clearing out the last active timestamp value when the user is signed out by our system, in both the inactivity and manual sign out steps.  This way, the system knows that a non null last active timestamp means that the user had NOT been signed out by our system. 