### PR TITLE
[RW-3355] [risk=no] Add benchmark timing log messages for dev-up.

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -166,7 +166,7 @@ def read_db_vars(gcc)
 end
 
 def format_benchmark(bm)
-  "%.2fs" % [bm.real]
+  "%ds" % [bm.real]
 end
 
 def dev_up()
@@ -220,7 +220,7 @@ def dev_up()
     common.status "Pushing configs complete (#{format_benchmark(bm)})"
 
   }
-  common.status "All dev-env setup steps complete (#{format_benchmark(overall_bm)})"
+  common.status "Total dev-env setup time: #{format_benchmark(overall_bm)}"
 
   common.status "Starting API server..."
   run_api()


### PR DESCRIPTION
While working on docker-sync stuff, I realized it would be really helpful for our dev scripts to track timings of each of the setup steps. Example output from changes in this PR:

Database startup...
...
Database startup complete (0.66s)
Database init & migrations...
...
Database init & migrations complete (27.43s)
Pushing configs & data...
...
Pushing configs complete (506.18s)

All dev-env setup steps complete (534.28s)