### PR TITLE
[risk=no] lint before tests in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ jobs:
           working_directory: ~/workbench/api
           command: ./project.rb validate-swagger --project-prop verboseTestLogging=yes
       - run:
-          # Lint before tests because it's much faster
-          name: Java linting
-          working_directory: ~/workbench/api
-          command: ./gradlew spotlessCheck
-      - run:
           name: Integration tests compile
           working_directory: ~/workbench/api
           command: ./project.rb gradle compileBigQuery compileIntegration
@@ -241,15 +236,23 @@ jobs:
           name: Build with strict compilation
           working_directory: ~/workbench/ui
           command: ./project.rb build --environment test
-      - run:
-          # Lint last; it's more important to surface test failures early.
-          name: Lint Typescript
-          working_directory: ~/workbench/ui
-          command: yarn run lint
       - persist_to_workspace:
           root: .
           paths:
             - ui
+
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+        name: Lint Typescript
+        working_directory: ~/workbench/ui
+        command: yarn run lint
+      - run:
+	name: Java/Kotlin linting
+	working_directory: ~/workbench/api
+	command: ./gradlew spotlessCheck
 
   ui-deploy-to-test:
     <<: *defaults
@@ -349,6 +352,7 @@ workflows:
       - ui-build-test
       - api-bigquery-test
       - api-integration-test
+      - lint
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
           <<: *filter_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
           working_directory: ~/workbench/api
           command: ./project.rb validate-swagger --project-prop verboseTestLogging=yes
       - run:
+          # Lint before tests because it's much faster
+          name: Java linting
+          working_directory: ~/workbench/api
+          command: ./gradlew spotlessCheck
+      - run:
           name: Integration tests compile
           working_directory: ~/workbench/api
           command: ./project.rb gradle compileBigQuery compileIntegration
@@ -46,11 +51,6 @@ jobs:
           name: Unit tests
           working_directory: ~/workbench/api
           command: ./project.rb test
-      - run:
-          # Lint last; it's more important to surface test failures early.
-          name: Java linting
-          working_directory: ~/workbench/api
-          command: ./gradlew spotlessCheck
       - save_cache:
           paths:
             - ~/.gradle


### PR DESCRIPTION
My preference would be to run the lint check BEFORE our tests because it runs much faster and it will exit early if the PR can't merge due to linting issues. 

Example scenario:
- Upload PR / respond to feed back / prepare to merge
- Tests run for ~20 min
- Linter fails 
- Fix and rerun Circle ~20 min

Proposed scenario:
- Upload PR / respond to feed back / prepare to merge
- Linter fails ~1 m
- Fix and rerun Circle ~20 min

Time saved - ~20m


Downside - linter failures are less important than test failures when evaluating a branch. Could negatively impact workflows where people run circle before lunch/meetings and come back to linter failures instead of tests.