### PR TITLE
[RW-3868][risk=no] Fix count preview when editing demo items

### DIFF
--- a/ui/src/app/cohort-search/demographics/demographics.component.html
+++ b/ui/src/app/cohort-search/demographics/demographics.component.html
@@ -79,7 +79,7 @@
       </div>
     </div>
 </form>
-<div class="container count-preview" *ngIf="(selections && selections.length) && wizard.type !== criteriaType.AGE">
+<div class="container count-preview" *ngIf="showPreview">
   <div class="row">
     <ng-container>
       <div class="col-lg-12 text-padding" *ngIf="count">


### PR DESCRIPTION
Fixes issue when editing a non-age demographics item on an existing cohort, the count preview was empty.

Before:
<img width="859" alt="Screen Shot 2019-11-01 at 4 28 47 PM" src="https://user-images.githubusercontent.com/40036095/68057820-16a24180-fcc5-11e9-96b0-57002c3ba843.png">

After:
<img width="846" alt="Screen Shot 2019-11-01 at 4 29 15 PM" src="https://user-images.githubusercontent.com/40036095/68057826-1e61e600-fcc5-11e9-8d4c-d4ff37103449.png">
