### PR TITLE
[RW-3855][risk=no] Abort pending fetches on unmount as well

### DIFF
--- a/ui/src/app/utils/errors.tsx
+++ b/ui/src/app/utils/errors.tsx
@@ -25,3 +25,8 @@ export function reportError(err: Error) {
     });
   }
 }
+
+/** Returns true if the given error is an AbortError, as used in fetch() aborts. */
+export function isAbortError(e: Error) {
+  return (e instanceof DOMException) && e.name === 'AbortError';
+}


### PR DESCRIPTION
This catches an additional situation where processing might continue after the user leaves the page. Uses the fetch abort pattern which we could adapt elsewhere.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
