### PR TITLE
[RW-3518][Risk=no] Srubenst/data set variable names

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -29,7 +29,6 @@ import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -256,7 +255,8 @@ public class DataSetController implements DataSetApiDelegate {
         return domainValuePair;
       };
 
-  private String generateRandomEightCharacterQualifier() {
+  @VisibleForTesting
+  public String generateRandomEightCharacterQualifier() {
     return RandomStringUtils.randomNumeric(8);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
@@ -31,5 +31,6 @@ public interface DataSetService {
   List<String> generateCodeCells(
       KernelTypeEnum kernelTypeEnum,
       String dataSetName,
+      String qualifier,
       Map<String, QueryJobConfiguration> queryJobConfigurationMap);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -616,15 +616,15 @@ public class DataSetServiceImpl implements DataSetService {
 
     // Define [namespace]_sql, [namespace]_query_config, and [namespace]_df variables
     String domainAsString = domain.toString().toLowerCase();
-    String namespace =
-        "dataset_" + qualifier + "_" + domainAsString + "_";
+    String namespace = "dataset_" + qualifier + "_" + domainAsString + "_";
     // Comments in R and Python have the same syntax
-    String descriptiveComment = new StringBuilder("# This query represents dataset \"")
-        .append(dataSetName)
-        .append("\" for domain \"")
-        .append(domainAsString)
-        .append("\"")
-        .toString();
+    String descriptiveComment =
+        new StringBuilder("# This query represents dataset \"")
+            .append(dataSetName)
+            .append("\" for domain \"")
+            .append(domainAsString)
+            .append("\"")
+            .toString();
     String sqlSection;
     String namedParamsSection;
     String dataFrameSection;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -613,7 +613,7 @@ public class DataSetServiceImpl implements DataSetService {
 
     // Define [namespace]_sql, [namespace]_query_config, and [namespace]_df variables
     String namespace =
-        prefix.toLowerCase().replaceAll(" ", "_") + "_" + domain.toString().toLowerCase() + "_";
+        prefix.toLowerCase().replaceAll(" ", "_").replaceAll("[^a-zA-Z0-9_]", "") + "_" + domain.toString().toLowerCase() + "_";
     String sqlSection;
     String namedParamsSection;
     String dataFrameSection;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -505,6 +505,7 @@ public class DataSetServiceImpl implements DataSetService {
   public List<String> generateCodeCells(
       KernelTypeEnum kernelTypeEnum,
       String dataSetName,
+      String qualifier,
       Map<String, QueryJobConfiguration> queryJobConfigurationMap) {
     String prerequisites;
     switch (kernelTypeEnum) {
@@ -530,6 +531,7 @@ public class DataSetServiceImpl implements DataSetService {
                         entry.getValue(),
                         Domain.fromValue(entry.getKey()),
                         dataSetName,
+                        qualifier,
                         kernelTypeEnum))
         .collect(Collectors.toList());
   }
@@ -608,12 +610,21 @@ public class DataSetServiceImpl implements DataSetService {
   private static String generateNotebookUserCode(
       QueryJobConfiguration queryJobConfiguration,
       Domain domain,
-      String prefix,
+      String dataSetName,
+      String qualifier,
       KernelTypeEnum kernelTypeEnum) {
 
     // Define [namespace]_sql, [namespace]_query_config, and [namespace]_df variables
+    String domainAsString = domain.toString().toLowerCase();
     String namespace =
-        prefix.toLowerCase().replaceAll(" ", "_").replaceAll("[^a-zA-Z0-9_]", "") + "_" + domain.toString().toLowerCase() + "_";
+        "dataset_" + qualifier + "_" + domainAsString + "_";
+    // Comments in R and Python have the same syntax
+    String descriptiveComment = new StringBuilder("# This query represents dataset \"")
+        .append(dataSetName)
+        .append("\" for domain \"")
+        .append(domainAsString)
+        .append("\"")
+        .toString();
     String sqlSection;
     String namedParamsSection;
     String dataFrameSection;
@@ -678,7 +689,9 @@ public class DataSetServiceImpl implements DataSetService {
         throw new BadRequestException("Language " + kernelTypeEnum.toString() + " not supported.");
     }
 
-    return sqlSection
+    return descriptiveComment
+        + "\n"
+        + sqlSection
         + "\n\n"
         + namedParamsSection
         + "\n\n"

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -497,9 +497,7 @@ public class DataSetControllerTest {
               returnSql = returnSql.replace("${dataSetId}", TEST_CDR_DATA_SET_ID);
               return queryJobConfiguration.toBuilder().setQuery(returnSql).build();
             });
-
     when(dataSetController.generateRandomEightCharacterQualifier()).thenReturn("00000000");
-    //    doReturn("00000000").when(dataSetController.generateRandomEightCharacterQualifier());
   }
 
   private DataSetRequest buildEmptyDataSetRequest() {

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -275,21 +275,22 @@ public class DataSetControllerTest {
             cohortQueryBuilder,
             dataSetDao);
     dataSetController =
-        spy(new DataSetController(
-            bigQueryService,
-            CLOCK,
-            cdrVersionDao,
-            cohortDao,
-            conceptDao,
-            conceptSetDao,
-            dataDictionaryEntryDao,
-            dataSetDao,
-            dataSetMapper,
-            dataSetService,
-            fireCloudService,
-            notebooksService,
-            userProvider,
-            workspaceService));
+        spy(
+            new DataSetController(
+                bigQueryService,
+                CLOCK,
+                cdrVersionDao,
+                cohortDao,
+                conceptDao,
+                conceptSetDao,
+                dataDictionaryEntryDao,
+                dataSetDao,
+                dataSetMapper,
+                dataSetService,
+                fireCloudService,
+                notebooksService,
+                userProvider,
+                workspaceService));
     WorkspacesController workspacesController =
         new WorkspacesController(
             billingProjectBufferService,


### PR DESCRIPTION
The product ideal that Karthik and I talked about was to have the dataset variables qualified by the id, and then a comment at the top describing what dataset it corresponded to. ID ended up falling through, because there were no guarantees the dataset was created in the DB at this point, so I moved to random eight numeric characters. Eight was an arbitrary number I chose as likely enough to avoid conflicts, but few enough that it doesn't create too much clutter in the notebook.