### PR TITLE
[RW-3706][risk=no] Increase VM upload rate limiter to 16Mib/s

### DIFF
--- a/api/cluster-resources/README.md
+++ b/api/cluster-resources/README.md
@@ -11,7 +11,7 @@ To manually test updates to this script locally:
 - Push the script to GCS (username-suffixed):
 
   ```
-  api$ gsutil cp cluster-resources/setup_notebook_cluster.sh "gs://all-of-us-workbench-test-cluster-resources/setup_notebook_cluster-${USER}.sh""
+  api$ gsutil cp cluster-resources/setup_notebook_cluster.sh "gs://all-of-us-workbench-test-cluster-resources/setup_notebook_cluster-${USER}.sh"
   ```
 
 - (**Disclaimer**: local code change, do not submit) Temporarily update your

--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -39,9 +39,7 @@ apt-get update
 apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
 
 for v in "2.7" "3"; do
-  "pip${v}" install --upgrade \
-    plotnine \
-    'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py'
+  "pip${v}" install --upgrade plotnine
 done
 
 # Install wondershaper for basic egress throttling.
@@ -49,5 +47,8 @@ apt-get install -y --no-install-recommends iproute
 (cd /usr/local/share &&
  git clone https://github.com/magnific0/wondershaper.git &&
  cd wondershaper &&
- ./wondershaper -a eth0 -u 2048 # 2Mbit maximum upload
+ make install
+
+ # TODO(RW-3784): This approach does not outlive cluster pause/resumes.
+ wondershaper -a "eth0" -u 16384
 )


### PR DESCRIPTION
The current 2 Mib/s is too restrictive and causes Jupyter server errors.

I made several attempts to make Wondershaper long-lived across restarts, but I don't think it's possible without changes to Leo. Will discuss with Leo team next week. That change is tracked by https://precisionmedicineinitiative.atlassian.net/browse/RW-3874

Other changes here:
- Removed old pyclient for slightly faster startup (easier testing)
- Used make install to put wondershaper on path, not necessary for this change but may help later in setting up the recurring runs

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
