### PR TITLE
[risk=no][RW-3843] Refactor out usages of @VisibleForTesting for Spring Providers

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -16,13 +16,11 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import javax.inject.Provider;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.SearchGroupItemQueryBuilder;
 import org.pmiops.workbench.cohortreview.CohortReviewServiceImpl;
@@ -133,8 +131,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   @Autowired private CohortReviewDao cohortReviewDao;
 
-  @Autowired private DataSetService dataSetService;
-
   @Autowired private WorkspaceDao workspaceDao;
 
   @Autowired private CdrVersionDao cdrVersionDao;
@@ -144,8 +140,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   @Autowired private FireCloudService mockFireCloudService;
 
   @Autowired private UserDao userDao;
-
-  @Mock private Provider<DbUser> userProvider;
 
   private DbCohort cohort;
   private DbCohortReview review;
@@ -171,8 +165,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
     user = userDao.save(user);
     currentUser = user;
-    when(userProvider.get()).thenReturn(user);
-    controller.setUserProvider(userProvider);
 
     when(mockFireCloudService.getWorkspaceAcl(anyString(), anyString()))
         .thenReturn(
@@ -674,7 +666,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     WorkspaceAccessEntry accessLevelEntry =
         new WorkspaceAccessEntry().accessLevel(WorkspaceAccessLevel.WRITER.toString());
     Map<String, WorkspaceAccessEntry> userEmailToAccessEntry =
-        ImmutableMap.of(userProvider.get().getEmail(), accessLevelEntry);
+        ImmutableMap.of(currentUser.getEmail(), accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
     when(mockFireCloudService.getWorkspaceAcl(NAMESPACE, NAME))
         .thenReturn(workspaceAccessLevelResponse);

--- a/api/src/main/java/org/pmiops/workbench/api/CdrVersionsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CdrVersionsController.java
@@ -39,11 +39,6 @@ public class CdrVersionsController implements CdrVersionsApiDelegate {
     this.userProvider = userProvider;
   }
 
-  @VisibleForTesting
-  void setUserProvider(Provider<DbUser> userProvider) {
-    this.userProvider = userProvider;
-  }
-
   @Override
   public ResponseEntity<CdrVersionListResponse> getCdrVersions() {
     // TODO: Consider filtering this based on what is currently instantiated as a data source. Newly

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -28,7 +28,6 @@ import static org.pmiops.workbench.model.FilterColumns.VISIT_TYPE;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.TableResult;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -245,11 +244,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     this.userRecentResourceService = userRecentResourceService;
     this.userProvider = userProvider;
     this.clock = clock;
-  }
-
-  @VisibleForTesting
-  public void setUserProvider(Provider<DbUser> userProvider) {
-    this.userProvider = userProvider;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -118,11 +118,6 @@ public class CohortsController implements CohortsApiDelegate {
     this.userRecentResourceService = userRecentResourceService;
   }
 
-  @VisibleForTesting
-  public void setUserProvider(Provider<DbUser> userProvider) {
-    this.userProvider = userProvider;
-  }
-
   private void checkForDuplicateCohortNameException(String newCohortName, DbWorkspace workspace) {
     if (cohortDao.findCohortByNameAndWorkspaceId(newCohortName, workspace.getWorkspaceId())
         != null) {

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -127,11 +127,6 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     this.maxConceptsPerSet = MAX_CONCEPTS_PER_SET;
   }
 
-  @VisibleForTesting
-  public void setUserProvider(Provider<DbUser> userProvider) {
-    this.userProvider = userProvider;
-  }
-
   @Override
   public ResponseEntity<ConceptSet> createConceptSet(
       String workspaceNamespace, String workspaceId, CreateConceptSetRequest request) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.conceptset;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
@@ -41,10 +40,5 @@ public class ConceptSetService {
     // Allows for fetching concept sets for a workspace once its collection is no longer
     // bound to a session.
     return conceptSetDao.findByWorkspaceId(workspace.getWorkspaceId());
-  }
-
-  @VisibleForTesting
-  public void setConceptSetDao(ConceptSetDao conceptSetDao) {
-    this.conceptSetDao = conceptSetDao;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -146,11 +146,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   @VisibleForTesting
-  public void setUserProvider(Provider<DbUser> userProvider) {
-    this.userProvider = userProvider;
-  }
-
-  @VisibleForTesting
   void setWorkbenchConfigProvider(Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.workbenchConfigProvider = workbenchConfigProvider;
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -145,11 +145,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     this.workspaceAuditAdapter = workspaceAuditAdapter;
   }
 
-  @VisibleForTesting
-  void setWorkbenchConfigProvider(Provider<WorkbenchConfig> workbenchConfigProvider) {
-    this.workbenchConfigProvider = workbenchConfigProvider;
-  }
-
   private String getRegisteredUserDomainEmail() {
     ManagedGroupWithMembers registeredDomainGroup =
         fireCloudService.getGroup(workbenchConfigProvider.get().firecloud.registeredDomainName);

--- a/api/src/test/java/org/pmiops/workbench/api/CdrVersionsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CdrVersionsControllerTest.java
@@ -16,7 +16,6 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.CdrVersionListResponse;
 import org.pmiops.workbench.model.DataAccessLevel;
-import org.pmiops.workbench.test.Providers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -25,6 +24,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -45,17 +45,16 @@ public class CdrVersionsControllerTest {
 
   private CdrVersion defaultCdrVersion;
   private CdrVersion protectedCdrVersion;
-  private DbUser user;
+  private static DbUser user;
 
   @TestConfiguration
   @Import({CdrVersionService.class, CdrVersionsController.class})
   @MockBean({FireCloudService.class})
   static class Configuration {
     @Bean
+    @Scope("prototype")
     public DbUser user() {
-      // Allows for wiring of the initial Provider<User>; actual mocking of the
-      // user is achieved via setUserProvider().
-      return null;
+      return user;
     }
 
     @Bean
@@ -68,7 +67,7 @@ public class CdrVersionsControllerTest {
   public void setUp() {
     user = new DbUser();
     user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
-    cdrVersionsController.setUserProvider(Providers.of(user));
+
     defaultCdrVersion =
         makeCdrVersion(
             1L, /* isDefault */ true, "Test Registered CDR", 123L, DataAccessLevel.REGISTERED);

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -23,11 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import javax.inject.Provider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
@@ -144,8 +142,6 @@ public class CohortReviewControllerTest {
 
   @Autowired private UserDao userDao;
 
-  @Mock private Provider<DbUser> userProvider;
-
   private enum TestDemo {
     ASIAN("Asian", 8515),
     WHITE("White", 8527),
@@ -170,6 +166,8 @@ public class CohortReviewControllerTest {
     }
   }
 
+  private static DbUser user;
+
   @TestConfiguration
   @Import({CdrVersionService.class, CohortReviewController.class})
   @MockBean({
@@ -183,18 +181,21 @@ public class CohortReviewControllerTest {
     Clock clock() {
       return CLOCK;
     }
+
+    @Bean
+    DbUser user() {
+      return user;
+    }
   }
 
   @Before
   public void setUp() {
-    DbUser user = new DbUser();
+    user = new DbUser();
     user.setEmail("bob@gmail.com");
     user.setUserId(123L);
     user.setDisabled(false);
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
     user = userDao.save(user);
-    when(userProvider.get()).thenReturn(user);
-    cohortReviewController.setUserProvider(userProvider);
 
     cbCriteriaDao.save(
         new CBCriteria()

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -16,13 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import javax.inject.Provider;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.pmiops.workbench.actionaudit.adapters.WorkspaceAuditAdapter;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.cdr.CdrVersionService;
@@ -166,7 +164,6 @@ public class CohortsControllerTest {
   @Autowired UserRecentResourceService userRecentResourceService;
   @Autowired UserDao userDao;
   @Autowired CohortMaterializationService cohortMaterializationService;
-  @Mock Provider<DbUser> userProvider;
   @Autowired FireCloudService fireCloudService;
   @Autowired UserService userService;
   @Autowired CloudStorageService cloudStorageService;
@@ -238,10 +235,6 @@ public class CohortsControllerTest {
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
     user = userDao.save(user);
     currentUser = user;
-    when(userProvider.get()).thenReturn(user);
-    workspacesController.setUserProvider(userProvider);
-    cohortsController.setUserProvider(userProvider);
-    conceptSetsController.setUserProvider(userProvider);
 
     cdrVersion = new CdrVersion();
     cdrVersion.setName(CDR_VERSION_NAME);

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -195,7 +195,7 @@ public class ConceptSetsControllerTest {
 
   @Autowired FireCloudService fireCloudService;
 
-  private ConceptSetsController conceptSetsController;
+  @Autowired ConceptSetsController conceptSetsController;
 
   @Autowired UserRecentResourceService userRecentResourceService;
 
@@ -204,6 +204,8 @@ public class ConceptSetsControllerTest {
   @Mock Provider<DbUser> userProvider;
 
   @Autowired Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  @Autowired WorkspacesController workspacesController;
 
   @Autowired WorkspaceAuditAdapter workspaceAuditAdapter;
 
@@ -259,30 +261,6 @@ public class ConceptSetsControllerTest {
   public void setUp() throws Exception {
     testMockFactory = new TestMockFactory();
 
-    conceptSetsController =
-        new ConceptSetsController(
-            workspaceService,
-            conceptSetDao,
-            conceptDao,
-            conceptBigQueryService,
-            userRecentResourceService,
-            userProvider,
-            CLOCK);
-    WorkspacesController workspacesController =
-        new WorkspacesController(
-            billingProjectBufferService,
-            workspaceService,
-            cdrVersionDao,
-            userDao,
-            userProvider,
-            fireCloudService,
-            cloudStorageService,
-            CLOCK,
-            notebooksService,
-            userService,
-            workbenchConfigProvider,
-            workspaceAuditAdapter);
-
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);
     testMockFactory.stubCreateFcWorkspace(fireCloudService);
 
@@ -293,7 +271,6 @@ public class ConceptSetsControllerTest {
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
     user = userDao.save(user);
     currentUser = user;
-    when(userProvider.get()).thenReturn(user);
 
     CdrVersion cdrVersion = new CdrVersion();
     cdrVersion.setName("1");
@@ -315,9 +292,6 @@ public class ConceptSetsControllerTest {
     workspace2.setDataAccessLevel(DataAccessLevel.PROTECTED);
     workspace2.setResearchPurpose(new ResearchPurpose());
     workspace2.setCdrVersionId(String.valueOf(cdrVersion.getCdrVersionId()));
-
-    workspacesController.setUserProvider(userProvider);
-    conceptSetsController.setUserProvider(userProvider);
 
     workspace = workspacesController.createWorkspace(workspace).getBody();
     workspace2 = workspacesController.createWorkspace(workspace2).getBody();

--- a/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
@@ -36,21 +36,19 @@ public class ConceptSetServiceTest {
   @Autowired ConceptSetService conceptSetService;
 
   @TestConfiguration
-  @Import({
-    ConceptSetService.class,
-  })
+  @Import({ConceptSetService.class})
   @MockBean({ConceptBigQueryService.class})
   static class Configuration {}
 
   @Test
   public void testCloneConceptSetWithNoCdrVersionChange() {
-    DbWorkspace workspace = mockWorkspace();
+    DbWorkspace mockDbWorkspace = mockWorkspace();
     DbConceptSet fromConceptSet = mockConceptSet();
     DbConceptSet copiedConceptSet =
-        conceptSetService.cloneConceptSetAndConceptIds(fromConceptSet, workspace, false);
+        conceptSetService.cloneConceptSetAndConceptIds(fromConceptSet, mockDbWorkspace, false);
     assertNotNull(copiedConceptSet);
     assertEquals(copiedConceptSet.getConceptIds().size(), 5);
-    assertEquals(copiedConceptSet.getWorkspaceId(), workspace.getWorkspaceId());
+    assertEquals(copiedConceptSet.getWorkspaceId(), mockDbWorkspace.getWorkspaceId());
   }
 
   private DbConceptSet mockConceptSet() {

--- a/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
@@ -7,10 +7,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -19,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -30,22 +31,20 @@ import org.springframework.test.context.junit4.SpringRunner;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ConceptSetServiceTest {
 
-  @Autowired private ConceptSetDao conceptSetDao;
+  @Autowired WorkspaceDao workspaceDao;
 
-  @Autowired private WorkspaceDao workspaceDao;
+  @Autowired ConceptSetService conceptSetService;
 
-  private ConceptSetService conceptSetService;
-  private DbWorkspace workspace;
-
-  @Before
-  public void setUp() {
-    conceptSetService = new ConceptSetService();
-    conceptSetService.setConceptSetDao(conceptSetDao);
-    workspace = mockWorkspace();
-  }
+  @TestConfiguration
+  @Import({
+    ConceptSetService.class,
+  })
+  @MockBean({ConceptBigQueryService.class})
+  static class Configuration {}
 
   @Test
   public void testCloneConceptSetWithNoCdrVersionChange() {
+    DbWorkspace workspace = mockWorkspace();
     DbConceptSet fromConceptSet = mockConceptSet();
     DbConceptSet copiedConceptSet =
         conceptSetService.cloneConceptSetAndConceptIds(fromConceptSet, workspace, false);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -269,15 +269,15 @@ public class WorkspacesControllerTest {
     }
 
     @Bean
+    @Scope("prototype")
     WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
       return workbenchConfig;
     }
   }
 
   private static DbUser currentUser;
   private static WorkspaceACL fcWorkspaceAcl;
+  private static WorkbenchConfig workbenchConfig;
   @Autowired FireCloudService fireCloudService;
   @Autowired private WorkspaceService workspaceService;
   @Autowired CloudStorageService cloudStorageService;
@@ -307,6 +307,9 @@ public class WorkspacesControllerTest {
 
   @Before
   public void setUp() {
+    workbenchConfig = new WorkbenchConfig();
+    workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
+
     testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
     cdrVersion = new CdrVersion();
@@ -330,13 +333,9 @@ public class WorkspacesControllerTest {
 
     CLOCK.setInstant(NOW.toInstant());
 
-    WorkbenchConfig testConfig = new WorkbenchConfig();
-    testConfig.firecloud = new WorkbenchConfig.FireCloudConfig();
-    testConfig.firecloud.registeredDomainName = "allUsers";
-    testConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
-    when(configProvider.get()).thenReturn(testConfig);
+    workbenchConfig.firecloud = new WorkbenchConfig.FireCloudConfig();
+    workbenchConfig.firecloud.registeredDomainName = "allUsers";
 
-    workspacesController.setWorkbenchConfigProvider(configProvider);
     fcWorkspaceAcl = createWorkspaceACL();
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);
     testMockFactory.stubCreateFcWorkspace(fireCloudService);


### PR DESCRIPTION
We found a better way to dynamically change the value provided by Spring Providers in tests that no longer relies on exposing a test only method on our controllers.

To expand on the point above, we used to use a pattern of exposing a `setXProvider` methods on our service/controller classes for the sole purpose of being able to modify the provided value in tests.
ex. `@VisibleForTesting setUserProvider(Provider<User> userProvider) {}`.

We would use this in our tests by creating a provider to return the value we wanted to test and calling the `setUserProvider` method with our mocked provider.

We believe this was necessary because Spring would essentially treat values returned through the `Provider` mechanism as an immutable singleton, so it would cache the initialized value and return that as needed. The `@Scope("prototype")` annotation tells Spring that we can have multiple values for a given Bean so it should fetch the latest version.

^This might be an oversimplification of what's going on but I think its a valid mental model for how Spring DI is behaving within our tests.

https://docs.spring.io/spring/docs/3.0.0.M3/reference/html/ch04s04.html

Most of the changes are regarding the above but I took some liberty to refactor code smells I found along the way including...
- not using `Autowiring` for object initialization
- other usages of unnecessary setting/VisibleForTest