### PR TITLE
[risk=no] Clean the buffer hourly (up from daily)

### DIFF
--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -41,7 +41,7 @@ cron:
   target: api
 - description: 'Find BillingProjectBufferEntries that have failed during the creation or assignment step and set their statuses to ERROR'
   url: /v1/cron/cleanBillingBuffer
-  schedule: every 24 hours
+  schedule: every 1 hours
   timezone: UTC
   target: api
 - description: 'Find and alert users that have exceeded their free tier billing usage'


### PR DESCRIPTION
This cleans up projects stuck in various states more frequently, preventing the buffer from getting gummed up due to project creation issues. See https://pmi-engteam.slack.com/archives/CP4QVDS2H/p1571411860325500 for related discussion.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
