### PR TITLE
[RW-3784][risk=no] Remove extra "get" call from cloneWorkspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -69,7 +69,7 @@ public interface FireCloudService {
   /** Creates a new FC workspace. */
   Workspace createWorkspace(String projectName, String workspaceName);
 
-  void cloneWorkspace(String fromProject, String fromName, String toProject, String toName);
+  Workspace cloneWorkspace(String fromProject, String fromName, String toProject, String toName);
 
   /** Retrieves all billing project memberships for the user from FireCloud. */
   List<BillingProjectMembership> getBillingProjectMemberships();

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -301,7 +301,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public Workspace cloneWorkspace(String fromProject, String fromName, String toProject, String toName) {
+  public Workspace cloneWorkspace(
+      String fromProject, String fromName, String toProject, String toName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     WorkspaceIngest workspaceIngest = new WorkspaceIngest();
     workspaceIngest.setNamespace(toProject);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -301,17 +301,14 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void cloneWorkspace(String fromProject, String fromName, String toProject, String toName) {
+  public Workspace cloneWorkspace(String fromProject, String fromName, String toProject, String toName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
     WorkspaceIngest workspaceIngest = new WorkspaceIngest();
     workspaceIngest.setNamespace(toProject);
     workspaceIngest.setName(toName);
     checkAndAddRegistered(workspaceIngest);
-    retryHandler.run(
-        (context) -> {
-          workspacesApi.cloneWorkspace(fromProject, fromName, workspaceIngest);
-          return null;
-        });
+    return retryHandler.run(
+        (context) -> workspacesApi.cloneWorkspace(fromProject, fromName, workspaceIngest));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -391,11 +391,12 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     FirecloudWorkspaceId toFcWorkspaceId =
         generateFirecloudWorkspaceId(toWorkspaceName, toWorkspace.getName());
-    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace = fireCloudService.cloneWorkspace(
-        fromWorkspaceNamespace,
-        fromWorkspaceId,
-        toFcWorkspaceId.getWorkspaceNamespace(),
-        toFcWorkspaceId.getWorkspaceName());
+    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace =
+        fireCloudService.cloneWorkspace(
+            fromWorkspaceNamespace,
+            fromWorkspaceId,
+            toFcWorkspaceId.getWorkspaceNamespace(),
+            toFcWorkspaceId.getWorkspaceName());
 
     // In the future, we may want to allow callers to specify whether files
     // should be cloned at all (by default, yes), else they are currently stuck

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -391,17 +391,11 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     FirecloudWorkspaceId toFcWorkspaceId =
         generateFirecloudWorkspaceId(toWorkspaceName, toWorkspace.getName());
-    fireCloudService.cloneWorkspace(
+    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace = fireCloudService.cloneWorkspace(
         fromWorkspaceNamespace,
         fromWorkspaceId,
         toFcWorkspaceId.getWorkspaceNamespace(),
         toFcWorkspaceId.getWorkspaceName());
-
-    org.pmiops.workbench.firecloud.model.Workspace toFcWorkspace =
-        fireCloudService
-            .getWorkspace(
-                toFcWorkspaceId.getWorkspaceNamespace(), toFcWorkspaceId.getWorkspaceName())
-            .getWorkspace();
 
     // In the future, we may want to allow callers to specify whether files
     // should be cloned at all (by default, yes), else they are currently stuck

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -503,6 +503,8 @@ paths:
       responses:
         201:
           description: Successful Request
+          schema:
+            $ref: '#/definitions/Workspace'
         400:
           description: Unable to create resources for workspace
         404:
@@ -997,6 +999,11 @@ definitions:
         type: string
         description: User's email
 
+  # Core workspace data model object. Used by Get and List workspace. This schema is similar to, but not exactly the
+  # same, as the model used by Create and Clone workspace. The differences are not (currently) meaningful
+  # for any AoU workbench use case, so we've edited the YAML to merge these schemas for our own code simplicity.
+  #
+  # The Terra App Services team plans to clean this up with ticket AS-21.
   Workspace:
     description: ''
     required:
@@ -1086,6 +1093,7 @@ definitions:
           $ref: '#/definitions/ManagedGroupRef'
         description: The list of groups to form the Authorization Domain (empty if no Authorization Domain is set)
 
+  # The response object returned from Get or List workspace.
   WorkspaceResponse:
     description: ''
     properties:

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -14,7 +14,7 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 
 /** Created by brubenst on 9/4/19. */
 public class TestMockFactory {
-  private static final String BUCKET_NAME = "workspace-bucket";
+  public static final String BUCKET_NAME = "workspace-bucket";
 
   public org.pmiops.workbench.firecloud.model.Workspace createFcWorkspace(
       String ns, String name, String creator) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -426,6 +425,20 @@ public class WorkspacesControllerTest {
     List<WorkspaceResponse> workspaceResponses = fireCloudService.getWorkspaces(any());
     workspaceResponses.add(fcResponse);
     doReturn(workspaceResponses).when(fireCloudService).getWorkspaces(any());
+  }
+
+  private org.pmiops.workbench.firecloud.model.Workspace stubCloneWorkspace(
+      String ns, String name, String creator) {
+    org.pmiops.workbench.firecloud.model.Workspace fcResponse =
+        new org.pmiops.workbench.firecloud.model.Workspace();
+    fcResponse.setNamespace(ns);
+    fcResponse.setName(name);
+    fcResponse.setCreatedBy(creator);
+
+    when(fireCloudService.cloneWorkspace(anyString(), anyString(), eq(ns), eq(name)))
+        .thenReturn(fcResponse);
+
+    return fcResponse;
   }
 
   private void stubBigQueryCohortCalls() {
@@ -853,25 +866,13 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        LOGGED_IN_USER_EMAIL,
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
     mockBillingProjectBuffer("cloned-ns");
     Workspace workspace2 =
         workspacesController
             .cloneWorkspace(workspace.getNamespace(), workspace.getId(), req)
             .getBody()
             .getWorkspace();
-
-    assertWithMessage("get and clone responses are inconsistent")
-        .that(workspace2)
-        .isEqualTo(
-            workspacesController
-                .getWorkspace(workspace2.getNamespace(), workspace2.getId())
-                .getBody()
-                .getWorkspace());
 
     assertThat(workspace2.getName()).isEqualTo(modWorkspace.getName());
     assertThat(workspace2.getNamespace()).isEqualTo(modWorkspace.getNamespace());
@@ -1063,11 +1064,7 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        LOGGED_IN_USER_EMAIL,
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
 
     mockBillingProjectBuffer("cloned-ns");
     Workspace cloned =
@@ -1216,11 +1213,7 @@ public class WorkspacesControllerTest {
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
 
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        LOGGED_IN_USER_EMAIL,
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
             "condition_occurrence",
@@ -1315,11 +1308,11 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
+
     org.pmiops.workbench.firecloud.model.Workspace fcWorkspace =
-        testMockFactory.createFcWorkspace(
+        stubCloneWorkspace(
             modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
     fcWorkspace.setBucketName("bucket2");
-    stubGetWorkspace(fcWorkspace, WorkspaceAccessLevel.OWNER);
     String f1 = NotebooksService.withNotebookExtension("notebooks/f1");
     String f2 = NotebooksService.withNotebookExtension("notebooks/f2 with spaces");
     String f3 = "foo/f3.vcf";
@@ -1357,11 +1350,7 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        "cloner@gmail.com",
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), "cloner@gmail.com");
 
     mockBillingProjectBuffer("cloned-ns");
 
@@ -1390,11 +1379,7 @@ public class WorkspacesControllerTest {
             .namespace("cloned-ns")
             .researchPurpose(workspace.getResearchPurpose())
             .cdrVersionId(cdrVersionId2);
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        "cloner@gmail.com",
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), "cloner@gmail.com");
 
     mockBillingProjectBuffer("cloned-ns");
 
@@ -1418,11 +1403,7 @@ public class WorkspacesControllerTest {
             .namespace("cloned-ns")
             .researchPurpose(workspace.getResearchPurpose())
             .cdrVersionId("bad-cdr-version-id");
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        "cloner@gmail.com",
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), "cloner@gmail.com");
     mockBillingProjectBuffer("cloned-ns");
     workspacesController.cloneWorkspace(
         workspace.getNamespace(),
@@ -1440,11 +1421,7 @@ public class WorkspacesControllerTest {
             .namespace("cloned-ns")
             .researchPurpose(workspace.getResearchPurpose())
             .cdrVersionId(archivedCdrVersionId);
-    stubGetWorkspace(
-        modWorkspace.getNamespace(),
-        modWorkspace.getName(),
-        "cloner@gmail.com",
-        WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), "cloner@gmail.com");
     mockBillingProjectBuffer("cloned-ns");
     workspacesController.cloneWorkspace(
         workspace.getNamespace(),
@@ -1519,7 +1496,7 @@ public class WorkspacesControllerTest {
             .name("cloned")
             .researchPurpose(workspace.getResearchPurpose());
 
-    stubGetWorkspace("cloned-ns", "cloned", cloner.getEmail(), WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace("cloned-ns", "cloned", cloner.getEmail());
     mockBillingProjectBuffer("cloned-ns");
 
     Workspace workspace2 =

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -428,6 +428,11 @@ public class WorkspacesControllerTest {
     doReturn(workspaceResponses).when(fireCloudService).getWorkspaces(any());
   }
 
+  /**
+   * Mocks out the FireCloud cloneWorkspace call with a FC-model workspace based on the provided
+   * details. The mocked workspace object is returned so the caller can make further modifications
+   * if needed.
+   */
   private org.pmiops.workbench.firecloud.model.Workspace stubCloneWorkspace(
       String ns, String name, String creator) {
     org.pmiops.workbench.firecloud.model.Workspace fcResponse =
@@ -867,8 +872,9 @@ public class WorkspacesControllerTest {
     modPurpose.setAncestry(true);
     modWorkspace.setResearchPurpose(modPurpose);
     req.setWorkspace(modWorkspace);
-    org.pmiops.workbench.firecloud.model.Workspace clonedWorkspace = stubCloneWorkspace(
-        modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
+    org.pmiops.workbench.firecloud.model.Workspace clonedWorkspace =
+        stubCloneWorkspace(
+            modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
     // Assign the same bucket name as the mock-factory's bucket name, so the clone vs. get equality
     // assertion below will pass.
     clonedWorkspace.setBucketName(TestMockFactory.BUCKET_NAME);
@@ -889,7 +895,6 @@ public class WorkspacesControllerTest {
                 .getWorkspace(workspace2.getNamespace(), workspace2.getId())
                 .getBody()
                 .getWorkspace());
-
 
     assertThat(workspace2.getName()).isEqualTo(modWorkspace.getName());
     assertThat(workspace2.getNamespace()).isEqualTo(modWorkspace.getNamespace());


### PR DESCRIPTION
This makes a performance-focused optimization, to directly store & use the response object from a Terra cloneWorkspace call.

I had to finagle the API docs a bit, to pretend that get/list/clone/create Workspace all share the same underlying Workspace API model schema. As I understand from David An, this isn't strictly correct, but in practice the schemas are similar enough for our current usage.

David's team is tracking API doc fix-ups in https://broadworkbench.atlassian.net/browse/AS-21. I've set a watcher on that ticket, and we should do a one-off re-import of their Swagger once we're confident the API docs match reality.

TESTED: manually tested on a local env by duplicating a workspace as an owner. Seemed to work fine.