### PR TITLE
[RW-3829][risk=low] Revert ACL check logic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -94,8 +94,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     this.conceptSetService = conceptSetService;
     this.dataSetService = dataSetService;
     this.fireCloudService = fireCloudService;
-    this.userProvider = userProvider;
     this.userDao = userDao;
+    this.userProvider = userProvider;
     this.userRecentWorkspaceDao = userRecentWorkspaceDao;
     this.workspaceDao = workspaceDao;
   }
@@ -433,17 +433,9 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public WorkspaceAccessLevel getWorkspaceAccessLevel(
       String workspaceNamespace, String workspaceId) {
-    WorkspaceACL workspaceACL = fireCloudService.getWorkspaceAcl(workspaceNamespace, workspaceId);
-    WorkspaceAccessEntry workspaceAccessEntry =
-        Optional.of(workspaceACL.getAcl().get(userProvider.get().getEmail()))
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format(
-                            "DbWorkspace %s/%s not found", workspaceNamespace, workspaceId)));
-    final String userAccess = workspaceAccessEntry.getAccessLevel();
-
-    if (userAccess.equals(PROJECT_OWNER_ACCESS_LEVEL)) {
+    String userAccess =
+        fireCloudService.getWorkspace(workspaceNamespace, workspaceId).getAccessLevel();
+    if (PROJECT_OWNER_ACCESS_LEVEL.equals(userAccess)) {
       return WorkspaceAccessLevel.OWNER;
     }
     WorkspaceAccessLevel result = WorkspaceAccessLevel.fromValue(userAccess);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -4,14 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -32,8 +30,6 @@ import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.Workspace;
-import org.pmiops.workbench.firecloud.model.WorkspaceACL;
-import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.WorkspaceResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
@@ -168,20 +164,13 @@ public class WorkspaceServiceTest {
       WorkspaceAccessLevel accessLevel,
       WorkspaceActiveStatus activeStatus) {
 
-    WorkspaceACL workspaceAccessLevelResponse = spy(WorkspaceACL.class);
-    HashMap<String, WorkspaceAccessEntry> acl = new HashMap<>();
-    WorkspaceAccessEntry accessLevelEntry =
-        new WorkspaceAccessEntry().accessLevel(accessLevel.toString());
-    acl.put(DEFAULT_USER_EMAIL, accessLevelEntry);
-    doReturn(acl).when(workspaceAccessLevelResponse).getAcl();
-    workspaceAccessLevelResponse.setAcl(acl);
     WorkspaceResponse mockWorkspaceResponse =
         mockFirecloudWorkspaceResponse(
             Long.toString(workspaceId), workspaceName, workspaceNamespace, accessLevel);
-    doReturn(workspaceAccessLevelResponse)
-        .when(mockFireCloudService)
-        .getWorkspaceAcl(workspaceNamespace, workspaceName);
     mockWorkspaceResponses.add(mockWorkspaceResponse);
+    doReturn(mockWorkspaceResponse)
+        .when(mockFireCloudService)
+        .getWorkspace(workspaceNamespace, workspaceName);
 
     DbWorkspace dbWorkspace =
         workspaceDao.save(


### PR DESCRIPTION
This change was originally made as a performance optimization: https://github.com/all-of-us/workbench/pull/2522 . Now that we have partial field responses on `getWorkspace()`, this approach is probably the same as or faster than the `getWorkspaceAcl()` approach, and requires less custom logic on our side.

From looking at the code and surrounding context for the comment about "not using this for access checks", I'm comfortable using this as we are in our application (but have an email out to clarify), and at worst it looks equivalently authoritative to getWorkspaceAcl: https://github.com/broadinstitute/rawls/blob/e4983e78748dffcc444924ec2b3c96a9bcd1e06a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L317-L330

Manual testing: published a workspace locally, verified a second user could view workspace resources and clone the workspace.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
