### PR TITLE
[RW-3801][Risk=no] Fix jitteriness with share and delete, and improve loading spinners

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -340,11 +340,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
                                 <React.Fragment>
                                   {this.state.userHasWorkspaces ?
-
-                                  (<React.Fragment>
-                                    <SmallHeader>Recently Accessed Items</SmallHeader>
-                                    <RecentResources/>
-                                  </React.Fragment>) :
+                                  <RecentResources/> :
 
                                   <div style={{
                                     backgroundColor: addOpacity(colors.primary, .1).toString(),

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -10,6 +10,7 @@ import {ResourceCard} from 'app/components/resource-card';
 import {NotebookResourceCard} from 'app/pages/analysis/notebook-resource-card';
 import {CohortResourceCard} from 'app/pages/data/cohort/cohort-resource-card';
 import {RecentResource} from 'generated/fetch';
+import {SmallHeader} from "../../components/headers";
 
 export const RecentResources = (fp.flow as any)(
   withContentRect('client'),
@@ -86,24 +87,27 @@ export const RecentResources = (fp.flow as any)(
     const {contentRect, measureRef} = this.props;
     const {offset, resources, loading} = this.state;
     const limit = (contentRect.client.width - 24) / 224;
-    return <div ref={measureRef} style={{display: 'flex', position: 'relative', minHeight: 247}}>
-      <div style={{display: 'flex', position: 'relative', alignItems: 'center',
-        marginTop: '-1rem', marginLeft: '-1rem', paddingLeft: '1rem', opacity: loading ? 0.5 : 1}}>
-        {resources.slice(offset, offset + limit).map((resource, i) => {
-          return <div key={i}> {this.createResourceCard(resource)} </div>;
-        })}
-        {offset > 0 && <Scroll
-          dir='left'
-          onClick={() => this.setState({offset: offset - 1})}
-          style={{position: 'absolute', left: 0, paddingBottom: '0.5rem'}}
-        />}
-        {offset + limit < resources.length && <Scroll
-          dir='right'
-          onClick={() => this.setState({offset: offset + 1})}
-          style={{position: 'absolute', right: 0, paddingBottom: '0.5rem'}}
-        />}
+    return (resources !== null && resources.length > 0) || loading ? <React.Fragment>
+      <SmallHeader>Recently Accessed Items</SmallHeader>
+      <div ref={measureRef} style={{display: 'flex', position: 'relative', minHeight: 247}}>
+        <div style={{display: 'flex', position: 'relative', alignItems: 'center',
+          marginTop: '-1rem', marginLeft: '-1rem', paddingLeft: '1rem', opacity: loading ? 0.5 : 1}}>
+          {resources.slice(offset, offset + limit).map((resource, i) => {
+            return <div key={i}> {this.createResourceCard(resource)} </div>;
+          })}
+          {offset > 0 && <Scroll
+            dir='left'
+            onClick={() => this.setState({offset: offset - 1})}
+            style={{position: 'absolute', left: 0, paddingBottom: '0.5rem'}}
+          />}
+          {offset + limit < resources.length && <Scroll
+            dir='right'
+            onClick={() => this.setState({offset: offset + 1})}
+            style={{position: 'absolute', right: 0, paddingBottom: '0.5rem'}}
+          />}
+        </div>
+        {loading && <SpinnerOverlay dark={this.props.dark} />}
       </div>
-      {loading && <SpinnerOverlay dark={this.props.dark} />}
-    </div>;
+    </React.Fragment> : null;
   }
 });

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {withContentRect} from 'react-measure';
 
+import {SmallHeader} from 'app/components/headers';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {Scroll} from 'app/icons/scroll';
 import {userMetricsApi} from 'app/services/swagger-fetch-clients';
@@ -10,7 +11,6 @@ import {ResourceCard} from 'app/components/resource-card';
 import {NotebookResourceCard} from 'app/pages/analysis/notebook-resource-card';
 import {CohortResourceCard} from 'app/pages/data/cohort/cohort-resource-card';
 import {RecentResource} from 'generated/fetch';
-import {SmallHeader} from "../../components/headers";
 
 export const RecentResources = (fp.flow as any)(
   withContentRect('client'),

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {withContentRect} from 'react-measure';
 
+import {FlexRow} from 'app/components/flex';
 import {SmallHeader} from 'app/components/headers';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {Scroll} from 'app/icons/scroll';

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -87,27 +87,29 @@ export const RecentResources = (fp.flow as any)(
     const {contentRect, measureRef} = this.props;
     const {offset, resources, loading} = this.state;
     const limit = (contentRect.client.width - 24) / 224;
-    return (resources !== null && resources.length > 0) || loading ? <React.Fragment>
-      <SmallHeader>Recently Accessed Items</SmallHeader>
-      <div ref={measureRef} style={{display: 'flex', position: 'relative', minHeight: 247}}>
-        <div style={{display: 'flex', position: 'relative', alignItems: 'center',
-          marginTop: '-1rem', marginLeft: '-1rem', paddingLeft: '1rem', opacity: loading ? 0.5 : 1}}>
-          {resources.slice(offset, offset + limit).map((resource, i) => {
-            return <div key={i}> {this.createResourceCard(resource)} </div>;
-          })}
-          {offset > 0 && <Scroll
-            dir='left'
-            onClick={() => this.setState({offset: offset - 1})}
-            style={{position: 'absolute', left: 0, paddingBottom: '0.5rem'}}
-          />}
-          {offset + limit < resources.length && <Scroll
-            dir='right'
-            onClick={() => this.setState({offset: offset + 1})}
-            style={{position: 'absolute', right: 0, paddingBottom: '0.5rem'}}
-          />}
+    return (resources !== null && resources.length > 0) || loading ?
+      <React.Fragment>
+        <SmallHeader>Recently Accessed Items</SmallHeader>
+        <div ref={measureRef} style={{display: 'flex', position: 'relative', minHeight: 247}}>
+          <FlexRow style={{position: 'relative', alignItems: 'center', marginTop: '-1rem',
+            marginLeft: '-1rem', paddingLeft: '1rem', opacity: loading ? 0.5 : 1}}>
+            {resources.slice(offset, offset + limit).map((resource, i) => {
+              return <div key={i}> {this.createResourceCard(resource)} </div>;
+            })}
+            {offset > 0 && <Scroll
+              dir='left'
+              onClick={() => this.setState({offset: offset - 1})}
+              style={{position: 'absolute', left: 0, paddingBottom: '0.5rem'}}
+            />}
+            {offset + limit < resources.length && <Scroll
+              dir='right'
+              onClick={() => this.setState({offset: offset + 1})}
+              style={{position: 'absolute', right: 0, paddingBottom: '0.5rem'}}
+            />}
+          </FlexRow>
+          {loading && <SpinnerOverlay dark={this.props.dark} />}
         </div>
-        {loading && <SpinnerOverlay dark={this.props.dark} />}
-      </div>
-    </React.Fragment> : null;
+      </React.Fragment> :
+      null;
   }
 });

--- a/ui/src/app/pages/homepage/recent-workspaces.tsx
+++ b/ui/src/app/pages/homepage/recent-workspaces.tsx
@@ -42,35 +42,29 @@ export const RecentWorkspaces = withUserProfile()
 
   render() {
     // Needs a min-height so the spinner will render when loading and position: relative so said spinner will center.
-    return <React.Fragment>
-      {
-        this.state.loading ?
-          <SpinnerOverlay dark={true} /> :
-
-          this.state.recentWorkspaces.length === 0 ?
-
-            <div style={{color: colors.primary, margin: '.5em 2em'}}>
-              <h2 style={{fontWeight: 600, lineHeight: 1.5}}>Create your first Workspace</h2>
-              <div>As you create your workspaces, this area will store your most recent workspaces.</div>
-              <div>To see all workspaces created, click on <b>See all Workspaces</b> to the right.</div>
-            </div> :
-
-            <div>
-              <FlexRow style={{marginTop: '1rem', minHeight: 247, position: 'relative'}}>
-                {
-                  this.state.recentWorkspaces.map(recentWorkspace => {
-                    return <WorkspaceCard
-                      key={recentWorkspace.workspace.name}
-                      userEmail={this.props.profileState.profile.username}
-                      workspace={recentWorkspace.workspace}
-                      accessLevel={recentWorkspace.accessLevel}
-                      reload={() => this.loadWorkspaces()}
-                    />;
-                  })
-                }
-              </FlexRow>
-            </div>
-      }
-    </React.Fragment>;
+    return <div style={{position: 'relative'}}>
+      {this.state.loading && <SpinnerOverlay dark={true} />}
+      {this.state.recentWorkspaces.length === 0 && !this.state.loading ?
+        <div style={{color: colors.primary, margin: '.5em 2em'}}>
+          <h2 style={{fontWeight: 600, lineHeight: 1.5}}>Create your first Workspace</h2>
+          <div>As you create your workspaces, this area will store your most recent workspaces.</div>
+          <div>To see all workspaces created, click on <b>See all Workspaces</b> to the right.</div>
+        </div> :
+        <div>
+          <FlexRow style={{marginTop: '1rem', minHeight: 247, position: 'relative'}}>
+            {
+              this.state.recentWorkspaces.map(recentWorkspace => {
+                return <WorkspaceCard
+                  key={recentWorkspace.workspace.name}
+                  userEmail={this.props.profileState.profile.username}
+                  workspace={recentWorkspace.workspace}
+                  accessLevel={recentWorkspace.accessLevel}
+                  reload={() => this.loadWorkspaces()}
+                />;
+              })
+            }
+          </FlexRow>
+        </div>}
+    </div>;
   }
 });


### PR DESCRIPTION
So, this fixes a few things. First, it addresses the ticket, which is to remove the jitteriness/movement of the page when you share or delete a recent workspace. Then, from feedback from Lou, it hides the recent resources header when there is no content there. Third, it reduces the amount of spinner jitteriness while the data is loading.

There is one todo that I am going to pick up, where if there are no recent resources, it currently hides the header and the area for the content, Lou wants it to have some text stating "you have no recent resources" instead, to reduce content moving. Doing that as a follow up task/PR since it is technically a new functional change.