### PR TITLE
[RW-2032][risk=low] Include recovery email on user creation

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -344,7 +344,7 @@ dependencies {
   compile "com.fasterxml.jackson.core:jackson-core:${JACKSON_VERSION}"
   compile "com.fasterxml.jackson.core:jackson-databind:${JACKSON_DATABIND_VERSION}"
 
-  compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev86-1.23.0'
+  compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev20190806-1.30.3'
   compile 'com.google.apis:google-api-services-oauth2:v2-rev139-1.23.0'
   compile 'com.google.cloud:google-cloud-bigquery:1.51.0'
   compile 'com.google.cloud:google-cloud-storage:1.51.0'

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -344,7 +344,7 @@ public class ProfileController implements ProfileApiDelegate {
           "Username should be at least 3 characters and not more than 64 characters");
     request.getProfile().setUsername(request.getProfile().getUsername().toLowerCase());
     validateProfileFields(request.getProfile());
-    com.google.api.services.admin.directory.model.User googleUser =
+    com.google.api.services.directory.model.User googleUser =
         directoryService.createUser(
             request.getProfile().getGivenName(),
             request.getProfile().getFamilyName(),
@@ -476,8 +476,7 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Void> updateContactEmail(
       UpdateContactEmailRequest updateContactEmailRequest) {
     String username = updateContactEmailRequest.getUsername().toLowerCase();
-    com.google.api.services.admin.directory.model.User googleUser =
-        directoryService.getUser(username);
+    com.google.api.services.directory.model.User googleUser = directoryService.getUser(username);
     User user = userDao.findUserByEmail(username);
     checkUserCreationNonce(user, updateContactEmailRequest.getCreationNonce());
     if (!userNeverLoggedIn(googleUser, user)) {
@@ -497,8 +496,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Void> resendWelcomeEmail(ResendWelcomeEmailRequest resendRequest) {
     String username = resendRequest.getUsername().toLowerCase();
-    com.google.api.services.admin.directory.model.User googleUser =
-        directoryService.getUser(username);
+    com.google.api.services.directory.model.User googleUser = directoryService.getUser(username);
     User user = userDao.findUserByEmail(username);
     checkUserCreationNonce(user, resendRequest.getCreationNonce());
     if (!userNeverLoggedIn(googleUser, user)) {
@@ -508,12 +506,12 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   private boolean userNeverLoggedIn(
-      com.google.api.services.admin.directory.model.User googleUser, User user) {
+      com.google.api.services.directory.model.User googleUser, User user) {
     return user.getFirstSignInTime() == null && googleUser.getChangePasswordAtNextLogin();
   }
 
   private ResponseEntity<Void> resetPasswordAndSendWelcomeEmail(String username, User user) {
-    com.google.api.services.admin.directory.model.User googleUser =
+    com.google.api.services.directory.model.User googleUser =
         directoryService.resetUserPassword(username);
     try {
       mailServiceProvider

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -1,18 +1,16 @@
 package org.pmiops.workbench.google;
 
-import com.google.api.services.admin.directory.model.User;
+import com.google.api.services.directory.model.User;
 
 /** Encapsulate Googe APIs for handling GSuite user accounts. */
 public interface DirectoryService {
-  public boolean isUsernameTaken(String username);
+  boolean isUsernameTaken(String username);
 
-  public User getUser(String email);
+  User getUser(String email);
 
-  public User createUser(String givenName, String familyName, String username, String contactEmail);
+  User createUser(String givenName, String familyName, String username, String contactEmail);
 
-  public User updateUser(User user);
+  User resetUserPassword(String userName);
 
-  public User resetUserPassword(String userName);
-
-  public void deleteUser(String username);
+  void deleteUser(String username);
 }

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -158,7 +158,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     // GSuite custom fields for Workbench user accounts.
     // See the Moodle integration doc (broad.io/aou-moodle) for more details, as this
     // was primarily set up for Moodle SSO integration.
-    Map<String, Object> aouCustomFields = new HashMap<String, Object>();
+    Map<String, Object> aouCustomFields = new HashMap<>();
     // The value of this field must match one of the allowed values in the Moodle installation.
     // Since this value is unlikely to ever change, we use a hard-coded constant rather than an env
     // variable.
@@ -180,6 +180,7 @@ public class DirectoryServiceImpl implements DirectoryService {
       emails.add(new UserEmail().setType("home").setAddress(contactEmail));
     }
     user.setEmails(emails)
+        .setRecoveryEmail(contactEmail)
         .setCustomSchemas(Collections.singletonMap(GSUITE_AOU_SCHEMA_NAME, aouCustomFields));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -9,11 +9,11 @@ import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.services.admin.directory.Directory;
-import com.google.api.services.admin.directory.DirectoryScopes;
-import com.google.api.services.admin.directory.model.User;
-import com.google.api.services.admin.directory.model.UserEmail;
-import com.google.api.services.admin.directory.model.UserName;
+import com.google.api.services.directory.Directory;
+import com.google.api.services.directory.DirectoryScopes;
+import com.google.api.services.directory.model.User;
+import com.google.api.services.directory.model.UserEmail;
+import com.google.api.services.directory.model.UserName;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -199,14 +199,6 @@ public class DirectoryServiceImpl implements DirectoryService {
     addCustomSchemaAndEmails(user, primaryEmail, contactEmail);
 
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());
-    return user;
-  }
-
-  @Override
-  public User updateUser(User user) {
-    retryHandler.run(
-        (context) ->
-            getGoogleDirectoryService().users().update(user.getPrimaryEmail(), user).execute());
     return user;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.mail;
 
-import com.google.api.services.admin.directory.model.User;
+import com.google.api.services.directory.model.User;
 import javax.mail.MessagingException;
 
 public interface MailService {

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.mail;
 
-import com.google.api.services.admin.directory.model.User;
+import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import java.io.IOException;

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -107,7 +107,7 @@ public class ProfileControllerTest {
   private ProfileController cloudProfileController;
   private CreateAccountRequest createAccountRequest;
   private InvitationVerificationRequest invitationVerificationRequest;
-  private com.google.api.services.admin.directory.model.User googleUser;
+  private com.google.api.services.directory.model.User googleUser;
   private FakeClock clock;
   private User user;
 
@@ -132,7 +132,7 @@ public class ProfileControllerTest {
     createAccountRequest.setProfile(profile);
     createAccountRequest.setInvitationKey(INVITATION_KEY);
     invitationVerificationRequest.setInvitationKey(INVITATION_KEY);
-    googleUser = new com.google.api.services.admin.directory.model.User();
+    googleUser = new com.google.api.services.directory.model.User();
     googleUser.setPrimaryEmail(PRIMARY_EMAIL);
     googleUser.setChangePasswordAtNextLogin(true);
     googleUser.setPassword("testPassword");

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -187,8 +187,8 @@ public class UserServiceTest {
 
   @Test
   public void testSyncTwoFactorAuthStatus() throws Exception {
-    com.google.api.services.admin.directory.model.User googleUser =
-        new com.google.api.services.admin.directory.model.User();
+    com.google.api.services.directory.model.User googleUser =
+        new com.google.api.services.directory.model.User();
     googleUser.setPrimaryEmail(EMAIL_ADDRESS);
     googleUser.setIsEnrolledIn2Sv(true);
 

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
@@ -3,9 +3,9 @@ package org.pmiops.workbench.mail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.google.api.services.admin.directory.model.User;
-import com.google.api.services.admin.directory.model.UserEmail;
-import com.google.api.services.admin.directory.model.UserName;
+import com.google.api.services.directory.model.User;
+import com.google.api.services.directory.model.UserEmail;
+import com.google.api.services.directory.model.UserName;
 import javax.mail.MessagingException;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
Tested locally. Verified I could reset my password via recovery email link.

Required upgrading the gsuite SDK.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
