### PR TITLE
[RW-3716][risk=no] Stop the Kotlin logspam

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -365,6 +365,10 @@ dependencies {
   compile 'org.springframework.security:spring-security-web:4.2.13.RELEASE'
   compile "org.hibernate:hibernate-core:${HIBERNATE_VERSION}"
 
+  // Force the Kotlin version, otherwise the Kotlin plugin conflicts with Jackson's
+  // Kotlin dep, resulting in massive logspam.
+  compile "org.jetbrains.kotlin:kotlin-reflect:${KOTLIN_VERSION}"
+
   compile "com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION}"
   compile "com.fasterxml.jackson.core:jackson-core:${JACKSON_VERSION}"
   compile "com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION}"


### PR DESCRIPTION
Eliminates pages of warnings on local API server startup like:

```
api_1_53d67eaeafd6       | 2019-10-24 01:17:00.482:WARN:oeja.AnnotationParser:qtp1912962767-20: kotlin.sequences.SequencesKt___SequencesKt scanned from multiple locations: jar:file:///w/api/build/exploded-api/WEB-INF/lib/kotlin-stdlib-1.3.10.jar!/kotlin/sequences/SequencesKt___SequencesKt.class, jar:file:///w/api/build/exploded-api/WEB-INF/lib/kotlin-stdlib-1.3.50.jar!/kotlin/sequences/SequencesKt___SequencesKt.class
```

