### PR TITLE
[RW-3674][risk=no]Set a minimum width on the Dataset Builder to prevent text collisions

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -84,7 +84,8 @@ export const styles = {
     borderBottom: `1px solid ${colors.light}`,
     display: 'flex',
     justifyContent: 'space-between',
-    flexDirection: 'row'
+    flexDirection: 'row',
+    minWidth: '14.5rem'
   } as React.CSSProperties,
 
   listItem: {
@@ -169,7 +170,6 @@ export const styles = {
 
   selectAllContainer: {
     marginLeft: 'auto',
-    width: '5rem',
     display: 'flex',
     alignItems: 'center'
   } as React.CSSProperties,
@@ -818,7 +818,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
             variables and values for one or more of your cohorts. Then export the completed dataset
             to Notebooks where you can perform your analysis</div>
           <div style={{display: 'flex', paddingTop: '1rem'}}>
-            <div style={{width: '33%', height: '80%'}}>
+            <div style={{width: '33%', height: '80%', minWidth: styles.selectBoxHeader.minWidth}}>
               <div style={{backgroundColor: 'white', border: `1px solid ${colors.light}`}}>
                 <BoxHeader step='1' header='Select Cohorts' subHeader='Participants'>
                   {plusLink('cohorts-link', cohortsPath, !this.canWrite)}
@@ -939,7 +939,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
               <div style={{display: 'flex', alignItems: 'flex-end'}}>
                 <div style={styles.previewDataHeader}>
                   <div>
-                    <StepNumber step={'4'}/>
+                    <StepNumber step='4'/>
                   </div>
                   <label style={{marginLeft: '0.5rem', color: colors.primary}}>
                     Preview Dataset

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -85,7 +85,7 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     flexDirection: 'row',
-    minWidth: '14.5rem'
+    minWidth: '15rem'
   } as React.CSSProperties,
 
   listItem: {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -346,11 +346,15 @@ const plusLink = (dataTestId: string, path: string, disable?: boolean) => {
   </Clickable></TooltipTrigger>;
 };
 
-const BoxHeader = ({text= '', header =  '', subHeader = '', style= {}, ...props}) => {
+const StepNumber = ({step, style = {}}) => {
+  return <CircleWithText text={step} width='23.78px' height='23.78px'
+                         style={{fill: colorWithWhiteness(colors.primary, 0.5), ...style}}/>;
+};
+
+const BoxHeader = ({step = '', header =  '', subHeader = '', style = {}, ...props}) => {
   return  <div style={styles.selectBoxHeader}>
     <div style={{display: 'flex', marginLeft: '0.2rem'}}>
-      <CircleWithText text={text} width='23.78px' height='23.78px'
-                      style={{fill: colorWithWhiteness(colors.primary, 0.5), marginTop: '0.5rem'}}/>
+      <StepNumber step={step} style={{marginTop: '0.5rem'}}/>
       <label style={{marginLeft: '0.5rem', color: colors.primary, display: 'flex', ...style}}>
         <div style={{fontWeight: 600, marginRight: '0.3rem'}}>{header}</div>
         ({subHeader})
@@ -816,7 +820,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
           <div style={{display: 'flex', paddingTop: '1rem'}}>
             <div style={{width: '33%', height: '80%'}}>
               <div style={{backgroundColor: 'white', border: `1px solid ${colors.light}`}}>
-                <BoxHeader text='1' header='Select Cohorts' subHeader='Participants'>
+                <BoxHeader step='1' header='Select Cohorts' subHeader='Participants'>
                   {plusLink('cohorts-link', cohortsPath, !this.canWrite)}
                 </BoxHeader>
                 <div style={{height: '9rem', overflowY: 'auto'}}>
@@ -845,7 +849,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
               <div style={{display: 'flex', backgroundColor: colors.white,
                 border: `1px solid ${colors.light}`}}>
                 <div style={{width: '60%', borderRight: `1px solid ${colors.light}`}}>
-                    <BoxHeader text='2' header='Select Concept Sets' subHeader='Rows'
+                    <BoxHeader step='2' header='Select Concept Sets' subHeader='Rows'
                                style={{paddingRight: '1rem'}}>
                       {plusLink('concept-sets-link', conceptSetsPath, !this.canWrite)}
                     </BoxHeader>
@@ -883,7 +887,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                   </div>
                 </div>
                 <div style={{width: '55%'}}>
-                    <BoxHeader text='3' header='Select Values' subHeader='Columns'>
+                    <BoxHeader step='3' header='Select Values' subHeader='Columns'>
                     <div style={styles.selectAllContainer}>
                       <CheckBox style={{height: 17, width: 17}}
                                 disabled={fp.isEmpty(valueSets)}
@@ -935,8 +939,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
               <div style={{display: 'flex', alignItems: 'flex-end'}}>
                 <div style={styles.previewDataHeader}>
                   <div>
-                    <CircleWithText text={4} width='23.78px' height='23.78px'
-                      style={{marignTop: '0.3rem', fill: colorWithWhiteness(colors.primary, 0.5)}}/>
+                    <StepNumber step={'4'}/>
                   </div>
                   <label style={{marginLeft: '0.5rem', color: colors.primary}}>
                     Preview Dataset


### PR DESCRIPTION
Before: we allow shrinking screen width arbitrarily, but text overlaps into the the next section
![Screen Shot 2019-10-29 at 12 11 09 PM](https://user-images.githubusercontent.com/2701406/67786466-4c38f780-fa45-11e9-9248-58fc86a657c5.png)

After: we prevent decreasing screen width past a certain size and text does not overlap
![Screen Shot 2019-10-29 at 12 11 26 PM](https://user-images.githubusercontent.com/2701406/67786477-4e9b5180-fa45-11e9-9f74-0a234fffd2f2.png)

