### PR TITLE
[RW-3653] [risk=no] Fix bug in Hibernate table mapping and add missing @Transactional to getRecentWorkspaces

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/UserRecentWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/UserRecentWorkspace.java
@@ -45,7 +45,7 @@ public class UserRecentWorkspace {
     this.workspaceId = workspaceId;
   }
 
-  @Column(name = "lastAccessDate")
+  @Column(name = "last_access_date")
   public Timestamp getLastAccessDate() {
     return lastAccessDate;
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -504,6 +504,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  @Transactional
   public List<UserRecentWorkspace> getRecentWorkspaces() {
     long userId = userProvider.get().getUserId();
     List<UserRecentWorkspace> userRecentWorkspaces =


### PR DESCRIPTION
In `UserRecentWorkspace`, the `@Column` annotation for `getLastAccessDate` was in camel case and should have been in snake case.

In `WorkspaceServiceImpl`, calls to `getRecentWorkspaces` that resulted in `user_recent_workspaces` needing to be pruned threw an error on the `.deleteByWorkspaceIdIn` because Spring thinks it should have been part of a transaction and it was not. So added a `@Transactional` to `getRecentWorkspaces` since that's where we get the data we pass in to `pruneInaccessibleRecentWorkspaces`.