### PR TITLE
[RW-3458][risk=no] Sort based on DataSet "sub-value" rather than value

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -362,9 +362,14 @@ public class DataSetController implements DataSetApiDelegate {
                 "Timeout while querying the CDR to pull preview information.");
           }
 
+          final List<String> requestValues =
+              dataSet.getValues().stream()
+                  .map(DomainValuePair::getValue)
+                  .collect(Collectors.toList());
+
           Collections.sort(
               valuePreviewList,
-              Comparator.comparing(item -> dataSet.getValues().indexOf(item.getValue())));
+              Comparator.comparing(item -> requestValues.indexOf(item.getValue())));
 
           previewQueryResponse.addDomainValueItem(
               new DataSetPreviewList().domain(domain).values(valuePreviewList));
@@ -581,10 +586,7 @@ public class DataSetController implements DataSetApiDelegate {
     }
     DataSetListResponse dataSetResponse =
         new DataSetListResponse()
-            .items(
-                dbDataSets.stream()
-                    .map(dbDataSet -> TO_CLIENT_DATA_SET.apply(dbDataSet))
-                    .collect(Collectors.toList()));
+            .items(dbDataSets.stream().map(TO_CLIENT_DATA_SET).collect(Collectors.toList()));
     return ResponseEntity.ok(dataSetResponse);
   }
 


### PR DESCRIPTION
Sneaky bug here: the "values" member of DataSet does not actually contain values we want to compare against.  Instead it refers to `DomainValuePair`s which must then be dereferenced to get their actual values.

This is confusing!  I'm going to fix that situation, but in PR #2631 since that is a much larger change.  This PR simply fixes the bug.