### PR TITLE
[risk=no] Improve cleanBuffer CREATING -> ERROR transition logic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -1,13 +1,17 @@
 package org.pmiops.workbench.billing;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.hash.Hashing;
 import java.sql.Timestamp;
 import java.time.Clock;
-import java.time.temporal.ChronoUnit;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.BillingProjectBufferEntryDao;
@@ -29,8 +33,8 @@ public class BillingProjectBufferService {
 
   private static final int SYNCS_PER_INVOCATION = 5;
   private static final int PROJECT_BILLING_ID_SIZE = 8;
-  private static final int CREATING_TIMEOUT_MINUTES = 60;
-  private static final int ASSIGNING_TIMEOUT_MINUTES = 10;
+  @VisibleForTesting static final Duration CREATING_TIMEOUT = Duration.ofMinutes(60);
+  @VisibleForTesting static final Duration ASSIGNING_TIMEOUT = Duration.ofMinutes(10);
 
   private final BillingProjectBufferEntryDao billingProjectBufferEntryDao;
   private final Clock clock;
@@ -132,22 +136,14 @@ public class BillingProjectBufferService {
   }
 
   public void cleanBillingBuffer() {
+    Instant now = clock.instant();
     Iterables.concat(
+            findExpiredCreatingEntries(now),
+            // For the ASSIGNING status monitor, we can simply filter by the current time as this
+            // status tracks internal state rather than the Firecloud status.
             billingProjectBufferEntryDao.findAllByStatusAndLastStatusChangedTimeLessThan(
-                DbStorageEnums.billingProjectBufferEntryStatusToStorage(BufferEntryStatus.CREATING),
-                new Timestamp(
-                    clock
-                        .instant()
-                        .minus(CREATING_TIMEOUT_MINUTES, ChronoUnit.MINUTES)
-                        .toEpochMilli())),
-            billingProjectBufferEntryDao.findAllByStatusAndLastStatusChangedTimeLessThan(
-                DbStorageEnums.billingProjectBufferEntryStatusToStorage(
-                    BufferEntryStatus.ASSIGNING),
-                new Timestamp(
-                    clock
-                        .instant()
-                        .minus(ASSIGNING_TIMEOUT_MINUTES, ChronoUnit.MINUTES)
-                        .toEpochMilli())))
+                DbStorageEnums.billingProjectBufferEntryStatusToStorage(BufferEntryStatus.ASSIGNING),
+                new Timestamp(now.minus(ASSIGNING_TIMEOUT).toEpochMilli())))
         .forEach(
             entry -> {
               log.warning(
@@ -158,6 +154,30 @@ public class BillingProjectBufferService {
               entry.setStatusEnum(BufferEntryStatus.ERROR, this::getCurrentTimestamp);
               billingProjectBufferEntryDao.save(entry);
             });
+  }
+
+  private List<DbBillingProjectBufferEntry> findExpiredCreatingEntries(Instant now) {
+    return billingProjectBufferEntryDao
+        .findAllByStatusAndLastStatusChangedTimeLessThan(
+            DbStorageEnums.billingProjectBufferEntryStatusToStorage(BufferEntryStatus.CREATING),
+            new Timestamp(now.minus(CREATING_TIMEOUT).toEpochMilli()))
+        .stream()
+        // Ensure that we've also synchronized the status since the deadline elapsed. This
+        // covers degenerate cases where syncBillingProjectStatus might be backlogged and
+        // hasn't caught up to check all the CREATING projects, or covers periods where
+        // the Firecloud API is unresponsive. Ideally we'd push this logic directly down
+        // into the DAO, but JPQL has poor support for date comparisons. Keep the above
+        // filter as well as a first pass filter to limit what we pull into memory.
+        .filter(entry -> entry.getLastStatusChangedTime() != null)
+        .filter(entry -> entry.getLastSyncRequestTime() != null)
+        .filter(
+            entry ->
+                Duration.between(
+                            entry.getLastStatusChangedTime().toInstant(),
+                            entry.getLastSyncRequestTime().toInstant())
+                        .toMillis()
+                    >= CREATING_TIMEOUT.toMillis())
+        .collect(Collectors.toList());
   }
 
   public DbBillingProjectBufferEntry assignBillingProject(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -142,7 +142,8 @@ public class BillingProjectBufferService {
             // For the ASSIGNING status monitor, we can simply filter by the current time as this
             // status tracks internal state rather than the Firecloud status.
             billingProjectBufferEntryDao.findAllByStatusAndLastStatusChangedTimeLessThan(
-                DbStorageEnums.billingProjectBufferEntryStatusToStorage(BufferEntryStatus.ASSIGNING),
+                DbStorageEnums.billingProjectBufferEntryStatusToStorage(
+                    BufferEntryStatus.ASSIGNING),
                 new Timestamp(now.minus(ASSIGNING_TIMEOUT).toEpochMilli())))
         .forEach(
             entry -> {


### PR DESCRIPTION
Per slack discussion, comparing to the current time may not be correct given:
- large sets of billing projects (syncBillingProjectBuffer may not visit all projects within the deadline)
- Firecloud API errors, or extended outages

Transitions in either of these cases would result in leaked billing projects.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
