### PR TITLE
[no ticket][risk=no] Don't try to cast WorkbenchExceptions to ApiExceptions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -64,9 +64,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private ClusterRequest createFirecloudClusterRequest(
       String userEmail,
-      String workspaceNamespace,
-      String workspaceName,
-      @Nullable ClusterConfig clusterOverride) {
+      @Nullable ClusterConfig clusterOverride,
+      Map<String, String> customClusterEnvironmentVariables) {
     if (clusterOverride == null) {
       clusterOverride = new ClusterConfig();
     }
@@ -79,17 +78,6 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     nbExtensions.put("aou-download-extension", gcsPrefix + "/aou-download-policy-extension.js");
     nbExtensions.put(
         "aou-activity-checker-extension", gcsPrefix + "/activity-checker-extension.js");
-
-    Workspace workspace = workspaceService.getRequired(workspaceNamespace, workspaceName);
-    Map<String, String> customClusterEnvironmentVariables = new HashMap<>();
-    // i.e. is NEW or MIGRATED
-    if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
-      customClusterEnvironmentVariables.put(
-          WORKSPACE_CDR,
-          workspace.getCdrVersion().getBigqueryProject()
-              + "."
-              + workspace.getCdrVersion().getBigqueryDataset());
-    }
 
     return new ClusterRequest()
         .labels(ImmutableMap.of(CLUSTER_LABEL_AOU, "true", CLUSTER_LABEL_CREATED_BY, userEmail))
@@ -122,6 +110,16 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   public Cluster createCluster(String googleProject, String clusterName, String workspaceName) {
     ClusterApi clusterApi = clusterApiProvider.get();
     User user = userProvider.get();
+    Workspace workspace = workspaceService.getRequired(googleProject, workspaceName);
+    Map<String, String> customClusterEnvironmentVariables = new HashMap<>();
+    // i.e. is NEW or MIGRATED
+    if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
+      customClusterEnvironmentVariables.put(
+          WORKSPACE_CDR,
+          workspace.getCdrVersion().getBigqueryProject()
+              + "."
+              + workspace.getCdrVersion().getBigqueryDataset());
+    }
     return retryHandler.run(
         (context) ->
             clusterApi.createClusterV2(
@@ -129,9 +127,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                 clusterName,
                 createFirecloudClusterRequest(
                     user.getEmail(),
-                    googleProject,
-                    workspaceName,
-                    user.getClusterConfigDefault())));
+                    user.getClusterConfigDefault(),
+                    customClusterEnvironmentVariables)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
@@ -34,6 +34,9 @@ public abstract class RetryHandler<E extends Exception> {
       return retryTemplate.execute(retryCallback);
     } catch (RetryException retryException) {
       throw new ServerErrorException(retryException.getCause());
+    } catch (WorkbenchException workbenchException) {
+      // No need to convert here, just pass through.
+      throw workbenchException;
     } catch (Exception exception) {
       throw convertException((E) exception);
     }

--- a/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
@@ -34,9 +34,6 @@ public abstract class RetryHandler<E extends Exception> {
       return retryTemplate.execute(retryCallback);
     } catch (RetryException retryException) {
       throw new ServerErrorException(retryException.getCause());
-    } catch (WorkbenchException workbenchException) {
-      // No need to convert here, just pass through.
-      throw workbenchException;
     } catch (Exception exception) {
       throw convertException((E) exception);
     }


### PR DESCRIPTION
When working on #2796, I was getting exceptions like:
```
api_1                    | SEVERE: java.lang.ClassCastException
api_1                    | java.lang.ClassCastException: org.pmiops.workbench.exceptions.NotFoundException cannot be cast to org.pmiops.workbench.notebooks.ApiException
api_1                    |     at org.pmiops.workbench.notebooks.NotebooksRetryHandler.convertException(NotebooksRetryHandler.java:14)
api_1                    |     at org.pmiops.workbench.utils.RetryHandler.run(RetryHandler.java:38)
api_1                    |     at org.pmiops.workbench.notebooks.LeonardoNotebooksClientImpl.createCluster(LeonardoNotebooksClientImpl.java:125)
api_1                    |     at org.pmiops.workbench.api.ClusterController.listClusters(ClusterController.java:133)
api_1                    |     at org.pmiops.workbench.api.ClusterApiController.listClusters(ClusterApiController.java:47)
```
This is caused by our assumption in `RetryHandler` that every error that happens is an `ApiException`. We then try to cast those errors to `WorkbenchException`s (line 41), which causes the `ClassCastException`. If we get a `WorkbenchException` within a `RetryHandler.run`, we should just straight up throw it.