### PR TITLE
[risk=low][RW-3982] Create project.rb tool to get workspace details from project ID

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -627,6 +627,16 @@ task fetchFireCloudUserProfile(type: JavaExec) {
   }
 }
 
+// See project.rb command: fetch-workspace-details
+task fetchWorkspaceDetails(type: JavaExec) {
+  classpath = sourceSets.tools.runtimeClasspath
+  main = "org.pmiops.workbench.tools.FetchWorkspaceDetails"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
 // This task is called from a few different places:
 // - devstart.rb > load_config (used by "deploy" and "update_cloud_config" commands)
 // - directly via gradlew (used by "run-local-migrations" command)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1135,7 +1135,7 @@ def fetch_workspace_details(cmd_name, *args)
       "--projectId=[projectId]",
       String,
       ->(opts, v) { opts.projectId = v},
-      "The Workspace to fetch details for (e.g. 'aou-rw-231823128'")
+      "Fetches details for workspace(s) that match the given project ID / namespace (e.g. 'aou-rw-231823128'")
 
   # Create a cloud context and apply the DB connection variables to the environment.
   # These will be read by Gradle and passed as Spring Boot properties to the command-line.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -43,6 +43,8 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long> {
 
   List<DbWorkspace> findAllByWorkspaceIdIn(Collection<Long> dbIds);
 
+  List<DbWorkspace> findAllByWorkspaceNamespace(String workspaceNamespace);
+
   List<DbWorkspace> findAllByBillingMigrationStatus(Short billingMigrationStatus);
 
   default List<DbWorkspace> findAllByBillingMigrationStatus(BillingMigrationStatus status) {

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
@@ -143,7 +143,7 @@ public class BackfillBillingProjectUsers {
 
       backfill(
           apiFactory.workspacesApi(),
-          apiFactory.newBillingApi(),
+          apiFactory.billingApi(),
           opts.getOptionValue(billingProjectPrefixOpt.getLongOpt()),
           opts.hasOption(dryRunOpt.getLongOpt()));
     };

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectUsers.java
@@ -1,12 +1,9 @@
 package org.pmiops.workbench.tools;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -15,7 +12,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.pmiops.workbench.firecloud.ApiClient;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
@@ -142,7 +138,8 @@ public class BackfillBillingProjectUsers {
     return (args) -> {
       CommandLine opts = new DefaultParser().parse(options, args);
 
-      ServiceAccountAPIClientFactory apiFactory = new ServiceAccountAPIClientFactory(opts.getOptionValue(fcBaseUrlOpt.getLongOpt()));
+      ServiceAccountAPIClientFactory apiFactory =
+          new ServiceAccountAPIClientFactory(opts.getOptionValue(fcBaseUrlOpt.getLongOpt()));
 
       backfill(
           apiFactory.workspacesApi(),

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.tools;
 
 import java.util.Arrays;
 import java.util.logging.Logger;
-import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.ApiClient;
@@ -34,8 +33,7 @@ public class FetchFireCloudUserProfile {
       Logger.getLogger(org.pmiops.workbench.tools.FetchFireCloudUserProfile.class.getName());
 
   @Bean
-  public CommandLineRunner run(
-      UserDao userDao, FireCloudService fireCloudService) {
+  public CommandLineRunner run(UserDao userDao, FireCloudService fireCloudService) {
     return (args) -> {
       if (args.length != 1) {
         throw new IllegalArgumentException("Expected 1 arg (username). Got " + Arrays.asList(args));

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -35,7 +35,7 @@ public class FetchFireCloudUserProfile {
 
   @Bean
   public CommandLineRunner run(
-      UserDao userDao, WorkbenchConfig workbenchConfig, FireCloudService fireCloudService) {
+      UserDao userDao, FireCloudService fireCloudService) {
     return (args) -> {
       if (args.length != 1) {
         throw new IllegalArgumentException("Expected 1 arg (username). Got " + Arrays.asList(args));

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -1,0 +1,104 @@
+package org.pmiops.workbench.tools;
+
+import static org.pmiops.workbench.tools.BackfillBillingProjectUsers.extractAclResponse;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.firecloud.ApiClient;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.api.NihApi;
+import org.pmiops.workbench.firecloud.api.ProfileApi;
+import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+import org.pmiops.workbench.firecloud.model.Me;
+import org.pmiops.workbench.firecloud.model.NihStatus;
+import org.pmiops.workbench.firecloud.model.WorkspaceACL;
+import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * A tool that takes an AoU username (e.g. gjordan) and fetches the FireCloud profile associated
+ * with that AoU user.
+ *
+ * <p>This is intended mostly for demonstration / testing purposes, to show how we leverage
+ * domain-wide delegation to make FireCloud API calls impersonating other users.
+ */
+@SpringBootApplication
+// Load the DBA and DB model classes required for UserDao.
+@EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
+@EntityScan("org.pmiops.workbench.db.model")
+public class FetchWorkspaceDetails {
+  private static final Logger log =
+      Logger.getLogger(FetchWorkspaceDetails.class.getName());
+
+  private static Option fcBaseUrlOpt =
+      Option.builder()
+          .longOpt("fc-base-url")
+          .desc("Firecloud API base URL")
+          .required()
+          .hasArg()
+          .build();
+
+  private static Option projectIdOpt =
+      Option.builder()
+          .longOpt("projectId")
+          .desc("Billing project ID")
+          .required()
+          .hasArg()
+          .build();
+
+  private static Options options = new Options().addOption(fcBaseUrlOpt).addOption(projectIdOpt);
+
+  @Bean
+  public CommandLineRunner run(
+      WorkspaceDao workspaceDao) {
+    return (args) -> {
+      CommandLine opts = new DefaultParser().parse(options, args);
+
+      WorkspacesApi workspacesApi = (new ServiceAccountAPIClientFactory(opts.getOptionValue(fcBaseUrlOpt.getLongOpt()))).workspacesApi();
+
+      StringBuilder sb = new StringBuilder();
+      sb.append(String.join("\n", Collections.nCopies(10, "***")));
+
+      for (DbWorkspace workspace : workspaceDao.findAllByWorkspaceNamespace(opts.getOptionValue(projectIdOpt.getLongOpt()))) {
+        Map<String, WorkspaceAccessEntry> acl =
+            extractAclResponse(workspacesApi.getWorkspaceAcl(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()));
+
+        sb.append("\nWorkspace Name: " + workspace.getName() + "\n");
+        sb.append("Workspace Namespace: " + workspace.getWorkspaceNamespace() + "\n");
+        sb.append("Creator: " + workspace.getCreator().getEmail() + "\n");
+        sb.append("Collaborators:\n");
+        for (Map.Entry<String, WorkspaceAccessEntry> aclEntry : acl.entrySet()) {
+          sb.append("\t" +  aclEntry.getKey() + " (" + aclEntry.getValue().getAccessLevel() + ")\n");
+        }
+
+        sb.append(String.join("\n", Collections.nCopies(3, "***")));
+      }
+
+      log.info(sb.toString());
+    };
+  }
+
+  public static void main(String[] args) {
+    new SpringApplicationBuilder(FetchWorkspaceDetails.class).web(false).run(args);
+  }
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -2,12 +2,6 @@ package org.pmiops.workbench.tools;
 
 import static org.pmiops.workbench.tools.BackfillBillingProjectUsers.extractAclResponse;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -15,18 +9,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.firecloud.ApiClient;
-import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.api.NihApi;
-import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
-import org.pmiops.workbench.firecloud.model.Me;
-import org.pmiops.workbench.firecloud.model.NihStatus;
-import org.pmiops.workbench.firecloud.model.WorkspaceACL;
 import org.pmiops.workbench.firecloud.model.WorkspaceAccessEntry;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -47,8 +32,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
 @EntityScan("org.pmiops.workbench.db.model")
 public class FetchWorkspaceDetails {
-  private static final Logger log =
-      Logger.getLogger(FetchWorkspaceDetails.class.getName());
+  private static final Logger log = Logger.getLogger(FetchWorkspaceDetails.class.getName());
 
   private static Option fcBaseUrlOpt =
       Option.builder()
@@ -59,36 +43,36 @@ public class FetchWorkspaceDetails {
           .build();
 
   private static Option projectIdOpt =
-      Option.builder()
-          .longOpt("projectId")
-          .desc("Billing project ID")
-          .required()
-          .hasArg()
-          .build();
+      Option.builder().longOpt("projectId").desc("Billing project ID").required().hasArg().build();
 
   private static Options options = new Options().addOption(fcBaseUrlOpt).addOption(projectIdOpt);
 
   @Bean
-  public CommandLineRunner run(
-      WorkspaceDao workspaceDao) {
+  public CommandLineRunner run(WorkspaceDao workspaceDao) {
     return (args) -> {
       CommandLine opts = new DefaultParser().parse(options, args);
 
-      WorkspacesApi workspacesApi = (new ServiceAccountAPIClientFactory(opts.getOptionValue(fcBaseUrlOpt.getLongOpt()))).workspacesApi();
+      WorkspacesApi workspacesApi =
+          (new ServiceAccountAPIClientFactory(opts.getOptionValue(fcBaseUrlOpt.getLongOpt())))
+              .workspacesApi();
 
       StringBuilder sb = new StringBuilder();
       sb.append(String.join("\n", Collections.nCopies(10, "***")));
 
-      for (DbWorkspace workspace : workspaceDao.findAllByWorkspaceNamespace(opts.getOptionValue(projectIdOpt.getLongOpt()))) {
+      for (DbWorkspace workspace :
+          workspaceDao.findAllByWorkspaceNamespace(
+              opts.getOptionValue(projectIdOpt.getLongOpt()))) {
         Map<String, WorkspaceAccessEntry> acl =
-            extractAclResponse(workspacesApi.getWorkspaceAcl(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()));
+            extractAclResponse(
+                workspacesApi.getWorkspaceAcl(
+                    workspace.getWorkspaceNamespace(), workspace.getFirecloudName()));
 
         sb.append("\nWorkspace Name: " + workspace.getName() + "\n");
         sb.append("Workspace Namespace: " + workspace.getWorkspaceNamespace() + "\n");
         sb.append("Creator: " + workspace.getCreator().getEmail() + "\n");
         sb.append("Collaborators:\n");
         for (Map.Entry<String, WorkspaceAccessEntry> aclEntry : acl.entrySet()) {
-          sb.append("\t" +  aclEntry.getKey() + " (" + aclEntry.getValue().getAccessLevel() + ")\n");
+          sb.append("\t" + aclEntry.getKey() + " (" + aclEntry.getValue().getAccessLevel() + ")\n");
         }
 
         sb.append(String.join("\n", Collections.nCopies(3, "***")));

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -21,19 +21,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
- * A tool that takes a Workspace namespace / Firecloud Project ID and returns details for
- * any workspaces found.
+ * A tool that takes a Workspace namespace / Firecloud Project ID and returns details for any
+ * workspaces found.
  *
- * Details currently include...
- * - Name
- * - Creator Email
- * - Collaborator Emails and Access Levels
+ * <p>Details currently include... - Name - Creator Email - Collaborator Emails and Access Levels
  */
 @SpringBootApplication
 @EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
 @EntityScan("org.pmiops.workbench.db.model")
 public class FetchWorkspaceDetails {
-  
+
   private static final Logger log = Logger.getLogger(FetchWorkspaceDetails.class.getName());
 
   private static Option fcBaseUrlOpt =

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -21,17 +21,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
- * A tool that takes an AoU username (e.g. gjordan) and fetches the FireCloud profile associated
- * with that AoU user.
+ * A tool that takes a Workspace namespace / Firecloud Project ID and returns details for
+ * any workspaces found.
  *
- * <p>This is intended mostly for demonstration / testing purposes, to show how we leverage
- * domain-wide delegation to make FireCloud API calls impersonating other users.
+ * Details currently include...
+ * - Name
+ * - Creator Email
+ * - Collaborator Emails and Access Levels
  */
 @SpringBootApplication
-// Load the DBA and DB model classes required for UserDao.
 @EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
 @EntityScan("org.pmiops.workbench.db.model")
 public class FetchWorkspaceDetails {
+  
   private static final Logger log = Logger.getLogger(FetchWorkspaceDetails.class.getName());
 
   private static Option fcBaseUrlOpt =

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
@@ -1,0 +1,47 @@
+package org.pmiops.workbench.tools;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import java.io.IOException;
+import java.util.Arrays;
+import org.pmiops.workbench.firecloud.ApiClient;
+import org.pmiops.workbench.firecloud.api.BillingApi;
+import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+
+public class ServiceAccountAPIClientFactory {
+
+  final String apiUrl;
+
+  private static final String[] FC_SCOPES =
+      new String[] {
+          "https://www.googleapis.com/auth/userinfo.profile",
+          "https://www.googleapis.com/auth/userinfo.email"
+      };
+
+
+  public ServiceAccountAPIClientFactory(String apiUrl) {
+    this.apiUrl = apiUrl;
+  }
+
+  private ApiClient newApiClient(String apiUrl) throws IOException {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(apiUrl);
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault().createScoped(Arrays.asList(FC_SCOPES));
+    credential.refreshToken();
+    apiClient.setAccessToken(credential.getAccessToken());
+    return apiClient;
+  }
+
+  public WorkspacesApi workspacesApi() throws IOException {
+    WorkspacesApi api = new WorkspacesApi();
+    api.setApiClient(newApiClient(apiUrl));
+    return api;
+  }
+
+  public BillingApi newBillingApi() throws IOException {
+    BillingApi api = new BillingApi();
+    api.setApiClient(newApiClient(apiUrl));
+    return api;
+  }
+
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
@@ -13,10 +13,9 @@ public class ServiceAccountAPIClientFactory {
 
   private static final String[] FC_SCOPES =
       new String[] {
-          "https://www.googleapis.com/auth/userinfo.profile",
-          "https://www.googleapis.com/auth/userinfo.email"
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "https://www.googleapis.com/auth/userinfo.email"
       };
-
 
   public ServiceAccountAPIClientFactory(String apiUrl) {
     this.apiUrl = apiUrl;
@@ -43,5 +42,4 @@ public class ServiceAccountAPIClientFactory {
     api.setApiClient(newApiClient(apiUrl));
     return api;
   }
-
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ServiceAccountAPIClientFactory.java
@@ -37,7 +37,7 @@ public class ServiceAccountAPIClientFactory {
     return api;
   }
 
-  public BillingApi newBillingApi() throws IOException {
+  public BillingApi billingApi() throws IOException {
     BillingApi api = new BillingApi();
     api.setApiClient(newApiClient(apiUrl));
     return api;


### PR DESCRIPTION
This adds a new project.rb tool which can take a Firecloud Project ID or workspace namespace and output workspace details (creator + collaborator emails).

Example Input
`./project.rb fetch-workspace-details --project all-of-us-workbench-test --projectId=aou-rw-test-3f23b78e`

Example output
```
***
***
***
Workspace Name: Should be seen
Workspace Namespace: aou-rw-test-3f23b78e
Creator: ericsong3@fake-research-aou.org
Collaborators:
        ericsong3@fake-research-aou.org (OWNER)
        ericsong@fake-research-aou.org (WRITER)
***
***
***
```