### PR TITLE
[risk=no]Increase cluster name display width for deletion script

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -79,7 +79,7 @@ public class ManageClusters {
       status = c.getStatus();
     }
     return String.format(
-        "%-30.30s %-50.50s %-10s %-15s", clusterId(c), creator, status, c.getCreatedDate());
+        "%-40.40s %-50.50s %-10s %-15s", clusterId(c), creator, status, c.getCreatedDate());
   }
 
   private static void listClusters(String apiUrl) throws IOException, ApiException {


### PR DESCRIPTION
Full cluster names can be longer than this script expects.  This increase accommodated all of the currently-on-test clusters.
