### PR TITLE
[risk=no] Add featured workspaces in staging for QA purposes

### DIFF
--- a/api/config/featured_workspaces_staging.json
+++ b/api/config/featured_workspaces_staging.json
@@ -1,3 +1,13 @@
 {
-  "featuredWorkspaces": []
+  "featuredWorkspaces": [{
+    "name": "Featured1",
+    "namespace": "aou-rw-staging-99bc96d6",
+    "id": "featured1",
+    "category": "TUTORIAL_WORKSPACES"
+  }, {
+    "name": "Featured2",
+    "namespace": "aou-rw-staging-edde2df7",
+    "id": "featured2",
+    "category": "PHENOTYPE_LIBRARY"
+  }]
 }


### PR DESCRIPTION
Minimally, this will be useful for manual QA purposes. This is a gap I identified when pushing out new featured workspaces content a few weeks back. 

Before:
![image](https://user-images.githubusercontent.com/822298/68517647-4610fb00-023d-11ea-9cd6-e112e0256c13.png)

After:
![image](https://user-images.githubusercontent.com/822298/68517801-df401180-023d-11ea-8cc4-d11b86a61ada.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
