### PR TITLE
[noticket][risk=no] remove unused code in workspace-wrapper test

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {ClarityModule} from '@clr/angular';
@@ -18,13 +17,13 @@ import {WorkspaceShareComponent} from 'app/pages/workspace/workspace-share';
 import {WorkspaceWrapperComponent} from 'app/pages/workspace/workspace-wrapper/component';
 
 import {UserService, WorkspaceAccessLevel} from 'generated';
-import {WorkspaceAccessLevel as FetchWorkspaceAccessLevel, WorkspaceResponse, WorkspacesApi} from 'generated/fetch';
+import {WorkspacesApi} from 'generated/fetch';
 
 import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-stub';
 import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 import {UserServiceStub} from 'testing/stubs/user-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
-import {WorkspacesApiStub, workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
+import {WorkspacesApiStub, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
 
 import {findElements} from 'testing/react-testing-utility';
 import {setupModals, updateAndTick} from 'testing/test-helpers';
@@ -35,14 +34,8 @@ import {setupModals, updateAndTick} from 'testing/test-helpers';
 })
 class FakeAppComponent {}
 
-const workspaceResponse: WorkspaceResponse = {
-  workspace: {...workspaceStubs[0]},
-  accessLevel: FetchWorkspaceAccessLevel.OWNER,
-};
-
 describe('WorkspaceWrapperComponent', () => {
   let fixture: ComponentFixture<WorkspaceWrapperComponent>;
-  let router: Router;
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -82,24 +75,11 @@ describe('WorkspaceWrapperComponent', () => {
       registerApiClient(WorkspacesApi, new WorkspacesApiStub());
       fixture = TestBed.createComponent(WorkspaceWrapperComponent);
       setupModals(fixture);
-      router = TestBed.get(Router);
-
-      router.navigateByUrl(
-        `/workspaces/${WorkspaceStubVariables.DEFAULT_WORKSPACE_NS}/` +
-        `WorkspaceStubVariables.DEFAULT_WORKSPACE_ID)/about`);
-
-      spyOn(workspacesApi(), 'getWorkspace')
-        .and.returnValue(Promise.resolve(workspaceResponse));
 
       urlParamsStore.next({
         ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
         wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
       });
-
-      // Clarity needs several ticks/redraw cycles to render its button group.
-      tick();
-      updateAndTick(fixture);
-      updateAndTick(fixture);
     });
   }));
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -9,7 +9,7 @@ import {ClarityModule} from '@clr/angular';
 import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {registerApiClient, workspacesApi} from 'app/services/swagger-fetch-clients';
-import {currentWorkspaceStore, urlParamsStore} from 'app/utils/navigation';
+import {urlParamsStore} from 'app/utils/navigation';
 
 import {BugReportComponent} from 'app/components/bug-report';
 import {ConfirmDeleteModalComponent} from 'app/components/confirm-delete-modal';
@@ -18,7 +18,7 @@ import {WorkspaceShareComponent} from 'app/pages/workspace/workspace-share';
 import {WorkspaceWrapperComponent} from 'app/pages/workspace/workspace-wrapper/component';
 
 import {UserService, WorkspaceAccessLevel} from 'generated';
-import {WorkspaceAccessLevel as FetchWorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
+import {WorkspaceAccessLevel as FetchWorkspaceAccessLevel, WorkspaceResponse, WorkspacesApi} from 'generated/fetch';
 
 import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-stub';
 import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
@@ -35,8 +35,8 @@ import {setupModals, updateAndTick} from 'testing/test-helpers';
 })
 class FakeAppComponent {}
 
-const workspace = {
-  ...workspaceStubs[0],
+const workspaceResponse: WorkspaceResponse = {
+  workspace: {...workspaceStubs[0]},
   accessLevel: FetchWorkspaceAccessLevel.OWNER,
 };
 
@@ -89,7 +89,7 @@ describe('WorkspaceWrapperComponent', () => {
         `WorkspaceStubVariables.DEFAULT_WORKSPACE_ID)/about`);
 
       spyOn(workspacesApi(), 'getWorkspace')
-        .and.returnValue(Promise.resolve(workspace));
+        .and.returnValue(Promise.resolve(workspaceResponse));
 
       urlParamsStore.next({
         ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
@@ -100,7 +100,6 @@ describe('WorkspaceWrapperComponent', () => {
       tick();
       updateAndTick(fixture);
       updateAndTick(fixture);
-      currentWorkspaceStore.next(workspace);
     });
   }));
 


### PR DESCRIPTION
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

Found errors while updating dependencies

```
Error:(39, 7) TS2322: Type '{ accessLevel: WorkspaceAccessLevel; id?: string; etag?: string; name: string; namespace?: string; cdrVersionId?: string; creator?: string; googleBucketName?: string; dataAccessLevel?: DataAccessLevel; researchPurpose?: ResearchPurpose; creationTime?: number; lastModifiedTime?: number; published?: boolean; }' is not assignable to type 'WorkspaceResponse'.
  Property 'workspace' is missing in type '{ accessLevel: WorkspaceAccessLevel; id?: string; etag?: string; name: string; namespace?: string; cdrVersionId?: string; creator?: string; googleBucketName?: string; dataAccessLevel?: DataAccessLevel; researchPurpose?: ResearchPurpose; creationTime?: number; lastModifiedTime?: number; published?: boolean; }'.

Error:(105, 34) TS2345: Argument of type 'WorkspaceResponse' is not assignable to parameter of type 'WorkspaceData'.
  Property 'name' is missing in type 'WorkspaceResponse'.

```



Fixed by:
* giving a type for workspace: WorkspaceResponse
* and removing currentWorkspaceStore since it doesn't seem used in the test.
* removing more parts of the test that don't seem to get used.