### PR TITLE
[RW-3858][RISK=NO] fix generic ambiguity warning

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -31,7 +31,7 @@ public class WorkbenchConfig {
     config.access = new AccessConfig();
     config.admin = new AdminConfig();
     config.auth = new AuthConfig();
-    config.auth.serviceAccountApiUsers = new ArrayList();
+    config.auth.serviceAccountApiUsers = new ArrayList<>();
     config.cdr = new CdrConfig();
     config.cohortbuilder = new CohortBuilderConfig();
     config.elasticsearch = new ElasticsearchConfig();


### PR DESCRIPTION
Use angle brackets in declaration so that we're relying on the smarter flavor of generics.