### PR TITLE
[risk=no] Attempt fix for failing UI test

### DIFF
--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -181,20 +181,22 @@ export function stripHtml(string: string) {
 }
 
 export function getChartObj(chartObj: any) {
-  this.chart = chartObj;
-  const chartRef = this.chart.container.parentElement;
-  if (this.chart && typeof ResizeObserver === 'function') {
+  if (chartObj && typeof ResizeObserver === 'function') {
     // Unbind window.onresize handler so we don't do double redraws
-    if (this.chart.unbindReflow) {
-      this.chart.unbindReflow();
+    if (chartObj.unbindReflow) {
+      chartObj.unbindReflow();
     }
-    // create observer to redraw charts on div resize
-    const ro = new ResizeObserver(() => {
-      if (this.chart) {
-        this.chart.reflow();
-      }
-    });
-    ro.observe(chartRef);
+    const chartRef = chartObj.container.parentElement;
+    // check that chartRef is of type Element
+    if (chartRef && chartRef.tagName) {
+      // create observer to redraw charts on div resize
+      const ro = new ResizeObserver(() => {
+        if (chartObj) {
+          chartObj.reflow();
+        }
+      });
+      ro.observe(chartRef);
+    }
   }
 }
 


### PR DESCRIPTION
Seems flaky and fails tests for random components with the error message:

```
HeadlessChrome 70.0.3538 (Linux 0.0.0) ERROR
  {
    "message": "An error was thrown in afterAll\nUncaught TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'.",
    "str": "An error was thrown in afterAll\nUncaught TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'."
  }
HeadlessChrome 70.0.3538 (Linux 0.0.0): Executed 22 of 41 ERROR (0 secs / 7.39 secs)
HeadlessChrome 70.0.3538 (Linux 0.0.0) ERROR
  {
    "message": "An error was thrown in afterAll\nUncaught TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'.",
    "str": "An error was thrown in afterAll\nUncaught TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'."
  }
```