### PR TITLE
[RW-3765][risk=no] Update demographics display and text

### DIFF
--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -4,8 +4,8 @@ export const LIST_PROGRAM_TYPES = [
   {
     name: 'Demographics', domain: DomainType.PERSON, children: [
       {name: 'Current Age/Deceased', domain: DomainType.PERSON, type: CriteriaType.AGE},
-      {name: 'Gender', domain: DomainType.PERSON, type: CriteriaType.GENDER},
-      {name: 'Sex', domain: DomainType.PERSON, type: CriteriaType.SEX},
+      {name: 'Gender Identity', domain: DomainType.PERSON, type: CriteriaType.GENDER},
+      {name: 'Sex Assigned at Birth', domain: DomainType.PERSON, type: CriteriaType.SEX},
       {name: 'Race', domain: DomainType.PERSON, type: CriteriaType.RACE},
       {name: 'Ethnicity', domain: DomainType.PERSON, type: CriteriaType.ETHNICITY},
     ]

--- a/ui/src/app/cohort-search/demographics/demographics.component.css
+++ b/ui/src/app/cohort-search/demographics/demographics.component.css
@@ -114,3 +114,23 @@ h3 {
 .badge.badge-info {
   margin-left: 0.25rem;
 }
+.alert.alert-warning {
+  background: #f7981c;
+  color: #ffffff;
+  border: 1px solid #ebafa6;
+  margin: 0.5rem 0.25rem;
+}
+.alert.alert-warning .alert-item {
+  display: table;
+}
+.alert.alert-warning .alert-icon-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+.alert.alert-warning .alert-text {
+  margin-right: 0;
+}
+.alert.alert-warning .alert-icon {
+  color: #ffffff;
+  margin-right: 0.25rem;
+}

--- a/ui/src/app/cohort-search/demographics/demographics.component.html
+++ b/ui/src/app/cohort-search/demographics/demographics.component.html
@@ -46,6 +46,18 @@
 
   <!-- Gender/Race/Ethnicity -->
     <div *ngSwitchDefault>
+      <div *ngIf="noSexData" class="alert alert-warning">
+        <div class="alert-items">
+          <div class="alert-item static">
+            <div class="alert-icon-wrapper">
+              <clr-icon class="alert-icon is-solid" shape="exclamation-triangle"></clr-icon>
+            </div>
+            <span class="alert-text">
+                This data does not exist in the dataset you’re currently using. To use this data, please create a new workspace with the most recent dataset.
+              </span>
+          </div>
+        </div>
+      </div>
       <div class="control-wrapper">
         <div class="ds-wrapper">
           <div class="ds-options">

--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -324,7 +324,7 @@ export class DemographicsComponent implements OnInit, OnDestroy {
     triggerEvent('Cohort Builder Search', 'Click', `Demo - ${typeToTitle(opt.type)} - ${opt.name}`);
     if (!this.selections.includes(opt.parameterId)) {
       const wizard = this.wizard;
-      wizard.item.searchParameters.push(opt);
+      wizard.item.searchParameters.push({...opt, name: `${typeToTitle(opt.type)} - ${opt.name}`});
       const selections = [...this.selections, opt.parameterId];
       wizardStore.next(wizard);
       selectionsStore.next(selections);

--- a/ui/src/app/cohort-search/demographics/demographics.component.ts
+++ b/ui/src/app/cohort-search/demographics/demographics.component.ts
@@ -337,4 +337,8 @@ export class DemographicsComponent implements OnInit, OnDestroy {
       this.count += selection.count;
     });
   }
+
+  get noSexData() {
+    return !this.loading && this.wizard.type === CriteriaType.SEX && this.nodes.length === 0;
+  }
 }

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {MODIFIERS_MAP} from 'app/cohort-search/constant';
 import {encountersStore, initExisting, searchRequestStore, selectionsStore, wizardStore} from 'app/cohort-search/search-state.service';
-import {domainToTitle, getTypeAndStandard, mapGroupItem} from 'app/cohort-search/utils';
+import {domainToTitle, getTypeAndStandard, mapGroupItem, typeToTitle} from 'app/cohort-search/utils';
 import {Button, Clickable} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
@@ -274,6 +274,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
       const {item: {modifiers, searchParameters, type}} = this.props;
       const {count, paramListOpen, error, loading, status} = this.state;
       const codeDisplay = searchParameters.length > 1 ? 'Codes' : 'Code';
+      const titleDisplay = type === DomainType.PERSON ? typeToTitle(searchParameters[0].type) : domainToTitle(type);
       const showCount = !loading && status !== 'hidden' && count !== null;
       const actionItems = [
         {label: 'Edit criteria', command: () => this.launchWizard()},
@@ -289,7 +290,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
               <ClrIcon shape='ellipsis-vertical' />
             </Clickable>
             <span className='item-title' style={{...styles.codeText, paddingRight: '10px'}} onClick={() => this.launchWizard()}>
-              Contains {domainToTitle(type)} {codeDisplay}
+              Contains {titleDisplay} {codeDisplay}
             </span>
             {status !== 'hidden' && <span style={{...styles.codeText, paddingRight: '10px'}}>|</span>}
             {loading && <span className='spinner spinner-inline'>Loading...</span>}

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -16,7 +16,8 @@ export function typeDisplay(parameter): string {
   const {domainId, type} = parameter;
   if (domainId === DomainType.PERSON) {
     return {
-      'GENDER': 'Gender',
+      'GENDER': 'Gender Identity',
+      'SEX': 'Sex Assigned at Birth',
       'RACE': 'Race',
       'ETHNICITY': 'Ethnicity',
       'AGE': 'Age',
@@ -114,10 +115,13 @@ export function typeToTitle(_type: string): string {
       _type = 'Ethnicity';
       break;
     case CriteriaType[CriteriaType.GENDER]:
-      _type = 'Gender';
+      _type = 'Gender Identity';
       break;
     case CriteriaType[CriteriaType.RACE]:
       _type = 'Race';
+      break;
+    case CriteriaType[CriteriaType.SEX]:
+      _type = 'Sex Assigned at Birth';
       break;
   }
   return _type;

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -13,19 +13,7 @@ import {
 import {idsInUse} from './search-state.service';
 
 export function typeDisplay(parameter): string {
-  const {domainId, type} = parameter;
-  if (domainId === DomainType.PERSON) {
-    return {
-      'GENDER': 'Gender Identity',
-      'SEX': 'Sex Assigned at Birth',
-      'RACE': 'Race',
-      'ETHNICITY': 'Ethnicity',
-      'AGE': 'Age',
-      'DECEASED': 'Deceased'
-    }[type] || '';
-  } else if (
-      [DomainType.CONDITION, DomainType.PROCEDURE, DomainType.MEASUREMENT].includes(domainId)
-  ) {
+  if ([DomainType.CONDITION, DomainType.PROCEDURE, DomainType.MEASUREMENT].includes(parameter.domainId)) {
     return parameter.code;
   }
 }


### PR DESCRIPTION
- Show message for Sex Assigned at Birth wizard if no data in CDR
- Change parameter names and search item titles to show criteria types instead of 'Demographics'
- Update text for Sex and Gender in criteria dropdown list
<img width="937" alt="Screen Shot 2019-11-01 at 1 57 08 PM" src="https://user-images.githubusercontent.com/40036095/68051332-2dd93300-fcb5-11e9-9b33-ecc251746fc9.png">

<img width="516" alt="Screen Shot 2019-11-01 at 2 33 22 PM" src="https://user-images.githubusercontent.com/40036095/68051346-35004100-fcb5-11e9-94a3-325e4cabd54f.png">

<img width="560" alt="Screen Shot 2019-11-01 at 2 33 59 PM" src="https://user-images.githubusercontent.com/40036095/68051352-39c4f500-fcb5-11e9-8e23-f6eb47250172.png">
