### PR TITLE
[no ticket][risk=no] push @Transactional all the way up the ServiceImpl call stack

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -593,12 +593,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  @Transactional
   public UserRecentWorkspace updateRecentWorkspaces(Workspace workspace) {
     return updateRecentWorkspaces(
         workspace, userProvider.get().getUserId(), new Timestamp(clock.instant().toEpochMilli()));
   }
 
-  @Transactional
   private void handleWorkspaceLimit(long userId) {
     List<UserRecentWorkspace> userRecentWorkspaces =
         userRecentWorkspaceDao.findByUserIdOrderByLastAccessDateDesc(userId);


### PR DESCRIPTION
Apparently if a method without a `@Transactional` calls a method with a `@Transactional` in the same classfile you will get an error. This has to do with how Spring handles objects - for things like this it wraps the entire instance in a proxy that intercepts calls to annotated methods. If the first method called on the instance is not a `@Transactional` method, the proxy won't catch the call.

I _could_ set `@Transactional` on the class itself, which says 'by default, run everything in this class in a transaction with propagation required'. Bringing that one up in eng sync.