### PR TITLE
Refactor  org.pmiops.workbench.firecloud.model.Workspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -27,6 +27,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterListResponse;
@@ -165,7 +166,7 @@ public class ClusterController implements ClusterApiDelegate {
   @Override
   public ResponseEntity<ClusterLocalizeResponse> localize(
       String projectName, String clusterName, ClusterLocalizeRequest body) {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
+    FirecloudWorkspace fcWorkspace;
     try {
       fcWorkspace =
           fireCloudService
@@ -280,9 +281,7 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   private String aouConfigDataUri(
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace,
-      CdrVersion cdrVersion,
-      String cdrBillingCloudProject) {
+      FirecloudWorkspace fcWorkspace, CdrVersion cdrVersion, String cdrBillingCloudProject) {
     JSONObject config = new JSONObject();
 
     String host = null;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.util.List;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
 import org.pmiops.workbench.firecloud.model.BillingProjectStatus;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.JWTWrapper;
 import org.pmiops.workbench.firecloud.model.ManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.Me;
 import org.pmiops.workbench.firecloud.model.NihStatus;
-import org.pmiops.workbench.firecloud.model.Workspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
@@ -67,7 +67,7 @@ public interface FireCloudService {
       String projectName, String ownerEmailToRemove, String callerAccessToken);
 
   /** Creates a new FC workspace. */
-  Workspace createWorkspace(String projectName, String workspaceName);
+  FirecloudWorkspace createWorkspace(String projectName, String workspaceName);
 
   void cloneWorkspace(String fromProject, String fromName, String toProject, String toName);
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -23,13 +23,13 @@ import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.firecloud.model.BillingProjectMembership;
 import org.pmiops.workbench.firecloud.model.BillingProjectStatus;
 import org.pmiops.workbench.firecloud.model.CreateRawlsBillingProjectFullRequest;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.JWTWrapper;
 import org.pmiops.workbench.firecloud.model.ManagedGroupRef;
 import org.pmiops.workbench.firecloud.model.ManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.Me;
 import org.pmiops.workbench.firecloud.model.NihStatus;
 import org.pmiops.workbench.firecloud.model.Profile;
-import org.pmiops.workbench.firecloud.model.Workspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
@@ -291,7 +291,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public Workspace createWorkspace(String projectName, String workspaceName) {
+  public FirecloudWorkspace createWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     WorkspaceIngest workspaceIngest = new WorkspaceIngest();
     workspaceIngest.setName(workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceConversionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceConversionUtils.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.db.model.UserRecentWorkspace;
 import org.pmiops.workbench.db.model.Workspace.FirecloudWorkspaceId;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -52,8 +53,7 @@ public class WorkspaceConversionUtils {
   }
 
   public static Workspace toApiWorkspace(
-      org.pmiops.workbench.db.model.Workspace workspace,
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace) {
+      org.pmiops.workbench.db.model.Workspace workspace, FirecloudWorkspace fcWorkspace) {
     ResearchPurpose researchPurpose = createResearchPurpose(workspace);
     if (workspace.getPopulation()) {
       researchPurpose.setPopulationDetails(new ArrayList<>(workspace.getSpecificPopulationsEnum()));

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdateResponseList;
@@ -169,7 +170,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     Workspace dbWorkspace = getRequired(workspaceNamespace, workspaceId);
 
     org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse;
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace;
+    FirecloudWorkspace fcWorkspace;
 
     WorkspaceResponse workspaceResponse = new WorkspaceResponse();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -52,6 +52,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.ManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -202,8 +203,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     return new FirecloudWorkspaceId(namespace, strippedName);
   }
 
-  private org.pmiops.workbench.firecloud.model.Workspace attemptFirecloudWorkspaceCreation(
-      FirecloudWorkspaceId workspaceId) {
+  private FirecloudWorkspace attemptFirecloudWorkspaceCreation(FirecloudWorkspaceId workspaceId) {
     return fireCloudService.createWorkspace(
         workspaceId.getWorkspaceNamespace(), workspaceId.getWorkspaceName());
   }
@@ -233,8 +233,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // Note: please keep any initialization logic here in sync with CloneWorkspace().
     FirecloudWorkspaceId workspaceId =
         generateFirecloudWorkspaceId(workspaceNamespace, workspace.getName());
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        attemptFirecloudWorkspaceCreation(workspaceId);
+    FirecloudWorkspace fcWorkspace = attemptFirecloudWorkspaceCreation(workspaceId);
 
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     org.pmiops.workbench.db.model.Workspace dbWorkspace =
@@ -269,7 +268,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       org.pmiops.workbench.db.model.Workspace dbWorkspace,
       User user,
       FirecloudWorkspaceId workspaceId,
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace,
+      FirecloudWorkspace fcWorkspace,
       Timestamp createdAndLastModifiedTime) {
     dbWorkspace.setFirecloudName(workspaceId.getWorkspaceName());
     dbWorkspace.setWorkspaceNamespace(workspaceId.getWorkspaceNamespace());
@@ -320,7 +319,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     workspaceService.enforceWorkspaceAccessLevel(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.OWNER);
     Workspace workspace = request.getWorkspace();
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         fireCloudService.getWorkspace(workspaceNamespace, workspaceId).getWorkspace();
     if (workspace == null) {
       throw new BadRequestException("No workspace provided in request");
@@ -397,7 +396,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
         toFcWorkspaceId.getWorkspaceNamespace(),
         toFcWorkspaceId.getWorkspaceName());
 
-    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace =
+    FirecloudWorkspace toFcWorkspace =
         fireCloudService
             .getWorkspace(
                 toFcWorkspaceId.getWorkspaceNamespace(), toFcWorkspaceId.getWorkspaceName())

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -37,6 +37,7 @@ import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterConfig;
@@ -179,9 +180,8 @@ public class ClusterControllerTest {
             .createdDate(createdDate);
   }
 
-  private org.pmiops.workbench.firecloud.model.Workspace createFcWorkspace(
-      String ns, String name, String creator) {
-    return new org.pmiops.workbench.firecloud.model.Workspace()
+  private FirecloudWorkspace createFcWorkspace(String ns, String name, String creator) {
+    return new FirecloudWorkspace()
         .namespace(ns)
         .name(name)
         .createdBy(creator)
@@ -197,8 +197,7 @@ public class ClusterControllerTest {
     stubGetFcWorkspace(createFcWorkspace(ns, name, creator));
   }
 
-  private void stubGetFcWorkspace(org.pmiops.workbench.firecloud.model.Workspace fcWorkspace)
-      throws Exception {
+  private void stubGetFcWorkspace(FirecloudWorkspace fcWorkspace) throws Exception {
     org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =
         new org.pmiops.workbench.firecloud.model.WorkspaceResponse();
     fcResponse.setWorkspace(fcWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -50,6 +50,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -294,8 +295,7 @@ public class CohortsControllerTest {
 
   private void stubGetWorkspace(String ns, String name, String creator, WorkspaceAccessLevel access)
       throws Exception {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(ns);
     fcWorkspace.setName(name);
     fcWorkspace.setCreatedBy(creator);

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -41,6 +41,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -799,8 +800,7 @@ public class ConceptSetsControllerTest {
 
   private void stubGetWorkspace(String ns, String name, String creator, WorkspaceAccessLevel access)
       throws Exception {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(ns);
     fcWorkspace.setName(name);
     fcWorkspace.setCreatedBy(creator);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -66,6 +66,7 @@ import org.pmiops.workbench.db.model.CdrVersion;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageService;
@@ -512,8 +513,7 @@ public class DataSetControllerTest {
 
   private void stubGetWorkspace(String ns, String name, String creator, WorkspaceAccessLevel access)
       throws Exception {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(ns);
     fcWorkspace.setName(name);
     fcWorkspace.setCreatedBy(creator);

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.UserRecentResource;
 import org.pmiops.workbench.db.model.Workspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.model.RecentResource;
@@ -103,12 +104,10 @@ public class UserMetricsControllerTest {
     resource3.setUserId(user.getUserId());
     resource3.setWorkspaceId(workspace2.getWorkspaceId());
 
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(workspace1.getFirecloudName());
 
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace2 =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+    FirecloudWorkspace fcWorkspace2 = new FirecloudWorkspace();
     fcWorkspace.setNamespace(workspace2.getFirecloudName());
 
     WorkspaceResponse workspaceResponse = new WorkspaceResponse();

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.Workspace;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.test.FakeClock;
@@ -54,7 +54,7 @@ public class NotebooksServiceImplTest {
   @Test
   public void testGetReadOnlyHtml_basicContent() {
     when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(new WorkspaceResponse().workspace(new Workspace().bucketName("bkt")));
+        .thenReturn(new WorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
     when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<html><body><div>asdf</div></body></html>");
@@ -67,7 +67,7 @@ public class NotebooksServiceImplTest {
   @Test
   public void testGetReadOnlyHtml_scriptSanitization() {
     when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(new WorkspaceResponse().workspace(new Workspace().bucketName("bkt")));
+        .thenReturn(new WorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
     when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<html><script>window.alert('hacked');</script></html>");
@@ -80,7 +80,7 @@ public class NotebooksServiceImplTest {
   @Test
   public void testGetReadOnlyHtml_styleSanitization() {
     when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(new WorkspaceResponse().workspace(new Workspace().bucketName("bkt")));
+        .thenReturn(new WorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
     when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn(
@@ -99,7 +99,7 @@ public class NotebooksServiceImplTest {
   @Test
   public void testGetReadOnlyHtml_allowsDataImage() {
     when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(new WorkspaceResponse().workspace(new Workspace().bucketName("bkt")));
+        .thenReturn(new WorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
     when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
 
     String dataUri = "data:image/png;base64,MTIz";
@@ -113,7 +113,7 @@ public class NotebooksServiceImplTest {
   @Test
   public void testGetReadOnlyHtml_disallowsRemoteImage() {
     when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(new WorkspaceResponse().workspace(new Workspace().bucketName("bkt")));
+        .thenReturn(new WorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
     when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<img src=\"https://eviltrackingpixel.com\" />\n");

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -10,16 +10,15 @@ import java.util.UUID;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.db.model.BillingProjectBufferEntry;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
 /** Created by brubenst on 9/4/19. */
 public class TestMockFactory {
   private static final String BUCKET_NAME = "workspace-bucket";
 
-  public org.pmiops.workbench.firecloud.model.Workspace createFcWorkspace(
-      String ns, String name, String creator) {
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        new org.pmiops.workbench.firecloud.model.Workspace();
+  public FirecloudWorkspace createFcWorkspace(String ns, String name, String creator) {
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(ns);
     fcWorkspace.setWorkspaceId(ns);
     fcWorkspace.setName(name);
@@ -33,7 +32,7 @@ public class TestMockFactory {
             invocation -> {
               String capturedWorkspaceName = (String) invocation.getArguments()[1];
               String capturedWorkspaceNamespace = (String) invocation.getArguments()[0];
-              org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+              FirecloudWorkspace fcWorkspace =
                   createFcWorkspace(capturedWorkspaceNamespace, capturedWorkspaceName, null);
 
               org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -30,7 +30,7 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.UserRecentWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.Workspace;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
@@ -135,7 +135,7 @@ public class WorkspaceServiceTest {
       String workspaceName,
       String workspaceNamespace,
       WorkspaceAccessLevel accessLevel) {
-    Workspace mockWorkspace = mock(Workspace.class);
+    FirecloudWorkspace mockWorkspace = mock(FirecloudWorkspace.class);
     doReturn(workspaceNamespace).when(mockWorkspace).getNamespace();
     doReturn(workspaceName).when(mockWorkspace).getName();
     doReturn(workspaceId).when(mockWorkspace).getWorkspaceId();

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -89,6 +89,7 @@ import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.ManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceACLUpdate;
@@ -414,8 +415,7 @@ public class WorkspacesControllerTest {
     stubGetWorkspace(testMockFactory.createFcWorkspace(ns, name, creator), access);
   }
 
-  private void stubGetWorkspace(
-      org.pmiops.workbench.firecloud.model.Workspace fcWorkspace, WorkspaceAccessLevel access) {
+  private void stubGetWorkspace(FirecloudWorkspace fcWorkspace, WorkspaceAccessLevel access) {
     org.pmiops.workbench.firecloud.model.WorkspaceResponse fcResponse =
         new org.pmiops.workbench.firecloud.model.WorkspaceResponse();
     fcResponse.setWorkspace(fcWorkspace);
@@ -1315,7 +1315,7 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         testMockFactory.createFcWorkspace(
             modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
     fcWorkspace.setBucketName("bucket2");
@@ -1597,7 +1597,7 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         testMockFactory.createFcWorkspace(
             modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
     fcWorkspace.setBucketName("bucket2");
@@ -1937,8 +1937,7 @@ public class WorkspacesControllerTest {
     when(fireCloudService.getWorkspace("project", "workspace"))
         .thenReturn(
             new org.pmiops.workbench.firecloud.model.WorkspaceResponse()
-                .workspace(
-                    new org.pmiops.workbench.firecloud.model.Workspace().bucketName("bucket")));
+                .workspace(new FirecloudWorkspace().bucketName("bucket")));
     Blob mockBlob1 = mock(Blob.class);
     Blob mockBlob2 = mock(Blob.class);
     Blob mockBlob3 = mock(Blob.class);
@@ -1967,8 +1966,7 @@ public class WorkspacesControllerTest {
     when(fireCloudService.getWorkspace("project", "workspace"))
         .thenReturn(
             new org.pmiops.workbench.firecloud.model.WorkspaceResponse()
-                .workspace(
-                    new org.pmiops.workbench.firecloud.model.Workspace().bucketName("bucket")));
+                .workspace(new FirecloudWorkspace().bucketName("bucket")));
     Blob mockBlob1 = mock(Blob.class);
     Blob mockBlob2 = mock(Blob.class);
     when(mockBlob1.getName())
@@ -2408,7 +2406,7 @@ public class WorkspacesControllerTest {
     final String testWorkspaceName = "test-ws";
     final String testNotebook = NotebooksService.withNotebookExtension("test-notebook");
 
-    org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
+    FirecloudWorkspace fcWorkspace =
         testMockFactory.createFcWorkspace(
             testWorkspaceNamespace, testWorkspaceName, LOGGED_IN_USER_EMAIL);
     fcWorkspace.setBucketName(BUCKET_NAME);

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
@@ -19,7 +19,7 @@ import org.pmiops.workbench.firecloud.ApiClient;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
-import org.pmiops.workbench.firecloud.model.Workspace;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
@@ -119,7 +119,7 @@ public class BackfillBillingProjectUsers {
     int userUpgrades = 0;
     for (WorkspaceResponse resp :
         workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS)) {
-      Workspace w = resp.getWorkspace();
+      FirecloudWorkspace w = resp.getWorkspace();
       if (!w.getNamespace().startsWith(billingProjectPrefix)) {
         continue;
       }


### PR DESCRIPTION
I found a much easier and safer method for applying the prefix to a generated class which will take advantage of IntelliJ's capabilities around updating package qualifiers and import statements.

1. Choose the class you want to apply a prefix to, such as `org.pmiops.workbench.firecloud.model.Workspace`.
2. Use Shift+F6 to refactor that class name. IJ will warn that those changes in the file will be lost on regeneration (that's OK). We'll need to do this for every generated class in that package, but it's still far preferable to manual fixup after codegen changes or going through the regex olympics to try to roll our own.
3. Update the Gradle job that generates the class. In `generateFirecloudClient()` do `    `config.setModelNamePrefix('Firecloud')`
4. Rerun swagger codegen and observe your new class
<img width="1051" alt="Screen Shot 2019-10-25 at 9 08 08 AM" src="https://user-images.githubusercontent.com/53479492/67573759-12938400-f707-11e9-9b9d-16c14b4e37db.png">

The tests don't pass right now because I only renamed one class here.