### PR TITLE
[risk=no] Fix NPE caused by missing "AddingToPerimeter" FireCloud status

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -99,6 +99,7 @@ public class BillingProjectBufferService {
             entry.setStatusEnum(ERROR, this::getCurrentTimestamp);
             break;
           case CREATING:
+          case ADDINGTOPERIMETER:
           default:
             break;
         }

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -791,7 +791,7 @@ definitions:
         description: the name of the billing project
       creationStatus:
         type: string
-        enum: ["Creating", "Ready", "Error"]
+        enum: ["Creating", "AddingToPerimeter", "Ready", "Error"]
 
   CreateRawlsBillingProjectFullRequest:
     description: ''

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -246,9 +246,9 @@ public class BillingProjectBufferServiceTest {
 
     billingProjectBufferService.syncBillingProjectStatus();
     assertThat(
-        billingProjectBufferEntryDao
-            .findByFireCloudProjectName(billingProjectName)
-            .getStatusEnum())
+            billingProjectBufferEntryDao
+                .findByFireCloudProjectName(billingProjectName)
+                .getStatusEnum())
         .isEqualTo(CREATING);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -231,11 +231,24 @@ public class BillingProjectBufferServiceTest {
     doReturn(billingProjectStatus)
         .when(fireCloudService)
         .getBillingProjectStatus(billingProjectName);
+
     billingProjectBufferService.syncBillingProjectStatus();
     assertThat(
             billingProjectBufferEntryDao
                 .findByFireCloudProjectName(billingProjectName)
                 .getStatusEnum())
+        .isEqualTo(CREATING);
+
+    billingProjectStatus.setCreationStatus(CreationStatusEnum.ADDINGTOPERIMETER);
+    doReturn(billingProjectStatus)
+        .when(fireCloudService)
+        .getBillingProjectStatus(billingProjectName);
+
+    billingProjectBufferService.syncBillingProjectStatus();
+    assertThat(
+        billingProjectBufferEntryDao
+            .findByFireCloudProjectName(billingProjectName)
+            .getStatusEnum())
         .isEqualTo(CREATING);
   }
 


### PR DESCRIPTION
Firecloud responded to `getBillingProjectStatus` with a `AddingToPerimeter`, a value that we are not currently tracking. Adding it so we do not NPE when we run into it.

Note: It's not clear when this change went out as it is undocumented, https://github.com/broadinstitute/firecloud-orchestration/blob/8aa0915a34e78893b07dccf9666291500a5d348b/src/main/resources/swagger/api-docs.yaml#L5196 

