### PR TITLE
[RW-3426] demo of renaming swagger codegen classes

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -27,6 +27,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterListResponse;
@@ -165,7 +166,7 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterLocalizeResponse> localize(
       String projectName, String clusterName, ClusterLocalizeRequest body) {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
+    FirecloudWorkspace fcWorkspace;
     try {
       fcWorkspace =
           fireCloudService
@@ -280,7 +281,7 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   private String aouConfigDataUri(
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace,
+      FirecloudWorkspace fcWorkspace,
       CdrVersion cdrVersion,
       String cdrBillingCloudProject) {
     JSONObject config = new JSONObject();

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceConversionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceConversionUtils.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.db.model.UserRecentWorkspace;
 import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -53,7 +54,7 @@ public class WorkspaceConversionUtils {
 
   public static Workspace toApiWorkspace(
       org.pmiops.workbench.db.model.Workspace workspace,
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace) {
+      FirecloudWorkspace fcWorkspace) {
     ResearchPurpose researchPurpose = createResearchPurpose(workspace);
     if (workspace.getPopulation()) {
       researchPurpose.setPopulationDetails(new ArrayList<>(workspace.getSpecificPopulationsEnum()));

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
@@ -169,7 +170,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     Workspace dbWorkspace = getRequired(workspaceNamespace, workspaceId);
 
     org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse;
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
+    FirecloudWorkspace fcWorkspace;
 
     WorkspaceResponse workspaceResponse = new WorkspaceResponse();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -52,6 +52,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.ManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -202,7 +203,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     return new FirecloudWorkspaceId(namespace, strippedName);
   }
 
-  private org.pmiops.workbench.firecloud.model.Workspace attemptFirecloudWorkspaceCreation(
+  private FirecloudWorkspace attemptFirecloudWorkspaceCreation(
       FirecloudWorkspaceId workspaceId) {
     fireCloudService.createWorkspace(
         workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
@@ -236,7 +237,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // Note: please keep any initialization logic here in sync with CloneWorkspace().
     FirecloudWorkspaceId workspaceId =
         generateFirecloudWorkspaceId(workspaceNamespace, workspace.getName());
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         attemptFirecloudWorkspaceCreation(workspaceId);
 
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
@@ -272,7 +273,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       org.pmiops.workbench.db.model.Workspace dbWorkspace,
       User user,
       FirecloudWorkspaceId workspaceId,
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace,
+      FirecloudWorkspace fcWorkspace,
       Timestamp createdAndLastModifiedTime) {
     dbWorkspace.setFirecloudName(workspaceId.getWorkspaceName());
     dbWorkspace.setWorkspaceNamespace(workspaceId.getWorkspaceNamespace());
@@ -323,7 +324,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     workspaceService.enforceWorkspaceAccessLevel(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.OWNER);
     Workspace workspace = request.getWorkspace();
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         fireCloudService.getWorkspace(workspaceNamespace, workspaceId).getWorkspace();
     if (workspace == null) {
       throw new BadRequestException("No workspace provided in request");
@@ -400,7 +401,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
         toFcWorkspaceId.getWorkspaceNamespace(),
         toFcWorkspaceId.getWorkspaceName());
 
-    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace =
+    FirecloudWorkspace toFcWorkspace =
         fireCloudService
             .getWorkspace(
                 toFcWorkspaceId.getWorkspaceNamespace(), toFcWorkspaceId.getWorkspaceName())

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -370,7 +370,7 @@ paths:
         201:
           description: Successful Request
           schema:
-            $ref: '#/definitions/Workspace'
+            $ref: '#/definitions/FirecloudWorkspace'
         403:
           description: Unable to create bucket for workspace
         409:
@@ -999,7 +999,7 @@ definitions:
         type: string
         description: User's email
 
-  Workspace:
+  FirecloudWorkspace:
     description: ''
     required:
       - namespace
@@ -1098,7 +1098,7 @@ definitions:
       catalog:
         type: boolean
       workspace:
-        $ref: '#/definitions/Workspace'
+        $ref: '#/definitions/FirecloudWorkspace'
       workspaceSubmissionStats:
         $ref: '#/definitions/WorkspaceSubmissionStats'
       owners:


### PR DESCRIPTION
Looking at ways to avoid confusion among the three classes named `Workspace`. Starting with the external Workspace in the Firecloud API.