### PR TITLE
[RW-3684][risk=no] Tune background image transition points on account creation

### DIFF
--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -16,7 +16,7 @@ describe('SignInReact', () => {
     props = {
       onInit: () => {},
       signIn: signIn,
-      windowSize: {width: 1400, height: 0}
+      windowSize: {width: 1700, height: 0}
     } as SignInProps;
   });
 
@@ -28,7 +28,7 @@ describe('SignInReact', () => {
     expect(wrapper.exists('[data-test-id="login"]')).toBeTruthy();
   });
 
-  it('should display small background image when window width is between 900 and 1300', () => {
+  it('should display small background image when window width is moderately sized', () => {
     props.windowSize.width = 999;
     const wrapper = component();
     const templateImage = wrapper.find('[data-test-id="template"]');
@@ -52,7 +52,7 @@ describe('SignInReact', () => {
     expect(wrapper.exists('[data-test-id="invitationKey"]')).toBeTruthy();
   });
 
-  it('should display invitation key with small image when width is between 900 and 1300 ', () => {
+  it('should display invitation key with small image when width is moderately sized ', () => {
     props.windowSize.width = 999;
     const wrapper = component();
     const createAccountButton = wrapper.find(Button).find({type: 'secondary'});

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -29,19 +29,24 @@ interface SignInState {
 
 const styles = {
   template: (windowSize, images) => {
+    // Lower bounds to prevent the small and large images from covering the
+    // creation controls, respectively.
+    const bgWidthMinPx = 900;
+    const bgWidthSmallLimitPx = 1600;
+
     return {
       backgroundImage: calculateImage(),
       backgroundColor: colors.light,
       backgroundRepeat: 'no-repeat',
       width: '100%',
       minHeight: '100vh',
-      backgroundSize: windowSize.width <= 900 ? '0% 0%' : 'contain',
+      backgroundSize: windowSize.width <= bgWidthMinPx ? '0% 0%' : 'contain',
       backgroundPosition: calculateBackgroundPosition()
     };
 
     function calculateImage() {
       let imageUrl = 'url(\'' + images.backgroundImgSrc + '\')';
-      if (windowSize.width > 900 && windowSize.width <= 1300) {
+      if (windowSize.width > bgWidthMinPx && windowSize.width <= bgWidthSmallLimitPx) {
         imageUrl = 'url(\'' + images.smallerBackgroundImgSrc + '\')';
       }
       return imageUrl;
@@ -49,7 +54,7 @@ const styles = {
 
     function calculateBackgroundPosition() {
       let position = 'bottom right -1rem';
-      if (windowSize.width > 900 && windowSize.width <= 1300) {
+      if (windowSize.width > bgWidthMinPx && windowSize.width <= bgWidthSmallLimitPx) {
         position = 'bottom right';
       }
       return position;


### PR DESCRIPTION
The new demographics survey has larger controls, where the overlap is more noticeable. Though this was already a problem on existing creation pages.

Transition point (increased window size a few pixels between screenshots):
![image](https://user-images.githubusercontent.com/822298/66852164-30a3fc00-ef31-11e9-96d7-56ed4cc7ca9c.png)

![image](https://user-images.githubusercontent.com/822298/66852171-34378300-ef31-11e9-81b8-fe6d5ded8da6.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
