### PR TITLE
[RW-3540][RW-3342][risk=no] Fix synchronization of CdrVersionStore

### DIFF
--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -89,7 +89,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
         this.hasDataAccess = hasRegisteredAccess(profile.dataAccessLevel);
         if (this.hasDataAccess) {
           cdrVersionsApi().getCdrVersions().then(resp => {
-            cdrVersionStore.next(resp.items);
+            cdrVersionStore.next(resp);
           });
         }
 

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -12,7 +12,7 @@ import {cdrVersionStore, currentWorkspaceStore, serverConfigStore, userProfileSt
 import {userRolesStub, workspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ClusterApiStub} from 'testing/stubs/cluster-api-stub';
-import {cdrVersions, CdrVersionsStubVariables} from '../../../testing/stubs/cdr-versions-api-stub';
+import {CdrVersionsStubVariables, cdrVersionListResponse} from '../../../testing/stubs/cdr-versions-api-stub';
 
 describe('WorkspaceAbout', () => {
   const profile = ProfileStubVariables.PROFILE_STUB as unknown as Profile;
@@ -49,7 +49,7 @@ describe('WorkspaceAbout', () => {
       publicApiKeyForErrorReports: 'aaa',
       enableEraCommons: true,
     });
-    cdrVersionStore.next(cdrVersions);
+    cdrVersionStore.next(cdrVersionListResponse);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -12,7 +12,7 @@ import {cdrVersionStore, currentWorkspaceStore, serverConfigStore, userProfileSt
 import {userRolesStub, workspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ClusterApiStub} from 'testing/stubs/cluster-api-stub';
-import {CdrVersionsStubVariables, cdrVersionListResponse} from '../../../testing/stubs/cdr-versions-api-stub';
+import {CdrVersionsStubVariables, cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
 
 describe('WorkspaceAbout', () => {
   const profile = ProfileStubVariables.PROFILE_STUB as unknown as Profile;

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -19,6 +19,10 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
 import {Authority, CdrVersion, CdrVersionListResponse, Profile, UserRole, WorkspaceAccessLevel} from 'generated/fetch';
 
+interface WorkspaceProps {
+  profileState: {profile: Profile, reload: Function, updateCache: Function};
+  cdrVersionListResponse: CdrVersionListResponse;
+}
 
 interface WorkspaceState {
   sharing: boolean;
@@ -84,8 +88,7 @@ const WorkspaceInfoTooltipText = () => {
 };
 
 export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCdrVersions())
-(class extends React.Component<
-  {profileState: {profile: Profile, reload: Function, updateCache: Function}, cdrVersionListResponse: CdrVersionListResponse}, WorkspaceState> {
+(class extends React.Component<WorkspaceProps, WorkspaceState> {
 
   constructor(props) {
     super(props);

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1,11 +1,13 @@
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
-import {currentWorkspaceStore} from 'app/utils/navigation';
+import {cdrVersionStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {mount} from 'enzyme';
 import {CdrVersionsApi, WorkspaceAccessLevel} from 'generated/fetch';
 import * as React from 'react';
 import {ClusterApiStub} from 'testing/stubs/cluster-api-stub';
 import {WorkspaceEdit, WorkspaceEditMode} from './workspace-edit';
 import {workspaceStubs} from 'testing/stubs/workspaces-api-stub';
+import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+
 
 let props: {};
 const workspace = {
@@ -21,6 +23,7 @@ beforeEach(() => {
   registerApiClient(CdrVersionsApi, new ClusterApiStub());
   props = {workspace: workspace, routeConfigData: {mode: WorkspaceEditMode.Create}};
   currentWorkspaceStore.next(workspace);
+  cdrVersionStore.next(cdrVersionListResponse);
 });
 
 it('displays workspaces edit page', () => {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -9,7 +9,7 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SearchInput} from 'app/components/search-input';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {TwoColPaddedTable} from 'app/components/tables';
-import {cdrVersionsApi, workspacesApi} from 'app/services/swagger-fetch-clients';
+import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, sliceByHalfLength, withCdrVersions, withCurrentWorkspace, withRouteConfigData} from 'app/utils';
 import {currentWorkspaceStore, navigate, serverConfigStore} from 'app/utils/navigation';

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -309,12 +309,9 @@ export const connectReplaySubject = <T extends {}>(subject: ReplaySubject<T>, na
 
       render() {
         const {value} = this.state;
-        if (!value) {
-          return <React.Fragment/>;
-        }
         // Since ReplaySubject may not have an initial value, only render the
         // connected value once the value is available.
-        return <WrappedComponent {...{[name]: value}} {...this.props}/>;
+        return value && <WrappedComponent {...{[name]: value}} {...this.props}/>;
       }
     }
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -7,10 +7,12 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 export const WINDOW_REF = 'window-ref';
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
+  cdrVersionStore,
   currentCohortStore,
   currentConceptSetStore,
   currentWorkspaceStore,
@@ -286,6 +288,40 @@ export const connectBehaviorSubject = <T extends {}>(subject: BehaviorSubject<T>
   };
 };
 
+export const connectReplaySubject = <T extends {}>(subject: ReplaySubject<T>, name: string) => {
+  return (WrappedComponent) => {
+    class Wrapper extends React.Component<any, {value: T}> {
+      static displayName = 'connectReplaySubject()';
+      private subscription;
+
+      constructor(props) {
+        super(props);
+        this.state = {value: null};
+      }
+
+      componentDidMount() {
+        this.subscription = subject.subscribe(v => this.setState({value: v}));
+      }
+
+      componentWillUnmount() {
+        this.subscription.unsubscribe();
+      }
+
+      render() {
+        const {value} = this.state;
+        if (!value) {
+          return <React.Fragment/>;
+        }
+        // Since ReplaySubject may not have an initial value, only render the
+        // connected value once the value is available.
+        return <WrappedComponent {...{[name]: value}} {...this.props}/>;
+      }
+    }
+
+    return Wrapper;
+  };
+};
+
 // HOC that provides a 'workspace' prop with current WorkspaceData
 export const withCurrentWorkspace = () => {
   return connectBehaviorSubject(currentWorkspaceStore, 'workspace');
@@ -314,6 +350,14 @@ export const withUrlParams = () => {
 // HOC that provides a 'routeConfigData' prop with current route's data object
 export const withRouteConfigData = () => {
   return connectBehaviorSubject(routeConfigDataStore, 'routeConfigData');
+};
+
+// HOC that provides a 'cdrVersionListResponse' prop with the CDR version
+// information. Rendering of the connected component is blocked on initial load
+// of the CDR versions. This should only affect initial page loads, this HOC can
+// be included last (if multiple HOCs are in use) to minimize this impact.
+export const withCdrVersions = () => {
+  return connectReplaySubject(cdrVersionStore, 'cdrVersionListResponse');
 };
 
 // Temporary method for converting generated/models/Domain to generated/models/fetch/Domain

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -33,6 +33,11 @@ export const signInStore =
     signOut: () => {},
     profileImage: {} as string,
   });
+
+// Use ReplaySubject over BehaviorSubject as this store does not have a legal
+// initial value and should not be accessed synchronously. The other stores
+// which meet this criteria should likely follow this same pattern, though a
+// broader redesign of these value stores is also probably in order.
 export const cdrVersionStore = new ReplaySubject<CdrVersionListResponse>(1);
 
 /**

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -2,9 +2,10 @@ import {ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy} from '@
 
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ConfigResponse} from 'generated';
-import {Cohort, ConceptSet, Profile} from 'generated/fetch';
+import {CdrVersionListResponse, Cohort, ConceptSet, Profile} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 export const NavStore = {
   navigate: undefined,
@@ -18,7 +19,6 @@ export const urlParamsStore = new BehaviorSubject<any>({});
 export const queryParamsStore = new BehaviorSubject<any>({});
 export const routeConfigDataStore = new BehaviorSubject<any>({});
 export const serverConfigStore = new BehaviorSubject<ConfigResponse>(undefined);
-export const cdrVersionStore = new BehaviorSubject<any>(undefined);
 export const userProfileStore =
   new BehaviorSubject<{ profile: Profile, reload: Function, updateCache: Function }>({
     profile: {} as Profile,
@@ -33,7 +33,7 @@ export const signInStore =
     signOut: () => {},
     profileImage: {} as string,
   });
-
+export const cdrVersionStore = new ReplaySubject<CdrVersionListResponse>(1);
 
 /**
  * Slightly stricter variant of Angular's DefaultRouteReuseStrategy. This

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -5,26 +5,31 @@ export class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
 }
 
-export const cdrVersions = [
-  {
-    name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
-    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-    dataAccessLevel: DataAccessLevel.Registered,
-    creationTime: 0
-  }
-];
+export const cdrVersionListResponse = {
+  defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+  items: [
+    {
+      name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+      dataAccessLevel: DataAccessLevel.Registered,
+      creationTime: 0
+    }
+  ]
+};
 
 export class CdrVersionsApiStub extends CdrVersionsApi {
   public cdrVersions: CdrVersion[];
   constructor() {
     super(undefined, undefined, (..._: any[]) => { throw Error('cannot fetch in tests'); });
-    this.cdrVersions = cdrVersions;
+    this.cdrVersions = cdrVersionListResponse.items;
   }
 
   getCdrVersions(options?: any): Promise<CdrVersionListResponse> {
     return new Promise<CdrVersionListResponse>(resolve => {
-      resolve({items: this.cdrVersions,
-        defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID});
+      resolve({
+        ...cdrVersionListResponse,
+        items: this.cdrVersions,
+      });
     });
   }
 }


### PR DESCRIPTION
Problem: All cdrVersionStore access is done synchronously, however nothing was preventing components from rendering before CDRs were loaded.

Solution: Implement "withCdrVersions" HOC which blocks until CDR version load.

The rest of the data stores work inconsistently; the data load is highly decoupled from the assumption of synchronous data access. We should reassess this pattern.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
