### PR TITLE
[RW-3829][risk=no] Checking ACLs on featured workspaces breaks all the things

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -3,6 +3,8 @@ package org.pmiops.workbench.workspaces;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.UserRecentWorkspace;
 import org.pmiops.workbench.db.model.Workspace;
@@ -78,4 +80,8 @@ public interface WorkspaceService {
   UserRecentWorkspace updateRecentWorkspaces(Workspace workspace);
 
   boolean maybeDeleteRecentWorkspace(long workspaceId);
+
+  String getRegisteredUserDomainEmail();
+
+  void setWorkbenchConfigProvider(Provider<WorkbenchConfig> configProvider);
 }

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -280,7 +280,6 @@ public class ConceptSetsControllerTest {
             CLOCK,
             notebooksService,
             userService,
-            workbenchConfigProvider,
             workspaceAuditAdapterService);
 
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -303,7 +303,6 @@ public class DataSetControllerTest {
             CLOCK,
             notebooksService,
             userService,
-            workbenchConfigProvider,
             workspaceAuditAdapterService);
     CohortsController cohortsController =
         new CohortsController(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.DataSetService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentWorkspaceDao;
@@ -62,6 +63,7 @@ public class WorkspaceServiceTest {
   @Mock private ConceptSetService mockConceptSetService;
   @Mock private DataSetService mockDataSetService;
   @Mock private Provider<User> mockUserProvider;
+  @Mock private Provider<WorkbenchConfig> mockWorkbenchConfigProvider;
   @Mock private FireCloudService mockFireCloudService;
   @Mock private Clock mockClock;
 
@@ -88,6 +90,7 @@ public class WorkspaceServiceTest {
             userDao,
             mockUserProvider,
             userRecentWorkspaceDao,
+            mockWorkbenchConfigProvider,
             workspaceDao);
 
     mockWorkspaceResponses.clear();

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -320,7 +320,7 @@ public class WorkspacesControllerTest {
     testConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
     when(configProvider.get()).thenReturn(testConfig);
 
-    workspacesController.setWorkbenchConfigProvider(configProvider);
+    workspaceService.setWorkbenchConfigProvider(configProvider);
     fcWorkspaceAcl = createWorkspaceACL();
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);
     testMockFactory.stubCreateFcWorkspace(fireCloudService);


### PR DESCRIPTION
This fixes NPEs in:
- updateRecentWorkspaces
- getRecentWorkspaces
- getCohorts
- getCohortReviews
- getConceptSets
- getDataSets

ACLs for published workspaces don't work by adding an ACL for every user, they work by adding the registered user domain email as READER on the published workspace. We need to check that email as well as the user's email when checking ACLs.