### PR TITLE
[RW-3710][risk=no] use right ID list

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -551,7 +551,7 @@ public class DataSetServiceImpl implements DataSetService {
     toDataSet.setCreationTime(toWorkspace.getCreationTime());
 
     toDataSet.setConceptSetIds(new ArrayList<>(conceptSetIds));
-    toDataSet.setCohortIds(new ArrayList<>(conceptSetIds));
+    toDataSet.setCohortIds(new ArrayList<>(cohortIds));
     return dataSetDao.save(toDataSet);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -396,8 +396,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Transactional
   public Workspace saveAndCloneCohortsConceptSetsAndDataSets(Workspace from, Workspace to) {
     // Save the workspace first to allocate an ID.
-    Workspace saved = workspaceDao.save(to);
-    CdrVersionContext.setCdrVersionNoCheckAuthDomain(saved.getCdrVersion());
+    to = workspaceDao.save(to);
+    CdrVersionContext.setCdrVersionNoCheckAuthDomain(to.getCdrVersion());
     boolean cdrVersionChanged =
         from.getCdrVersion().getCdrVersionId() != to.getCdrVersion().getCdrVersionId();
     Map<Long, Long> fromCohortIdToToCohortId = new HashMap<>();
@@ -427,7 +427,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
               .map(Entry::getValue)
               .collect(Collectors.toSet()));
     }
-    return saved;
+    return to;
   }
 
   @Override


### PR DESCRIPTION
Fix an issue caught by @freemabd where the wrong ID list was set. This happened to work locally (if the range of cohort IDs and concept IDs was close enough).