### PR TITLE
[RW-3560][risk=no] minIdleInstances over minInstances

### DIFF
--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -16,5 +16,5 @@ CDR_DB_USER=workbench
 CDR_DB_PASSWORD=wb-notasecret
 
 # GAE_*_INSTANCES variables are substituted into the API appengine-web.xml
-GAE_MIN_INSTANCES=1
+GAE_MIN_IDLE_INSTANCES=1
 GAE_MAX_INSTANCES=10

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -27,7 +27,7 @@ DRY_RUN_CMD = %W{echo [DRY_RUN]}
 
 def make_gae_vars(min, max)
   {
-    "GAE_MIN_INSTANCES" => min.to_s,
+    "GAE_MIN_IDLE_INSTANCES" => min.to_s,
     "GAE_MAX_INSTANCES" => max.to_s
   }
 end

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -27,7 +27,7 @@
   </static-error-handlers>
 
   <automatic-scaling>
-    <min-instances>${GAE_MIN_INSTANCES}</min-instances>
+    <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
   </automatic-scaling>
 </appengine-web-app>


### PR DESCRIPTION
Critical distinction:

- minInstances: all versions will maintain this instance count, regardless of whether they are actively serving traffic
- minIdleInstances: only the traffic-serving version will maintain this instance count

https://cloud.google.com/appengine/docs/standard/python/config/appref

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
