### PR TITLE
[RW-3755][risk=no] Fix cron, add error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .externalToolBuilders
 .settings
 cron-emulator.log
+cron-emulator-err.log
 /api/?/
 /api/cluster-resources/generated/*
 /api/db/?/

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -531,13 +531,14 @@ task startCronEmulator(dependsOn: ':appengine-cron-emulator:jar') {
   doFirst {
     ext.process = new ProcessBuilder()
             .redirectOutput(ProcessBuilder.Redirect.to(new File("cron-emulator.log")))
+            .redirectError(ProcessBuilder.Redirect.to(new File("cron-emulator-err.log")))
             .directory(projectDir)
             .command("java", "-jar",
                     project(":appengine-cron-emulator").jar.archivePath.getPath(),
                     "$projectDir/src/main/webapp/WEB-INF/cron.yaml"
             ).start()
 
-    println "Started Cron Emulator"
+    println "Started Cron Emulator, check cron-emulator-err.log for startup errors (RW-3755)"
   }
 }
 

--- a/appengine-cron-emulator/src/main/java/org/broad/Cron.java
+++ b/appengine-cron-emulator/src/main/java/org/broad/Cron.java
@@ -16,4 +16,5 @@ public class Cron {
 
   public String description;
 
+  public String timezone;
 }


### PR DESCRIPTION
Stop-gap to get local dev working again. Longer term solution is https://precisionmedicineinitiative.atlassian.net/browse/RW-3755

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
