### PR TITLE
[RW-2818][risk=no] Further mitigate non-deterministic workspace ACL on creation

### DIFF
--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -12,6 +12,13 @@ export const NavStore = {
   navigateByUrl: undefined
 };
 
+// This is an optional warmup store which can be populated to avoid redundant
+// requests on navigation, e.g. from workspace creation/clone -> data page. It
+// is not guaranteed to be populated for all workspace transitions. The value
+// should only be consumed by central infrastructure, but can be updated from
+// specific application pages where appropriate.
+export const nextWorkspaceWarmupStore = new BehaviorSubject<WorkspaceData>(undefined);
+
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
 export const currentCohortStore = new BehaviorSubject<Cohort>(undefined);
 export const currentConceptSetStore = new BehaviorSubject<ConceptSet>(undefined);


### PR DESCRIPTION
@blrubenstein noticed during QA that in some situations, it’s possible for Firecloud to return: OWNER → NOACCESS. The current solution assumed that once we saw OWNER, we were safe to assume that subsequent calls would also return OWNER. With this new knowledge, we now have no way of confirming whether a workspace is “ready”.

This solution simply avoids the extra GET here (which was a nice optimization anyways). This defers the next access check until a later user action (e.g. create cohort, etc), which might still fail, but which becomes less likely to fail as time passes. Doing anything more complicated than this on our side introduces risk, I think after this the next improvement is to fix the root issue in Sam.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
