### PR TITLE
[RISK=LOW][RW-3822] Default selection of values

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -90,27 +90,23 @@ describe('DataSetPage', () => {
     async() => {
       const wrapper = mount(<DataSetPage/>);
       await waitOneTickAndUpdate(wrapper);
-      await waitOneTickAndUpdate(wrapper);
 
       // Select Condition Concept set
-      const condition_concept = wrapper.find('[data-test-id="concept-set-list-item"]').first()
+      const conditionConceptSet = wrapper.find('[data-test-id="concept-set-list-item"]').first()
           .find('input').first();
-      condition_concept.simulate('change');
+      conditionConceptSet.simulate('change');
       await waitOneTickAndUpdate(wrapper);
       let valueListItems = wrapper.find('[data-test-id="value-list-items"]');
-      const conditionValueList = valueListItems.first().find('input').first();
       expect(valueListItems.length).toBe(2);
       let checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
-
 
       // All values should be selected by default
       expect(checkedValuesList.length).toBe(2);
 
       // Select second concept set which is Measurement domain
-      const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
+      const measurementConceptSet = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
           .find('input').first();
-      measurement_concept.simulate('change');
-      await waitOneTickAndUpdate(wrapper);
+      measurementConceptSet.simulate('change');
       await waitOneTickAndUpdate(wrapper);
       valueListItems = wrapper.find('[data-test-id="value-list-items"]');
       checkedValuesList = valueListItems.filterWhere(value => value.props().checked)
@@ -118,18 +114,17 @@ describe('DataSetPage', () => {
       expect(valueListItems.length).toBe(5);
       expect(checkedValuesList.length).toBe(5);
 
-      // Unselect first Conidition value
+      // Unselect first Condition value
       valueListItems.first().find('input').first().simulate('change');
       valueListItems = wrapper.find('[data-test-id="value-list-items"]');
       checkedValuesList = valueListItems.filterWhere(value => value.props().checked)
       expect(checkedValuesList.length).toBe(4);
 
       // Select another condition concept set
-      const second_condition_concept =
+      const secondConditionConceptSet =
           wrapper.find('[data-test-id="concept-set-list-item"]').at(2)
           .find('input').first();
-      second_condition_concept.simulate('change');
-      await waitOneTickAndUpdate(wrapper);
+      secondConditionConceptSet.simulate('change');
       await waitOneTickAndUpdate(wrapper);
       valueListItems = wrapper.find('[data-test-id="value-list-items"]');
       checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
@@ -144,7 +139,6 @@ describe('DataSetPage', () => {
   it('should enable save button and preview button once cohorts, concepts and values are selected',
     async() => {
       const wrapper = mount(<DataSetPage />);
-      await waitOneTickAndUpdate(wrapper);
       await waitOneTickAndUpdate(wrapper);
 
       // Preview Button and Save Button should be disabled by default
@@ -180,7 +174,6 @@ describe('DataSetPage', () => {
   it('should display preview data table once preview button is clicked', async() => {
     const spy = jest.spyOn(dataSetApi(), 'previewDataSetByDomain');
     const wrapper = mount(<DataSetPage />);
-    await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
     // Select one cohort , concept and value
@@ -254,7 +247,6 @@ describe('DataSetPage', () => {
   it('should call load data dictionary when caret is expanded', async() => {
     const spy = jest.spyOn(dataSetApi(), 'getDataDictionaryEntry');
     const wrapper = mount(<DataSetPage />);
-    await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
     // Select one cohort , concept and value

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -69,11 +69,10 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     let valueListItems = wrapper.find('[data-test-id="value-list-items"]');
     expect(valueListItems.length).toBe(2);
-    let selectedValue = valueListItems.forEach(value =>
-        value.props().checked)
+    let checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
 
     // All values should be selected by default
-    expect(selectedValue.length).toBe(2);
+    expect(checkedValuesList.length).toBe(2);
 
     // Second Concept set in concept set list has domain "Measurement"
     const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
@@ -82,10 +81,64 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);
     valueListItems = wrapper.find('[data-test-id="value-list-items"]');
-    selectedValue = valueListItems.forEach(value =>
-        value.props().checked);
+    checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
     expect(valueListItems.length).toBe(5);
-    expect(selectedValue.length).toBe(5);
+    expect(checkedValuesList.length).toBe(5);
+  });
+
+  it('should select all values by default on selection on concept set only if the new domain is unique',
+    async() => {
+      const wrapper = mount(<DataSetPage/>);
+      await waitOneTickAndUpdate(wrapper);
+      await waitOneTickAndUpdate(wrapper);
+
+      // Select Condition Concept set
+      const condition_concept = wrapper.find('[data-test-id="concept-set-list-item"]').first()
+          .find('input').first();
+      condition_concept.simulate('change');
+      await waitOneTickAndUpdate(wrapper);
+      let valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+      const conditionValueList = valueListItems.first().find('input').first();
+      expect(valueListItems.length).toBe(2);
+      let checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
+
+
+      // All values should be selected by default
+      expect(checkedValuesList.length).toBe(2);
+
+      // Select second concept set which is Measurement domain
+      const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
+          .find('input').first();
+      measurement_concept.simulate('change');
+      await waitOneTickAndUpdate(wrapper);
+      await waitOneTickAndUpdate(wrapper);
+      valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+      checkedValuesList = valueListItems.filterWhere(value => value.props().checked)
+      // All values condition + measurement will be selected
+      expect(valueListItems.length).toBe(5);
+      expect(checkedValuesList.length).toBe(5);
+
+      // Unselect first Conidition value
+      valueListItems.first().find('input').first().simulate('change');
+      valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+      checkedValuesList = valueListItems.filterWhere(value => value.props().checked)
+      expect(checkedValuesList.length).toBe(4);
+
+      // Select another condition concept set
+      const second_condition_concept =
+          wrapper.find('[data-test-id="concept-set-list-item"]').at(2)
+          .find('input').first();
+      second_condition_concept.simulate('change');
+      await waitOneTickAndUpdate(wrapper);
+      await waitOneTickAndUpdate(wrapper);
+      valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+      checkedValuesList = valueListItems.filterWhere(value => value.props().checked);
+
+      // No change in value list since we already had selected condition concept set
+      expect(valueListItems.length).toBe(5);
+
+      // Should be no change in selected values
+      expect(checkedValuesList.length).toBe(4);
   });
 
   it('should enable save button and preview button once cohorts, concepts and values are selected',

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -67,7 +67,12 @@ describe('DataSetPage', () => {
         .find('input').first();
     condition_concept.simulate('change');
     await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('[data-test-id="value-list-items"]').length).toBe(2);
+    let valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+    expect(valueListItems.length).toBe(2);
+    let selectedValue = valueListItems.forEach(value =>
+        value.props().checked)
+
+    expect(selectedValue.length).toBe(valueListItems.length);
 
     // Second Concept set in concept set list has domain "Measurement"
     const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)
@@ -75,7 +80,11 @@ describe('DataSetPage', () => {
     measurement_concept.simulate('change');
     await waitOneTickAndUpdate(wrapper);
     await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('[data-test-id="value-list-items"]').length).toBe(5);
+    valueListItems = wrapper.find('[data-test-id="value-list-items"]');
+    selectedValue = valueListItems.forEach(value =>
+        value.props().checked);
+    expect(valueListItems.length).toBe(5);
+    expect(selectedValue.length).toBe(5);
   });
 
   it('should enable save button and preview button once cohorts, concepts and values are selected',

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -72,7 +72,8 @@ describe('DataSetPage', () => {
     let selectedValue = valueListItems.forEach(value =>
         value.props().checked)
 
-    expect(selectedValue.length).toBe(valueListItems.length);
+    // All values should be selected by default
+    expect(selectedValue.length).toBe(2);
 
     // Second Concept set in concept set list has domain "Measurement"
     const measurement_concept = wrapper.find('[data-test-id="concept-set-list-item"]').at(1)

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -571,7 +571,8 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
             this.getValuesList(newDomains)
                 .then(newValueSets => this.updateValueSets(newValueSets));
           }
-        } else {
+        } else if (removedDomains.length > 0 ) {
+          // if domains are being removed
           const updatedValueSets =
               valueSets.filter(valueSet => !(fp.contains(valueSet.domain, removedDomains)));
           this.setState({valueSets: updatedValueSets});

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -606,7 +606,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
     // Append newValueSets (values from API) to state's valueSets and to selectedDomainValuePairs.
     // Set valuesLoading to false once the state is updated
-    updateValueSets(newValueSets) {
+    updateValueSets(newValueSets: ValueSet[]) {
       const {selectedDomainValuePairs, valueSets} = this.state;
 
       newValueSets.map(newValueSet => {
@@ -622,9 +622,9 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
     }
 
     // Returns true if selected values set is empty or is not equal to the total values displayed
-    get partialOrNoneValuesSelected() {
-      return fp.isEmpty(this.state.selectedDomainValuePairs) ||
-          this.state.selectedDomainValuePairs.length !== this.valuesCount;
+    get allValuesSelected() {
+      return !fp.isEmpty(this.state.selectedDomainValuePairs) &&
+          this.state.selectedDomainValuePairs.length === this.valuesCount;
     }
 
     get valuesCount() {
@@ -634,17 +634,17 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
     }
 
     selectAllValues() {
-      if (!this.partialOrNoneValuesSelected) {
+      if (this.allValuesSelected) {
         this.setState({selectedDomainValuePairs: []});
         return;
       } else {
-        const allValuesSelected = [];
+        const selectedValuesList = [];
         this.state.valueSets.map(valueSet => {
           valueSet.values.items.map(value => {
-            allValuesSelected.push({domain: valueSet.domain, value: value.value});
+            selectedValuesList.push({domain: valueSet.domain, value: value.value});
           });
         });
-        this.setState({selectedDomainValuePairs: allValuesSelected});
+        this.setState({selectedDomainValuePairs: selectedValuesList});
       }
     }
 
@@ -917,9 +917,9 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                                 disabled={fp.isEmpty(valueSets)}
                                 data-test-id='select-all'
                                 onChange={() => this.selectAllValues()}
-                                checked={!this.partialOrNoneValuesSelected} />
+                                checked={this.allValuesSelected} />
                       <div style={{marginLeft: '0.25rem', fontSize: '13px', lineHeight: '17px'}}>
-                        {this.partialOrNoneValuesSelected ? 'Select All' : 'Deselect All'}
+                        {this.allValuesSelected ? 'Deselect All' : 'Select All'}
                       </div>
                     </div>
                   </BoxHeader>

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -541,7 +541,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
       this.setState({valuesLoading: true});
       this.getValuesList(newDomains)
-        .then(newValueSets => this.updateValueSets(valueSets, newValueSets));
+        .then(newValueSets => this.updateValueSets(newValueSets));
     }
 
     select(resource: ConceptSet | Cohort, rtype: ResourceType): void {
@@ -555,8 +555,6 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
         const origDomains = valueSets.map(valueSet => valueSet.domain);
         const newDomains = fp.without(origDomains, currentDomains) as unknown as Domain[];
         const removedDomains = fp.without(currentDomains, origDomains);
-        const updatedValueSets =
-          valueSets.filter(valueSet => !(fp.contains(valueSet.domain, removedDomains)));
         const updatedSelectedDomainValuePairs =
           selectedDomainValuePairs.filter(selectedDomainValuePair =>
             !fp.contains(selectedDomainValuePair.domain, removedDomains));
@@ -568,12 +566,14 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
           const cSet = resource as ConceptSet;
           if (cSet.survey != null ) {
             this.getValuesList(newDomains, cSet.survey)
-                .then(newValueSets => this.updateValueSets(updatedValueSets, newValueSets));
+                .then(newValueSets => this.updateValueSets(newValueSets));
           } else {
             this.getValuesList(newDomains)
-                .then(newValueSets => this.updateValueSets(updatedValueSets, newValueSets));
+                .then(newValueSets => this.updateValueSets(newValueSets));
           }
         } else {
+          const updatedValueSets =
+              valueSets.filter(valueSet => !(fp.contains(valueSet.domain, removedDomains)));
           this.setState({valueSets: updatedValueSets});
         }
       } else {
@@ -603,18 +603,18 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
       this.setState({selectedDomainValuePairs: valuesSelected, dataSetTouched: true});
     }
 
-    // Add the values to the valueSet as well as the selectedDomain list so that they are
-    // all selected by default and set valuesLoading to false
-    updateValueSets(updatedValueSets, newValueSets) {
-      const {selectedDomainValuePairs} = this.state;
+    // Append newValueSets (values from API) to state's valueSets and to selectedDomainValuePairs.
+    // Set valuesLoading to false once the state is updated
+    updateValueSets(newValueSets) {
+      const {selectedDomainValuePairs, valueSets} = this.state;
 
-      newValueSets.map(valueSet => {
-        valueSet.values.items.map(value => {
-          selectedDomainValuePairs.push({domain: valueSet.domain, value: value.value});
+      newValueSets.map(newValueSet => {
+        newValueSet.values.items.map(value => {
+          selectedDomainValuePairs.push({domain: newValueSet.domain, value: value.value});
         });
       });
       this.setState({
-        valueSets: updatedValueSets.concat(newValueSets),
+        valueSets: valueSets.concat(newValueSets),
         selectedDomainValuePairs: selectedDomainValuePairs,
         valuesLoading: false
       });

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -540,7 +540,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
       this.setState({valuesLoading: true});
       this.getValuesList(newDomains)
-        .then(newValueSets => this.updateValueSets(valueSets, newDomains));
+        .then(newValueSets => this.updateValueSets(valueSets, newValueSets));
     }
 
     select(resource: ConceptSet | Cohort, rtype: ResourceType): void {
@@ -609,7 +609,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
         valueSets: updatedValueSets.concat(newValueSets),
         valuesLoading: false
       });
-      const allValuesSelected = [];
+      const allValuesSelected = this.state.selectedDomainValuePairs;
 
       newValueSets.map(valueSet => {
         valueSet.values.items.map(value => {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -516,7 +516,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
       if (!selected) {
         const existingSameDomainCS = selectedConceptSetIds.filter(
           conceptId => conceptSetList.filter(
-              conceptSet => conceptSet.id === conceptId && conceptSet.domain === domain));
+            conceptSet => conceptSet.id === conceptId && conceptSet.domain === domain));
         if (existingSameDomainCS.length > 0) {
           return;
         }


### PR DESCRIPTION
Issue: https://precisionmedicineinitiative.atlassian.net/browse/RW-3822
**Solution**: If the selected concept set introduces a new domain add values to valueSet as well as selected domain list 
**Testing**:
1) Add a concept set with Domain say 'Condition'
    a) the values tab should be populated with list of Condition domain values
    b) All of the values should be selected by default
    c) Values tab header should have the selected Checkbox with label Deselect All 
2) De-select some of the values
    a) Values tab header should have the un-selected Checkbox with label Select All 
3) Select another Concept set with the same domain 'Condition'
   a) There should be no change in values, not only the values remain the same also the header should still say 'Select All' with un-selected checkbox