### PR TITLE
[RW-3052][risk=no] Add test that verifies all liquibase files are indexed for migration

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
@@ -1,0 +1,47 @@
+package org.pmiops.workbench.db;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class LiquibaseTest {
+
+  List<String> whitelist = Arrays.asList("db.changelog-master.xml");
+
+  @Test
+  public void allChangelogFilesAreInMaster() throws Exception {
+    List<String> indexedChangeLogs = getChangeLogIndexes();
+    for (File f : new File("db/changelog").listFiles()) {
+      if (!whitelist.contains(f.getName()) && !indexedChangeLogs.contains(f.getName())) {
+        fail(f.getName() + " is in the db/changelog directory but not in db.changelog-master.xml");
+      }
+    }
+  }
+
+  private List<String> getChangeLogIndexes() throws Exception {
+    File fXmlFile = new File("db/changelog/db.changelog-master.xml");
+    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+    Document doc = dBuilder.parse(fXmlFile);
+    doc.getDocumentElement().normalize();
+
+    NodeList changeLogs = doc.getElementsByTagName("include");
+
+    List<String> changeLogFilenames = new ArrayList<>();
+    for (int i = 0; i < changeLogs.getLength(); i++) {
+      changeLogFilenames.add(((Element) changeLogs.item(i)).getAttribute("file").substring(10));
+    }
+
+    return changeLogFilenames;
+  }
+
+}

--- a/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -28,20 +27,19 @@ public class LiquibaseTest {
   }
 
   private List<String> getIndexedChangeLogs() throws Exception {
-    Document doc = DocumentBuilderFactory.newInstance()
-        .newDocumentBuilder()
-        .parse(new File("db/changelog/db.changelog-master.xml"));
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new File("db/changelog/db.changelog-master.xml"));
 
     NodeList changeLogs = doc.getElementsByTagName("include");
 
     List<String> changeLogFilenames = new ArrayList<>();
     for (int i = 0; i < changeLogs.getLength(); i++) {
-      changeLogFilenames.add(((Element) changeLogs.item(i))
-          .getAttribute("file")
-          .split("changelog/")[1]);
+      changeLogFilenames.add(
+          ((Element) changeLogs.item(i)).getAttribute("file").split("changelog/")[1]);
     }
 
     return changeLogFilenames;
   }
-
 }

--- a/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
@@ -18,8 +18,8 @@ public class LiquibaseTest {
   List<String> whitelist = Arrays.asList("db.changelog-master.xml");
 
   @Test
-  public void allChangelogFilesAreInMaster() throws Exception {
-    List<String> indexedChangeLogs = getChangeLogIndexes();
+  public void allChangeLogFilesAreIndexed() throws Exception {
+    List<String> indexedChangeLogs = getIndexedChangeLogs();
     for (File f : new File("db/changelog").listFiles()) {
       if (!whitelist.contains(f.getName()) && !indexedChangeLogs.contains(f.getName())) {
         fail(f.getName() + " is in the db/changelog directory but not in db.changelog-master.xml");
@@ -27,7 +27,7 @@ public class LiquibaseTest {
     }
   }
 
-  private List<String> getChangeLogIndexes() throws Exception {
+  private List<String> getIndexedChangeLogs() throws Exception {
     File fXmlFile = new File("db/changelog/db.changelog-master.xml");
     DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
@@ -38,7 +38,7 @@ public class LiquibaseTest {
 
     List<String> changeLogFilenames = new ArrayList<>();
     for (int i = 0; i < changeLogs.getLength(); i++) {
-      changeLogFilenames.add(((Element) changeLogs.item(i)).getAttribute("file").substring(10));
+      changeLogFilenames.add(((Element) changeLogs.item(i)).getAttribute("file").split("changelog/")[1]);
     }
 
     return changeLogFilenames;

--- a/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
@@ -28,17 +28,17 @@ public class LiquibaseTest {
   }
 
   private List<String> getIndexedChangeLogs() throws Exception {
-    File fXmlFile = new File("db/changelog/db.changelog-master.xml");
-    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-    Document doc = dBuilder.parse(fXmlFile);
-    doc.getDocumentElement().normalize();
+    Document doc = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .parse(new File("db/changelog/db.changelog-master.xml"));
 
     NodeList changeLogs = doc.getElementsByTagName("include");
 
     List<String> changeLogFilenames = new ArrayList<>();
     for (int i = 0; i < changeLogs.getLength(); i++) {
-      changeLogFilenames.add(((Element) changeLogs.item(i)).getAttribute("file").split("changelog/")[1]);
+      changeLogFilenames.add(((Element) changeLogs.item(i))
+          .getAttribute("file")
+          .split("changelog/")[1]);
     }
 
     return changeLogFilenames;


### PR DESCRIPTION
See https://github.com/all-of-us/workbench/pull/2812 to see a failing example after I added a liquibase changelog file and "forgot" to add it to the changelog master file.

<img width="1141" alt="Screen Shot 2019-11-05 at 4 14 44 PM" src="https://user-images.githubusercontent.com/2770197/68246870-b45c8000-ffe7-11e9-9032-85241459e557.png">
