### PR TITLE
[RW-3779][risk=no] Fix the API endpoint targeted by the billing buffer cron task.

### DIFF
--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -29,8 +29,8 @@ cron:
   schedule: every 24 hours
   timezone: UTC
   target: api
-- description: 'If the AoU Billing Project buffer is not full, create a firecloud billing project and add one'
-  url: /v1/cron/bufferBillingProject
+- description: 'If the AoU Billing Project buffer is not full, refill with one or more projects.'
+  url: /v1/cron/bufferBillingProjects
   schedule: every 1 minutes
   timezone: UTC
   target: api


### PR DESCRIPTION
I knew there was added risk in renaming the API endpoint, but I failed to double-check my own soft dependencies and test thoroughly locally.

At some point we should also seek to have monitoring that would have caught this more immediately when it was pushed to test – either through cronjob failure logs, and/or through the buffer becoming depleted.