### PR TITLE
[risk=low][no ticket]Use the Workspace's firecloudName when interacting with Cluster APIs

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -116,7 +116,7 @@ public class ClusterController implements ClusterApiDelegate {
 
   @Override
   public ResponseEntity<ClusterListResponse> listClusters(
-      String billingProjectId, String workspaceName) {
+      String billingProjectId, String firecloudWorkspaceName) {
     if (billingProjectId == null) {
       throw new BadRequestException("Must specify billing project");
     }
@@ -130,7 +130,7 @@ public class ClusterController implements ClusterApiDelegate {
       fcCluster = this.leonardoNotebooksClient.getCluster(billingProjectId, clusterName);
     } catch (NotFoundException e) {
       fcCluster =
-          this.leonardoNotebooksClient.createCluster(billingProjectId, clusterName, workspaceName);
+          this.leonardoNotebooksClient.createCluster(billingProjectId, clusterName, firecloudWorkspaceName);
     }
 
     int retries = Optional.ofNullable(user.getClusterCreateRetries()).orElse(0);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -116,7 +116,7 @@ public class ClusterController implements ClusterApiDelegate {
 
   @Override
   public ResponseEntity<ClusterListResponse> listClusters(
-      String billingProjectId, String firecloudWorkspaceName) {
+      String billingProjectId, String workspaceFirecloudName) {
     if (billingProjectId == null) {
       throw new BadRequestException("Must specify billing project");
     }
@@ -131,7 +131,7 @@ public class ClusterController implements ClusterApiDelegate {
     } catch (NotFoundException e) {
       fcCluster =
           this.leonardoNotebooksClient.createCluster(
-              billingProjectId, clusterName, firecloudWorkspaceName);
+              billingProjectId, clusterName, workspaceFirecloudName);
     }
 
     int retries = Optional.ofNullable(user.getClusterCreateRetries()).orElse(0);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -130,7 +130,8 @@ public class ClusterController implements ClusterApiDelegate {
       fcCluster = this.leonardoNotebooksClient.getCluster(billingProjectId, clusterName);
     } catch (NotFoundException e) {
       fcCluster =
-          this.leonardoNotebooksClient.createCluster(billingProjectId, clusterName, firecloudWorkspaceName);
+          this.leonardoNotebooksClient.createCluster(
+              billingProjectId, clusterName, firecloudWorkspaceName);
     }
 
     int retries = Optional.ofNullable(user.getClusterCreateRetries()).orElse(0);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,7 +16,8 @@ public interface LeonardoNotebooksClient {
    *
    * @param googleProject the google project that will be used for this notebooks cluster
    * @param clusterName the user assigned/auto-generated name for this notebooks cluster
-   * @param firecloudWorkspaceName the firecloudName of the workspace this cluster is associated with
+   * @param firecloudWorkspaceName the firecloudName of the workspace this cluster is associated
+   *     with
    */
   Cluster createCluster(String googleProject, String clusterName, String firecloudWorkspaceName)
       throws WorkbenchException;

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,10 +16,9 @@ public interface LeonardoNotebooksClient {
    *
    * @param googleProject the google project that will be used for this notebooks cluster
    * @param clusterName the user assigned/auto-generated name for this notebooks cluster
-   * @param cdrVersion the version of the CDR that the workspace to which this notebook belongs is
-   *     using
+   * @param firecloudWorkspaceName the firecloudName of the workspace this cluster is associated with
    */
-  Cluster createCluster(String googleProject, String clusterName, String cdrVersion)
+  Cluster createCluster(String googleProject, String clusterName, String firecloudWorkspaceName)
       throws WorkbenchException;
 
   /** Deletes a notebook cluster */

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,10 +16,10 @@ public interface LeonardoNotebooksClient {
    *
    * @param googleProject the google project that will be used for this notebooks cluster
    * @param clusterName the user assigned/auto-generated name for this notebooks cluster
-   * @param firecloudWorkspaceName the firecloudName of the workspace this cluster is associated
+   * @param workspaceFirecloudName the firecloudName of the workspace this cluster is associated
    *     with
    */
-  Cluster createCluster(String googleProject, String clusterName, String firecloudWorkspaceName)
+  Cluster createCluster(String googleProject, String clusterName, String workspaceFirecloudName)
       throws WorkbenchException;
 
   /** Deletes a notebook cluster */

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -107,10 +107,10 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
-  public Cluster createCluster(String googleProject, String clusterName, String workspaceName) {
+  public Cluster createCluster(String googleProject, String clusterName, String firecloudWorkspaceName) {
     ClusterApi clusterApi = clusterApiProvider.get();
     User user = userProvider.get();
-    Workspace workspace = workspaceService.getRequired(googleProject, workspaceName);
+    Workspace workspace = workspaceService.getRequired(googleProject, firecloudWorkspaceName);
     Map<String, String> customClusterEnvironmentVariables = new HashMap<>();
     // i.e. is NEW or MIGRATED
     if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -108,10 +108,10 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   @Override
   public Cluster createCluster(
-      String googleProject, String clusterName, String firecloudWorkspaceName) {
+      String googleProject, String clusterName, String workspaceFirecloudName) {
     ClusterApi clusterApi = clusterApiProvider.get();
     User user = userProvider.get();
-    Workspace workspace = workspaceService.getRequired(googleProject, firecloudWorkspaceName);
+    Workspace workspace = workspaceService.getRequired(googleProject, workspaceFirecloudName);
     Map<String, String> customClusterEnvironmentVariables = new HashMap<>();
     // i.e. is NEW or MIGRATED
     if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -107,7 +107,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
-  public Cluster createCluster(String googleProject, String clusterName, String firecloudWorkspaceName) {
+  public Cluster createCluster(
+      String googleProject, String clusterName, String firecloudWorkspaceName) {
     ClusterApi clusterApi = clusterApiProvider.get();
     User user = userProvider.get();
     Workspace workspace = workspaceService.getRequired(googleProject, firecloudWorkspaceName);

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -527,7 +527,7 @@ paths:
 
   # Notebook clusters ####################################################################
 
-  /v1/clusters/{billingProjectId}/{workspaceName}:
+  /v1/clusters/{billingProjectId}/{firecloudWorkspaceName}:
     get:
       summary: List available notebook clusters
       description: >
@@ -546,8 +546,8 @@ paths:
           required: true
           type: string
         - in: path
-          name: workspaceName
-          description: The name of the workspace whose notebook we're looking at
+          name: firecloudWorkspaceName
+          description: The firecloudName of the workspace whose notebook we're looking at
           required: true
           type: string
       responses:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -527,7 +527,7 @@ paths:
 
   # Notebook clusters ####################################################################
 
-  /v1/clusters/{billingProjectId}/{firecloudWorkspaceName}:
+  /v1/clusters/{billingProjectId}/{workspaceFirecloudName}:
     get:
       summary: List available notebook clusters
       description: >
@@ -546,7 +546,7 @@ paths:
           required: true
           type: string
         - in: path
-          name: firecloudWorkspaceName
+          name: workspaceFirecloudName
           description: The firecloudName of the workspace whose notebook we're looking at
           required: true
           type: string

--- a/ui/src/app/pages/analysis/reset-cluster-button.spec.tsx
+++ b/ui/src/app/pages/analysis/reset-cluster-button.spec.tsx
@@ -20,7 +20,7 @@ describe('ResetClusterButton', () => {
   beforeEach(() => {
     props = {
       billingProjectId: "billing-project-123",
-      workspaceName: "workspace name 123"
+      workspaceFirecloudName: "workspace-name-123"
     };
 
     registerApiClient(ClusterApi, new ClusterApiStub());

--- a/ui/src/app/pages/analysis/reset-cluster-button.tsx
+++ b/ui/src/app/pages/analysis/reset-cluster-button.tsx
@@ -27,7 +27,7 @@ const styles = {
 
 export interface Props {
   billingProjectId: string;
-  workspaceName: string;
+  workspaceFirecloudName: string;
 }
 
 interface State {
@@ -131,7 +131,7 @@ export class ResetClusterButton extends React.Component<Props, State> {
     const repoll = () => {
       this.pollClusterTimer = setTimeout(() => this.pollCluster(billingProjectId), 15000);
     };
-    clusterApi().listClusters(billingProjectId, this.props.workspaceName)
+    clusterApi().listClusters(billingProjectId, this.props.workspaceFirecloudName)
       .then((body) => {
         const cluster = body.defaultCluster;
         if (TRANSITIONAL_STATUSES.has(cluster.status)) {

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -254,7 +254,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <Link disabled={!workspace}
                 onClick={() => this.setState({googleBucketModalOpen: true})}>Google Bucket</Link>
           {!!this.workspaceClusterBillingProjectId() &&
-            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()} workspaceName={this.state.workspace.name}/>}
+            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()} workspaceFirecloudName={this.state.workspace.id}/>}
         </div>
       </div>
       {googleBucketModalOpen && <Modal>

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -254,7 +254,8 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <Link disabled={!workspace}
                 onClick={() => this.setState({googleBucketModalOpen: true})}>Google Bucket</Link>
           {!!this.workspaceClusterBillingProjectId() &&
-            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()} workspaceFirecloudName={this.state.workspace.id}/>}
+            <ResetClusterButton billingProjectId={this.workspaceClusterBillingProjectId()}
+                                workspaceFirecloudName={this.state.workspace.id}/>}
         </div>
       </div>
       {googleBucketModalOpen && <Modal>


### PR DESCRIPTION
Introduced in this release's commits, so we can fix it before it goes to Production
