### PR TITLE
[risk=no] Don't populate signInStore when not signed in

### DIFF
--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -69,8 +69,8 @@ export class SignInService {
     this.zone.run(() => {
       const isSignedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
       this.isSignedIn.next(isSignedIn);
-      this.nextSignInStore();
       if (isSignedIn) {
+        this.nextSignInStore();
         this.clearIdToken();
       }
       setLoggedInState(isSignedIn);
@@ -78,8 +78,8 @@ export class SignInService {
     gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn: boolean) => {
       this.zone.run(() => {
         this.isSignedIn.next(isSignedIn);
-        this.nextSignInStore();
         if (isSignedIn) {
+          this.nextSignInStore();
           this.clearIdToken();
         }
       });


### PR DESCRIPTION
This currently generates a JS error whenever someone hits the site in the signed out state (see console). AFAICT it wasn't causing any actual user-facing issues.

```
Uncaught TypeError: Cannot read property 'getImageUrl' of undefined
    at SignInService.get [as profileImage] (sign-in.service.ts:106)
    at SignInService.push../src/app/services/sign-in.service.ts.SignInService.nextSignInStore (sign-in.service.ts:113)
    at sign-in.service.ts:72
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (zone.js:388)
    at Object.onInvoke (core.js:4760)
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (zone.js:387)
    at Zone.push../node_modules/zone.js/dist/zone.js.Zone.run (zone.js:138)
    at NgZone.push../node_modules/@angular/core/esm5/core.js.NgZone.run (core.js:4577)
    at SignInService.push../src/app/services/sign-in.service.ts.SignInService.subscribeToAuth2User (sign-in.service.ts:69)
    at sign-in.service.ts:53
get @ sign-in.service.ts:106
push../src/app/services/sign-in.service.ts.SignInService.nextSignInStore @ sign-in.service.ts:113
(anonymous) @ sign-in.service.ts:72
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke @ zone.js:388
onInvoke @ core.js:4760
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke @ zone.js:387
push../node_modules/zone.js/dist/zone.js.Zone.run @ zone.js:138
push../node_modules/@angular/core/esm5/core.js.NgZone.run @ core.js:4577
push../src/app/services/sign-in.service.ts.SignInService.subscribeToAuth2User @ sign-in.service.ts:69
(anonymous) @ sign-in.service.ts:53
(anonymous) @ cb=gapi.loaded_0:294
h.uJ @ cb=gapi.loaded_0:163
xs @ cb=gapi.loaded_0:166
Wq @ cb=gapi.loaded_0:166
_.C.uea @ cb=gapi.loaded_0:166
Ap @ cb=gapi.loaded_0:157
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke @ zone.js:388
push../node_modules/zone.js/dist/zone.js.Zone.run @ zone.js:138
(anonymous) @ zone.js:872
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask @ zone.js:421
push../node_modules/zone.js/dist/zone.js.Zone.runTask @ zone.js:188
drainMicroTaskQueue @ zone.js:595
push../node_modules/zone.js/dist/zone.js.ZoneTask.invokeTask @ zone.js:500
invokeTask @ zone.js:1540
globalZoneAwareCallback @ zone.js:1577
setTimeout (async)
scheduleTask @ zone.js:2075
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.scheduleTask @ zone.js:407
push../node_modules/zone.js/dist/zone.js.Zone.scheduleTask @ zone.js:232
push../node_modules/zone.js/dist/zone.js.Zone.scheduleMacroTask @ zone.js:255
scheduleMacroTaskWithCurrentZone @ zone.js:1114
(anonymous) @ zone.js:2090
proto.<computed> @ zone.js:1394
tp @ cb=gapi.loaded_0:151
(anonymous) @ cb=gapi.loaded_0:166
Ap @ cb=gapi.loaded_0:157
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke @ zone.js:388
push../node_modules/zone.js/dist/zone.js.Zone.run @ zone.js:138
(anonymous) @ zone.js:872
push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask @ zone.js:421
push../node_modules/zone.js/dist/zone.js.Zone.runTask @ zone.js:188
drainMicroTaskQueue @ zone.js:595
push../node_modules/zone.js/dist/zone.js.ZoneTask.invokeTask @ zone.js:500
invokeTask @ zone.js:1540
globalZoneAwareCallback @ zone.js:1577
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
