### PR TITLE
[RW-3525][Risk=no] Preview per domain

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -49,7 +49,6 @@ import org.pmiops.workbench.model.DataSet;
 import org.pmiops.workbench.model.DataSetCodeResponse;
 import org.pmiops.workbench.model.DataSetExportRequest;
 import org.pmiops.workbench.model.DataSetListResponse;
-import org.pmiops.workbench.model.DataSetPreviewList;
 import org.pmiops.workbench.model.DataSetPreviewRequest;
 import org.pmiops.workbench.model.DataSetPreviewResponse;
 import org.pmiops.workbench.model.DataSetPreviewValueList;

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -264,16 +264,22 @@ public class DataSetController implements DataSetApiDelegate {
   }
 
   // TODO (srubenst): Delete this method and make generate query take the composite parts.
-  private DataSetRequest generateDataSetRequestFromPreviewRequest(DataSetPreviewRequest dataSetPreviewRequest) {
+  private DataSetRequest generateDataSetRequestFromPreviewRequest(
+      DataSetPreviewRequest dataSetPreviewRequest) {
     return new DataSetRequest()
         .name("Does not matter")
         .conceptSetIds(dataSetPreviewRequest.getConceptSetIds())
         .cohortIds(dataSetPreviewRequest.getCohortIds())
         .prePackagedConceptSet(dataSetPreviewRequest.getPrePackagedConceptSet())
         .includesAllParticipants(dataSetPreviewRequest.getIncludesAllParticipants())
-        .values(dataSetPreviewRequest.getValues().stream()
-            .map(value -> new DomainValuePair().domain(dataSetPreviewRequest.getDomain()).value(value))
-            .collect(Collectors.toList()));
+        .values(
+            dataSetPreviewRequest.getValues().stream()
+                .map(
+                    value ->
+                        new DomainValuePair()
+                            .domain(dataSetPreviewRequest.getDomain())
+                            .value(value))
+                .collect(Collectors.toList()));
   }
 
   @Override
@@ -283,10 +289,12 @@ public class DataSetController implements DataSetApiDelegate {
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     DataSetPreviewResponse previewQueryResponse = new DataSetPreviewResponse();
     DataSetRequest dataSetRequest = generateDataSetRequestFromPreviewRequest(dataSetPreviewRequest);
-    Map<String, QueryJobConfiguration> bigQueryJobConfig = dataSetService.generateQuery(dataSetRequest);
+    Map<String, QueryJobConfiguration> bigQueryJobConfig =
+        dataSetService.generateQuery(dataSetRequest);
 
     if (bigQueryJobConfig.size() > 1) {
-      throw new BadRequestException("There should never be a preview request with more than one domain");
+      throw new BadRequestException(
+          "There should never be a preview request with more than one domain");
     }
     List<DataSetPreviewValueList> valuePreviewList = new ArrayList<>();
 
@@ -397,7 +405,8 @@ public class DataSetController implements DataSetApiDelegate {
 
           Collections.sort(
               valuePreviewList,
-              Comparator.comparing(item -> dataSetPreviewRequest.getValues().indexOf(item.getValue())));
+              Comparator.comparing(
+                  item -> dataSetPreviewRequest.getValues().indexOf(item.getValue())));
         });
 
     previewQueryResponse.setValues(valuePreviewList);

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -272,7 +272,7 @@ public class DataSetController implements DataSetApiDelegate {
         .cohortIds(dataSetPreviewRequest.getCohortIds())
         .prePackagedConceptSet(dataSetPreviewRequest.getPrePackagedConceptSet())
         .includesAllParticipants(dataSetPreviewRequest.getIncludesAllParticipants())
-        .values(
+        .domainValuePairs(
             dataSetPreviewRequest.getValues().stream()
                 .map(
                     value ->
@@ -290,7 +290,7 @@ public class DataSetController implements DataSetApiDelegate {
     DataSetPreviewResponse previewQueryResponse = new DataSetPreviewResponse();
     DataSetRequest dataSetRequest = generateDataSetRequestFromPreviewRequest(dataSetPreviewRequest);
     Map<String, QueryJobConfiguration> bigQueryJobConfig =
-        dataSetService.generateQuery(dataSetRequest);
+        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest);
 
     if (bigQueryJobConfig.size() > 1) {
       throw new BadRequestException(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class DataSetServiceImpl implements DataSetService {
 
-  private static final String SELCECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST =
+  private static final String SELECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST =
       "SELECT * FROM `${projectId}.${dataSetId}.ds_linking` "
           + "WHERE DOMAIN = @pDomain AND DENORMALIZED_NAME in unnest(@pValuesList)";
   private static final ImmutableSet<PrePackagedConceptSetEnum>
@@ -572,7 +572,7 @@ public class DataSetServiceImpl implements DataSetService {
         bigQueryService.executeQuery(
             buildQueryJobConfiguration(
                 queryParameterValuesByDomain,
-                SELCECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST));
+                SELECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST));
 
     final ImmutableList<String> valueSelects =
         StreamSupport.stream(valuesLinkingTableResult.getValues().spliterator(), false)

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2053,15 +2053,15 @@ paths:
         - dataSet
       description: >
         Preview data set
-      operationId: "previewQuery"
+      operationId: "generateDataSetPreview"
       parameters:
         - $ref: '#/parameters/workspaceNamespace'
         - $ref: '#/parameters/workspaceId'
         - in: body
-          name: dataSet
+          name: dataSetPreviewRequest
           required: true
           schema:
-            $ref: "#/definitions/DataSetRequest"
+            $ref: "#/definitions/DataSetPreviewRequest"
       responses:
         200:
           description: >
@@ -2981,19 +2981,45 @@ definitions:
         type: object
         description: Can be any value
 
+  DataSetPreviewRequest:
+    type: object
+    required:
+      - domain
+    properties:
+      domain:
+        $ref: "#/definitions/Domain"
+      includesAllParticipants:
+        type: boolean
+        default: false
+        description: >
+          Whether to include all participants or filter by cohorts
+      prePackagedConceptSet:
+        $ref: "#/definitions/PrePackagedConceptSetEnum"
+      conceptSetIds:
+        type: array
+        description: >
+          The ids of all concept sets in the data set
+        items:
+          type: integer
+          format: int64
+      cohortIds:
+        type: array
+        description: >
+          The ids of all cohorts in the data set
+        items:
+          type: integer
+          format: int64
+      values:
+        type: array
+        description: >
+          All the selected values in the data set
+        items:
+          type: string
+
+
   DataSetPreviewResponse:
     type: object
     properties:
-      domainValue:
-        type: "array"
-        items:
-          $ref: "#/definitions/DataSetPreviewList"
-
-  DataSetPreviewList:
-    type: object
-    properties:
-      domain:
-        type: string
       values:
         type: "array"
         items:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2053,7 +2053,7 @@ paths:
         - dataSet
       description: >
         Preview data set
-      operationId: "generateDataSetPreview"
+      operationId: "previewDataSetByDomain"
       parameters:
         - $ref: '#/parameters/workspaceNamespace'
         - $ref: '#/parameters/workspaceId'
@@ -3020,6 +3020,8 @@ definitions:
   DataSetPreviewResponse:
     type: object
     properties:
+      domain:
+        $ref: "#/definitions/Domain"
       values:
         type: "array"
         items:

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -115,7 +115,7 @@ describe('DataSet', () => {
     });
 
   it('should display preview data table once preview button is clicked', async() => {
-    const spy = jest.spyOn(dataSetApi(), 'generateDataSetPreview');
+    const spy = jest.spyOn(dataSetApi(), 'previewDataSetByDomain');
     const wrapper = mount(<DataSetPage />);
     await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -115,7 +115,7 @@ describe('DataSet', () => {
     });
 
   it('should display preview data table once preview button is clicked', async() => {
-    const spy = jest.spyOn(dataSetApi(), 'previewQuery');
+    const spy = jest.spyOn(dataSetApi(), 'generateDataSetPreview');
     const wrapper = mount(<DataSetPage />);
     await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -586,30 +586,15 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
       domain: Domain): string {
       switch (exceptionResponse.statusCode) {
         case 400:
-          if (exceptionResponse.message ===
-            'Data Sets must include at least one cohort and concept.') {
-            return exceptionResponse.message;
-          } else if (exceptionResponse.message ===
-            'Concept Sets must contain at least one concept') {
-            return `One or more of your concept sets in domain ${domain}
-                  has no concepts. Please check your concept sets to ensure all
-                  concept sets have concepts.`;
-          }
+          return exceptionResponse.message;
           break;
         case 404:
-          if (exceptionResponse.message.startsWith(
-            'Not Found: No Cohort definition matching cohortId')) {
-            return 'Error with one or more cohorts in the data set. ' +
-              'Please submit a bug using the contact support button';
-          }
+          return exceptionResponse.message;
           break;
         case 504:
-          if (exceptionResponse.message ===
-            'Timeout while querying the CDR to pull preview information.') {
-            return `Query to load data from the All of Us Database timed out for domain:
-                  ${domain}. Please either try again or export data set to a notebook to try
-                  there`;
-          }
+          return `Query to load data from the All of Us Database timed out for domain:
+                ${domain}. Please either try again or export data set to a notebook to try
+                there`;
           break;
         default:
           return `An unexpected error has occurred loading domain: ${domain}.

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -581,7 +581,9 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
       });
     }
 
-    generateErrorTextFromPreviewException(exceptionResponse: ErrorResponse, domain: Domain): string {
+    // TODO: Move to using a response based error handling method, rather than a error based one
+    generateErrorTextFromPreviewException(exceptionResponse: ErrorResponse,
+                                          domain: Domain): string {
       switch (exceptionResponse.statusCode) {
         case 400:
           if (exceptionResponse.message ===

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -22,12 +22,13 @@ import {
 import colors from 'app/styles/colors';
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
+  formatDomain,
+  formatDomainString,
   ReactWrapperBase,
   toggleIncludes,
   withCurrentWorkspace,
   withUrlParams
 } from 'app/utils';
-import {formatDomain} from 'app/utils/index';
 import {navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {ResourceType} from 'app/utils/resourceActions';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -840,11 +841,15 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
                   {fp.toPairs(previewList).map((value) => {
                     const domain: string = value[0];
                     const previewRow: DataSetPreviewInfo = value[1];
-                    return <TooltipTrigger content={'Preview for domain ' + fp.capitalize(domain)
-                    + ' is still loading. It may take up to one minute'}
+                    return <TooltipTrigger key={domain}
+                                           content={
+                                             'Preview for domain '
+                                             + formatDomainString(domain)
+                                             + ' is still loading. It may take up to one minute'
+                                           }
                                            disabled={!previewRow.isLoading}
                                            side='top'>
-                      <Clickable key={domain}
+                      <Clickable
                                  disabled={previewRow.isLoading}
                                  onClick={() =>
                                    this.setState({selectedPreviewDomain: Domain[domain]})}

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -544,7 +544,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
 
     async getPreviewList() {
       const {namespace, id} = this.props.workspace;
-      const domains = fp.uniq(this.state.selectedValues.map(domainValue => domainValue.domain));
+      const domains = fp.uniq(this.state.selectedDomainValuePairs.map(domainValue => domainValue.domain));
       const newPreviewList: Map<Domain, DataSetPreviewInfo> =
         new Map(domains.map<[Domain, DataSetPreviewInfo]>(domain => [domain, {isLoading: true, values: []}]));
       this.setState({
@@ -558,7 +558,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
           includesAllParticipants: this.state.includesAllParticipants,
           cohortIds: this.state.selectedCohortIds,
           prePackagedConceptSet: this.getPrePackagedConceptSet(),
-          values: this.state.selectedValues.map(domainValue => domainValue.value)
+          values: this.state.selectedDomainValuePairs.map(domainValue => domainValue.value)
         };
         try {
           const dataSetPreviewResp = await dataSetApi().previewDataSetByDomain(namespace, id, request);

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -231,7 +231,7 @@ const BoxHeader = ({text= '', header =  '', subHeader = '', style= {}, ...props}
 
 interface DataSetPreviewList {
   domain: Domain;
-  isLoading: boolean
+  isLoading: boolean;
   values?: Array<DataSetPreviewValueList>;
 }
 
@@ -538,7 +538,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
             domain: domain,
             isLoading: true,
             values: []
-          }
+          };
         }),
         previewDataLoading: true,
         selectedPreviewDomain: domains[0]
@@ -574,7 +574,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
               break;
             case 404:
               if (exceptionResponse.message.startsWith(
-                  'Not Found: No Cohort definition matching cohortId')) {
+                'Not Found: No Cohort definition matching cohortId')) {
                 errorText = 'Error with one or more cohorts in the data set. ' +
                   'Please submit a bug using the contact support button';
               }
@@ -629,7 +629,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
       const filteredPreviewData =
           this.state.previewList.filter(
             preview => preview.domain === this.state.selectedPreviewDomain)[0];
-      const domainDisplayed = this.state.selectedPreviewDomain.toString().toLowerCase()
+      const domainDisplayed = this.state.selectedPreviewDomain.toString().toLowerCase();
       return filteredPreviewData.values.length > 0 ?
         <DataTable ref={el => this.dt = el} key={this.state.selectedPreviewDomain}
                           scrollable={true} style={{width: '100%'}}

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -545,13 +545,8 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
     async getPreviewList() {
       const {namespace, id} = this.props.workspace;
       const domains = fp.uniq(this.state.selectedValues.map(domainValue => domainValue.domain));
-      const newPreviewList: Map<Domain, DataSetPreviewInfo> = new Map();
-      domains.forEach(domain => {
-        newPreviewList.set(domain, {
-          isLoading: true,
-          values: []
-        });
-      });
+      const newPreviewList: Map<Domain, DataSetPreviewInfo> =
+        new Map(domains.map<[Domain, DataSetPreviewInfo]>(domain => [domain, {isLoading: true, values: []}]));
       this.setState({
         previewList: newPreviewList,
         selectedPreviewDomain: domains[0]

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -583,7 +583,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
 
     // TODO: Move to using a response based error handling method, rather than a error based one
     generateErrorTextFromPreviewException(exceptionResponse: ErrorResponse,
-                                          domain: Domain): string {
+      domain: Domain): string {
       switch (exceptionResponse.statusCode) {
         case 400:
           if (exceptionResponse.message ===

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -383,8 +383,12 @@ export function formatRecentResourceDisplayDate(time: string): string {
   return date.toDateString().split(' ').slice(1).join(' ');
 }
 
+export function formatDomainString(domainString: string): string {
+  return fp.capitalize(domainString);
+}
+
 export function formatDomain(domain: FetchDomain): string {
-  return fp.capitalize(domain.toString());
+  return formatDomainString(domain.toString());
 }
 
 // Given a value and an array, return a new array with the value appended.

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -383,6 +383,10 @@ export function formatRecentResourceDisplayDate(time: string): string {
   return date.toDateString().split(' ').slice(1).join(' ');
 }
 
+export function formatDomain(domain: FetchDomain): string {
+  return fp.capitalize(domain.toString());
+}
+
 // Given a value and an array, return a new array with the value appended.
 export const append = fp.curry((value, arr) => fp.concat(arr, [value]));
 

--- a/ui/src/testing/stubs/data-set-api-stub.ts
+++ b/ui/src/testing/stubs/data-set-api-stub.ts
@@ -57,9 +57,10 @@ export class DataSetApiStub extends DataSetApi {
     });
   }
 
-  generateDataSetPreview(workspaceNamespace: string,
+  previewDataSetByDomain(workspaceNamespace: string,
     workspaceId: string, dataSetPreviewRequest: DataSetPreviewRequest): Promise<DataSetPreviewResponse> {
     return Promise.resolve({
+      domain: dataSetPreviewRequest.domain,
       values: [
         {value: 'Value1', queryValue: ['blah']},
         {value: 'Value2', queryValue: ['blah2']}

--- a/ui/src/testing/stubs/data-set-api-stub.ts
+++ b/ui/src/testing/stubs/data-set-api-stub.ts
@@ -4,6 +4,7 @@ import {
   DataSetCodeResponse,
   DataSetExportRequest,
   DataSetListResponse,
+  DataSetPreviewRequest,
   DataSetPreviewResponse,
   DataSetRequest,
   EmptyResponse,
@@ -56,11 +57,12 @@ export class DataSetApiStub extends DataSetApi {
     });
   }
 
-  previewQuery(workspaceNamespace: string,
-    workspaceId: string, dataSet: DataSetRequest): Promise<DataSetPreviewResponse> {
+  generateDataSetPreview(workspaceNamespace: string,
+    workspaceId: string, dataSetPreviewRequest: DataSetPreviewRequest): Promise<DataSetPreviewResponse> {
     return Promise.resolve({
-      domainValue: [
-        {domain: 'CONDITION', values: [{value: 'Value1'}, {value: 'Value2'}]}
+      values: [
+        {value: 'Value1', queryValue: ['blah']},
+        {value: 'Value2', queryValue: ['blah2']}
       ]
     });
   }


### PR DESCRIPTION
The reason to do this is to reduce the chance we would hit the appengine timeout, and make it more likely we don't hit unexpected timeouts. Also, this allows us to display queries that return more quickly to the user before all queries have returned.

Attached is a screenshot of a domain loading:
![Screen Shot 2019-09-25 at 11 57 35 AM](https://user-images.githubusercontent.com/15351021/65618095-bdd7de80-df8b-11e9-8f3e-784b8c1250cd.png)

For Mocks, those are here:
https://projects.invisionapp.com/d/main?origin=v7#/console/12820961/385557370/inspect