### PR TITLE
[RW-3905][risk=no] Revert removal of AoU pyclient package

### DIFF
--- a/api/cluster-resources/setup_notebook_cluster.sh
+++ b/api/cluster-resources/setup_notebook_cluster.sh
@@ -39,7 +39,9 @@ apt-get update
 apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
 
 for v in "2.7" "3"; do
-  "pip${v}" install --upgrade plotnine
+  "pip${v}" install --upgrade \
+    plotnine \
+    'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py'
 done
 
 # Install wondershaper for basic egress throttling.


### PR DESCRIPTION
Partly reverts changes from https://github.com/all-of-us/workbench/pull/2807

Before:
![image](https://user-images.githubusercontent.com/822298/68344300-8b012a00-00a3-11ea-87fa-7b261d61b7f3.png)

After:
![image](https://user-images.githubusercontent.com/822298/68344426-d582a680-00a3-11ea-8719-c242b2f3ded1.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
