### PR TITLE
[no ticket][risk=no] Change CDR env var name

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/WorkbenchConstants.java
@@ -1,8 +1,0 @@
-package org.pmiops.workbench;
-
-public class WorkbenchConstants {
-  /** Constants that should be made available everywhere in workbench package. */
-  public static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
-
-  public static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
-}

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -15,7 +15,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.json.JSONObject;
-import org.pmiops.workbench.WorkbenchConstants;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -53,6 +52,8 @@ public class ClusterController implements ClusterApiDelegate {
   private static final String WORKSPACE_ID_KEY = "WORKSPACE_ID";
   private static final String API_HOST_KEY = "API_HOST";
   private static final String BUCKET_NAME_KEY = "BUCKET_NAME";
+  private static final String CDR_VERSION_CLOUD_PROJECT = "CDR_VERSION_CLOUD_PROJECT";
+  private static final String CDR_VERSION_BIGQUERY_DATASET = "CDR_VERSION_BIGQUERY_DATASET";
   // The billing project to use for the analysis.
   private static final String BILLING_CLOUD_PROJECT = "BILLING_CLOUD_PROJECT";
   private static final String DATA_URI_PREFIX = "data:application/json;base64,";
@@ -297,8 +298,8 @@ public class ClusterController implements ClusterApiDelegate {
     config.put(WORKSPACE_ID_KEY, fcWorkspace.getName());
     config.put(BUCKET_NAME_KEY, fcWorkspace.getBucketName());
     config.put(API_HOST_KEY, host);
-    config.put(WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT, cdrVersion.getBigqueryProject());
-    config.put(WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET, cdrVersion.getBigqueryDataset());
+    config.put(CDR_VERSION_CLOUD_PROJECT, cdrVersion.getBigqueryProject());
+    config.put(CDR_VERSION_BIGQUERY_DATASET, cdrVersion.getBigqueryDataset());
     config.put(BILLING_CLOUD_PROJECT, cdrBillingCloudProject);
     return jsonToDataUri(config);
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -35,7 +35,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
-  private static final String WORKSPACE_CDR = "WORKSPCAE_CDR";
+  private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -10,7 +10,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
-import org.pmiops.workbench.WorkbenchConstants;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.User;
 import org.pmiops.workbench.db.model.User.ClusterConfig;
@@ -36,6 +35,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private static final String CLUSTER_LABEL_AOU = "all-of-us";
   private static final String CLUSTER_LABEL_CREATED_BY = "created-by";
+  private static final String WORKSPACE_CDR = "WORKSPCAE_CDR";
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
@@ -85,11 +85,10 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     // i.e. is NEW or MIGRATED
     if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
       customClusterEnvironmentVariables.put(
-          WorkbenchConstants.CDR_VERSION_CLOUD_PROJECT,
-          workspace.getCdrVersion().getBigqueryProject());
-      customClusterEnvironmentVariables.put(
-          WorkbenchConstants.CDR_VERSION_BIGQUERY_DATASET,
-          workspace.getCdrVersion().getBigqueryDataset());
+          WORKSPACE_CDR,
+          workspace.getCdrVersion().getBigqueryProject()
+              + "."
+              + workspace.getCdrVersion().getBigqueryDataset());
     }
 
     return new ClusterRequest()


### PR DESCRIPTION
Per conversation with Nicole Deflaux:
```
My recommendation would be to keep it simple: one new environment variable WORKSPACE_CDR where is value would be both the project id and the dataset name such as   'fc-aou-cdr-prod.R2019Q4R3'.

The only use case that comes to mind where I want the BigQuery project *only* is if I am programmatically trying to list all the BigQuery datasets in a particular GCP project. AoU curators might want to do this on occasion, but they know how to make that happen without the convenience of the environment variable.
```

![Screen Shot 2019-10-30 at 4 57 35 PM](https://user-images.githubusercontent.com/1847690/67898275-656da100-fb36-11e9-90a6-4da4a251e796.png)

There's an extra change here because Spotless has some opinions.