### PR TITLE
[RW-3710][RISK=NO] Fix foreign key error in clone 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortCloningService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortCloningService.java
@@ -26,15 +26,16 @@ public class CohortCloningService {
 
   @Transactional
   public Cohort cloneCohortAndReviews(Cohort fromCohort, Workspace targetWorkspace) {
-    Cohort toCohort =
+    final Cohort duplicatedCohort =
         cohortFactory.duplicateCohort(
             fromCohort.getName(), targetWorkspace.getCreator(), targetWorkspace, fromCohort);
-    cohortDao.save(toCohort);
+    final Cohort toCohort = cohortDao.save(duplicatedCohort);
     copyCohortAnnotations(fromCohort, toCohort);
 
     for (CohortReview fromReview : fromCohort.getCohortReviews()) {
-      CohortReview toReview = cohortFactory.duplicateCohortReview(fromReview, toCohort);
-      toReview = cohortReviewDao.save(toReview);
+      final CohortReview duplicatedReview =
+          cohortFactory.duplicateCohortReview(fromReview, toCohort);
+      final CohortReview toReview = cohortReviewDao.save(duplicatedReview);
       copyCohortReviewAnnotations(fromCohort, fromReview, toCohort, toReview);
     }
 


### PR DESCRIPTION
A call to `save` was ignoring the result, and thus not capturing the cohort ID (leaving it at zero). Later, the foreign key between dataset and cohort tables could not be satisfied b/c cohort 0 did not exist.

Unit test updates to follow.