### PR TITLE
[risk=no] Fix returning user creation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -245,7 +245,7 @@ public class UserService {
       String areaOfResearch,
       Address address,
       DemographicSurvey demographicSurvey,
-      List<InstitutionalAffiliation> institutionalAffiliation) {
+      List<InstitutionalAffiliation> institutionalAffiliations) {
     User user = new User();
     user.setCreationNonce(Math.abs(random.nextLong()));
     user.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
@@ -261,16 +261,18 @@ public class UserService {
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.UNVERIFIED);
     user.setAddress(address);
     user.setDemographicSurvey(demographicSurvey);
-    user.getInstitutionalAffiliations().clear();
-    user.getInstitutionalAffiliations().addAll(institutionalAffiliation);
     // For existing user that do not have address
     if (address != null) {
       address.setUser(user);
     }
     if (demographicSurvey != null) demographicSurvey.setUser(user);
-    if (institutionalAffiliation != null) {
+    if (institutionalAffiliations != null) {
       final User u = user;
-      institutionalAffiliation.forEach(affiliation -> affiliation.setUser(u));
+      institutionalAffiliations.forEach(
+          affiliation -> {
+            affiliation.setUser(u);
+            u.addInstitutionalAffiliation(affiliation);
+          });
     }
     try {
       userDao.save(user);


### PR DESCRIPTION
This codepath gets hit when a user visits the site and gets lazily created, rather than getting created by the account creation page. This happens primarily during local development.

Aside from this, the NPE is clearly visible within the UserService, since another method passes `userAffiliations = null`.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
