### PR TITLE
[RW-3543][risk=no] Make search items expandable to show selections

### DIFF
--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -1,4 +1,4 @@
-import {AttrName, CriteriaType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, CriteriaType, DomainType, ModifierType, Operator} from 'generated/fetch';
 
 export const LIST_PROGRAM_TYPES = [
   {
@@ -119,3 +119,40 @@ export const PREDEFINED_ATTRIBUTES = {
     }
   ],
 };
+
+export const MODIFIERS_TEXT = {
+  [ModifierType.AGEATEVENT]: {
+    name: 'Age At Event',
+    operators: {
+      [Operator.BETWEEN]: 'Between',
+      [Operator.GREATERTHANOREQUALTO]: 'Greater Than or Equal To',
+      [Operator.LESSTHANOREQUALTO]: 'Less Than or Equal To',
+    }
+  },
+  [ModifierType.ENCOUNTERS]: {
+    name: 'During Visit Type',
+    operators: {
+      [Operator.IN]: ''
+    }
+  },
+  [ModifierType.EVENTDATE]: {
+    name: 'Event Date',
+    operators: {
+      [Operator.BETWEEN]: 'Is Between',
+      [Operator.GREATERTHANOREQUALTO]: 'Is On or After',
+      [Operator.LESSTHANOREQUALTO]: 'Is On or Before',
+    }
+  },
+  [ModifierType.NUMOFOCCURRENCES]: {
+    name: 'Has Occurrences',
+    operators: {
+      [Operator.GREATERTHANOREQUALTO]: 'N or More',
+    }
+  },
+};
+
+export const ENCOUNTERS_MAP = {
+  '9201': 'Inpatient Visit',
+  '9202': 'Outpatient Visit',
+  '9203': 'Emergency Room Visit',
+}

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -120,7 +120,7 @@ export const PREDEFINED_ATTRIBUTES = {
   ],
 };
 
-export const MODIFIERS_TEXT = {
+export const MODIFIERS_MAP = {
   [ModifierType.AGEATEVENT]: {
     name: 'Age At Event',
     operators: {
@@ -149,10 +149,4 @@ export const MODIFIERS_TEXT = {
       [Operator.GREATERTHANOREQUALTO]: 'N or More',
     }
   },
-};
-
-export const ENCOUNTERS_MAP = {
-  '9201': 'Inpatient Visit',
-  '9202': 'Outpatient Visit',
-  '9203': 'Emergency Room Visit',
 };

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -138,9 +138,9 @@ export const MODIFIERS_MAP = {
   [ModifierType.EVENTDATE]: {
     name: 'Event Date',
     operators: {
-      [Operator.BETWEEN]: 'Is Between',
-      [Operator.GREATERTHANOREQUALTO]: 'Is On or After',
-      [Operator.LESSTHANOREQUALTO]: 'Is On or Before',
+      [Operator.BETWEEN]: 'Between',
+      [Operator.GREATERTHANOREQUALTO]: 'On or After',
+      [Operator.LESSTHANOREQUALTO]: 'On or Before',
     }
   },
   [ModifierType.NUMOFOCCURRENCES]: {

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -155,4 +155,4 @@ export const ENCOUNTERS_MAP = {
   '9201': 'Inpatient Visit',
   '9202': 'Outpatient Visit',
   '9203': 'Emergency Room Visit',
-}
+};

--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -135,7 +135,7 @@ export class DemographicsComponent implements OnInit, OnDestroy {
         const paramId = `age-param${this.ageNode.id}`;
         this.selectedNode = {
           ...this.ageNode,
-          name: `${minAge.toString()} - ${maxAge.toString()}`,
+          name: `Age In Range ${minAge.toString()} - ${maxAge.toString()}`,
           parameterId: paramId,
           attributes: [attr],
         };
@@ -252,7 +252,7 @@ export class DemographicsComponent implements OnInit, OnDestroy {
         const paramId = `age-param${this.ageNode.id}`;
         return {
           ...this.ageNode,
-          name: `${lo} - ${hi}`,
+          name: `Age In Range ${lo} - ${hi}`,
           parameterId: paramId,
           attributes: [attr],
         };

--- a/ui/src/app/cohort-search/modal/modal.component.html
+++ b/ui/src/app/cohort-search/modal/modal.component.html
@@ -71,7 +71,9 @@
                   </div>
                   <!-- Modifiers Page -->
                   <div class="panel-left" [class.show]="mode === 'modifiers'">
-                    <crit-list-modifier-page [disabled]="modifiersFlag" [wizard]="wizard"></crit-list-modifier-page>
+                    <crit-list-modifier-page *ngIf="showModifiers"
+                      [disabled]="modifiersFlag"
+                      [wizard]="wizard"></crit-list-modifier-page>
                   </div>
                   <!-- Attributes Page -->
                   <div class="panel-left" [class.show]="mode === 'attributes'">

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -63,47 +63,22 @@ export class SearchGroupItemName extends React.Component<{editItem: Function, it
     this.state = {};
   }
 
-  get itemTitleDisplay() {
-    const {item: {type}} = this.props;
-    return `${domainToTitle(type)} ${this.pluralizedCode}`;
-  }
-
-  get pluralizedCode() {
-    const {item: {searchParameters}} = this.props;
-    return searchParameters.length > 1 ? 'Codes' : 'Code';
-  }
-
-  get selectionsDisplay() {
-    const {item: {searchParameters, type}} = this.props;
-    const formatter = (param) => {
-      let funcs = [typeDisplay, attributeDisplay];
-      if (type === DomainType.PERSON) {
-        funcs = [typeDisplay, nameDisplay, attributeDisplay];
-      } else if (type === DomainType.PHYSICALMEASUREMENT
-        || type === DomainType.VISIT
-        || type === DomainType.DRUG
-        || type === DomainType.MEASUREMENT
-        || type === DomainType.SURVEY) {
-        funcs = [nameDisplay];
-      }
-      return funcs.map(f => f(param)).join(' ').trim();
-    };
-    const sep = type === DomainType[DomainType.PERSON] ? '; ' : ', ';
-    return searchParameters.map(formatter).join(sep);
-  }
-
   render() {
-    const {editItem} = this.props;
+    const {editItem, item: {searchParameters, type}} = this.props;
+    const codeDisplay = searchParameters.length > 1 ? 'Codes' : 'Code';
+    const showCode = [DomainType.CONDITION, DomainType.DRUG, DomainType.MEASUREMENT, DomainType.PROCEDURE].includes(type);
     return <React.Fragment>
       <span style={{paddingRight: '10px'}}
         onClick={() => editItem()}
         onMouseEnter={(e) => this.op.toggle(e)}
         onMouseLeave={(e) => this.op.toggle(e)}>
-        <span className='item-title' style={styles.codeText}>Contains {this.itemTitleDisplay}</span>
+        <span className='item-title' style={styles.codeText}>Contains {domainToTitle(type)} {codeDisplay}</span>
       </span>
       <OverlayPanel ref={(el) => this.op = el} appendTo={document.body} style={{maxWidth: '15rem'}}>
-        <h3 style={{margin: 0}}>{this.itemTitleDisplay}</h3>
-        {this.selectionsDisplay}
+        <h3 style={{margin: 0}}>{domainToTitle(type)}</h3>
+        {searchParameters.map((param, p) => {
+          return <div key={p}>{showCode && <b>{param.code}</b>} {param.name}</div>;
+        })}
       </OverlayPanel>
     </React.Fragment>;
   }

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -1,17 +1,18 @@
 import {Component, Input} from '@angular/core';
 import * as React from 'react';
 
-import {ENCOUNTERS_MAP, MODIFIERS_TEXT} from 'app/cohort-search/constant';
-import {initExisting, searchRequestStore, selectionsStore, wizardStore} from 'app/cohort-search/search-state.service';
+import {MODIFIERS_MAP} from 'app/cohort-search/constant';
+import {encountersStore, initExisting, searchRequestStore, selectionsStore, wizardStore} from 'app/cohort-search/search-state.service';
 import {domainToTitle, getTypeAndStandard, mapGroupItem} from 'app/cohort-search/utils';
 import {Button, Clickable} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {DomainType, Modifier, ModifierType, SearchRequest} from 'generated/fetch';
+import {WorkspaceData} from 'app/utils/workspace-data';
+import {CriteriaType, DomainType, Modifier, ModifierType, SearchRequest} from 'generated/fetch';
 import {Menu} from 'primereact/menu';
 import Timeout = NodeJS.Timeout;
 
@@ -78,197 +79,219 @@ const itemStyles = `
   }
 `;
 
-function modifiersDisplay(mod: Modifier) {
-  const {name, operands, operator} = mod;
-  switch (name) {
-    case ModifierType.AGEATEVENT:
-      return <span><b>{MODIFIERS_TEXT[name].name}</b> {MODIFIERS_TEXT[name].operators[operator]} {operands.join(' and ')}</span>;
-    case ModifierType.ENCOUNTERS:
-      return <span><b>{MODIFIERS_TEXT[name].name}</b> {ENCOUNTERS_MAP[operands[0]]}</span>;
-    case ModifierType.EVENTDATE:
-      return <span><b>{MODIFIERS_TEXT[name].name}</b> {MODIFIERS_TEXT[name].operators[operator]} {operands.join(' and ')}</span>;
-    case ModifierType.NUMOFOCCURRENCES:
-      return <span><b>{MODIFIERS_TEXT[name].name}</b> {operands[0]} Or More</span>;
-  }
-}
-
 interface Props {
   role: keyof SearchRequest;
   groupId: string;
   item: any;
   index: number;
   updateGroup: Function;
+  workspace: WorkspaceData;
 }
 
 interface State {
   count: number;
+  encounters: any;
   error: boolean;
   loading: boolean;
-  paramMenuOpen: boolean;
+  paramListOpen: boolean;
   status: string;
   timeout: Timeout;
 }
 
-export class SearchGroupItem extends React.Component<Props, State> {
-  actionsMenu: any;
-  constructor(props: Props) {
-    super(props);
-    this.state = {count: null, paramMenuOpen: false, error: false, loading: true, status: props.item.status, timeout: null};
-  }
-
-  componentDidMount(): void {
-    this.getItemCount();
-  }
-
-  async getItemCount() {
-    const {index, item, role, updateGroup} = this.props;
-    // prevent multiple group count calls when initializing multiple items simultaneously (on cohort edit or clone)
-    const init = initExisting.getValue();
-    if (!init || (init && index === 0)) {
-      updateGroup();
-    }
-    try {
-      const {cdrVersionId} = currentWorkspaceStore.getValue();
-      const mappedItem = mapGroupItem(item, false);
-      const request = {
-        includes: [],
-        excludes: [],
-        [role]: [{items: [mappedItem], temporal: false}]
+export const SearchGroupItem = withCurrentWorkspace()(
+  class extends React.Component<Props, State> {
+    actionsMenu: any;
+    constructor(props: Props) {
+      super(props);
+      this.state = {
+        count: null,
+        encounters: encountersStore.getValue(),
+        paramListOpen: false,
+        error: false,
+        loading: true,
+        status: props.item.status,
+        timeout: null
       };
-      await cohortBuilderApi().countParticipants(+cdrVersionId, request).then(count => this.setState({count}));
-    } catch (error) {
-      console.error(error);
-      this.setState({error: true});
-    } finally {
-      this.setState({loading: false});
     }
-  }
 
-  enable() {
-    triggerEvent('Enable', 'Click', 'Enable - Suppress Criteria - Cohort Builder');
-    this.setState({status: 'active'});
-    this.props.item.status = 'active';
-    this.updateSearchRequest();
-  }
+    componentDidMount(): void {
+      const {item: {modifiers}, workspace: {cdrVersionId}} = this.props;
+      const {encounters} = this.state;
+      this.getItemCount();
+      if (!!modifiers && modifiers.some(mod => mod.name === ModifierType.ENCOUNTERS) && !encounters) {
+        cohortBuilderApi().getCriteriaBy(+cdrVersionId, DomainType[DomainType.VISIT], CriteriaType[CriteriaType.VISIT]).then(res => {
+          encountersStore.next(res.items);
+          this.setState({encounters: res.items});
+        });
+      }
+    }
 
-  suppress() {
-    triggerEvent('Suppress', 'Click', 'Snowman - Suppress Criteria - Cohort Builder');
-    this.setState({status: 'hidden'});
-    this.props.item.status = 'hidden';
-    this.updateSearchRequest();
-  }
+    async getItemCount() {
+      const {index, item, role, updateGroup} = this.props;
+      // prevent multiple group count calls when initializing multiple items simultaneously (on cohort edit or clone)
+      const init = initExisting.getValue();
+      if (!init || (init && index === 0)) {
+        updateGroup();
+      }
+      try {
+        const {cdrVersionId} = currentWorkspaceStore.getValue();
+        const mappedItem = mapGroupItem(item, false);
+        const request = {
+          includes: [],
+          excludes: [],
+          [role]: [{items: [mappedItem], temporal: false}]
+        };
+        await cohortBuilderApi().countParticipants(+cdrVersionId, request).then(count => this.setState({count}));
+      } catch (error) {
+        console.error(error);
+        this.setState({error: true});
+      } finally {
+        this.setState({loading: false});
+      }
+    }
 
-  remove() {
-    triggerEvent('Delete', 'Click', 'Snowman - Delete Criteria - Cohort Builder');
-    this.setState({status: 'pending'});
-    this.props.item.status = 'pending';
-    this.updateSearchRequest();
-    const timeout = setTimeout(() => {
-      this.updateSearchRequest(true);
-    }, 10000);
-    this.setState({timeout});
-  }
+    enable() {
+      triggerEvent('Enable', 'Click', 'Enable - Suppress Criteria - Cohort Builder');
+      this.setState({status: 'active'});
+      this.props.item.status = 'active';
+      this.updateSearchRequest();
+    }
 
-  undo() {
-    triggerEvent('Undo', 'Click', 'Undo - Delete Criteria - Cohort Builder');
-    clearTimeout(this.state.timeout);
-    this.setState({status: 'active'});
-    this.props.item.status = 'active';
-    this.updateSearchRequest();
-  }
+    suppress() {
+      triggerEvent('Suppress', 'Click', 'Snowman - Suppress Criteria - Cohort Builder');
+      this.setState({status: 'hidden'});
+      this.props.item.status = 'hidden';
+      this.updateSearchRequest();
+    }
 
-  updateSearchRequest(remove?: boolean) {
-    const sr = searchRequestStore.getValue();
-    const {item, groupId, role, updateGroup} = this.props;
-    const groupIndex = sr[role].findIndex(grp => grp.id === groupId);
-    if (groupIndex > -1) {
-      const itemIndex = sr[role][groupIndex].items.findIndex(it => it.id === item.id);
-      if (itemIndex > -1) {
-        if (remove) {
-          sr[role][groupIndex].items = sr[role][groupIndex].items.filter(it => it.id !== item.id);
-          searchRequestStore.next(sr);
-        } else {
-          sr[role][groupIndex].items[itemIndex] = item;
-          searchRequestStore.next(sr);
-          updateGroup();
+    remove() {
+      triggerEvent('Delete', 'Click', 'Snowman - Delete Criteria - Cohort Builder');
+      this.setState({status: 'pending'});
+      this.props.item.status = 'pending';
+      this.updateSearchRequest();
+      const timeout = setTimeout(() => {
+        this.updateSearchRequest(true);
+      }, 10000);
+      this.setState({timeout});
+    }
+
+    undo() {
+      triggerEvent('Undo', 'Click', 'Undo - Delete Criteria - Cohort Builder');
+      clearTimeout(this.state.timeout);
+      this.setState({status: 'active'});
+      this.props.item.status = 'active';
+      this.updateSearchRequest();
+    }
+
+    updateSearchRequest(remove?: boolean) {
+      const sr = searchRequestStore.getValue();
+      const {item, groupId, role, updateGroup} = this.props;
+      const groupIndex = sr[role].findIndex(grp => grp.id === groupId);
+      if (groupIndex > -1) {
+        const itemIndex = sr[role][groupIndex].items.findIndex(it => it.id === item.id);
+        if (itemIndex > -1) {
+          if (remove) {
+            sr[role][groupIndex].items = sr[role][groupIndex].items.filter(it => it.id !== item.id);
+            searchRequestStore.next(sr);
+          } else {
+            sr[role][groupIndex].items[itemIndex] = item;
+            searchRequestStore.next(sr);
+            updateGroup();
+          }
         }
       }
     }
-  }
 
-  launchWizard() {
-    triggerEvent('Edit', 'Click', 'Snowman - Edit Criteria - Cohort Builder');
-    const {groupId, item, role} = this.props;
-    const _item = JSON.parse(JSON.stringify(item));
-    const {fullTree, id, searchParameters} = _item;
-    const selections = searchParameters.map(sp => sp.parameterId);
-    selectionsStore.next(selections);
-    const domain = _item.type;
-    const {type, standard} = getTypeAndStandard(searchParameters, domain);
-    const context = {item: _item, domain, type, role, groupId, itemId: id, fullTree, standard};
-    wizardStore.next(context);
-  }
+    launchWizard() {
+      triggerEvent('Edit', 'Click', 'Snowman - Edit Criteria - Cohort Builder');
+      const {groupId, item, role} = this.props;
+      const _item = JSON.parse(JSON.stringify(item));
+      const {fullTree, id, searchParameters} = _item;
+      const selections = searchParameters.map(sp => sp.parameterId);
+      selectionsStore.next(selections);
+      const domain = _item.type;
+      const {type, standard} = getTypeAndStandard(searchParameters, domain);
+      const context = {item: _item, domain, type, role, groupId, itemId: id, fullTree, standard};
+      wizardStore.next(context);
+    }
 
-  render() {
-    const {item: {modifiers, searchParameters, type}} = this.props;
-    const {count, paramMenuOpen, error, loading, status} = this.state;
-    const codeDisplay = searchParameters.length > 1 ? 'Codes' : 'Code';
-    const showCode = [DomainType.CONDITION, DomainType.DRUG, DomainType.MEASUREMENT, DomainType.PROCEDURE].includes(type);
-    const showCount = !loading && status !== 'hidden' && count !== null;
-    const actionItems = [
-      {label: 'Edit criteria', command: () => this.launchWizard()},
-      {label: 'Suppress criteria from total count', command: () => this.suppress()},
-      {label: 'Delete criteria', command: () => this.remove()},
-    ];
-    return <React.Fragment>
-      <style>{itemStyles}</style>
-      {status !== 'deleted' && <div style={{display: 'flex', fontSize: '12px'}}>
-        {(status === 'active' || !status) && <div style={styles.lineItem}>
-          <Menu style={styles.menu} appendTo={document.body} model={actionItems} popup={true} ref={el => this.actionsMenu = el} />
-          <Clickable style={{display: 'inline-block', paddingRight: '0.5rem'}} onClick={(event) => this.actionsMenu.toggle(event)}>
-            <ClrIcon shape='ellipsis-vertical' />
-          </Clickable>
-          <span className='item-title' style={{...styles.codeText, paddingRight: '10px'}} onClick={() => this.launchWizard()}>
-            Contains {domainToTitle(type)} {codeDisplay}
-          </span>
-          {status !== 'hidden' && <span style={{...styles.codeText, paddingRight: '10px'}}>|</span>}
-          {loading && <span className='spinner spinner-inline'>Loading...</span>}
-          {showCount && <span style={styles.codeText}>{count.toLocaleString()}</span>}
-          {error && <span><ClrIcon style={{color: colors.warning}} shape='exclamation-triangle' className='is-solid' size={22} /></span>}
+    modifiersDisplay(mod: Modifier) {
+      const {name, operands, operator} = mod;
+      switch (name) {
+        case ModifierType.AGEATEVENT:
+          return <span><b>{MODIFIERS_MAP[name].name}</b> {MODIFIERS_MAP[name].operators[operator]} {operands.join(' and ')}</span>;
+        case ModifierType.ENCOUNTERS:
+          const {encounters} = this.state;
+          const visit = !!encounters ? encounters.find(en => en.conceptId.toString() === operands[0]).name : '';
+          return <span><b>{MODIFIERS_MAP[name].name}</b> {visit}</span>;
+        case ModifierType.EVENTDATE:
+          return <span><b>{MODIFIERS_MAP[name].name}</b> {MODIFIERS_MAP[name].operators[operator]} {operands.join(' and ')}</span>;
+        case ModifierType.NUMOFOCCURRENCES:
+          return <span><b>{MODIFIERS_MAP[name].name}</b> {operands[0]} Or More</span>;
+      }
+    }
+
+    render() {
+      const {item: {modifiers, searchParameters, type}} = this.props;
+      const {count, paramListOpen, error, loading, status} = this.state;
+      const codeDisplay = searchParameters.length > 1 ? 'Codes' : 'Code';
+      const showCode = [DomainType.CONDITION, DomainType.DRUG, DomainType.MEASUREMENT, DomainType.PROCEDURE].includes(type);
+      const showCount = !loading && status !== 'hidden' && count !== null;
+      const actionItems = [
+        {label: 'Edit criteria', command: () => this.launchWizard()},
+        {label: 'Suppress criteria from total count', command: () => this.suppress()},
+        {label: 'Delete criteria', command: () => this.remove()},
+      ];
+      return <React.Fragment>
+        <style>{itemStyles}</style>
+        {status !== 'deleted' && <div style={{display: 'flex', fontSize: '12px'}}>
+          {(status === 'active' || !status) && <div style={styles.lineItem}>
+            <Menu style={styles.menu} appendTo={document.body} model={actionItems} popup={true} ref={el => this.actionsMenu = el} />
+            <Clickable style={{display: 'inline-block', paddingRight: '0.5rem'}} onClick={(event) => this.actionsMenu.toggle(event)}>
+              <ClrIcon shape='ellipsis-vertical' />
+            </Clickable>
+            <span className='item-title' style={{...styles.codeText, paddingRight: '10px'}} onClick={() => this.launchWizard()}>
+              Contains {domainToTitle(type)} {codeDisplay}
+            </span>
+            {status !== 'hidden' && <span style={{...styles.codeText, paddingRight: '10px'}}>|</span>}
+            {loading && <span className='spinner spinner-inline'>Loading...</span>}
+            {showCount && <span style={styles.codeText}>{count.toLocaleString()}</span>}
+            {error && <span><ClrIcon style={{color: colors.warning}} shape='exclamation-triangle' className='is-solid' size={22} /></span>}
+          </div>}
+          {status === 'pending' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
+            <ClrIcon shape='exclamation-triangle' className='is-solid' size={23} />
+            <span style={{margin: '0 0 2px 2px'}}>
+              This criteria has been deleted
+              <Button type='link' style={styles.link} onClick={() => this.undo()}>UNDO</Button>
+            </span>
+          </div>}
+          {status === 'hidden' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
+            <ClrIcon shape='eye-hide' className='is-solid' size={23} />
+            <span style={{margin: '0 0 2px 2px'}}>
+              This criteria has been suppressed
+              <Button type='link' style={styles.link} onClick={() => this.enable()}>ENABLE</Button>
+            </span>
+          </div>}
+          <ClrIcon style={{...styles.caret, ...(paramListOpen ? {transform: 'rotate(90deg)'} : {})}}
+                   shape={`caret right`} size={24}
+                   onClick={() => this.setState({paramListOpen: !paramListOpen})} />
         </div>}
-        {status === 'pending' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
-          <ClrIcon shape='exclamation-triangle' className='is-solid' size={23} />
-          <span style={{margin: '0 0 2px 2px'}}>
-            This criteria has been deleted
-            <Button type='link' style={styles.link} onClick={() => this.undo()}>UNDO</Button>
-          </span>
-        </div>}
-        {status === 'hidden' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
-          <ClrIcon shape='eye-hide' className='is-solid' size={23} />
-          <span style={{margin: '0 0 2px 2px'}}>
-            This criteria has been suppressed
-            <Button type='link' style={styles.link} onClick={() => this.enable()}>ENABLE</Button>
-          </span>
-        </div>}
-        <ClrIcon style={{...styles.caret, ...(paramMenuOpen ? {transform: 'rotate(90deg)'} : {})}}
-                 shape={`caret right`} size={24}
-                 onClick={() => this.setState({paramMenuOpen: !paramMenuOpen})} />
-      </div>}
-      <div style={{...styles.parameterList, maxHeight: paramMenuOpen ? '15rem' : 0}}>
-        {searchParameters.slice(0, 5).map((param, p) => <div key={p} style={styles.parameter}>
-          {showCode && <b>{param.code}</b>} {param.name}
-        </div>)}
-        {searchParameters.length > 5 && <span style={styles.viewMore} onClick={() => this.launchWizard()}>
-          View/edit all criteria ({searchParameters.length - 5} more)
-        </span>}
-        {!!modifiers && <React.Fragment>
-          <h3 style={{fontSize: '14px', marginTop: '0.25rem'}}>Modifiers</h3>
-          {modifiers.map((mod, m) => <div key={m} style={styles.parameter}>{modifiersDisplay(mod)}</div>)}
-        </React.Fragment>}
-      </div>
-    </React.Fragment>;
+        <div style={{...styles.parameterList, maxHeight: paramListOpen ? '15rem' : 0}}>
+          {searchParameters.slice(0, 5).map((param, p) => <div key={p} style={styles.parameter}>
+            {showCode && <b>{param.code}</b>} {param.name}
+          </div>)}
+          {searchParameters.length > 5 && <span style={styles.viewMore} onClick={() => this.launchWizard()}>
+            View/edit all criteria ({searchParameters.length - 5} more)
+          </span>}
+          {!!modifiers && <React.Fragment>
+            <h3 style={{fontSize: '14px', marginTop: '0.25rem'}}>Modifiers</h3>
+            {modifiers.map((mod, m) => <div key={m} style={styles.parameter}>{this.modifiersDisplay(mod)}</div>)}
+          </React.Fragment>}
+        </div>
+      </React.Fragment>;
+    }
   }
-}
+);
 
 @Component({
   selector: 'app-list-search-group-item',

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -261,7 +261,7 @@ export class SearchGroupItem extends React.Component<Props, State> {
         {searchParameters.length > 5 && <span style={styles.viewMore} onClick={() => this.launchWizard()}>
           View/edit all criteria ({searchParameters.length - 5} more)
         </span>}
-        {!!modifiers.length && <React.Fragment>
+        {!!modifiers && <React.Fragment>
           <h3 style={{fontSize: '14px', marginTop: '0.25rem'}}>Modifiers</h3>
           {modifiers.map((mod, m) => <div key={m} style={styles.parameter}>{modifiersDisplay(mod)}</div>)}
         </React.Fragment>}

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -30,6 +30,10 @@ const styles = reactStyles({
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis'
   },
+  suppressedItem: {
+    color: colorWithWhiteness(colors.warning, -.35),
+    flex: 4,
+  },
   codeText: {
     fontWeight: 300,
     color: colors.dark
@@ -63,6 +67,12 @@ const styles = reactStyles({
   viewMore: {
     color: colors.accent,
     cursor: 'pointer',
+    fontSize: '12px',
+  },
+  disabled: {
+    color: colors.accent,
+    pointerEvents: 'none',
+    opacity: 0.6,
     fontSize: '12px',
   }
 });
@@ -286,14 +296,14 @@ export const SearchGroupItem = withCurrentWorkspace()(
             {showCount && <span style={styles.codeText}>{count.toLocaleString()}</span>}
             {error && <span><ClrIcon style={{color: colors.warning}} shape='exclamation-triangle' className='is-solid' size={22} /></span>}
           </div>}
-          {status === 'pending' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
+          {status === 'pending' && <div style={styles.suppressedItem}>
             <ClrIcon shape='exclamation-triangle' className='is-solid' size={23} />
             <span style={{margin: '0 0 2px 2px'}}>
               This criteria has been deleted
               <Button type='link' style={styles.link} onClick={() => this.undo()}>UNDO</Button>
             </span>
           </div>}
-          {status === 'hidden' && <div style={{color: colorWithWhiteness(colors.warning, -.35)}}>
+          {status === 'hidden' && <div style={styles.suppressedItem}>
             <ClrIcon shape='eye-hide' className='is-solid' size={23} />
             <span style={{margin: '0 0 2px 2px'}}>
               This criteria has been suppressed
@@ -306,9 +316,11 @@ export const SearchGroupItem = withCurrentWorkspace()(
         </div>}
         <div style={{...styles.parameterList, maxHeight: paramListOpen ? '15rem' : 0}}>
           {searchParameters.slice(0, 5).map((param, p) => <SearchGroupItemParameter key={p} parameter={param} />)}
-          {searchParameters.length > 5 && <span style={styles.viewMore} onClick={() => this.launchWizard()}>
-            View/edit all criteria ({searchParameters.length - 5} more)
-          </span>}
+          {searchParameters.length > 5 &&
+            <span style={status === 'active' ? styles.viewMore : styles.disabled} onClick={() => this.launchWizard()}>
+              View/edit all criteria ({searchParameters.length - 5} more)
+            </span>
+          }
           {!!modifiers && modifiers.length > 0 && <React.Fragment>
             <h3 style={{fontSize: '14px', marginTop: '0.25rem'}}>Modifiers</h3>
             {modifiers.map((mod, m) => <div key={m} style={styles.parameter}>{this.modifierDisplay(mod)}</div>)}

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -40,6 +40,11 @@ const styles = reactStyles({
     padding: 0,
     fontSize: '12px',
     fontWeight: 600
+  },
+  parameter: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
   }
 });
 
@@ -75,7 +80,6 @@ export class SearchGroupItemName extends React.Component<{editItem: Function, it
   op: any;
   constructor(props: any) {
     super(props);
-    this.state = {};
   }
 
   render() {
@@ -91,14 +95,10 @@ export class SearchGroupItemName extends React.Component<{editItem: Function, it
       </span>
       <OverlayPanel ref={(el) => this.op = el} appendTo={document.body} style={{maxWidth: '30%'}}>
         <h3 style={{margin: 0}}>{domainToTitle(type)}</h3>
-        {searchParameters.map((param, p) => {
-          return <div key={p}>{showCode && <b>{param.code}</b>} {param.name}</div>;
-        })}
+        {searchParameters.map((param, p) => <div key={p} style={styles.parameter}>{showCode && <b>{param.code}</b>} {param.name}</div>)}
         {!!modifiers.length && <React.Fragment>
           <h3>Modifiers</h3>
-          {modifiers.map((mod, m) => {
-            return <div key={m}>{modifiersDisplay(mod)}</div>;
-          })}
+          {modifiers.map((mod, m) => <div key={m}>{modifiersDisplay(mod)}</div>)}
         </React.Fragment>}
       </OverlayPanel>
     </React.Fragment>;

--- a/ui/src/app/cohort-search/search-state.service.ts
+++ b/ui/src/app/cohort-search/search-state.service.ts
@@ -14,3 +14,4 @@ export const autocompleteStore = new BehaviorSubject<any>('');
 export const idsInUse = new BehaviorSubject<any>(new Set());
 export const ppiQuestions = new BehaviorSubject<any>({});
 export const initExisting = new BehaviorSubject<boolean>(false);
+export const encountersStore = new BehaviorSubject<any>(undefined);


### PR DESCRIPTION
Removes the tooltip from search group items and adds expanding section below each item with a list of selected criteria and modifiers.
![Screen Shot 2019-10-23 at 9 27 04 AM](https://user-images.githubusercontent.com/40036095/67403434-86068b80-f577-11e9-9d5c-5a8eaa478126.png)
