### PR TITLE
[RW-3972][risk=no] Fix height for CB graphs

### DIFF
--- a/ui/src/app/cohort-common/combo-chart/combo-chart.component.tsx
+++ b/ui/src/app/cohort-common/combo-chart/combo-chart.component.tsx
@@ -35,9 +35,10 @@ export class ComboChart extends React.Component<Props, State> {
     const {mode} = this.props;
     const normalized = mode === 'normalized';
     const {categories, series} = this.getCategoriesAndSeries();
+    const height = Math.max(categories.length * 30, 200);
     const options = {
       chart: {
-        height: 250,
+        height,
         type: 'bar'
       },
       credits: {

--- a/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
+++ b/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
@@ -33,9 +33,10 @@ export class GenderChart extends React.Component<Props, State> {
 
   getChartOptions() {
     const {categories, data} = this.getCategoriesAndData();
+    const height = Math.max(categories.length * 30, 200);
     const options = {
       chart: {
-        height: 200,
+        height,
         type: 'bar'
       },
       credits: {


### PR DESCRIPTION
Sets height for graphs based on the number of labels on the vertical axis, with a minimum of 200px. Prevents missing labels when there are too many categories, as seen in bottom chart in the attached screenshot:
![Screen Shot 2019-11-12 at 2 31 19 PM](https://user-images.githubusercontent.com/40036095/68708360-2a696580-0559-11ea-92e7-6939a5f1de69.png)
 The data is correct but the chart looks wrong because there are more bars than labels.