### PR TITLE
[RW-3961][risk=no] Bump prod project buffer limit from 100 to 200.

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -19,7 +19,7 @@
     "projectNamePrefix": "aou-rw-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.gcp_billing_export_v1_015EAA_E95687_1F8614",
     "retryCount": 4,
-    "bufferCapacity": 100,
+    "bufferCapacity": 200,
     "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsLimit": 100.0,
     "garbageCollectionUserCapacity": 1000,


### PR DESCRIPTION
Simple config change to guard against heavy use of workspace creation and cloning during the DRC workshop happening on Thursday.

There's an open question on what the correct long-term buffer size in production should be... based on what we see in the workshops and ongoing usage, we may be able to keep a smaller buffer (possibly with a higher replenishment rate) for ongoing workshops and even public launch scenarios.