### PR TITLE
[RW-3623][RISK=no] domains must be unique and we need actual title case

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -590,6 +590,9 @@ public class DataSetServiceImpl implements DataSetService {
     return new ValuesLinkingPair(valueSelects, valueJoins);
   }
 
+  // Capitalizes the first letter of a string and lowers the remaining ones.
+  // Assumes a single word, so you'd get "A tale of two cities" instead of
+  // "A Tale Of Two Cities"
   private static String toTitleCase(String name) {
     if (name.isEmpty()) {
       return name;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -594,7 +594,7 @@ public class DataSetServiceImpl implements DataSetService {
     if (name.isEmpty()) {
       return name;
     } else if (name.length() == 1) {
-      return name;
+      return name.toUpperCase();
     } else {
       return String.format("%s%s", name.charAt(0), name.substring(1).toLowerCase());
     }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -599,7 +599,9 @@ public class DataSetServiceImpl implements DataSetService {
     } else if (name.length() == 1) {
       return name.toUpperCase();
     } else {
-      return String.format("%s%s", name.charAt(0), name.substring(1).toLowerCase());
+      return String.format(
+          "%s%s",
+          Character.toString(name.charAt(0)).toUpperCase(), name.substring(1).toLowerCase());
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;


### PR DESCRIPTION
The map error was caused by passing in all domains from the domainvaluepairs, not just the unique ones. Aside: could we just use a map for domainValuePairs.

Another issue was the library method StringUtils.capitalize() didn't convert already uppercase letters to lowercase.

This lets me get through the dataset request stuff, but I'm seeing permissions errors locally 

```
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "all-of-us-workbench-test@appspot.gserviceaccount.com does not have storage.objects.create access to fc-secure-3f9af1df-24a5-44b2-82de-4c72e800a06d/notebooks/bb.ipynb.",
    "reason" : "forbidden"
  } ],
  "message" : "all-of-us-workbench-test@appspot.gserviceaccount.com does not have storage.objects.create access to fc-secure-3f9af1df-24a5-44b2-82de-4c72e800a06d/notebooks/bb.ipynb."
}
```