### PR TITLE
[risk=no] Add missing stub clone workspace call

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1339,6 +1339,7 @@ public class WorkspacesControllerTest {
         modWorkspace.getName(),
         LOGGED_IN_USER_EMAIL,
         WorkspaceAccessLevel.OWNER);
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
 
     mockBillingProjectBuffer("cloned-ns");
     Workspace cloned =


### PR DESCRIPTION
One of my PRs merged and broke the build even though my branch passed due to git cleanly resolving a merge despite there being some functional changes.

Adds the necessary stub call.