### PR TITLE
[RW-3651][Risk=no] Move from toString to map

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -7,6 +7,7 @@ import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.sql.Date;
@@ -85,7 +86,7 @@ public class DataSetController implements DataSetApiDelegate {
   private static String COHORT = "cohort";
 
   private static final String DATE_FORMAT_STRING = "yyyy/MM/dd HH:mm:ss";
-  private static final String EMPTY_CELL_MARKER = "";
+  public static final String EMPTY_CELL_MARKER = "";
 
   private static final Logger log = Logger.getLogger(DataSetController.class.getName());
 
@@ -360,7 +361,8 @@ public class DataSetController implements DataSetApiDelegate {
     return ResponseEntity.ok(previewQueryResponse);
   }
 
-  private void addFieldValuesFromBigQueryToPreviewList(
+  @VisibleForTesting
+  public void addFieldValuesFromBigQueryToPreviewList(
       List<DataSetPreviewValueList> valuePreviewList, FieldValueList fieldValueList) {
     IntStream.range(0, fieldValueList.size())
         .forEach(
@@ -370,7 +372,7 @@ public class DataSetController implements DataSetApiDelegate {
                   .addQueryValueItem(
                       Optional.ofNullable(fieldValueList.get(columnNumber).getValue())
                           .map(Object::toString)
-                          .orElse(""));
+                          .orElse(EMPTY_CELL_MARKER));
             });
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -368,7 +368,8 @@ public class DataSetController implements DataSetApiDelegate {
               valuePreviewList
                   .get(columnNumber)
                   .addQueryValueItem(
-                      Optional.ofNullable(fieldValueList.get(columnNumber).getValue().toString())
+                      Optional.ofNullable(fieldValueList.get(columnNumber).getValue())
+                          .map(Object::toString)
                           .orElse(""));
             });
   }

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -18,6 +18,7 @@ import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import java.io.FileReader;
@@ -81,6 +82,7 @@ import org.pmiops.workbench.model.CreateConceptSetRequest;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.DataSetCodeResponse;
 import org.pmiops.workbench.model.DataSetExportRequest;
+import org.pmiops.workbench.model.DataSetPreviewValueList;
 import org.pmiops.workbench.model.DataSetRequest;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainValuePair;
@@ -568,6 +570,16 @@ public class DataSetControllerTest {
         });
     doReturn(values).when(tableResultMock).getValues();
     doReturn(tableResultMock).when(bigQueryService).executeQuery(any());
+  }
+
+  @Test
+  public void testAddFieldValuesFromBigQueryToPreviewListWorksWithNullValues() {
+    DataSetPreviewValueList dataSetPreviewValueList = new DataSetPreviewValueList();
+    List<DataSetPreviewValueList> valuePreviewList = ImmutableList.of(dataSetPreviewValueList);
+    List<FieldValue> fieldValueListRows = ImmutableList.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, null));
+    FieldValueList fieldValueList = FieldValueList.of(fieldValueListRows);
+    dataSetController.addFieldValuesFromBigQueryToPreviewList(valuePreviewList, fieldValueList);
+    assertThat(valuePreviewList.get(0).getQueryValue().get(0)).isEqualTo(DataSetController.EMPTY_CELL_MARKER);
   }
 
   @Test(expected = BadRequestException.class)

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -576,10 +576,12 @@ public class DataSetControllerTest {
   public void testAddFieldValuesFromBigQueryToPreviewListWorksWithNullValues() {
     DataSetPreviewValueList dataSetPreviewValueList = new DataSetPreviewValueList();
     List<DataSetPreviewValueList> valuePreviewList = ImmutableList.of(dataSetPreviewValueList);
-    List<FieldValue> fieldValueListRows = ImmutableList.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, null));
+    List<FieldValue> fieldValueListRows =
+        ImmutableList.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, null));
     FieldValueList fieldValueList = FieldValueList.of(fieldValueListRows);
     dataSetController.addFieldValuesFromBigQueryToPreviewList(valuePreviewList, fieldValueList);
-    assertThat(valuePreviewList.get(0).getQueryValue().get(0)).isEqualTo(DataSetController.EMPTY_CELL_MARKER);
+    assertThat(valuePreviewList.get(0).getQueryValue().get(0))
+        .isEqualTo(DataSetController.EMPTY_CELL_MARKER);
   }
 
   @Test(expected = BadRequestException.class)


### PR DESCRIPTION
This addresses the bug in RW-3651, by using map as opposed to directly calling `toString`, which would NPE when there was no object in the optional.