### PR TITLE
[RW-3776][risk=no] Remove howtouse section from homepage

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -13,7 +13,6 @@ import {FlexColumn, FlexRow} from 'app/components/flex';
 import {Header, SmallHeader} from 'app/components/headers';
 import {ClrIcon} from 'app/components/icons';
 import {Modal} from 'app/components/modals';
-import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 import {QuickTourReact} from 'app/pages/homepage/quick-tour-modal';
 import {RecentResources} from 'app/pages/homepage/recent-resources';
@@ -30,7 +29,7 @@ import {
 export const styles = reactStyles({
   bottomBanner: {
     width: '100%', display: 'flex', backgroundColor: colors.primary,
-    paddingLeft: '3.5rem', alignItems: 'center'
+    paddingLeft: '3.5rem', alignItems: 'center', marginTop: '2rem'
   },
   bottomLinks: {
     color: colors.white, fontSize: '.5rem', height: '1rem',
@@ -44,29 +43,6 @@ export const styles = reactStyles({
   },
   fadeBox: {
     margin: '1rem 0 0 3%', width: '95%', padding: '0 0.1rem'
-  },
-  footer: {
-    width: '100%', backgroundColor: colors.light, marginTop: '2%'
-  },
-  footerInner: {
-    marginLeft: '3%', marginRight: '2%',
-  },
-  footerText: {
-    height: '176px', opacity: 0.87, color: colors.secondary,
-    fontSize: '0.6rem', fontWeight: 500, lineHeight: '30px', width: '100%',
-    flexWrap: 'nowrap', overflowY: 'auto'
-  },
-  footerTextTitle: {
-    color: colors.primary,
-    fontSize: '0.67rem',
-    fontWeight: 500
-  },
-  footerTitle: {
-    height: '34px', opacity: 0.87, color: colors.primary, fontSize: '0.75rem',
-    fontWeight: 600, lineHeight: '34px', marginTop: '1rem', marginBottom: '0.5rem'
-  },
-  linksBlock: {
-    marginBottom: '1rem', flexShrink: 1, minWidth: '13rem'
   },
   logo: {
     height: '3.5rem', width: '7rem', lineHeight: '85px'
@@ -287,27 +263,6 @@ export const Homepage = withUserProfile()(class extends React.Component<
         onClick: () => this.openVideo('/assets/videos/Workbench Tutorial - Notebooks.mp4')
       }
     ];
-    const footerLinks = [{
-      title: 'Working Within Researcher Workbench',
-      links: ['Researcher Workbench Mission',
-        'User interface components',
-        'What to do when things go wrong',
-        'Contributing to the Workbench']
-    },
-      {
-        title: 'Workspace',
-        links: ['Workspace interface components',
-          'User interface components',
-          'Collaborating with other researchers',
-          'Sharing and Publishing Workspaces']
-      },
-      {
-        title: 'Working with Notebooks',
-        links: ['Notebook interface components',
-          'Notebooks and data',
-          'Collaborating with other researchers',
-          'Sharing and Publishing Notebooks']
-      }];
 
     if (environment.enableHomepageRestyle) {
       return <React.Fragment>
@@ -393,32 +348,6 @@ export const Homepage = withUserProfile()(class extends React.Component<
                 })}
               </FlexRow>
             </FlexColumn>
-            <div>
-              <div style={styles.footer}>
-                <FlexColumn style={styles.footerInner}>
-                  <div style={styles.footerTitle}>
-                    How to Use the All of Us Researcher Workbench</div>
-                  <FlexRow style={{justifyContent: 'space-between'}}>
-                    {footerLinks.map((col, i) => {
-                      return <React.Fragment key={i}>
-                        <FlexColumn style={styles.linksBlock}>
-                          <FlexColumn style={styles.footerText}>
-                            <div style={styles.footerTextTitle}>{col.title}</div>
-                            <ul style={{color: colors.secondary, marginLeft: '2%'}}>
-                              {col.links.map((link, ii) => {
-                                return <li key={ii}>
-                                  <a href='#' style={{color: colors.accent}}>{link}</a>
-                                </li>;
-                              } )}
-                            </ul>
-                          </FlexColumn>
-                        </FlexColumn>
-                      </React.Fragment>;
-                    })}
-                  </FlexRow>
-                </FlexColumn>
-              </div>
-            </div>
             <div style={styles.bottomBanner}>
               <div style={styles.logo}>
                 <img src='/assets/images/all-of-us-logo-footer.svg'/>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -107,30 +107,9 @@ export const styles = reactStyles({
     fontSize: 28, lineHeight: '34px', color: colors.white, paddingRight: '2.3rem',
     marginTop: '2rem', width: '33%'
   },
-  footerToDelete: {
-    height: '300px', width: '100%', backgroundColor: colors.primary,
-    boxShadow: '0 0 2px 0 rgba(0, 0, 0, 0.12), 0 3px 2px 0 rgba(0, 0, 0, 0.12)',
-    marginTop: '2%',
-  },
-  footerInnerToDelete: {
-    display: 'flex', flexDirection: 'column', marginLeft: '5%', marginRight: '5%',
-  },
-  footerTitleToDelete: {
-    height: '34px', opacity: 0.87, color: colors.white, fontSize: 28,
-    fontWeight: 600, lineHeight: '34px', width: '87.34%', marginTop: '1.4rem'
-  },
-  footerTextToDelete: {
-    height: '176px', opacity: 0.87, color: colors.secondary, fontSize: '16px',
-    fontWeight: 400, lineHeight: '30px', display: 'flex', width: '100%',
-    flexDirection: 'column', flexWrap: 'nowrap', overflowY: 'auto'
-  },
-  linksBlockToDelete: {
-    display: 'flex', marginBottom: '1.2rem', marginLeft: '1.4rem',
-    flexDirection: 'column', flexShrink: 1, minWidth: 0
-  },
   bottomBannerToDelete: {
     width: '100%', display: 'flex', backgroundColor: colors.primary, height: '5rem',
-    paddingLeft: '3.5rem', alignItems: 'center'
+    paddingLeft: '3.5rem', alignItems: 'center', marginTop: '1rem'
   },
   bottomLinksToDelete: {
     color: colors.white, fontSize: '0.7rem', height: '1rem',
@@ -521,46 +500,14 @@ export const Homepage = withUserProfile()(class extends React.Component<
                 </React.Fragment>;
               })}
             </div>
-            <div>
-              <div style={styles.footerToDelete}>
-                <div style={styles.footerInnerToDelete}>
-                  <div style={styles.footerTitleToDelete}>
-                    How to Use the All of Us Researcher Workbench</div>
-                  <div style={{display: 'flex', justifyContent: 'flex-end'}}>
-                    <TooltipTrigger content='Coming Soon' side='left'>
-                      <a href='#' style={{color: colors.white}}>See all documentation</a>
-                    </TooltipTrigger>
-                  </div>
-                  <FlexRow style={{width: '87.34%', justifyContent: 'space-between'}}>
-                    {footerLinks.map((col, i) => {
-                      return <React.Fragment key={i}>
-                        <div style={styles.linksBlockToDelete}>
-                          <div style={styles.footerTextToDelete}>
-                            <div style={{color: colors.white, marginTop: '2%'}}>{col.title}</div>
-                            <ul style={{color: colors.secondary}}>
-                              {col.links.map((link, ii) => {
-                                return <li key={ii}>
-                                  <a href='#' style={{color: colors.secondary}}>{link}</a>
-                                </li>;
-                              } )}
-                            </ul>
-                          </div>
-                        </div>
-                      </React.Fragment>;
-                    })}
-                  </FlexRow>
-                </div>
+            <div style={styles.bottomBannerToDelete}>
+              <div style={styles.logo}>
+                <img src='/assets/images/all-of-us-logo-footer.svg'/>
               </div>
-              <div style={styles.bottomBannerToDelete}>
-                <div style={styles.logo}>
-                  <img src='/assets/images/all-of-us-logo-footer.svg'/>
-                </div>
-                <div style={styles.bottomLinksToDelete}>Privacy Policy</div>
-                <div style={styles.bottomLinksToDelete}>Terms of Service</div>
-              </div>
+              <div style={styles.bottomLinksToDelete}>Privacy Policy</div>
+              <div style={styles.bottomLinksToDelete}>Terms of Service</div>
             </div>
           </div>
-
         </div>
 
         {quickTour &&


### PR DESCRIPTION
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

Remove the section “How to Use the All of Us Researcher Workbench” from home page.

Styles and HTML were removed. Margin was added to the bottom between the main page and the bottom banner.

The goal is to re-add this in the future. I opted to delete the code rather than commenting the code out in order to keep the code base a bit cleaner. We can pull in whatever we need at that point.

Code for the old page (without feature flag) was removed in its own commit so that we don't have to pull it back in later.

Before
![Screen Shot 2019-10-24 at 5 44 00 PM](https://user-images.githubusercontent.com/5375000/67529498-55634680-f68a-11e9-95e3-c3b9987a303c.png)



After

![Screen Shot 2019-10-24 at 5 44 25 PM](https://user-images.githubusercontent.com/5375000/67529510-5b592780-f68a-11e9-8597-8993c559363d.png)
![Screen Shot 2019-10-24 at 5 55 23 PM](https://user-images.githubusercontent.com/5375000/67529511-5b592780-f68a-11e9-9f06-203423d3f3da.png)

