### PR TITLE
[RW-3435][risk=medium] Billing Project Garbage Collection cron endpoint

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -18,7 +18,11 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 2,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "aou-rw-gc-test-1@all-of-us-workbench-test.iam.gserviceaccount.com"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -20,7 +20,10 @@
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [
-      "TODO - will update PR once generated"
+      "aou-rw-gc-perf-1@all-of-us-rw-perf.iam.gserviceaccount.com",
+      "aou-rw-gc-perf-2@all-of-us-rw-perf.iam.gserviceaccount.com",
+      "aou-rw-gc-perf-3@all-of-us-rw-perf.iam.gserviceaccount.com",
+      "aou-rw-gc-perf-4@all-of-us-rw-perf.iam.gserviceaccount.com"
     ]
   },
   "auth": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -17,7 +17,11 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_00293C-5DEA2D-6887E7",
     "retryCount": 4,
     "bufferCapacity": 200,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "TODO - will update PR once generated"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -17,7 +17,11 @@
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.gcp_billing_export_v1_015EAA_E95687_1F8614",
     "retryCount": 4,
     "bufferCapacity": 20,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "TODO - will update PR once generated"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -20,7 +20,7 @@
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [
-      "TODO - will update PR once generated"
+      "aou-rw-gc-prod-1@all-of-us-rw-prod.iam.gserviceaccount.com"
     ]
   },
   "auth": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -20,7 +20,7 @@
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [
-      "TODO - will update PR once generated"
+      "aou-rw-gc-stable-1@all-of-us-rw-stable.iam.gserviceaccount.com"
     ]
   },
   "auth": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -17,7 +17,11 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 10,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "TODO - will update PR once generated"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -20,7 +20,7 @@
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [
-      "TODO - will update PR once generated"
+      "aou-rw-gc-staging-1@all-of-us-rw-staging.iam.gserviceaccount.com"
     ]
   },
   "auth": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -17,7 +17,11 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 10,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "TODO - will update PR once generated"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -18,7 +18,11 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 100,
-    "defaultFreeCreditsLimit": 300.0
+    "defaultFreeCreditsLimit": 300.0,
+    "garbageCollectionUserCapacity": 1000,
+    "garbageCollectionUsers": [
+      "aou-rw-gc-test-1@all-of-us-workbench-test.iam.gserviceaccount.com"
+    ]
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/db/changelog/db.changelog-101-billing-project-garbage-collection.xml
+++ b/api/db/changelog/db.changelog-101-billing-project-garbage-collection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-101-billing-project-garbage-collection">
+
+    <createTable tableName="billing_project_garbage_collection">
+      <column name="fireCloudProjectName" type="varchar(80)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="owner" type="varchar(80)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-101-billing-project-garbage-collection.xml
+++ b/api/db/changelog/db.changelog-101-billing-project-garbage-collection.xml
@@ -7,7 +7,7 @@
   <changeSet author="thibault" id="changelog-101-billing-project-garbage-collection">
 
     <createTable tableName="billing_project_garbage_collection">
-      <column name="fireCloudProjectName" type="varchar(80)">
+      <column name="firecloud_project_name" type="varchar(80)">
         <constraints nullable="false"/>
       </column>
       <column name="owner" type="varchar(80)">

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -105,9 +105,10 @@
     <include file="changelog/db.changelog-95-free-credits.xml"/>
     <include file="changelog/db.changelog-96-drop-free-tier-billing.xml"/>
     <include file="changelog/db.changelog-97-cdr-archival-status.xml"/>
-    <include file="changelog/db.changelog-98-add-demographic-survey.xml"/> 
+    <include file="changelog/db.changelog-98-add-demographic-survey.xml"/>
     <include file="changelog/db.changelog-99-add-address.xml"/>
-    <include file="changelog/db.changelog-100-update-institution-affiliations.xml"/> 
+    <include file="changelog/db.changelog-100-update-institution-affiliations.xml"/>
+    <include file="changelog/db.changelog-101-billing-project-garbage-collection.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
@@ -46,7 +46,6 @@ public class FireCloudIntegrationTest {
   @Mock private BillingApi billingApi;
   @Mock private WorkspacesApi workspacesApi;
   @Mock private GroupsApi allOfUsGroupsApi;
-  @Mock private GroupsApi endUserGroupsApi;
   @Mock private WorkspacesApi workspaceAclsApi;
   @Mock private StaticNotebooksApi staticNotebooksApi;
   @Mock private ProfileApi profileApi;

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -19,8 +19,8 @@ import org.pmiops.workbench.db.dao.BillingProjectGarbageCollectionDao;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry.BillingProjectBufferStatus;
 import org.pmiops.workbench.db.model.BillingProjectGarbageCollection;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -126,7 +126,11 @@ public class BillingGarbageCollectionService {
     try {
       final GoogleCredential gcsaCredential =
           garbageCollectionSACredentials.get(garbageCollectionSA);
-      fireCloudService.removeOwnerFromBillingProject(appEngineSA, gcsaCredential, projectName);
+
+      gcsaCredential.refreshToken();
+
+      fireCloudService.removeOwnerFromBillingProject(
+          projectName, appEngineSA, gcsaCredential.getAccessToken());
     } catch (final ExecutionException e) {
       final String msg =
           String.format(

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -72,7 +72,7 @@ public class BillingGarbageCollectionService {
             });
   }
 
-  // Is the App Engine SA a member of this FireCloud project?
+  // Checks whether the AppEngine service account is a member of this FireCloud project
   private boolean appSAIsMemberOfProject(String billingProject) {
     try {
       fireCloudService.getBillingProjectStatus(billingProject);

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -150,7 +150,7 @@ public class BillingGarbageCollectionService {
 
   BillingProjectGarbageCollectionResponse deletedWorkspaceGarbageCollection() {
     final List<String> billingProjects =
-        billingProjectGarbageCollectionDao.findBillingProjectsForGarbageCollection();
+        billingProjectBufferEntryDao.findBillingProjectsForGarbageCollection();
 
     final List<GarbageCollectedProject> garbageCollectedProjects =
         billingProjects.stream()

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -19,7 +19,7 @@ import org.pmiops.workbench.db.dao.BillingProjectGarbageCollectionDao;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry.BillingProjectBufferStatus;
 import org.pmiops.workbench.db.model.BillingProjectGarbageCollection;
-import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
@@ -96,7 +96,7 @@ public class BillingGarbageCollectionService {
             "No available Garbage Collection Service Accounts.  "
                 + "These GCSAs exceed the configured capacity limit of %d: %s",
             config.garbageCollectionUserCapacity, String.join(", ", config.garbageCollectionUsers));
-    throw new BadRequestException(msg);
+    throw new ServerErrorException(msg);
   }
 
   private GarbageCollectedProject recordGarbageCollection(
@@ -132,13 +132,13 @@ public class BillingGarbageCollectionService {
           String.format(
               "Failure retrieving credentials for garbage collection service account %s",
               garbageCollectionSA);
-      throw new BadRequestException(msg, e);
+      throw new ServerErrorException(msg, e);
     } catch (final IOException e) {
       final String msg =
           String.format(
               "Failure removing user %s as owner of project %s. Successfully added new owner %s",
               appEngineSA, projectName, garbageCollectionSA);
-      throw new BadRequestException(msg, e);
+      throw new ServerErrorException(msg, e);
     }
 
     return recordGarbageCollection(projectName, garbageCollectionSA);

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -1,0 +1,164 @@
+package org.pmiops.workbench.billing;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.BillingProjectBufferEntryDao;
+import org.pmiops.workbench.db.dao.BillingProjectGarbageCollectionDao;
+import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
+import org.pmiops.workbench.db.model.BillingProjectBufferEntry.BillingProjectBufferStatus;
+import org.pmiops.workbench.db.model.BillingProjectGarbageCollection;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
+import org.pmiops.workbench.google.CloudStorageService;
+import org.pmiops.workbench.model.BillingProjectGarbageCollectionResponse;
+import org.pmiops.workbench.model.GarbageCollectedProject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BillingGarbageCollectionService {
+  private final BillingProjectGarbageCollectionDao billingProjectGarbageCollectionDao;
+  private final BillingProjectBufferEntryDao billingProjectBufferEntryDao;
+  private final FireCloudService fireCloudService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final Provider<CloudStorageService> cloudStorageServiceProvider;
+  private final Clock clock;
+  private final LoadingCache<String, GoogleCredential> garbageCollectionSACredentials;
+
+  @Autowired
+  public BillingGarbageCollectionService(
+      BillingProjectGarbageCollectionDao billingProjectGarbageCollectionDao,
+      BillingProjectBufferEntryDao billingProjectBufferEntryDao,
+      FireCloudService fireCloudService,
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      Provider<CloudStorageService> cloudStorageServiceProvider,
+      Clock clock) {
+    this.billingProjectGarbageCollectionDao = billingProjectGarbageCollectionDao;
+    this.billingProjectBufferEntryDao = billingProjectBufferEntryDao;
+    this.fireCloudService = fireCloudService;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+    this.cloudStorageServiceProvider = cloudStorageServiceProvider;
+    this.clock = clock;
+
+    this.garbageCollectionSACredentials = initializeCredentialCache();
+  }
+
+  private LoadingCache<String, GoogleCredential> initializeCredentialCache() {
+    return CacheBuilder.newBuilder()
+        .expireAfterWrite(24, TimeUnit.HOURS)
+        .build(
+            new CacheLoader<String, GoogleCredential>() {
+              @Override
+              public GoogleCredential load(String saEmail) throws IOException {
+                return cloudStorageServiceProvider
+                    .get()
+                    .getGarbageCollectionServiceAccountCredentials(saEmail)
+                    .createScoped(FireCloudServiceImpl.FIRECLOUD_API_OAUTH_SCOPES);
+              }
+            });
+  }
+
+  // Is the App Engine SA a member of this FireCloud project?
+  private Boolean appSAIsMemberOfProject(String billingProject) {
+    try {
+      fireCloudService.getBillingProjectStatus(billingProject);
+      return true;
+    } catch (NotFoundException e) {
+      return false;
+    }
+  }
+
+  private String chooseGarbageCollectionSA() {
+    for (final String sa : workbenchConfigProvider.get().billing.garbageCollectionUsers) {
+      final long count = billingProjectGarbageCollectionDao.countAllByOwner(sa);
+      if (count < workbenchConfigProvider.get().billing.garbageCollectionUserCapacity) {
+        return sa;
+      }
+    }
+
+    throw new BadRequestException("No available Garbage Collection Service Accounts");
+  }
+
+  private GarbageCollectedProject recordGarbageCollection(
+      final String projectName, final String garbageCollectionSA) {
+
+    final BillingProjectGarbageCollection gc = new BillingProjectGarbageCollection();
+    gc.setFireCloudProjectName(projectName);
+    gc.setOwner(garbageCollectionSA);
+    billingProjectGarbageCollectionDao.save(gc);
+
+    final BillingProjectBufferEntry entry =
+        billingProjectBufferEntryDao.findByFireCloudProjectName(projectName);
+    entry.setStatusEnum(
+        BillingProjectBufferStatus.GARBAGE_COLLECTED,
+        () -> new Timestamp(clock.instant().toEpochMilli()));
+    billingProjectBufferEntryDao.save(entry);
+
+    return gc.toGarbageCollectedProject();
+  }
+
+  private GarbageCollectedProject transferOwnership(final String projectName) {
+    final String appEngineSA = workbenchConfigProvider.get().auth.serviceAccountApiUsers.get(0);
+
+    final String garbageCollectionSA = chooseGarbageCollectionSA();
+    fireCloudService.addOwnerToBillingProject(garbageCollectionSA, projectName);
+
+    try {
+      final GoogleCredential gcsaCredential =
+          garbageCollectionSACredentials.get(garbageCollectionSA);
+      fireCloudService.removeOwnerFromBillingProject(appEngineSA, gcsaCredential, projectName);
+    } catch (final ExecutionException e) {
+      final String msg =
+          String.format(
+              "Failure retrieving credentials for garbage collection service account %s",
+              garbageCollectionSA);
+      throw new BadRequestException(msg, e);
+    } catch (final IOException e) {
+      final String msg =
+          String.format(
+              "Failure removing user %s as owner of project %s. Successfully added new owner %s",
+              appEngineSA, projectName, garbageCollectionSA);
+      throw new BadRequestException(msg, e);
+    }
+
+    return recordGarbageCollection(projectName, garbageCollectionSA);
+  }
+
+  BillingProjectGarbageCollectionResponse deletedWorkspaceGarbageCollection() {
+    final List<String> billingProjects =
+        billingProjectGarbageCollectionDao.findBillingProjectsForGarbageCollection();
+
+    final List<GarbageCollectedProject> garbageCollectedProjects =
+        billingProjects.stream()
+            .map(
+                projectName -> {
+                  // determine whether this candidate for garbage collection
+                  // has already been deleted or transferred by a process other than GC
+                  if (appSAIsMemberOfProject(projectName)) {
+                    return transferOwnership(projectName);
+                  } else {
+                    // if it's in the DB as garbage-collected we won't try to do it again
+                    return recordGarbageCollection(projectName, "unknown");
+                  }
+                })
+            .collect(Collectors.toList());
+
+    final BillingProjectGarbageCollectionResponse response =
+        new BillingProjectGarbageCollectionResponse();
+    response.addAll(garbageCollectedProjects);
+    return response;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -73,7 +73,7 @@ public class BillingGarbageCollectionService {
   }
 
   // Is the App Engine SA a member of this FireCloud project?
-  private Boolean appSAIsMemberOfProject(String billingProject) {
+  private boolean appSAIsMemberOfProject(String billingProject) {
     try {
       fireCloudService.getBillingProjectStatus(billingProject);
       return true;

--- a/api/src/main/java/org/pmiops/workbench/billing/OfflineBillingController.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/OfflineBillingController.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.billing;
 
 import org.pmiops.workbench.api.OfflineBillingApiDelegate;
+import org.pmiops.workbench.model.BillingProjectGarbageCollectionResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,13 +12,23 @@ public class OfflineBillingController implements OfflineBillingApiDelegate {
 
   private final BillingAlertsService billingAlertsService;
   private final BillingProjectBufferService billingProjectBufferService;
+  private final BillingGarbageCollectionService billingGarbageCollectionService;
 
   @Autowired
   OfflineBillingController(
       BillingAlertsService billingAlertsService,
-      BillingProjectBufferService billingProjectBufferService) {
+      BillingProjectBufferService billingProjectBufferService,
+      BillingGarbageCollectionService billingGarbageCollectionService) {
     this.billingAlertsService = billingAlertsService;
     this.billingProjectBufferService = billingProjectBufferService;
+    this.billingGarbageCollectionService = billingGarbageCollectionService;
+  }
+
+  @Override
+  public ResponseEntity<BillingProjectGarbageCollectionResponse> billingProjectGarbageCollection() {
+    BillingProjectGarbageCollectionResponse response =
+        billingGarbageCollectionService.deletedWorkspaceGarbageCollection();
+    return ResponseEntity.ok(response);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
@@ -56,7 +56,7 @@ public interface BillingProjectBufferEntryDao
           + "AND w.activeStatus = :workspaceStatus "
           + "AND w.billingMigrationStatus = :migrationStatus")
   List<String> findByStatusAndActiveStatusAndBillingMigrationStatus(
-      @Param("billingStatus") long billingStatus,
-      @Param("workspaceStatus") long workspaceStatus,
-      @Param("migrationStatus") long migrationStatus);
+      @Param("billingStatus") short billingStatus,
+      @Param("workspaceStatus") short workspaceStatus,
+      @Param("migrationStatus") short migrationStatus);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
@@ -3,8 +3,13 @@ package org.pmiops.workbench.db.dao;
 import java.sql.Timestamp;
 import java.util.List;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
+import org.pmiops.workbench.db.model.BillingProjectBufferEntry.BillingProjectBufferStatus;
+import org.pmiops.workbench.db.model.StorageEnums;
+import org.pmiops.workbench.db.model.Workspace.BillingMigrationStatus;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,4 +37,26 @@ public interface BillingProjectBufferEntryDao
 
   @Query(value = "SELECT RELEASE_LOCK('" + ASSIGNING_LOCK + "')", nativeQuery = true)
   int releaseAssigningLock();
+
+  // get Billing Projects which are ASSIGNED to Workspaces which have been DELETED and have NEW
+  // Billing Migration Status.  These are ready to be garbage-collected
+  default List<String> findBillingProjectsForGarbageCollection() {
+    return findByStatusAndActiveStatusAndBillingMigrationStatus(
+        StorageEnums.billingProjectBufferStatusToStorage(BillingProjectBufferStatus.ASSIGNED),
+        StorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.DELETED),
+        StorageEnums.billingMigrationStatusToStorage(BillingMigrationStatus.NEW));
+  }
+
+  @Query(
+      "SELECT p.fireCloudProjectName "
+          + "FROM BillingProjectBufferEntry p "
+          + "JOIN Workspace w "
+          + "ON w.workspaceNamespace = p.fireCloudProjectName "
+          + "AND p.status = :billingStatus "
+          + "AND w.activeStatus = :workspaceStatus "
+          + "AND w.billingMigrationStatus = :migrationStatus")
+  List<String> findByStatusAndActiveStatusAndBillingMigrationStatus(
+      @Param("billingStatus") long billingStatus,
+      @Param("workspaceStatus") long workspaceStatus,
+      @Param("migrationStatus") long migrationStatus);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectGarbageCollectionDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectGarbageCollectionDao.java
@@ -1,0 +1,26 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.List;
+import org.pmiops.workbench.db.model.BillingProjectGarbageCollection;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BillingProjectGarbageCollectionDao
+    extends CrudRepository<BillingProjectGarbageCollection, Long> {
+
+  // get Billing Projects which are ASSIGNED to Workspaces which have been DELETED and have NEW
+  // Billing Migration Status.  These are ready to be garbage-collected
+  @Query(
+      "SELECT p.fireCloudProjectName "
+          + "FROM BillingProjectBufferEntry p "
+          + "JOIN Workspace w "
+          + "ON w.workspaceNamespace = p.fireCloudProjectName "
+          + "AND p.status = 4 " // BillingProjectBufferStatus.ASSIGNED
+          + "AND w.activeStatus = 1 " // WorkspaceActiveStatus.DELETED
+          + "AND w.billingMigrationStatus = 1") // BillingMigrationStatus.NEW
+  List<String> findBillingProjectsForGarbageCollection();
+
+  Long countAllByOwner(String owner);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectGarbageCollectionDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectGarbageCollectionDao.java
@@ -1,26 +1,11 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.List;
 import org.pmiops.workbench.db.model.BillingProjectGarbageCollection;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BillingProjectGarbageCollectionDao
     extends CrudRepository<BillingProjectGarbageCollection, Long> {
-
-  // get Billing Projects which are ASSIGNED to Workspaces which have been DELETED and have NEW
-  // Billing Migration Status.  These are ready to be garbage-collected
-  @Query(
-      "SELECT p.fireCloudProjectName "
-          + "FROM BillingProjectBufferEntry p "
-          + "JOIN Workspace w "
-          + "ON w.workspaceNamespace = p.fireCloudProjectName "
-          + "AND p.status = 4 " // BillingProjectBufferStatus.ASSIGNED
-          + "AND w.activeStatus = 1 " // WorkspaceActiveStatus.DELETED
-          + "AND w.billingMigrationStatus = 1") // BillingMigrationStatus.NEW
-  List<String> findBillingProjectsForGarbageCollection();
-
   Long countAllByOwner(String owner);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
@@ -25,8 +25,9 @@ public class BillingProjectBufferEntry {
   private User assignedUser;
 
   public enum BillingProjectBufferStatus {
-    CREATING, // Sent a request to FireCloud to create a BillingProject. Status of BillingProject is
-    // TBD
+    // Sent a request to FireCloud to create a BillingProject. Status of BillingProject is TBD
+    CREATING,
+
     ERROR, // Failed to create BillingProject
     AVAILABLE, // BillingProject is ready to be assigned to a user
     ASSIGNING, //  BillingProject is being assigned to a user

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectBufferEntry.java
@@ -31,7 +31,12 @@ public class BillingProjectBufferEntry {
     ERROR, // Failed to create BillingProject
     AVAILABLE, // BillingProject is ready to be assigned to a user
     ASSIGNING, //  BillingProject is being assigned to a user
-    ASSIGNED // BillingProject has been assigned to a user
+    ASSIGNED, // BillingProject has been assigned to a user
+
+    // The ownership of this project has been transferred from the AoU App Engine SA
+    // to an alternate SA, to help ensure that the AoU App Engine SA is not a member of too many
+    // groups. See https://precisionmedicineinitiative.atlassian.net/browse/RW-3435
+    GARBAGE_COLLECTED,
   }
 
   @Id

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
@@ -14,7 +14,7 @@ public class BillingProjectGarbageCollection {
   private String owner;
 
   @Id
-  @JoinColumn(name = "firecloud_project_name")
+  @Column(name = "firecloud_project_name")
   public String getFireCloudProjectName() {
     return fireCloudProjectName;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
@@ -1,0 +1,39 @@
+package org.pmiops.workbench.db.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import org.pmiops.workbench.model.GarbageCollectedProject;
+
+@Entity
+@Table(name = "billing_project_garbage_collection")
+public class BillingProjectGarbageCollection {
+  private String fireCloudProjectName;
+  private String owner;
+
+  @Id
+  @JoinColumn(name = "firecloud_project_name")
+  public String getFireCloudProjectName() {
+    return fireCloudProjectName;
+  }
+
+  public void setFireCloudProjectName(String fireCloudProjectName) {
+    this.fireCloudProjectName = fireCloudProjectName;
+  }
+
+  @Column(name = "owner")
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  // convert to Swagger model class
+  public GarbageCollectedProject toGarbageCollectedProject() {
+    return new GarbageCollectedProject().project(fireCloudProjectName).newOwner(owner);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/BillingProjectGarbageCollection.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.db.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import org.pmiops.workbench.model.GarbageCollectedProject;
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/StorageEnums.java
@@ -59,6 +59,7 @@ public final class StorageEnums {
               .put(BillingProjectBufferStatus.AVAILABLE, (short) 2)
               .put(BillingProjectBufferStatus.ASSIGNING, (short) 3)
               .put(BillingProjectBufferStatus.ASSIGNED, (short) 4)
+              .put(BillingProjectBufferStatus.GARBAGE_COLLECTED, (short) 5)
               .build();
 
   public static BillingProjectBufferStatus billingProjectBufferStatusFromStorage(Short s) {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.firecloud;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import java.io.IOException;
 import java.util.List;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
@@ -64,8 +63,7 @@ public interface FireCloudService {
    * <p>Only used for billing project garbage collection
    */
   void removeOwnerFromBillingProject(
-      String ownerEmailToRemove, GoogleCredential retainingOwnerCredential, String projectName)
-      throws IOException;
+      String projectName, String ownerEmailToRemove, String callerAccessToken);
 
   /** Creates a new FC workspace. */
   void createWorkspace(String projectName, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.firecloud;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import java.io.IOException;
 import java.util.List;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
@@ -46,10 +47,25 @@ public interface FireCloudService {
   void addUserToBillingProject(String email, String projectName);
 
   /**
-   * Removes the specified user from the specified billing project. Only used for errored billing
-   * projects
+   * Removes the specified user from the specified billing project.
+   *
+   * <p>Only used for errored billing projects
    */
   void removeUserFromBillingProject(String email, String projectName);
+
+  /** Adds the specified user as an owner to the specified billing project. */
+  void addOwnerToBillingProject(String ownerEmail, String projectName);
+
+  /**
+   * Removes the specified user as an owner from the specified billing project. Since FireCloud
+   * users cannot remove themselves, we need to supply the credential of a different user which will
+   * retain ownership to make the call
+   *
+   * <p>Only used for billing project garbage collection
+   */
+  void removeOwnerFromBillingProject(
+      String ownerEmailToRemove, GoogleCredential retainingOwnerCredential, String projectName)
+      throws IOException;
 
   /** Creates a new FC workspace. */
   void createWorkspace(String projectName, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -273,13 +273,10 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public void removeOwnerFromBillingProject(
-      String ownerEmailToRemove, GoogleCredential retainingOwnerCredential, String projectName)
-      throws IOException {
-
-    retainingOwnerCredential.refreshToken();
+      String projectName, String ownerEmailToRemove, String callerAccessToken) {
 
     final ApiClient apiClient = FireCloudConfig.buildApiClient(configProvider.get());
-    apiClient.setAccessToken(retainingOwnerCredential.getAccessToken());
+    apiClient.setAccessToken(callerAccessToken);
 
     // use a private instance of BillingApi instead of the provider
     // b/c we don't want to modify its ApiClient globally

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -61,6 +61,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private static final String STATUS_SUBSYSTEMS_KEY = "systems";
 
   private static final String USER_FC_ROLE = "user";
+  private static final String OWNER_FC_ROLE = "owner";
   private static final String THURLOE_STATUS_NAME = "Thurloe";
   private static final String SAM_STATUS_NAME = "Sam";
   private static final String RAWLS_STATUS_NAME = "Rawls";
@@ -93,8 +94,10 @@ public class FireCloudServiceImpl implements FireCloudService {
       Provider<BillingApi> billingApiProvider,
       Provider<GroupsApi> groupsApiProvider,
       Provider<NihApi> nihApiProvider,
-      @Qualifier("workspacesApi") Provider<WorkspacesApi> workspacesApiProvider,
-      @Qualifier("workspaceAclsApi") Provider<WorkspacesApi> workspaceAclsApiProvider,
+      @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
+          Provider<WorkspacesApi> workspacesApiProvider,
+      @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_WORKSPACE_API)
+          Provider<WorkspacesApi> workspaceAclsApiProvider,
       Provider<StatusApi> statusApiProvider,
       Provider<StaticNotebooksApi> staticNotebooksApiProvider,
       FirecloudRetryHandler retryHandler,
@@ -239,14 +242,18 @@ public class FireCloudServiceImpl implements FireCloudService {
         (context) -> billingApiProvider.get().billingProjectStatus(projectName));
   }
 
-  @Override
-  public void addUserToBillingProject(String email, String projectName) {
+  private void addRoleToBillingProject(String email, String projectName, String role) {
     BillingApi billingApi = billingApiProvider.get();
     retryHandler.run(
         (context) -> {
-          billingApi.addUserToBillingProject(projectName, USER_FC_ROLE, email);
+          billingApi.addUserToBillingProject(projectName, role, email);
           return null;
         });
+  }
+
+  @Override
+  public void addUserToBillingProject(String email, String projectName) {
+    addRoleToBillingProject(email, projectName, USER_FC_ROLE);
   }
 
   @Override
@@ -255,6 +262,32 @@ public class FireCloudServiceImpl implements FireCloudService {
     retryHandler.run(
         (context) -> {
           billingApi.removeUserFromBillingProject(projectName, USER_FC_ROLE, email);
+          return null;
+        });
+  }
+
+  @Override
+  public void addOwnerToBillingProject(String ownerEmail, String projectName) {
+    addRoleToBillingProject(ownerEmail, projectName, OWNER_FC_ROLE);
+  }
+
+  @Override
+  public void removeOwnerFromBillingProject(
+      String ownerEmailToRemove, GoogleCredential retainingOwnerCredential, String projectName)
+      throws IOException {
+
+    retainingOwnerCredential.refreshToken();
+
+    final ApiClient apiClient = FireCloudConfig.buildApiClient(configProvider.get());
+    apiClient.setAccessToken(retainingOwnerCredential.getAccessToken());
+
+    // use a private instance of BillingApi instead of the provider
+    // b/c we don't want to modify its ApiClient globally
+    final BillingApi billingApi = new BillingApi();
+    billingApi.setApiClient(apiClient);
+    retryHandler.run(
+        (context) -> {
+          billingApi.removeUserFromBillingProject(projectName, OWNER_FC_ROLE, ownerEmailToRemove);
           return null;
         });
   }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
@@ -40,6 +40,9 @@ public interface CloudStorageService {
 
   GoogleCredential getDefaultServiceAccountCredentials() throws IOException;
 
+  GoogleCredential getGarbageCollectionServiceAccountCredentials(String garbageCollectionEmail)
+      throws IOException;
+
   JSONObject getFileAsJson(String bucketName, String fileName);
 
   Map<String, String> getMetadata(String bucketName, String objectPath);

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -155,6 +155,13 @@ public class CloudStorageServiceImpl implements CloudStorageService {
   }
 
   @Override
+  public GoogleCredential getGarbageCollectionServiceAccountCredentials(
+      String garbageCollectionEmail) throws IOException {
+    final String objectPath = String.format("garbage-collection/%s.json", garbageCollectionEmail);
+    return getCredential(objectPath);
+  }
+
+  @Override
   public JSONObject getFileAsJson(String bucketName, String fileName) {
     return new JSONObject(readToString(bucketName, fileName));
   }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1031,6 +1031,7 @@ paths:
           schema:
             $ref: "#/definitions/EmptyResponse"
 
+  # Cron ############################################################################
 
   # Note: all requests tagged as "cron" must have the header X-Appengine-Cron:
   # true, which app engine itself only sets when invoking as a cronjob.
@@ -1197,6 +1198,27 @@ paths:
       responses:
         200:
           description: No Error
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
+  /v1/cron/billingProjectGarbageCollection:
+    get:
+      security: []
+      tags:
+        - offlineBilling
+        - cron
+      description: >
+        Endpoint meant to be called offline to trigger a bulk transfer of ownership of billing
+        projects associated with deleted workspaces; may be
+        slow to execute. Only executable via App Engine cronjob.
+      operationId: billingProjectGarbageCollection
+      responses:
+        200:
+          description: Billing Project Garbage Collection was successful.
+          schema:
+            $ref: "#/definitions/BillingProjectGarbageCollectionResponse"
         500:
           description: Internal Error
           schema:
@@ -3530,6 +3552,22 @@ definitions:
         format: int32
         description: >
           Number of clusters deleted during the check.
+
+  BillingProjectGarbageCollectionResponse:
+    type: array
+    items:
+      $ref: "#/definitions/GarbageCollectedProject"
+
+  GarbageCollectedProject:
+    type: object
+    properties:
+      project:
+        type: string
+      newOwner:
+        type: string
+    required:
+      - project
+      - newOwner
 
   User:
     type: object

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1209,10 +1209,7 @@ paths:
       tags:
         - offlineBilling
         - cron
-      description: >
-        Endpoint meant to be called offline to trigger a bulk transfer of ownership of billing
-        projects associated with deleted workspaces; may be
-        slow to execute. Only executable via App Engine cronjob.
+      description: Trigger a bulk transfer of ownership of billing projects associated with deleted workspaces
       operationId: billingProjectGarbageCollection
       responses:
         200:

--- a/api/src/main/webapp/WEB-INF/cron.xml
+++ b/api/src/main/webapp/WEB-INF/cron.xml
@@ -60,4 +60,10 @@
     <description> Find and alert users that have exceeded their free tier billing usage</description>
     <schedule>every 3 hours</schedule>
   </cron>
+  <cron>
+    <url>/v1/cron/billingProjectGarbageCollection</url>
+    <target>api</target>
+    <description>Find billing projects associated with deleted workspaces and transfer ownership to Garbage Collection Service Accounts</description>
+    <schedule>every 24 hours</schedule>
+  </cron>
 </cronentries>

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -52,6 +52,9 @@ public class WorkbenchConfig {
     public String accountId;
     public String exportBigQueryTable;
     public Double defaultFreeCreditsLimit;
+    public Integer garbageCollectionUserCapacity;
+    // A list of GCP service accounts for billing project garbage collection
+    public ArrayList<String> garbageCollectionUsers;
   }
 
   public static class FireCloudConfig {


### PR DESCRIPTION
Cron endpoint for reassigning the Billing Projects associated with deleted Workspaces to "garbage collection" Service Accounts as a workaround to https://precisionmedicineinitiative.atlassian.net/browse/RW-3069

These GCSAs need to be created manually in the appropriate project for each environment and their credentials are copied to the environments' credentials buckets under a `garbage-collection` subdirectory.  When all the GCSAs for an environment become associated with too many groups, we will need to add more of them.