### PR TITLE
[risk=no] Revert "patch version of mysql in circle"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   api-local-test:
     docker:
       - image: allofustest/workbench:buildimage-0.0.13
-      - image: mysql:5.7.27
+      - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu
           - MYSQL_USER=ubuntu

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
       - ~/.config:/.config:cached
       - ~/.gsutil:/.gsutil:cached
   db:
-    # TODO: An update to MySql 5.7.28 broke Circle, try reverting to 5.7 when newer releases are published
     image: mysql:5.7.27
     env_file:
       - db/vars.env


### PR DESCRIPTION
Should now be resolved per https://discuss.circleci.com/t/mysql-v5-7-docker-image-issue-october-16th-2019/32933

Reverts all-of-us/workbench#2686