### PR TITLE
[RW-3902][risk=moderate] key enum and package updates - take #2

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -112,6 +112,7 @@
     "stackdriver-errors-js": "^0.4.0",
     "stacktrace-js": "^2.0.0",
     "ts-jest": "^23.10.5",
+    "ts-key-enum": "^3.0.0",
     "tslib": "^1.9.0",
     "validate.js": "^0.12.0",
     "yarn": "^1.17.3",

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -13,6 +13,7 @@ import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {CriteriaType, DomainType} from 'generated/fetch';
 import * as React from 'react';
+import {Key} from 'ts-key-enum';
 
 const styles = reactStyles({
   searchContainer: {
@@ -171,7 +172,7 @@ export const ListSearch = withCurrentWorkspace()(
 
     handleInput = (event: any) => {
       const {key, target: {value}} = event;
-      if (key === 'Enter') {
+      if (key === Key.Enter) {
         const {wizard: {domain}} = this.props;
         triggerEvent(`Cohort Builder Search - ${domainToTitle(domain)}`, 'Search', value);
         this.getResults(value);

--- a/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
@@ -12,6 +12,7 @@ import {cohortAnnotationDefinitionApi} from 'app/services/swagger-fetch-clients'
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, summarizeErrors, withUrlParams} from 'app/utils';
 import {AnnotationType, CohortAnnotationDefinition} from 'generated/fetch';
+import {Key} from 'ts-key-enum';
 
 const styles = reactStyles({
   editRow: {
@@ -244,7 +245,7 @@ export const EditAnnotationDefinitionsModal = withUrlParams()(class extends Reac
                     onChange={v => this.setState({editValue: v})}
                     onBlur={() => this.rename()}
                     onKeyPress={e => {
-                      if (e.key === 'Enter') {
+                      if (e.key === Key.Enter) {
                         this.rename();
                       }
                     }}

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -24,6 +24,7 @@ import {
   WorkspacesApiStub,
   WorkspaceStubVariables
 } from 'testing/stubs/workspaces-api-stub';
+import {Key} from 'ts-key-enum';
 
 
 function isSelectedDomain(
@@ -45,7 +46,7 @@ function searchTable(searchTerm: string, wrapper) {
   wrapper.find('[data-test-id="concept-search-input"]')
     .find('input').simulate('change', {target: {value: searchTerm}});
   wrapper.find('[data-test-id="concept-search-input"]')
-    .find('input').simulate('keypress', {key: 'Enter'});
+    .find('input').simulate('keypress', {key: Key.Enter});
 }
 
 const defaultSearchTerm = 'test';

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -32,6 +32,7 @@ import {
   SurveyQuestionsResponse,
   VocabularyCount,
 } from 'generated/fetch';
+import { Key } from 'ts-key-enum';
 import {SurveyDetails} from './survey-details';
 
 const styles = reactStyles({
@@ -272,7 +273,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
 
     handleSearchKeyPress(e) {
       // search on enter key
-      if (e.key === 'Enter' ) {
+      if (e.key === Key.Enter) {
         const searchTermLength = this.state.currentSearchString.trim().length;
         if (searchTermLength < 3) {
           this.setState({showSearchError: true});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8293,6 +8293,11 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
+ts-key-enum@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ts-key-enum/-/ts-key-enum-3.0.0.tgz#82ec990b90bb9a51352e2e6a654f234d3e907811"
+  integrity sha512-ld+vqp6GgJ4rDtaDSZwXQraBznklEO/lkpQn/SSUx2RLNWthxamdUtti/GdnQSUhB/OR46XVpNb0eBoMtnPtuw==
+
 ts-node@~3.0.4:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.0.6.tgz#55127ff790c7eebf6ba68c1e6dde94b09aaa21e0"


### PR DESCRIPTION
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

This is essentially the same PR as this one:
https://github.com/all-of-us/workbench/pull/2817
minus many updates to packages, which are being handled in a separate PR.


----

(Opt) Bare strings always scare me. Either here or as a follow-on, we could use https://github.com/nfriend/ts-key-enum to refer to these keys in a type-safe way.

_Originally posted by @gjuggler in https://github.com/all-of-us/workbench/pull/2813_


This PR addresses this issue

----

Previously, npm was accidentally used to install the package. We use yarn instead of npm as a package manager so that was resolved in my local env by deleting the package-lock.json file that npm generated. It doesn't seem like it affected the dev code at all. Phew!


I considered adding the package as a yarn devDependency with: `yarn add --dev package-name`
but then the package wouldn't be in production and I'm assuming we need this dependency for the code to work in prod. Relevant documentation:

>Yarn will not install any package listed in devDependencies if the NODE_ENV environment variable is set to production. Use this flag to instruct Yarn to ignore NODE_ENV and take its production-or-not status from this flag instead.



------
note to security folks - I set risk = medium because of the new package and because I'm not sure what level of risk that introduces (and I'm open to feedback!)