### PR TITLE
[RW-3528][Risk=no] Retry Preview Table from Front End only

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -44,7 +44,6 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.GatewayTimeoutException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.model.ConceptSet;

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -340,18 +340,12 @@ public class DataSetController implements DataSetApiDelegate {
               IntStream.range(0, fieldValueList.size())
                   .forEach(
                       columnNumber -> {
-                        try {
-                          valuePreviewList
-                              .get(columnNumber)
-                              .addQueryValueItem(
-                                  fieldValueList.get(columnNumber).getValue().toString());
-                        } catch (NullPointerException ex) {
-                          log.severe(
-                              String.format(
-                                  "Null pointer exception while retriving value for query: Column %s ",
-                                  columnNumber));
-                          valuePreviewList.get(columnNumber).addQueryValueItem("");
-                        }
+                        valuePreviewList
+                            .get(columnNumber)
+                            .addQueryValueItem(
+                                Optional.ofNullable(fieldValueList.get(columnNumber).getValue())
+                                    .orElse("")
+                                    .toString());
                       });
             });
     queryResponse

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -85,8 +85,8 @@ public class DataSetController implements DataSetApiDelegate {
   private static String CONCEPT_SET = "conceptSet";
   private static String COHORT = "cohort";
 
-  private static final String dateFormatString = "yyyy/MM/dd HH:mm:ss";
-  private static final String emptyCellMarker = "";
+  private static final String DATE_FORMAT_STRING = "yyyy/MM/dd HH:mm:ss";
+  private static final String EMPTY_CELL_MARKER = "";
 
   private static final Logger log = Logger.getLogger(DataSetController.class.getName());
 
@@ -369,29 +369,30 @@ public class DataSetController implements DataSetApiDelegate {
               valuePreviewList
                   .get(columnNumber)
                   .addQueryValueItem(
-                      Optional.ofNullable(fieldValueList.get(columnNumber).getValue())
-                          .orElse("")
-                          .toString());
+                      Optional.ofNullable(fieldValueList.get(columnNumber).getValue().toString())
+                          .orElse(""));
             });
   }
 
-  private void formatTimestampValues(List<DataSetPreviewValueList> valuePreviewList, Field fields) {
+  // Iterates through all values associated with a specific field, and converts all timestamps
+  // to a timestamp formatted string.
+  private void formatTimestampValues(List<DataSetPreviewValueList> valuePreviewList, Field field) {
     DataSetPreviewValueList previewValue =
         valuePreviewList.stream()
-            .filter(preview -> preview.getValue().equalsIgnoreCase(fields.getName()))
+            .filter(preview -> preview.getValue().equalsIgnoreCase(field.getName()))
             .findFirst()
             .orElseThrow(
                 () ->
-                    new ServerErrorException(
+                    new IllegalStateException(
                         "Value should be present when it is not in dataset preview request"));
-    if (fields.getType() == LegacySQLTypeName.TIMESTAMP) {
+    if (field.getType() == LegacySQLTypeName.TIMESTAMP) {
       List<String> queryValues = new ArrayList<>();
-      DateFormat dateFormat = new SimpleDateFormat(dateFormatString);
+      DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STRING);
       previewValue
           .getQueryValue()
           .forEach(
               value -> {
-                if (!value.equals(emptyCellMarker)) {
+                if (!value.equals(EMPTY_CELL_MARKER)) {
                   Double fieldValue = Double.parseDouble(value);
                   queryValues.add(dateFormat.format(new Date(fieldValue.longValue())));
                 } else {

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -348,6 +348,7 @@ public class DataSetController implements DataSetApiDelegate {
                                     .toString());
                       });
             });
+    String dateFormatString = "yyyy/MM/dd HH:mm:ss";
     queryResponse
         .getSchema()
         .getFields()
@@ -360,7 +361,7 @@ public class DataSetController implements DataSetApiDelegate {
                       .get();
               if (fields.getType() == LegacySQLTypeName.TIMESTAMP) {
                 List<String> queryValues = new ArrayList<String>();
-                DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+                DateFormat dateFormat = new SimpleDateFormat(dateFormatString);
                 previewValue
                     .getQueryValue()
                     .forEach(

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -348,7 +348,8 @@ public class DataSetController implements DataSetApiDelegate {
                                     .toString());
                       });
             });
-    String dateFormatString = "yyyy/MM/dd HH:mm:ss";
+    final String dateFormatString = "yyyy/MM/dd HH:mm:ss";
+    final String emptyCellMarker = "";
     queryResponse
         .getSchema()
         .getFields()
@@ -366,11 +367,11 @@ public class DataSetController implements DataSetApiDelegate {
                     .getQueryValue()
                     .forEach(
                         value -> {
-                          try {
+                          if (!value.equals(emptyCellMarker)) {
                             Double fieldValue = Double.parseDouble(value);
                             queryValues.add(dateFormat.format(new Date(fieldValue.longValue())));
-                          } catch (NumberFormatException ex) {
-                            queryValues.add("");
+                          } else {
+                            queryValues.add(value);
                           }
                         });
                 previewValue.setQueryValue(queryValues);

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -88,7 +88,6 @@ public class DataSetController implements DataSetApiDelegate {
   private static final String dateFormatString = "yyyy/MM/dd HH:mm:ss";
   private static final String emptyCellMarker = "";
 
-
   private static final Logger log = Logger.getLogger(DataSetController.class.getName());
 
   private final CohortDao cohortDao;
@@ -333,13 +332,10 @@ public class DataSetController implements DataSetApiDelegate {
       }
     }
 
-    valuePreviewList.addAll(queryResponse
-        .getSchema()
-        .getFields()
-        .stream()
-        .map(fields ->
-          new DataSetPreviewValueList().value(fields.getName())
-        ).collect(Collectors.toList()));
+    valuePreviewList.addAll(
+        queryResponse.getSchema().getFields().stream()
+            .map(fields -> new DataSetPreviewValueList().value(fields.getName()))
+            .collect(Collectors.toList()));
 
     queryResponse
         .getValues()
@@ -365,7 +361,8 @@ public class DataSetController implements DataSetApiDelegate {
     return ResponseEntity.ok(previewQueryResponse);
   }
 
-  private void addFieldValuesFromBigQueryToPreviewList(List<DataSetPreviewValueList> valuePreviewList, FieldValueList fieldValueList) {
+  private void addFieldValuesFromBigQueryToPreviewList(
+      List<DataSetPreviewValueList> valuePreviewList, FieldValueList fieldValueList) {
     IntStream.range(0, fieldValueList.size())
         .forEach(
             columnNumber -> {
@@ -383,7 +380,10 @@ public class DataSetController implements DataSetApiDelegate {
         valuePreviewList.stream()
             .filter(preview -> preview.getValue().equalsIgnoreCase(fields.getName()))
             .findFirst()
-            .orElseThrow(() -> new ServerErrorException("Value should be present when it is not in dataset preview request"));
+            .orElseThrow(
+                () ->
+                    new ServerErrorException(
+                        "Value should be present when it is not in dataset preview request"));
     if (fields.getType() == LegacySQLTypeName.TIMESTAMP) {
       List<String> queryValues = new ArrayList<>();
       DateFormat dateFormat = new SimpleDateFormat(dateFormatString);

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -558,7 +558,7 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
 
     async getPreviewByDomain(domain: Domain) {
       const {namespace, id} = this.props.workspace;
-      const request: DataSetPreviewRequest = {
+      const domainRequest: DataSetPreviewRequest = {
         domain: domain,
         conceptSetIds: this.state.selectedConceptSetIds,
         includesAllParticipants: this.state.includesAllParticipants,
@@ -567,18 +567,17 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         values: this.state.selectedDomainValuePairs.map(domainValue => domainValue.value)
       };
       try {
-        const dataSetPreviewResp = await apiCallWithGatewayTimeoutRetries(
-          () => dataSetApi().previewDataSetByDomain(namespace, id, request));
+        const domainPreviewResponse = await apiCallWithGatewayTimeoutRetries(
+          () => dataSetApi().previewDataSetByDomain(namespace, id, domainRequest));
         const newPreviewInformation = {
           isLoading: false,
-          values: dataSetPreviewResp.values
+          values: domainPreviewResponse.values
         };
-        this.setState({previewList: this.state.previewList.set(dataSetPreviewResp.domain, newPreviewInformation)});
+        this.setState(state => ({previewList: state.previewList.set(domainPreviewResponse.domain, newPreviewInformation)}));
       } catch (ex) {
         const exceptionResponse = await ex.json() as unknown as ErrorResponse;
         const errorText = this.generateErrorTextFromPreviewException(exceptionResponse, domain);
         this.setState({previewError: true, previewErrorText: errorText});
-        console.error(ex);
       }
     }
 

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -22,6 +22,7 @@ import {
 import colors from 'app/styles/colors';
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
+  apiCallWithGatewayTimeoutRetries,
   formatDomain,
   formatDomainString,
   ReactWrapperBase,
@@ -566,7 +567,8 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         values: this.state.selectedDomainValuePairs.map(domainValue => domainValue.value)
       };
       try {
-        const dataSetPreviewResp = await dataSetApi().previewDataSetByDomain(namespace, id, request);
+        const dataSetPreviewResp = await apiCallWithGatewayTimeoutRetries(
+          () => dataSetApi().previewDataSetByDomain(namespace, id, request));
         const newPreviewInformation = {
           isLoading: false,
           values: dataSetPreviewResp.values

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -8,7 +8,6 @@ import {FlexRow} from 'app/components/flex';
 import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox} from 'app/components/inputs';
-import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 import {CircleWithText} from 'app/icons/circleWithText';

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -268,8 +268,6 @@ interface State {
   prePackagedSurvey: boolean;
   loadingResources: boolean;
   openSaveModal: boolean;
-  previewError: boolean;
-  previewErrorText: string;
   previewList: Map<Domain, DataSetPreviewInfo>;
   selectedCohortIds: number[];
   selectedConceptSetIds: number[];
@@ -295,8 +293,6 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         openSaveModal: false,
         prePackagedDemographics: false,
         prePackagedSurvey: false,
-        previewError: false,
-        previewErrorText: '',
         previewList: new Map(),
         selectedCohortIds: [],
         selectedConceptSetIds: [],
@@ -679,8 +675,6 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
         openSaveModal,
         prePackagedDemographics,
         prePackagedSurvey,
-        previewError,
-        previewErrorText,
         previewList,
         selectedCohortIds,
         selectedConceptSetIds,
@@ -897,15 +891,6 @@ const DataSetPage = fp.flow(withCurrentWorkspace(), withUrlParams())(
                                              this.setState({openSaveModal: false});
                                            }}
         />}
-        {previewError && <Modal>
-          <ModalTitle>Error Loading Data Set Preview</ModalTitle>
-          <ModalBody>{previewErrorText}</ModalBody>
-          <ModalFooter>
-            <Button type='secondary' onClick={() => {this.setState({previewError: false}); }}>
-              Close
-            </Button>
-          </ModalFooter>
-        </Modal>}
         <HelpSidebar location='datasetBuilder' />
       </React.Fragment>;
     }

--- a/ui/src/app/utils/index.spec.tsx
+++ b/ui/src/app/utils/index.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import {apiCallWithGatewayTimeoutRetries} from 'app/utils/index';
+
+const functionStub = {
+  successfulFunction() {
+    return Promise.resolve();
+  },
+  failedFunction() {
+    return Promise.resolve({status: 504}).then(response => {throw response});
+  }
+}
+
+
+describe('IndexUtils', () => {
+  it('should not retry if successful', async() => {
+    const successfulFunctionSpy = spyOn(functionStub, 'successfulFunction').and.callThrough();
+    await apiCallWithGatewayTimeoutRetries(() => functionStub.successfulFunction());
+    expect(successfulFunctionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry three times by default', async() => {
+    const failedFunctionSpy = spyOn(functionStub, 'failedFunction').and.callThrough();
+    await apiCallWithGatewayTimeoutRetries(() => functionStub.failedFunction(), 3, 1).catch(() => {});
+    expect(failedFunctionSpy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/ui/src/app/utils/index.spec.tsx
+++ b/ui/src/app/utils/index.spec.tsx
@@ -19,7 +19,7 @@ describe('IndexUtils', () => {
     expect(successfulFunctionSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should retry three times by default', async() => {
+  it('should retry three times by default using apiCallWithGatewayTimeout', async() => {
     const failedFunctionSpy = spyOn(functionStub, 'failedFunction').and.callThrough();
     await apiCallWithGatewayTimeoutRetries(() => functionStub.failedFunction(), 3, 1).catch(() => {});
     expect(failedFunctionSpy).toHaveBeenCalledTimes(4);

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -476,7 +476,7 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
  */
 export async function apiCallWithGatewayTimeoutRetries<T>(
   apiCall: () => Promise<T>, maxRetries = 3, initialWaitTime = 1000): Promise<T> {
-  return apiCallWithGatewayTimeoutRetriesAndRetryCount(apiCall, maxRetries, 1, defaultWaitTime);
+  return apiCallWithGatewayTimeoutRetriesAndRetryCount(apiCall, maxRetries, 1, initialWaitTime);
 }
 
 async function apiCallWithGatewayTimeoutRetriesAndRetryCount<T>(
@@ -487,8 +487,8 @@ async function apiCallWithGatewayTimeoutRetriesAndRetryCount<T>(
     if (ex.status !== 504 || retryCount > maxRetries) {
       throw ex;
     }
-    await new Promise(resolve => setTimeout(resolve, defaultWaitTime * Math.pow(2, retryCount)));
+    await new Promise(resolve => setTimeout(resolve, initialWaitTime * Math.pow(2, retryCount)));
     return await apiCallWithGatewayTimeoutRetriesAndRetryCount(
-      apiCall, maxRetries, retryCount + 1, defaultWaitTime);
+      apiCall, maxRetries, retryCount + 1, initialWaitTime);
   }
 }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -475,12 +475,12 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
  *      2s for the second, etc.
  */
 export async function apiCallWithGatewayTimeoutRetries<T>(
-  apiCall: () => Promise<T>, maxRetries = 3, defaultWaitTime = 1000): Promise<T> {
+  apiCall: () => Promise<T>, maxRetries = 3, initialWaitTime = 1000): Promise<T> {
   return apiCallWithGatewayTimeoutRetriesAndRetryCount(apiCall, maxRetries, 1, defaultWaitTime);
 }
 
 async function apiCallWithGatewayTimeoutRetriesAndRetryCount<T>(
-  apiCall: () => Promise<T>, maxRetries = 3, retryCount = 1, defaultWaitTime = 1000): Promise<T> {
+  apiCall: () => Promise<T>, maxRetries = 3, retryCount = 1, initialWaitTime = 1000): Promise<T> {
   try {
     return await apiCall();
   } catch (ex) {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -464,17 +464,31 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
     </span>);
 }
 
-const BACKOFF_DEFAULT_WAIT_TIME_IN_MS = 1000;
-
+/*
+ * A method to run an api call with a specified number of retries and exponential backoff.
+ * This method will only error
+ * Parameters:
+ *    apiCall: Lambda that will run an API call, in the form of () => apiClient.apiCall(args)
+ *    maxRetries: The amount of retries the system will take before erroring
+ *    defaultWaitTime: How long the base exponential backoff is, in milliseconds
+ *      For example, if 1000 is passed in, it will wait 1s for the first retry,
+ *      2s for the second, etc.
+ */
 export async function apiCallWithGatewayTimeoutRetries<T>(
-  apiCall: () => Promise<T>, maxRetries = 3, retryCount = 1): Promise<T> {
+  apiCall: () => Promise<T>, maxRetries = 3, defaultWaitTime = 1000): Promise<T> {
+  return apiCallWithGatewayTimeoutRetriesAndRetryCount(apiCall, maxRetries, 1, defaultWaitTime);
+}
+
+async function apiCallWithGatewayTimeoutRetriesAndRetryCount<T>(
+  apiCall: () => Promise<T>, maxRetries = 3, retryCount = 1, defaultWaitTime = 1000): Promise<T> {
   try {
     return await apiCall();
   } catch (ex) {
     if (ex.status !== 504 || retryCount > maxRetries) {
       throw ex;
     }
-    await new Promise(resolve => setTimeout(resolve, BACKOFF_DEFAULT_WAIT_TIME_IN_MS * retryCount));
-    return await apiCallWithGatewayTimeoutRetries(apiCall, maxRetries, retryCount + 1);
+    await new Promise(resolve => setTimeout(resolve, defaultWaitTime * Math.pow(2, retryCount)));
+    return await apiCallWithGatewayTimeoutRetriesAndRetryCount(
+      apiCall, maxRetries, retryCount + 1, defaultWaitTime);
   }
 }


### PR DESCRIPTION
This is to avoid the AppEngine hard timeout limit, giving us the full time for each retry. 

Open question for reviewers: should I add a 'requested rows' parameter to the request that shrinks with each retry? This would be an optional parameter with some reasonable default.