### PR TITLE
[RW-3878][risk=no] Bump firecloud timeout from 40 to 60s

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -12,7 +12,7 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-test@dev.test.firecloud.org",
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -11,7 +11,7 @@
     "registeredDomainGroup": "all-of-us-registered-perf@perf.test.firecloud.org",
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -11,7 +11,7 @@
     "registeredDomainGroup": "all-of-us-registered-prod@firecloud.org",
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -11,7 +11,7 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-stable@firecloud.org",
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -11,7 +11,7 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-staging@firecloud.org",
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -12,7 +12,7 @@
     "registeredDomainGroup": "GROUP_all-of-us-registered-test@dev.test.firecloud.org",
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
-    "timeoutInSeconds": 40,
+    "timeoutInSeconds": 60,
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
   },
   "billing": {


### PR DESCRIPTION
See PR description for more details. We've decided to extend the Firecloud API request timeout to err on the side of caution for next week's workshop.