### PR TITLE
[RW-3686][Risk=moderate] Upgrade Jupyter docker

### DIFF
--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -39,12 +39,10 @@ apt-get update
 apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
 apt-get install -y --no-install-recommends jq
 
-for v in "3"; do
-  "pip${v}" install --upgrade \
-    plotnine \
-    'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py' \
-    statsmodels==0.10.0rc2
-done
+"pip3" install --upgrade \
+  plotnine \
+  'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py' \
+  statsmodels==0.10.0rc2
 
 # Install wondershaper for basic egress throttling.
 apt-get install -y --no-install-recommends iproute2

--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -36,16 +36,17 @@ echo "Sys.setenv(RETICULATE_PYTHON = '$(which python3)')" >> ~/.Rprofile
 # TODO: These steps are quite slow, we could also consider pushing this into the
 # base Leo image or a custom AoU docker image.
 apt-get update
-apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6 jq
+apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
+apt-get install -y --no-install-recommends jq
 
-for v in "2.7" "3"; do
+for v in "3"; do
   "pip${v}" install --upgrade \
     plotnine \
     'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py'
 done
 
 # Install wondershaper for basic egress throttling.
-apt-get install -y --no-install-recommends iproute
+apt-get install -y --no-install-recommends iproute2
 (cd /usr/local/share &&
  git clone https://github.com/magnific0/wondershaper.git &&
  cd wondershaper &&

--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -36,7 +36,7 @@ echo "Sys.setenv(RETICULATE_PYTHON = '$(which python3)')" >> ~/.Rprofile
 # TODO: These steps are quite slow, we could also consider pushing this into the
 # base Leo image or a custom AoU docker image.
 apt-get update
-apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
+apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6 jq
 
 for v in "2.7" "3"; do
   "pip${v}" install --upgrade \

--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -42,7 +42,8 @@ apt-get install -y --no-install-recommends jq
 for v in "3"; do
   "pip${v}" install --upgrade \
     plotnine \
-    'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py'
+    'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py' \
+    statsmodels==0.10.0rc2
 done
 
 # Install wondershaper for basic egress throttling.

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -12,7 +12,8 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-test@dev.test.firecloud.org",
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -11,7 +11,8 @@
     "registeredDomainGroup": "all-of-us-registered-perf@perf.test.firecloud.org",
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -11,7 +11,8 @@
     "registeredDomainGroup": "all-of-us-registered-prod@firecloud.org",
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "015EAA-E95687-1F8614",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -11,7 +11,8 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-stable@firecloud.org",
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -11,7 +11,8 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-staging@firecloud.org",
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -12,7 +12,8 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-test@dev.test.firecloud.org",
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
-    "timeoutInSeconds": 40
+    "timeoutInSeconds": 40,
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -36,7 +36,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
-  private static final String JUPYTER_DOCKER_IMAGE = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.2";
+  private static final String JUPYTER_DOCKER_IMAGE = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -36,6 +36,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
+  private static final String JUPYTER_DOCKER_IMAGE = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.2";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
@@ -103,6 +104,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                 .masterMachineType(
                     Optional.ofNullable(clusterOverride.machineType)
                         .orElse(config.firecloud.clusterDefaultMachineType)))
+        .jupyterDockerImage(JUPYTER_DOCKER_IMAGE)
         .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -36,7 +36,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
-  private static final String JUPYTER_DOCKER_IMAGE = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3";
+  private static final String JUPYTER_DOCKER_IMAGE =
+      "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -36,8 +36,6 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
-  private static final String JUPYTER_DOCKER_IMAGE =
-      "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
@@ -105,7 +103,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                 .masterMachineType(
                     Optional.ofNullable(clusterOverride.machineType)
                         .orElse(config.firecloud.clusterDefaultMachineType)))
-        .jupyterDockerImage(JUPYTER_DOCKER_IMAGE)
+        .jupyterDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
         .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
   }
 

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -100,6 +100,8 @@ public class WorkbenchConfig {
     public String vpcServicePerimeterName;
     // The length of our API HTTP client timeouts to firecloud
     public Integer timeoutInSeconds;
+    // The image in GCR that we use for our jupyter dockers
+    public String jupyterDockerImage;
   }
 
   public static class AuthConfig {


### PR DESCRIPTION
This upgrades us to the new Jupyter Docker image. We are using the 'GATK' image, because it has up to date python and R. Manually tested in both R and Python by exporting a dataset, running both queries generated, and trying setup and a selection of other snippets. (All of the AoU specific snippets, unless I noticed a pattern that broke them, like with measurement_ext)