### PR TITLE
[RW-3628][risk=low] Allow base64 notebook images, disallow other sources

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -7,6 +7,7 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.json.JSONObject;
@@ -33,6 +34,14 @@ public class NotebooksServiceImpl implements NotebooksService {
           .and(Sanitizers.LINKS)
           .and(Sanitizers.STYLES)
           .and(Sanitizers.TABLES)
+          .and(
+              new HtmlPolicyBuilder()
+                  .allowElements("img")
+                  .allowUrlProtocols("data")
+                  .allowAttributes("src")
+                  .matching(Pattern.compile("^data:image.*"))
+                  .onElements("img")
+                  .toFactory())
           .and(
               new HtmlPolicyBuilder()
                   // nbconvert renders styles into a style tag; unfortunately the OWASP library does


### PR DESCRIPTION
Currently notebook plots don't work. These are implemented with inline data URIs, which are reasonably safe to render.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
