### PR TITLE
[RW-3736][risk=low] Move cluster defaults to config, increase size

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -4,6 +4,8 @@
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
+    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -3,7 +3,7 @@
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-perf.broadinstitute.org",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
-    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultMachineType": "n1-standard-2",
     "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/leonardo.dsde-perf.broadinstitute.org",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -3,6 +3,8 @@
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-perf.broadinstitute.org",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
+    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/leonardo.dsde-perf.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-perf",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -3,7 +3,7 @@
     "baseUrl": "https:\/\/api.firecloud.org",
     "clusterMaxAgeDays": 14,
     "clusterIdleMaxAgeDays": 7,
-    "clusterDefaultMachineType": "n1-standard-2",
+    "clusterDefaultMachineType": "n1-standard-4",
     "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -3,6 +3,8 @@
     "baseUrl": "https:\/\/api.firecloud.org",
     "clusterMaxAgeDays": 14,
     "clusterIdleMaxAgeDays": 7,
+    "clusterDefaultMachineType": "n1-standard-2",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -3,6 +3,8 @@
     "baseUrl": "https:\/\/api.firecloud.org",
     "clusterMaxAgeDays": 14,
     "clusterIdleMaxAgeDays": 7,
+    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -3,6 +3,8 @@
     "baseUrl": "https:\/\/api.firecloud.org",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
+    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "registeredDomainName": "all-of-us-registered-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -4,6 +4,8 @@
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",
     "clusterMaxAgeDays": 7,
     "clusterIdleMaxAgeDays": 3,
+    "clusterDefaultMachineType": "n1-standard-4",
+    "clusterDefaultDiskSizeGb": 50,
     "debugEndpoints": false,
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "registeredDomainName": "all-of-us-registered-test",

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -89,9 +89,11 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         .machineConfig(
             new MachineConfig()
                 .masterDiskSize(
-                    Optional.ofNullable(clusterOverride.masterDiskSize).orElse(40 /* GB */))
+                    Optional.ofNullable(clusterOverride.masterDiskSize)
+                        .orElse(config.firecloud.clusterDefaultDiskSizeGb))
                 .masterMachineType(
-                    Optional.ofNullable(clusterOverride.machineType).orElse("n1-standard-2")));
+                    Optional.ofNullable(clusterOverride.machineType)
+                        .orElse(config.firecloud.clusterDefaultMachineType)));
   }
 
   @Override

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -146,6 +146,8 @@ public class ClusterControllerTest {
     config.server.apiBaseUrl = API_BASE_URL;
     config.firecloud = new WorkbenchConfig.FireCloudConfig();
     config.firecloud.registeredDomainName = "";
+    config.firecloud.clusterDefaultMachineType = "n1-standard-4";
+    config.firecloud.clusterDefaultDiskSizeGb = 50;
     config.access = new WorkbenchConfig.AccessConfig();
     config.access.enableComplianceTraining = true;
     config.featureFlags = new FeatureFlagsConfig();
@@ -267,11 +269,11 @@ public class ClusterControllerTest {
             new UpdateClusterConfigRequest()
                 .userEmail(OTHER_USER_EMAIL)
                 .clusterConfig(
-                    new ClusterConfig().machineType("n1-standard-4").masterDiskSize(100)));
+                    new ClusterConfig().machineType("n1-standard-16").masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     User updatedUser = userDao.findUserByEmail(OTHER_USER_EMAIL);
-    assertThat(updatedUser.getClusterConfigDefault().machineType).isEqualTo("n1-standard-4");
+    assertThat(updatedUser.getClusterConfigDefault().machineType).isEqualTo("n1-standard-16");
     assertThat(updatedUser.getClusterConfigDefault().masterDiskSize).isEqualTo(100);
   }
 
@@ -282,7 +284,7 @@ public class ClusterControllerTest {
             new UpdateClusterConfigRequest()
                 .userEmail(OTHER_USER_EMAIL)
                 .clusterConfig(
-                    new ClusterConfig().machineType("n1-standard-4").masterDiskSize(100)));
+                    new ClusterConfig().machineType("n1-standard-16").masterDiskSize(100)));
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
     response =

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -62,6 +62,8 @@ public class WorkbenchConfig {
     public String baseUrl;
     public Integer clusterMaxAgeDays;
     public Integer clusterIdleMaxAgeDays;
+    public String clusterDefaultMachineType;
+    public Integer clusterDefaultDiskSizeGb;
     public String registeredDomainName;
     public String registeredDomainGroup;
     public String leoBaseUrl;


### PR DESCRIPTION
- Keep `n1-standard-2` for perf to save some costs.
- Increase all other environments to `n1-standard-4`, from n1-standard-2
- Increase all environments boot disk size from `40GB` -> `50GB`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
