### PR TITLE
[RW-3578][risk=no] Track a loggedIn custom dimension in Analytics

### DIFF
--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -11,6 +11,7 @@ import {
 
 import {ServerConfigService} from 'app/services/server-config.service';
 import {cookiesEnabled} from 'app/utils';
+import {initializeAnalytics} from 'app/utils/analytics';
 import {
   queryParamsStore,
   routeConfigDataStore,
@@ -20,8 +21,6 @@ import {
 import {environment} from 'environments/environment';
 
 import outdatedBrowserRework from 'outdated-browser-rework';
-
-declare let gtag: Function;
 
 export const overriddenUrlKey = 'allOfUsApiUrlOverride';
 
@@ -96,7 +95,7 @@ export class AppComponent implements OnInit {
       }
     });
 
-    this.setGTagManager();
+    initializeAnalytics();
   }
 
   getLeafRoute(route = this.activatedRoute) {
@@ -118,23 +117,6 @@ export class AppComponent implements OnInit {
         });
       }
     }
-  }
-
-  /**
-   * Setting the Google Analytics ID here.
-   * This first injects Google's gtag script via iife, then secondarily defines
-   * the global gtag function.
-   */
-  private setGTagManager() {
-    gtag('config', environment.gaId, {
-      custom_map: {
-        [environment.gaUserAgentDimension]: 'user_agent'
-      }
-    });
-    // There is some interpolation issues here that cause some useragents to be too long
-    // limit is 150. Slicing to 100 pretty much guarantees that even with the encoding
-    // it comes in under this limit -US 2/27/18
-    gtag('set', 'user_agent', window.navigator.userAgent.slice(0, 100));
   }
 
   private checkBrowserSupport() {

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -3,6 +3,7 @@
  */
 import {Injectable, NgZone} from '@angular/core';
 import {ServerConfigService} from 'app/services/server-config.service';
+import {setLoggedInState} from 'app/utils/analytics';
 import {signInStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
@@ -72,6 +73,7 @@ export class SignInService {
       if (isSignedIn) {
         this.clearIdToken();
       }
+      setLoggedInState(isSignedIn);
     });
     gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn: boolean) => {
       this.zone.run(() => {

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -1,3 +1,5 @@
+import {environment} from 'environments/environment';
+
 declare let gtag: Function;
 
 /**
@@ -25,4 +27,35 @@ export function triggerEvent(
   } else {
     console.error('Google Analytics gtag.js has not been loaded');
   }
+}
+
+enum UserAuthState {
+  LOGGED_IN = 'Logged in',
+  LOGGED_OUT = 'Logged out'
+}
+
+/**
+ * Sets the Analytics custom dimension indicating whether the current user
+ * session should be treated as logged-in or logged-out. This allows us to
+ * create Analytics segments which only show logged-in user activity.
+ * @param signedIn
+ */
+export function setLoggedInState(loggedIn: boolean) {
+  gtag('set', {
+    [environment.gaLoggedInDimension]: loggedIn ? UserAuthState.LOGGED_IN : UserAuthState.LOGGED_OUT
+  });
+}
+
+/**
+ * Initializes the Google Analytics config using gtag.js. This method looks to
+ * environment variables for various GA configuration parameters, and sets
+ * initial values for contextual custom dimensions.
+ */
+export function initializeAnalytics() {
+  gtag('js', new Date());
+  gtag('set', {
+    [environment.gaUserAgentDimension]: window.navigator.userAgent.slice(0, 100),
+    [environment.gaLoggedInDimension]: UserAuthState.LOGGED_OUT
+  });
+  gtag('config', environment.gaId);
 }

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -23,9 +23,12 @@ export interface Environment {
   gaId: string;
   // The Google Analytics custom dimension ID for sending User Agent
   // info, allowing us to filter out Pingdom, Appscan, etc
-  // This value should look like 'dimension1' with the digit
-  // being the variable
+  // This value should look like 'dimension1' or similar.
   gaUserAgentDimension: string;
+  // The Google Analytics custom dimension ID for sending logged-in state,
+  // allowing us to distinguish between unauthenticated and logged-in sessions.
+  // This value should look like 'dimension2' or similar.
+  gaLoggedInDimension: string;
   // API endpoint to use for Leonardo (notebook proxy) API calls.
   // Example value: 'https://notebooks.firecloud.org'
   leoApiUrl: string;

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -13,6 +13,7 @@ export const environment: Environment = {
   debug: true,
   gaId: 'UA-112406425-5',
   gaUserAgentDimension: 'dimension1',
+  gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -11,6 +11,7 @@ export const environment: Environment = {
   debug: false,
   gaId: 'UA-112406425-2',
   gaUserAgentDimension: 'dimension1',
+  gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'https://shibboleth.dsde-perf.broadinstitute.org',

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -10,6 +10,7 @@ export const environment: Environment = {
   debug: false,
   gaId: 'UA-112406425-4',
   gaUserAgentDimension: 'dimension1',
+  gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   trainingUrl: 'https://aou.nnlm.gov',

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -10,6 +10,7 @@ export const environment: Environment = {
   debug: false,
   gaId: 'UA-112406425-3',
   gaUserAgentDimension: 'dimension1',
+  gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   trainingUrl: 'https://aoudev.nnlm.gov',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -10,6 +10,7 @@ export const environment: Environment = {
   debug: false,
   gaId: 'UA-112406425-2',
   gaUserAgentDimension: 'dimension1',
+  gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -8,6 +8,7 @@ export const testEnvironmentBase = {
   publicUiUrl: 'https://aou-db-test.appspot.com',
   gaId: 'UA-112406425-1',
   gaUserAgentDimension: 'dimension2',
+  gaLoggedInDimension: 'dimension3',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -16,7 +16,6 @@
     <script type="text/javascript">
       window.dataLayer=window.dataLayer||[];
       function gtag() {window.dataLayer.push(arguments)}
-      gtag('js', new Date());
     </script>
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">


### PR DESCRIPTION
This PR is a step towards handling the "incorrect user counts" issue.

After digging into the Analytics data some more, I concluded that the bulk of our discrepancy is from short-lived user sessions that land on the login page of workbench.researchallofus.org but don't sign in. (This makes sense, since the site is publicly-accessible.)

The best way to ensure we're looking only at active, logged-in users is to track it as a custom dimension. I added a new per-session custom dimension in each of our Analytics properties, and this code will cause our client to start logging to this dimension. Once this pushes to prod, we can add segments & filters to data studio to differentiate between "all sessions" and "logged-in sessions".

One bump I encountered along the way was that at some point our existing code for custom dimension tracking stopped working (I think https://github.com/all-of-us/workbench/pull/2417 inadvertently had this effect). I had to slightly change our use of gtag.js to work around some of its quirks (ref https://stackoverflow.com/questions/50552141/gtag-multiple-custom-dimensions), and I also took the opportunity to centralize a bit of the functionality.

TESTING

I ran a local UI server and used the GA debugger extension (https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) to look at the reports being sent.

1) Hit login screen in a logged-out state, state is "Logged out":

<img width="500" alt="Screen Shot 2019-10-18 at 9 23 59 AM" src="https://user-images.githubusercontent.com/51842/67105502-e15f0500-f196-11e9-8395-478f1c016611.png">

2) Sign in and hit the homepage, state is "Logged in":

<img width="863" alt="Screen Shot 2019-10-18 at 9 24 22 AM" src="https://user-images.githubusercontent.com/51842/67105525-e8861300-f196-11e9-88ac-bd6972d15d28.png">

Plus the user-agent dimension is now being sent too.