### PR TITLE
[no ticket] [risk=no] remove line-height

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -274,12 +274,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
             >
               {accessLevel}
             </div>
-            <div
-              style={{
-                fontSize: 12,
-                lineHeight: 17
-              }}
-            >
+            <div style={{fontSize: 12}}>
               Last Changed: {displayDate(workspace.lastModifiedTime)}
             </div>
           </FlexColumn>


### PR DESCRIPTION
Default line-height is usually 1.2. Of course a line-height of 17 exploded things.
![Screen Shot 2019-10-14 at 2 30 42 PM](https://user-images.githubusercontent.com/1847690/66844205-e8d6a200-ef3b-11e9-9ce4-a8cabad4e559.png)
should be
![Screen Shot 2019-10-15 at 11 07 09 AM](https://user-images.githubusercontent.com/1847690/66844226-f3913700-ef3b-11e9-8891-154c6e34b72d.png)

