### PR TITLE
[RW-3779][risk=no] Add a WorkbenchConfig field to control rate of buffer refill

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -20,6 +20,7 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 2,
+    "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -19,6 +19,7 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_00293C-5DEA2D-6887E7",
     "retryCount": 4,
     "bufferCapacity": 300,
+    "bufferRefillProjectsPerTask": 5,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -19,6 +19,7 @@
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.gcp_billing_export_v1_015EAA_E95687_1F8614",
     "retryCount": 4,
     "bufferCapacity": 100,
+    "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -19,6 +19,7 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 10,
+    "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -19,6 +19,7 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 50,
+    "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -20,6 +20,7 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
     "retryCount": 2,
     "bufferCapacity": 100,
+    "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 300.0,
     "garbageCollectionUserCapacity": 1000,
     "garbageCollectionUsers": [

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -57,7 +57,22 @@ public class BillingProjectBufferService {
     return new Timestamp(clock.instant().toEpochMilli());
   }
 
-  public void bufferBillingProject() {
+  /**
+   * Makes a configurable number of project creation attempts.
+   */
+  public void bufferBillingProjects() {
+    int creationAttempts = this.workbenchConfigProvider.get().billing.bufferRefillProjectsPerTask;
+    for (int i = 0; i < creationAttempts; i++) {
+      bufferBillingProject();
+    }
+  }
+
+  /**
+   * Creates a new billing project in the buffer, and kicks off the FireCloud project creation.
+   *
+   * No action is taken if the buffer is full.
+   */
+  private void bufferBillingProject() {
     if (getUnfilledBufferSpace() <= 0) {
       return;
     }

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -57,9 +57,7 @@ public class BillingProjectBufferService {
     return new Timestamp(clock.instant().toEpochMilli());
   }
 
-  /**
-   * Makes a configurable number of project creation attempts.
-   */
+  /** Makes a configurable number of project creation attempts. */
   public void bufferBillingProjects() {
     int creationAttempts = this.workbenchConfigProvider.get().billing.bufferRefillProjectsPerTask;
     for (int i = 0; i < creationAttempts; i++) {
@@ -70,7 +68,7 @@ public class BillingProjectBufferService {
   /**
    * Creates a new billing project in the buffer, and kicks off the FireCloud project creation.
    *
-   * No action is taken if the buffer is full.
+   * <p>No action is taken if the buffer is full.
    */
   private void bufferBillingProject() {
     if (getUnfilledBufferSpace() <= 0) {

--- a/api/src/main/java/org/pmiops/workbench/billing/OfflineBillingController.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/OfflineBillingController.java
@@ -29,8 +29,8 @@ public class OfflineBillingController implements OfflineBillingApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Void> bufferBillingProject() {
-    billingProjectBufferService.bufferBillingProject();
+  public ResponseEntity<Void> bufferBillingProjects() {
+    billingProjectBufferService.bufferBillingProjects();
     return ResponseEntity.noContent().build();
   }
 

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1139,14 +1139,14 @@ paths:
 
   # Billing ##############################################################################
 
-  /v1/cron/bufferBillingProject:
+  /v1/cron/bufferBillingProjects:
     get:
       security: []
       tags:
         - offlineBilling
         - cron
-      description: If the AoU Billing Project buffer is not full, create a firecloud billing project and add one
-      operationId: bufferBillingProject
+      description: If the AoU Billing Project buffer is not full, refill with one or more billing projects.
+      operationId: bufferBillingProjects
       responses:
         204:
           description: No Error

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -105,6 +105,7 @@ public class BillingProjectBufferServiceTest {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.billing.projectNamePrefix = "test-prefix";
     workbenchConfig.billing.bufferCapacity = (int) BUFFER_CAPACITY;
+    workbenchConfig.billing.bufferRefillProjectsPerTask = 1;
 
     billingProjectBufferEntryDao = spy(billingProjectBufferEntryDao);
     TestLock lock = new TestLock();

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -48,6 +48,7 @@ public class WorkbenchConfig {
   public static class BillingConfig {
     public Integer retryCount;
     public Integer bufferCapacity;
+    public Integer bufferRefillProjectsPerTask;
     public String projectNamePrefix;
     public String accountId;
     public String exportBigQueryTable;


### PR DESCRIPTION
See the RW ticket for more context: https://precisionmedicineinitiative.atlassian.net/browse/RW-3779

This PR adjusts the cron endpoint to become pluralized and tunable via a WorkbenchConfig environment variable.

The intent is to give us a knob to be able to tune up the perf environment's refill rate, since we've been encountering times when testing during the day isn't possible due to an empty buffer.

This kind of tuning may also help us in a production scenario – we currently can't quickly refill the buffer if a need arose.