### PR TITLE
Draft pattern idea to prevent leaky timeouts: clearAndSetTimeout

### DIFF
--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -122,9 +122,14 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
       this.aborter.abort();
     }
 
+    clearAndSetTimeout(f, millis) {
+      clearTimeout(this.runClusterTimer);
+      this.runClusterTimer = setTimeout(f, millis);
+    }
+
     private runCluster(onClusterReady: Function): void {
       const retry = () => {
-        this.runClusterTimer = setTimeout(() => this.runCluster(onClusterReady), 5000);
+        this.clearAndSetTimeout(() => this.runCluster(onClusterReady), 5000);
       };
 
       clusterApi().listClusters(this.props.urlParams.ns, this.props.urlParams.wsid, {


### PR DESCRIPTION
In a variety of places, we're setting timeout handles which we later clear which may already have handles to existing timeouts.  Thus, we can't clear the original timeout on unmount.  Here is a suggestion for a new pattern to help account for these.
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
