### PR TITLE
[no ticket][risk=no] update README.md again

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git submodule update --init --recursive
 
 Then set up [git secrets](#git-secrets) and fire up the [development servers](#running-the-dev-servers). Optionally, you can [set up your Intellij](https://docs.google.com/document/d/1DtESBapEzvuti7xODTFPHorwmLM7LybF-6D5lhbIkLU/edit) for UI or API work.
 
-Before doing any development, you must run:
+Before doing any development, you must run the following from `/api`:
 ```Shell
 ./gradlew compileGeneratedJava appengineRun
 ```
@@ -152,12 +152,12 @@ While the API is running locally, saving a .java file should cause a recompile a
 
 #### Caveats
 
-The first time a server is started after a database clear (`./project.rb docker-clean`, `./project.rb run-local-all-migrations`), it may take some time for a billing project to become available for workspace creation. Generally, this takes about 5 minutes, but has been known to take upwards of 40 in some cases. The billing project buffer size is set to 2 for local environments (`config_local.json`). A cron job runs every minute while the API server is running to check if there are empty slots.
+The first time a server is started after a database clear (`./project.rb docker-clean`), it may take some time for a billing project to become available for workspace creation. Generally, this takes about 5 minutes, but has been known to take upwards of 40 in some cases. The billing project buffer size is set to 2 for local environments (`config_local.json`). A cron job runs every minute while the API server is running to check if there are empty slots.
 
 To check whether you have available billing projects:
 ```Shell
 ./project.rb connect-to-db
-select * from billing_project_buffer_entry;
+select * from billing_project_buffer_entry where status=2;
 ```
 
 The `status` column enum values can be found in `org.pmiops.workbench.db.model.StorageEnums`.


### PR DESCRIPTION
Merged too soon.

@ericsong `appengineRun` does not depend on `compileGeneratedJava`.