### PR TITLE
[RW-3586][risk=no] Populate CDR version as env vars in notebooks

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/NotebooksIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/NotebooksIntegrationTest.java
@@ -11,6 +11,7 @@ import org.pmiops.workbench.notebooks.NotebooksRetryHandler;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
 import org.pmiops.workbench.test.Providers;
+import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 
 /** Created by brubenst on 5/8/18. */
@@ -23,6 +24,7 @@ public class NotebooksIntegrationTest {
 
   @Mock private ClusterApi clusterApi;
   @Mock private NotebooksApi notebooksApi;
+  @Mock private WorkspaceService workspaceService;
 
   private final LeonardoNotebooksClient leonardoNotebooksClient =
       new LeonardoNotebooksClientImpl(
@@ -30,7 +32,8 @@ public class NotebooksIntegrationTest {
           Providers.of(notebooksApi),
           Providers.of(createConfig()),
           Providers.of(null),
-          new NotebooksRetryHandler(new NoBackOffPolicy()));
+          new NotebooksRetryHandler(new NoBackOffPolicy()),
+          workspaceService);
 
   @Test
   public void testStatus() {

--- a/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
@@ -1,0 +1,9 @@
+package org.pmiops.workbench;
+
+public class WorkbenchConstants {
+  /**
+   * Constants that should be made available everywhere in workbench package.
+   */
+  public static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
+  public static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
+}

--- a/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
@@ -1,9 +1,8 @@
 package org.pmiops.workbench;
 
 public class WorkbenchConstants {
-  /**
-   * Constants that should be made available everywhere in workbench package.
-   */
+  /** Constants that should be made available everywhere in workbench package. */
   public static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
+
   public static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.json.JSONObject;
+import org.pmiops.workbench.WorkbenchConstants;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -52,8 +53,6 @@ public class ClusterController implements ClusterApiDelegate {
   private static final String WORKSPACE_ID_KEY = "WORKSPACE_ID";
   private static final String API_HOST_KEY = "API_HOST";
   private static final String BUCKET_NAME_KEY = "BUCKET_NAME";
-  private static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
-  private static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
   // The billing project to use for the analysis.
   private static final String BILLING_CLOUD_PROJECT = "BILLING_CLOUD_PROJECT";
   private static final String DATA_URI_PREFIX = "data:application/json;base64,";
@@ -115,7 +114,8 @@ public class ClusterController implements ClusterApiDelegate {
   }
 
   @Override
-  public ResponseEntity<ClusterListResponse> listClusters(String billingProjectId) {
+  public ResponseEntity<ClusterListResponse> listClusters(
+      String billingProjectId, String workspaceName) {
     if (billingProjectId == null) {
       throw new BadRequestException("Must specify billing project");
     }
@@ -128,7 +128,8 @@ public class ClusterController implements ClusterApiDelegate {
     try {
       fcCluster = this.leonardoNotebooksClient.getCluster(billingProjectId, clusterName);
     } catch (NotFoundException e) {
-      fcCluster = this.leonardoNotebooksClient.createCluster(billingProjectId, clusterName);
+      fcCluster =
+          this.leonardoNotebooksClient.createCluster(billingProjectId, clusterName, workspaceName);
     }
 
     int retries = Optional.ofNullable(user.getClusterCreateRetries()).orElse(0);
@@ -296,8 +297,8 @@ public class ClusterController implements ClusterApiDelegate {
     config.put(WORKSPACE_ID_KEY, fcWorkspace.getName());
     config.put(BUCKET_NAME_KEY, fcWorkspace.getBucketName());
     config.put(API_HOST_KEY, host);
-    config.put(CDR_VERSION_CLOUD_PROJECT, cdrVersion.getBigqueryProject());
-    config.put(CDR_VERSION_BIGQUERY_DATASET, cdrVersion.getBigqueryDataset());
+    config.put(WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT, cdrVersion.getBigqueryProject());
+    config.put(WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET, cdrVersion.getBigqueryDataset());
     config.put(BILLING_CLOUD_PROJECT, cdrBillingCloudProject);
     return jsonToDataUri(config);
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,8 +16,11 @@ public interface LeonardoNotebooksClient {
    *
    * @param googleProject the google project that will be used for this notebooks cluster
    * @param clusterName the user assigned/auto-generated name for this notebooks cluster
+   * @param cdrVersion the version of the CDR that the workspace to which this notebook belongs is
+   *     using
    */
-  Cluster createCluster(String googleProject, String clusterName) throws WorkbenchException;
+  Cluster createCluster(String googleProject, String clusterName, String cdrVersion)
+      throws WorkbenchException;
 
   /** Deletes a notebook cluster */
   void deleteCluster(String googleProject, String clusterName) throws WorkbenchException;

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -85,9 +85,11 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     // i.e. is NEW or MIGRATED
     if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
       customClusterEnvironmentVariables.put(
-          WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT, workspace.getCdrVersion().getBigqueryProject());
+          WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT,
+          workspace.getCdrVersion().getBigqueryProject());
       customClusterEnvironmentVariables.put(
-          WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET, workspace.getCdrVersion().getBigqueryDataset());
+          WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET,
+          workspace.getCdrVersion().getBigqueryDataset());
     }
 
     return new ClusterRequest()

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -10,9 +10,12 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
+import org.pmiops.workbench.WorkbenchConstants;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.User.ClusterConfig;
+import org.pmiops.workbench.db.model.Workspace;
+import org.pmiops.workbench.db.model.Workspace.BillingMigrationStatus;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
 import org.pmiops.workbench.notebooks.api.NotebooksApi;
 import org.pmiops.workbench.notebooks.api.StatusApi;
@@ -23,6 +26,7 @@ import org.pmiops.workbench.notebooks.model.Localize;
 import org.pmiops.workbench.notebooks.model.MachineConfig;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 import org.pmiops.workbench.notebooks.model.UserJupyterExtensionConfig;
+import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -40,6 +44,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final Provider<User> userProvider;
   private final NotebooksRetryHandler retryHandler;
+  private final WorkspaceService workspaceService;
 
   @Autowired
   public LeonardoNotebooksClientImpl(
@@ -47,16 +52,21 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
       Provider<NotebooksApi> notebooksApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       Provider<User> userProvider,
-      NotebooksRetryHandler retryHandler) {
+      NotebooksRetryHandler retryHandler,
+      WorkspaceService workspaceService) {
     this.clusterApiProvider = clusterApiProvider;
     this.notebooksApiProvider = notebooksApiProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.userProvider = userProvider;
     this.retryHandler = retryHandler;
+    this.workspaceService = workspaceService;
   }
 
   private ClusterRequest createFirecloudClusterRequest(
-      String userEmail, @Nullable ClusterConfig clusterOverride) {
+      String userEmail,
+      String workspaceNamespace,
+      String workspaceName,
+      @Nullable ClusterConfig clusterOverride) {
     if (clusterOverride == null) {
       clusterOverride = new ClusterConfig();
     }
@@ -69,6 +79,16 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     nbExtensions.put("aou-download-extension", gcsPrefix + "/aou-download-policy-extension.js");
     nbExtensions.put(
         "aou-activity-checker-extension", gcsPrefix + "/activity-checker-extension.js");
+
+    Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceName);
+    Map<String, String> customClusterEnvironmentVariables = new HashMap<>();
+    // i.e. is NEW or MIGRATED
+    if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
+      customClusterEnvironmentVariables.put(
+          WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT, workspace.getCdrVersion().getBigqueryProject());
+      customClusterEnvironmentVariables.put(
+          WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET, workspace.getCdrVersion().getBigqueryDataset());
+    }
 
     return new ClusterRequest()
         .labels(ImmutableMap.of(CLUSTER_LABEL_AOU, "true", CLUSTER_LABEL_CREATED_BY, userEmail))
@@ -93,11 +113,12 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                         .orElse(config.firecloud.clusterDefaultDiskSizeGb))
                 .masterMachineType(
                     Optional.ofNullable(clusterOverride.machineType)
-                        .orElse(config.firecloud.clusterDefaultMachineType)));
+                        .orElse(config.firecloud.clusterDefaultMachineType)))
+        .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
   }
 
   @Override
-  public Cluster createCluster(String googleProject, String clusterName) {
+  public Cluster createCluster(String googleProject, String clusterName, String workspaceName) {
     ClusterApi clusterApi = clusterApiProvider.get();
     User user = userProvider.get();
     return retryHandler.run(
@@ -105,7 +126,11 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             clusterApi.createClusterV2(
                 googleProject,
                 clusterName,
-                createFirecloudClusterRequest(user.getEmail(), user.getClusterConfigDefault())));
+                createFirecloudClusterRequest(
+                    user.getEmail(),
+                    googleProject,
+                    workspaceName,
+                    user.getClusterConfigDefault())));
   }
 
   @Override

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1360,6 +1360,11 @@ definitions:
         type: boolean
         description: If set to true, sets up welder on the cluster. If unset, welder will not be put on the cluster.
         default: false
+      customClusterEnvironmentVariables:
+        type: object
+        description: A collection of key/value pairs of environment variable names and their desired value to be set in the cluster.
+        additionalProperties:
+          type: string
 
 
   ClusterError:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -527,7 +527,7 @@ paths:
 
   # Notebook clusters ####################################################################
 
-  /v1/clusters/{billingProjectId}:
+  /v1/clusters/{billingProjectId}/{workspaceName}:
     get:
       summary: List available notebook clusters
       description: >
@@ -543,6 +543,11 @@ paths:
         - in: path
           name: billingProjectId
           description: The unique identifier of the Google Billing Project containing the clusters
+          required: true
+          type: string
+        - in: path
+          name: workspaceName
+          description: The name of the workspace whose notebook we're looking at
           required: true
           type: string
       responses:

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -263,7 +263,7 @@ public class ClusterControllerTest {
     when(notebookService.getCluster(BILLING_PROJECT_ID, getClusterName()))
         .thenThrow(new NotFoundException());
     when(notebookService.createCluster(
-            eq(BILLING_PROJECT_ID), eq(getClusterName()), eq(BIGQUERY_DATASET)))
+            eq(BILLING_PROJECT_ID), eq(getClusterName()), eq(WORKSPACE_NAME)))
         .thenReturn(testFcCluster);
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_NAME, "test");
 

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -78,6 +78,7 @@ public class ClusterControllerTest {
   // a workspace's namespace is always its billing project ID
   private static final String WORKSPACE_NS = BILLING_PROJECT_ID;
   private static final String WORKSPACE_ID = "wsid";
+  private static final String WORKSPACE_NAME = "wsn";
   private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
   private static final String OTHER_USER_EMAIL = "alice@gmail.com";
   private static final String BUCKET_NAME = "workspace-bucket";
@@ -85,6 +86,7 @@ public class ClusterControllerTest {
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
   private static final String API_HOST = "api.stable.fake-research-aou.org";
   private static final String API_BASE_URL = "https://" + API_HOST;
+  private static final String BIGQUERY_DATASET = "dataset-name";
 
   private static WorkbenchConfig config = new WorkbenchConfig();
   private static User user = new User();
@@ -138,6 +140,7 @@ public class ClusterControllerTest {
   private CdrVersion cdrVersion;
   private org.pmiops.workbench.notebooks.model.Cluster testFcCluster;
   private Cluster testCluster;
+  private Workspace testWorkspace;
 
   @Before
   public void setUp() {
@@ -163,6 +166,7 @@ public class ClusterControllerTest {
     // set the db name to be empty since test cases currently
     // run in the workbench schema only.
     cdrVersion.setCdrDbName("");
+    cdrVersion.setBigqueryDataset(BIGQUERY_DATASET);
 
     String createdDate = Date.fromYearMonthDay(1988, 12, 26).toString();
     testFcCluster =
@@ -177,6 +181,11 @@ public class ClusterControllerTest {
             .clusterNamespace(BILLING_PROJECT_ID)
             .status(ClusterStatus.DELETING)
             .createdDate(createdDate);
+
+    testWorkspace = new Workspace();
+    testWorkspace.setWorkspaceNamespace(WORKSPACE_NS);
+    testWorkspace.setName(WORKSPACE_NAME);
+    testWorkspace.setCdrVersion(cdrVersion);
   }
 
   private org.pmiops.workbench.firecloud.model.Workspace createFcWorkspace(
@@ -222,7 +231,11 @@ public class ClusterControllerTest {
     when(notebookService.getCluster(BILLING_PROJECT_ID, getClusterName()))
         .thenReturn(testFcCluster);
 
-    assertThat(clusterController.listClusters(BILLING_PROJECT_ID).getBody().getDefaultCluster())
+    assertThat(
+            clusterController
+                .listClusters(BILLING_PROJECT_ID, WORKSPACE_NAME)
+                .getBody()
+                .getDefaultCluster())
         .isEqualTo(testCluster);
   }
 
@@ -233,7 +246,7 @@ public class ClusterControllerTest {
 
     assertThat(
             clusterController
-                .listClusters(BILLING_PROJECT_ID)
+                .listClusters(BILLING_PROJECT_ID, WORKSPACE_NAME)
                 .getBody()
                 .getDefaultCluster()
                 .getStatus())
@@ -242,17 +255,23 @@ public class ClusterControllerTest {
 
   @Test(expected = BadRequestException.class)
   public void testListClustersNullBillingProject() throws Exception {
-    clusterController.listClusters(null);
+    clusterController.listClusters(null, WORKSPACE_NAME);
   }
 
   @Test
-  public void testListClustersLazyCreate() {
+  public void testListClustersLazyCreate() throws Exception {
     when(notebookService.getCluster(BILLING_PROJECT_ID, getClusterName()))
         .thenThrow(new NotFoundException());
-    when(notebookService.createCluster(eq(BILLING_PROJECT_ID), eq(getClusterName())))
+    when(notebookService.createCluster(
+            eq(BILLING_PROJECT_ID), eq(getClusterName()), eq(BIGQUERY_DATASET)))
         .thenReturn(testFcCluster);
+    stubGetWorkspace(WORKSPACE_NS, WORKSPACE_NAME, "test");
 
-    assertThat(clusterController.listClusters(BILLING_PROJECT_ID).getBody().getDefaultCluster())
+    assertThat(
+            clusterController
+                .listClusters(BILLING_PROJECT_ID, WORKSPACE_NAME)
+                .getBody()
+                .getDefaultCluster())
         .isEqualTo(testCluster);
   }
 

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -134,7 +134,7 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
         setTimeout(() => this.runCluster(onClusterReady), 5000);
       };
 
-      clusterApi().listClusters(this.props.urlParams.ns)
+      clusterApi().listClusters(this.props.urlParams.ns, this.props.urlParams.wsid)
         .then((body) => {
           const cluster = body.defaultCluster;
           this.setState({clusterStatus: cluster.status});

--- a/ui/src/app/pages/analysis/notebook-redirect/component.ts
+++ b/ui/src/app/pages/analysis/notebook-redirect/component.ts
@@ -133,7 +133,7 @@ export class NotebookRedirectComponent implements OnInit, OnDestroy {
     this.setNotebookNames();
 
     let initializedProgress = false;
-    this.loadingSub = this.clusterService.listClusters(this.wsNamespace)
+    this.loadingSub = this.clusterService.listClusters(this.wsNamespace, this.wsId)
       .do((resp) => {
         if (initializedProgress) {
           // Only initialize progress once. This callback will re-execute as we

--- a/ui/src/app/pages/analysis/reset-cluster-button.spec.tsx
+++ b/ui/src/app/pages/analysis/reset-cluster-button.spec.tsx
@@ -19,7 +19,8 @@ describe('ResetClusterButton', () => {
 
   beforeEach(() => {
     props = {
-      billingProjectId: "billing-project-123"
+      billingProjectId: "billing-project-123",
+      workspaceName: "workspace name 123"
     };
 
     registerApiClient(ClusterApi, new ClusterApiStub());

--- a/ui/src/app/pages/analysis/reset-cluster-button.tsx
+++ b/ui/src/app/pages/analysis/reset-cluster-button.tsx
@@ -27,6 +27,7 @@ const styles = {
 
 export interface Props {
   billingProjectId: string;
+  workspaceName: string;
 }
 
 interface State {
@@ -130,7 +131,7 @@ export class ResetClusterButton extends React.Component<Props, State> {
     const repoll = () => {
       this.pollClusterTimer = setTimeout(() => this.pollCluster(billingProjectId), 15000);
     };
-    clusterApi().listClusters(billingProjectId)
+    clusterApi().listClusters(billingProjectId, this.props.workspaceName)
       .then((body) => {
         const cluster = body.defaultCluster;
         if (TRANSITIONAL_STATUSES.has(cluster.status)) {

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -254,7 +254,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <Link disabled={!workspace}
                 onClick={() => this.setState({googleBucketModalOpen: true})}>Google Bucket</Link>
           {!!this.workspaceClusterBillingProjectId() &&
-            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()}/>}
+            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()} workspaceName={this.state.workspace.name}/>}
         </div>
       </div>
       {googleBucketModalOpen && <Modal>


### PR DESCRIPTION
Using the same variables that we use in code snippets - `CDR_VERSION_CLOUD_PROJECT` and `CDR_VERSION_BIGQUERY_DATASET`.
![Screen Shot 2019-10-29 at 10 02 36 AM](https://user-images.githubusercontent.com/1847690/67774453-c6608080-fa33-11e9-9528-70335d5b987d.png)
