### PR TITLE
[RW-3771][risk=no] Move help tips sidebar into workspace wrapper

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -95,7 +95,8 @@ const routes: Routes = [
                 component: WorkspaceAboutComponent,
                 data: {
                   title: 'View Workspace Details',
-                  breadcrumb: BreadcrumbType.Workspace
+                  breadcrumb: BreadcrumbType.Workspace,
+                  helpContent: 'data'
                 }
               }, {
                 path: 'edit',
@@ -103,7 +104,8 @@ const routes: Routes = [
                 data: {
                   title: 'Edit Workspace',
                   mode: WorkspaceEditMode.Edit,
-                  breadcrumb: BreadcrumbType.WorkspaceEdit
+                  breadcrumb: BreadcrumbType.WorkspaceEdit,
+                  helpContent: 'data'
                 }
               }, {
                 path: 'duplicate',
@@ -111,7 +113,8 @@ const routes: Routes = [
                 data: {
                   title: 'Duplicate Workspace',
                   mode: WorkspaceEditMode.Duplicate,
-                  breadcrumb: BreadcrumbType.WorkspaceDuplicate
+                  breadcrumb: BreadcrumbType.WorkspaceDuplicate,
+                  helpContent: 'data'
                 }
               },
               {
@@ -122,7 +125,8 @@ const routes: Routes = [
                     component: NotebookListComponent,
                     data: {
                       title: 'View Notebooks',
-                      breadcrumb: BreadcrumbType.Workspace
+                      breadcrumb: BreadcrumbType.Workspace,
+                      helpContent: 'data'
                     }
                   }, {
                     path: ':nbName',
@@ -131,7 +135,8 @@ const routes: Routes = [
                       // use the (urldecoded) captured value nbName
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
-                      minimizeChrome: true
+                      minimizeChrome: true,
+                      helpContent: 'data'
                     }
                   }, {
                     path: 'preview/:nbName',
@@ -139,7 +144,8 @@ const routes: Routes = [
                     data: {
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
-                      minimizeChrome: true
+                      minimizeChrome: true,
+                      helpContent: 'data'
                     }
                   }
                 ]
@@ -152,7 +158,8 @@ const routes: Routes = [
                     component: DataPageComponent,
                     data: {
                       title: 'Data Page',
-                      breadcrumb: BreadcrumbType.Workspace
+                      breadcrumb: BreadcrumbType.Workspace,
+                      helpContent: 'data'
                     }
                   },
                   {
@@ -160,7 +167,8 @@ const routes: Routes = [
                     component: DataSetPageComponent,
                     data: {
                       title: 'Dataset Page',
-                      breadcrumb: BreadcrumbType.Dataset
+                      breadcrumb: BreadcrumbType.Dataset,
+                      helpContent: 'datasetBuilder'
                     }
                   },
                   {
@@ -168,7 +176,8 @@ const routes: Routes = [
                     component: DataSetPageComponent,
                     data: {
                       title: 'Edit Dataset',
-                      breadcrumb: BreadcrumbType.Dataset
+                      breadcrumb: BreadcrumbType.Dataset,
+                      helpContent: 'datasetBuilder'
                     }
                   }, {
                     path: 'cohorts',
@@ -178,7 +187,8 @@ const routes: Routes = [
                         component: CohortActionsComponent,
                         data: {
                           title: 'Cohort Actions',
-                          breadcrumb: BreadcrumbType.Cohort
+                          breadcrumb: BreadcrumbType.Cohort,
+                          helpContent: 'cohortBuilder'
                         },
                       },
                       {
@@ -193,21 +203,24 @@ const routes: Routes = [
                             component: CohortReviewComponent,
                             data: {
                               title: 'Review Cohort Participants',
-                              breadcrumb: BreadcrumbType.Cohort
+                              breadcrumb: BreadcrumbType.Cohort,
+                              helpContent: 'reviewParticipants'
                             }
                           }, {
                             path: 'participants',
                             component: TablePage,
                             data: {
                               title: 'Review Cohort Participants',
-                              breadcrumb: BreadcrumbType.Cohort
+                              breadcrumb: BreadcrumbType.Cohort,
+                              helpContent: 'reviewParticipants'
                             }
                           }, {
                             path: 'cohort-description',
                             component: QueryReportComponent,
                             data: {
                               title: 'Review Cohort Description',
-                              breadcrumb: BreadcrumbType.Cohort
+                              breadcrumb: BreadcrumbType.Cohort,
+                              helpContent: 'reviewParticipants'
                             }
                           }, {
                             path: 'participants/:pid',
@@ -215,7 +228,8 @@ const routes: Routes = [
                             data: {
                               title: 'Participant Detail',
                               breadcrumb: BreadcrumbType.Participant,
-                              shouldReuse: true
+                              shouldReuse: true,
+                              helpContent: 'reviewParticipantDetail'
                             }
                           }
                         ],
@@ -227,7 +241,8 @@ const routes: Routes = [
                     component: ConceptHomepageComponent,
                     data: {
                       title: 'Search Concepts',
-                      breadcrumb: BreadcrumbType.SearchConcepts
+                      breadcrumb: BreadcrumbType.SearchConcepts,
+                      helpContent: 'conceptSets'
                     }
                   },
                   {
@@ -237,14 +252,16 @@ const routes: Routes = [
                       component: ConceptSetDetailsComponent,
                       data: {
                         title: 'Concept Set',
-                        breadcrumb: BreadcrumbType.ConceptSet
+                        breadcrumb: BreadcrumbType.ConceptSet,
+                        helpContent: 'conceptSets'
                       },
                     }, {
                       path: ':csid/actions',
                       component: ConceptSetActionsComponent,
                       data: {
                         title: 'Concept Set Actions',
-                        breadcrumb: BreadcrumbType.ConceptSet
+                        breadcrumb: BreadcrumbType.ConceptSet,
+                        helpContent: 'conceptSets'
                       },
                     }, ]
                   }

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -144,7 +144,7 @@ const routes: Routes = [
                     data: {
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
-                      minimizeChrome: true,
+                      minimizeChrome: true
                     }
                   }
                 ]

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -145,7 +145,6 @@ const routes: Routes = [
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
                       minimizeChrome: true,
-                      helpContent: 'data'
                     }
                   }
                 ]

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -24,6 +24,7 @@ import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {BugReportComponent} from './components/bug-report';
 import {ErrorHandlerComponent} from './components/error-handler/component';
+import {HelpSidebarComponent} from './components/help-sidebar';
 import {RoutingSpinnerComponent} from './components/routing-spinner/component';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AdminUserComponent} from './pages/admin/admin-user';
@@ -144,6 +145,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     DataUseAgreementComponent,
     DetailPageComponent,
     ErrorHandlerComponent,
+    HelpSidebarComponent,
     InitialErrorComponent,
     InteractiveNotebookComponent,
     NotebookListComponent,

--- a/ui/src/app/cohort-search/cohort-search.module.ts
+++ b/ui/src/app/cohort-search/cohort-search.module.ts
@@ -8,7 +8,6 @@ import {NouisliderModule} from 'ng2-nouislider';
 import {NgxPopperModule} from 'ngx-popper';
 
 /* Components */
-import {HelpSidebarComponent} from 'app/components/help-sidebar';
 import {AttributesPageComponent} from './attributes-page/attributes-page.component';
 import {CohortSearchComponent} from './cohort-search/cohort-search.component';
 import {DemographicsComponent} from './demographics/demographics.component';
@@ -64,7 +63,6 @@ const routes: Routes = [{
     CohortSearchComponent,
     GenderChartComponent,
     DemographicsComponent,
-    HelpSidebarComponent,
     ModalComponent,
     ModifierPageComponent,
     NodeComponent,

--- a/ui/src/app/cohort-search/cohort-search.module.ts
+++ b/ui/src/app/cohort-search/cohort-search.module.ts
@@ -40,7 +40,8 @@ const routes: Routes = [{
   canDeactivate: [CanDeactivateGuard],
   data: {
     title: 'Build Cohort Criteria',
-    breadcrumb: BreadcrumbType.CohortAdd
+    breadcrumb: BreadcrumbType.CohortAdd,
+    helpContent: 'cohortBuilder'
   },
 }];
 

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.css
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.css
@@ -1,6 +1,5 @@
 .cohort-search-wrapper {
   padding: 1rem 1rem 2rem;
-  margin-right: 45px;
   position: relative;
 }
 .cohort-name {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
@@ -34,7 +34,6 @@
       Loading...
     </div>
   </div>
-  <app-help-sidebar location="cohortBuilder"></app-help-sidebar>
 </div>
 <app-list-modal></app-list-modal>
 <clr-modal [(clrModalOpen)]="modalOpen" [clrModalClosable]="false">

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -11,7 +11,7 @@ import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-r
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {HelpSidebar} from './help-sidebar';
 
-describe('SidebarContent', () => {
+describe('HelpSidebar', () => {
   beforeEach(() => {
     registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
     registerApiClient(CohortAnnotationDefinitionApi, new CohortAnnotationDefinitionServiceStub());
@@ -20,7 +20,7 @@ describe('SidebarContent', () => {
   });
 
   it('should render', () => {
-    const wrapper = mount(<HelpSidebar location='data' />);
+    const wrapper = mount(<HelpSidebar helpContent='data' hideSidebar={0} />);
     expect(wrapper.exists()).toBeTruthy();
   });
 });

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -11,6 +11,8 @@ import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-r
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {HelpSidebar} from './help-sidebar';
 
+const sidebarContent = require('assets/json/help-sidebar.json');
+
 describe('HelpSidebar', () => {
   beforeEach(() => {
     registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
@@ -20,7 +22,21 @@ describe('HelpSidebar', () => {
   });
 
   it('should render', () => {
-    const wrapper = mount(<HelpSidebar helpContent='data' hideSidebar={0} />);
+    const wrapper = mount(<HelpSidebar helpContent='data' sidebarOpen={true} />);
     expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should update content when helpContent prop changes', () => {
+    const wrapper = mount(<HelpSidebar helpContent='data' sidebarOpen={true} />);
+    expect(wrapper.find('[data-test-id="section-title-0"]').text()).toBe(sidebarContent.data[0].title);
+    wrapper.setProps({helpContent: 'cohortBuilder'});
+    expect(wrapper.find('[data-test-id="section-title-0"]').text()).toBe(sidebarContent.cohortBuilder[0].title);
+  });
+
+  it('should update marginRight style when sidebarOpen prop changes', () => {
+    const wrapper = mount(<HelpSidebar helpContent='data' sidebarOpen={true} />);
+    expect(wrapper.find('[data-test-id="sidebar-content"]').prop('style').marginRight).toBe(0);
+    wrapper.setProps({sidebarOpen: false});
+    expect(wrapper.find('[data-test-id="sidebar-content"]').prop('style').marginRight).toBe('calc(-14rem - 40px)');
   });
 });

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -1,9 +1,24 @@
+import {mount} from 'enzyme';
 import * as React from 'react';
 
-import {mount} from 'enzyme';
+import {cohortReviewStore} from 'app/services/review-state.service';
+import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import {currentWorkspaceStore} from 'app/utils/navigation';
+import {CohortAnnotationDefinitionApi, CohortReviewApi} from 'generated/fetch';
+import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
+import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
+
+import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {HelpSidebar} from './help-sidebar';
 
 describe('SidebarContent', () => {
+  beforeEach(() => {
+    registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
+    registerApiClient(CohortAnnotationDefinitionApi, new CohortAnnotationDefinitionServiceStub());
+    currentWorkspaceStore.next(workspaceDataStub);
+    cohortReviewStore.next(cohortReviewStubs[0]);
+  });
+
   it('should render', () => {
     const wrapper = mount(<HelpSidebar location='data' />);
     expect(wrapper.exists()).toBeTruthy();

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -13,9 +13,9 @@ const sidebarContent = require('assets/json/help-sidebar.json');
 const styles = reactStyles({
   sidebarContainer: {
     position: 'absolute',
-    top: 0,
-    right: 'calc(-0.6rem - 45px)',
-    height: '100%',
+    top: '60px',
+    right: 0,
+    height: 'calc(100% - 60px)',
     minHeight: 'calc(100vh - 156px)',
     width: 'calc(14rem + 45px)',
     overflow: 'hidden',
@@ -41,9 +41,9 @@ const styles = reactStyles({
   },
   iconContainer: {
     position: 'absolute',
-    top: 0,
-    right: 'calc(-0.6rem - 45px)',
-    height: '100%',
+    top: '60px',
+    right: 0,
+    height: 'calc(100% - 60px)',
     minHeight: 'calc(100vh - 156px)',
     width: '45px',
     background: colorWithWhiteness(colors.primary, 0.4),

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -163,7 +163,7 @@ export const HelpSidebar = withUserProfile()(
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
-      const {helpContent, hideSidebar} = this.props
+      const {helpContent, hideSidebar} = this.props;
       // close the sidebar on each navigation excluding navigating between participants in cohort review
       if (hideSidebar > prevProps.hideSidebar &&
         !(helpContent === 'reviewParticipantDetail' && prevProps.helpContent === 'reviewParticipantDetail')) {
@@ -287,12 +287,12 @@ export const HelpSidebar = withUserProfile()(
               {!!displayContent && displayContent.length > 0
                 ? displayContent.map((section, s) => <div key={s}>
                   <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
-                  {section.content.map((sectionContent, c) => {
-                    return typeof sectionContent === 'string'
-                      ? <p key={c} style={styles.contentItem}>{this.highlightMatches(sectionContent)}</p>
+                  {section.content.map((content, c) => {
+                    return typeof content === 'string'
+                      ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>
                       : <div key={c}>
-                        <h4 style={styles.contentTitle}>{this.highlightMatches(sectionContent.title)}</h4>
-                        {sectionContent.content.map((item, i) =>
+                        <h4 style={styles.contentTitle}>{this.highlightMatches(content.title)}</h4>
+                        {content.content.map((item, i) =>
                           <p key={i} style={styles.contentItem}>{this.highlightMatches(item)}</p>)
                         }
                       </div>;

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -125,6 +125,7 @@ const iconStyles = {
 
 interface Props {
   helpContent: string;
+  hideSidebar: number;
   profileState: any;
   participant?: any;
   setParticipant?: Function;
@@ -155,6 +156,13 @@ export const HelpSidebar = withUserProfile()(
         this.searchHelpTips(input.trim().toLowerCase());
       }
     });
+
+    componentDidUpdate(prevProps: Readonly<Props>): void {
+      // close the sidebar on each navigation
+      if (this.props.hideSidebar > prevProps.hideSidebar) {
+        this.setState({sidebarOpen: false});
+      }
+    }
 
     searchHelpTips(input: string) {
       // For each object, we check the title first. If it matches, we return the entire content array.
@@ -315,10 +323,11 @@ export const HelpSidebar = withUserProfile()(
 })
 export class HelpSidebarComponent extends ReactWrapperBase {
   @Input('helpContent') helpContent: Props['helpContent'];
+  @Input('hideSidebar') hideSidebar: Props['hideSidebar'];
   @Input('participant') participant: Props['participant'];
   @Input('setParticipant') setParticipant: Props['setParticipant'];
 
   constructor() {
-    super(HelpSidebar, ['helpContent', 'participant', 'setParticipant']);
+    super(HelpSidebar, ['helpContent', 'hideSidebar', 'participant', 'setParticipant']);
   }
 }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -124,7 +124,7 @@ const iconStyles = {
 };
 
 interface Props {
-  location: string;
+  helpContent: string;
   profileState: any;
   participant?: any;
   setParticipant?: Function;
@@ -224,9 +224,9 @@ export const HelpSidebar = withUserProfile()(
     }
 
     render() {
-      const {location, participant, setParticipant} = this.props;
+      const {helpContent, participant, setParticipant} = this.props;
       const {activeIcon, filteredContent, searchTerm, sidebarOpen} = this.state;
-      const displayContent = filteredContent !== undefined ? filteredContent : sidebarContent[location];
+      const displayContent = filteredContent !== undefined ? filteredContent : sidebarContent[helpContent];
       const contentStyle = (tab: string) => ({
         display: activeIcon === tab ? 'block' : 'none',
         height: 'calc(100% - 1rem)',
@@ -245,7 +245,7 @@ export const HelpSidebar = withUserProfile()(
               <ClrIcon className='is-solid' shape='book' size={32} title='Data Dictionary' />
             </a>
           </div>
-          {location === 'reviewParticipantDetail' &&
+          {helpContent === 'reviewParticipantDetail' &&
             <div style={activeIcon === 'annotations' ? iconStyles.active : styles.icon}>
               <ClrIcon shape='note' size={32}  title='Participant Status and Annotations'
                 onClick={() => this.onIconClick('annotations')} />
@@ -269,15 +269,15 @@ export const HelpSidebar = withUserProfile()(
                   onChange={(e) => this.onInputChange(e.target.value)}
                   placeholder={'Search'} />
               </div>
-              {displayContent.length > 0
+              {!!displayContent && displayContent.length > 0
                 ? displayContent.map((section, s) => <div key={s}>
                   <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
-                  {section.content.map((content, c) => {
-                    return typeof content === 'string'
-                      ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>
+                  {section.content.map((sectionContent, c) => {
+                    return typeof sectionContent === 'string'
+                      ? <p key={c} style={styles.contentItem}>{this.highlightMatches(sectionContent)}</p>
                       : <div key={c}>
-                        <h4 style={styles.contentTitle}>{this.highlightMatches(content.title)}</h4>
-                        {content.content.map((item, i) =>
+                        <h4 style={styles.contentTitle}>{this.highlightMatches(sectionContent.title)}</h4>
+                        {sectionContent.content.map((item, i) =>
                           <p key={i} style={styles.contentItem}>{this.highlightMatches(item)}</p>)
                         }
                       </div>;
@@ -314,11 +314,11 @@ export const HelpSidebar = withUserProfile()(
   template: '<div #root></div>',
 })
 export class HelpSidebarComponent extends ReactWrapperBase {
-  @Input('location') location: Props['location'];
+  @Input('helpContent') helpContent: Props['helpContent'];
   @Input('participant') participant: Props['participant'];
   @Input('setParticipant') setParticipant: Props['setParticipant'];
 
   constructor() {
-    super(HelpSidebar, ['location', 'participant', 'setParticipant']);
+    super(HelpSidebar, ['helpContent', 'participant', 'setParticipant']);
   }
 }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -278,10 +278,9 @@ export const HelpSidebar = withUserProfile()(
           }
         </div>
         <div style={activeIcon ? {...styles.sidebarContainer, ...styles.sidebarContainerActive} : styles.sidebarContainer}>
-          <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar}>
+          <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar} data-test-id='sidebar-content'>
             <div style={styles.topBar}>
-              <ClrIcon shape='caret right' size={22} style={styles.closeIcon}
-                onClick={() => setSidebarState(false)} />
+              <ClrIcon shape='caret right' size={22} style={styles.closeIcon} onClick={() => setSidebarState(false)} />
             </div>
             <div style={contentStyle('help')}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
@@ -296,7 +295,7 @@ export const HelpSidebar = withUserProfile()(
               </div>
               {!!displayContent && displayContent.length > 0
                 ? displayContent.map((section, s) => <div key={s}>
-                  <h3 style={styles.sectionTitle}>{this.highlightMatches(section.title)}</h3>
+                  <h3 style={styles.sectionTitle} data-test-id={`section-title-${s}`}>{this.highlightMatches(section.title)}</h3>
                   {section.content.map((content, c) => {
                     return typeof content === 'string'
                       ? <p key={c} style={styles.contentItem}>{this.highlightMatches(content)}</p>

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -6,7 +6,7 @@ import {from} from 'rxjs/observable/from';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {DetailHeader} from 'app/pages/data/cohort-review/detail-header.component';
 import {DetailTabs} from 'app/pages/data/cohort-review/detail-tabs.component';
-import {cohortReviewStore, getVocabOptions, vocabOptions} from 'app/services/review-state.service';
+import {cohortReviewStore, getVocabOptions, participantStore, vocabOptions} from 'app/services/review-state.service';
 import {cohortReviewApi, cohortsApi} from 'app/services/swagger-fetch-clients';
 import {ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {currentCohortStore, urlParamsStore} from 'app/utils/navigation';
@@ -53,25 +53,19 @@ export const DetailPage = withCurrentWorkspace()(
         .filter(params => !!params.pid)
         .switchMap(({pid}) => {
           return from(cohortReviewApi()
-            .getParticipantCohortStatus(ns, wsid,
-              cohortReviewStore.getValue().cohortReviewId, +pid))
-            .do(ps => {
-              this.setState({participant: ps});
-            });
+            .getParticipantCohortStatus(ns, wsid, cohortReviewStore.getValue().cohortReviewId, +pid))
+            .do(ps => participantStore.next(ps));
         })
         .subscribe();
       if (!vocabOptions.getValue()) {
         const {cohortReviewId} = cohortReviewStore.getValue();
         getVocabOptions(namespace, id, cohortReviewId);
       }
+      participantStore.subscribe(participant => this.setState({participant}));
     }
 
     componentWillUnmount() {
       this.subscription.unsubscribe();
-    }
-
-    setParticipant(v) {
-      this.setState({participant: v});
     }
 
     render() {

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -3,7 +3,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {from} from 'rxjs/observable/from';
 
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {DetailHeader} from 'app/pages/data/cohort-review/detail-header.component';
 import {DetailTabs} from 'app/pages/data/cohort-review/detail-tabs.component';
@@ -87,8 +86,6 @@ export const DetailPage = withCurrentWorkspace()(
           ? <React.Fragment>
             <DetailHeader participant={participant} />
             <DetailTabs />
-            <HelpSidebar location='reviewParticipantDetail' participant={participant}
-              setParticipant={(p) => this.setParticipant(p)} />
           </React.Fragment>
           : <SpinnerOverlay />
         }

--- a/ui/src/app/pages/data/cohort-review/sidebar-content.component.spec.tsx
+++ b/ui/src/app/pages/data/cohort-review/sidebar-content.component.spec.tsx
@@ -1,9 +1,10 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
 import {cohortReviewStore} from 'app/services/review-state.service';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {mount} from 'enzyme';
 import {CohortAnnotationDefinitionApi, CohortReviewApi} from 'generated/fetch';
-import * as React from 'react';
 import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
@@ -18,15 +19,7 @@ describe('SidebarContent', () => {
   });
 
   it('should render', () => {
-    const wrapper = mount(<SidebarContent
-      participant={{}}
-      setParticipant={() => {}}
-      annotations={[]}
-      annotationDefinitions={[]}
-      setAnnotations={() => {}}
-      openCreateDefinitionModal={() => {}}
-      openEditDefinitionsModal={() => {}}
-    />);
+    const wrapper = mount(<SidebarContent />);
     expect(wrapper.exists()).toBeTruthy();
   });
 });

--- a/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
@@ -294,7 +294,7 @@ export const SidebarContent = fp.flow(
       .then(({items}) => {
         this.setState({annotationDefinitions: items});
       });
-    participantStore.subscribe(participant => this.setState({participant}));
+    participantStore.subscribe(participant => this.setState({participant: participant || {} as ParticipantCohortStatus}));
   }
 
   componentDidUpdate(prevProps: any): void {

--- a/ui/src/app/pages/data/cohort-review/table-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/table-page.tsx
@@ -6,7 +6,6 @@ import {OverlayPanel} from 'primereact/overlaypanel';
 import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewStore, filterStateStore, getVocabOptions, multiOptions, vocabOptions} from 'app/services/review-state.service';
@@ -649,7 +648,6 @@ export const ParticipantsTable = withCurrentWorkspace()(
           </DataTable>
         </React.Fragment>}
         {loading && <SpinnerOverlay />}
-        <HelpSidebar location='reviewParticipants' />
       </div>;
     }
   }

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -568,7 +568,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
 );
 
 @Component({
-  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
+  template: '<div #root></div>'
 })
 export class ConceptHomepageComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -8,7 +8,6 @@ import {DomainCardBase} from 'app/components/card';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {Header} from 'app/components/headers';
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox, TextInput} from 'app/components/inputs';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
@@ -563,7 +562,6 @@ export const ConceptHomepage = withCurrentWorkspace()(
                                  onSave={() => this.setState({surveyAddModalOpen: false})}
                                  surveyName={selectedSurvey}/>}
         </FadeBox>
-        <HelpSidebar location='conceptSets' />
       </React.Fragment>;
     }
   }

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -9,7 +9,6 @@ import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {FadeBox} from 'app/components/containers';
 import {CopyModal} from 'app/components/copy-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon, SnowmanIcon} from 'app/components/icons';
 import {TextArea, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalFooter, ModalTitle} from 'app/components/modals';
@@ -381,7 +380,6 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
             saveFunction={(copyRequest: CopyRequest) => this.copyConceptSet(copyRequest)}/>
           }
         </FadeBox>
-        <HelpSidebar location='conceptSets' />
       </React.Fragment>;
     }
   });

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -386,7 +386,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
 
 
 @Component({
-  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
+  template: '<div #root></div>'
 })
 export class ConceptSetDetailsComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/data-page.tsx
+++ b/ui/src/app/pages/data/data-page.tsx
@@ -298,13 +298,12 @@ export const DataPage = withCurrentWorkspace()(class extends React.Component<
           {isLoading && <SpinnerOverlay></SpinnerOverlay>}
         </div>
       </FadeBox>
-      {/*<HelpSidebar location='data' />*/}
     </React.Fragment>;
   }
 });
 
 @Component({
-  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
+  template: '<div #root></div>'
 })
 export class DataPageComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/data-page.tsx
+++ b/ui/src/app/pages/data/data-page.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import {CardButton, TabButton} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {ResourceCard} from 'app/components/resource-card';
@@ -299,7 +298,7 @@ export const DataPage = withCurrentWorkspace()(class extends React.Component<
           {isLoading && <SpinnerOverlay></SpinnerOverlay>}
         </div>
       </FadeBox>
-      <HelpSidebar location='data' />
+      {/*<HelpSidebar location='data' />*/}
     </React.Fragment>;
   }
 });

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1036,7 +1036,7 @@ export {
 };
 
 @Component({
-  template: '<div #root style="position: relative; margin-right: 45px;"></div>'
+  template: '<div #root></div>'
 })
 export class DataSetPageComponent extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import {Button, Clickable, Link} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {HelpSidebar} from 'app/components/help-sidebar';
 import {ClrIcon} from 'app/components/icons';
 import {CheckBox} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
@@ -1027,7 +1026,6 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                                              this.setState({openSaveModal: false});
                                            }}
         />}
-        <HelpSidebar location='datasetBuilder' />
       </React.Fragment>;
     }
   });

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -25,7 +25,7 @@
   <app-bug-report *ngIf="bugReportOpen"
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
-  <app-help-sidebar [helpContent]="helpContent"></app-help-sidebar>
+  <app-help-sidebar [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
   <router-outlet *ngIf="workspace"></router-outlet>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -26,6 +26,8 @@
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
   <app-help-sidebar *ngIf="helpContent" [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
-  <div  style="margin-right: 45px;"><router-outlet *ngIf="workspace"></router-outlet></div>
+  <div style="margin-right: 45px;">
+    <router-outlet *ngIf="workspace"></router-outlet>
+  </div>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -25,7 +25,7 @@
   <app-bug-report *ngIf="bugReportOpen"
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
-  <app-help-sidebar [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
-  <router-outlet *ngIf="workspace"></router-outlet>
+  <app-help-sidebar *ngIf="helpContent" [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
+  <div  style="margin-right: 45px;"><router-outlet *ngIf="workspace"></router-outlet></div>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -25,7 +25,10 @@
   <app-bug-report *ngIf="bugReportOpen"
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
-  <app-help-sidebar *ngIf="helpContent" [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
+  <app-help-sidebar *ngIf="helpContent"
+                    [helpContent]="helpContent"
+                    [setSidebarState]="setSidebarState"
+                    [sidebarOpen]="sidebarOpen"></app-help-sidebar>
   <div [ngStyle]="helpContent ? {'margin-right': '45px'} : {}">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -25,6 +25,8 @@
   <app-bug-report *ngIf="bugReportOpen"
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
+  <!-- TODO get actual location to pass in to help sidebar. Hardcoded 'data' for now -->
+  <app-help-sidebar [location]="'data'"></app-help-sidebar>
   <router-outlet *ngIf="workspace"></router-outlet>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -26,7 +26,7 @@
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
   <app-help-sidebar *ngIf="helpContent" [helpContent]="helpContent" [hideSidebar]="hideSidebar"></app-help-sidebar>
-  <div style="margin-right: 45px;">
+  <div [ngStyle]="helpContent ? {'margin-right': '45px'} : {}">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>
 </ng-container>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -25,8 +25,7 @@
   <app-bug-report *ngIf="bugReportOpen"
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
-  <!-- TODO get actual location to pass in to help sidebar. Hardcoded 'data' for now -->
-  <app-help-sidebar [location]="'data'"></app-help-sidebar>
+  <app-help-sidebar [helpContent]="helpContent"></app-help-sidebar>
   <router-outlet *ngIf="workspace"></router-outlet>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -12,6 +12,7 @@ import {urlParamsStore} from 'app/utils/navigation';
 
 import {BugReportComponent} from 'app/components/bug-report';
 import {ConfirmDeleteModalComponent} from 'app/components/confirm-delete-modal';
+import {HelpSidebarComponent} from 'app/components/help-sidebar';
 import {WorkspaceNavBarComponent} from 'app/pages/workspace/workspace-nav-bar';
 import {WorkspaceShareComponent} from 'app/pages/workspace/workspace-share';
 import {WorkspaceWrapperComponent} from 'app/pages/workspace/workspace-wrapper/component';
@@ -57,6 +58,7 @@ describe('WorkspaceWrapperComponent', () => {
         BugReportComponent,
         ConfirmDeleteModalComponent,
         FakeAppComponent,
+        HelpSidebarComponent,
         WorkspaceWrapperComponent,
         WorkspaceNavBarComponent,
         WorkspaceShareComponent,

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -37,6 +37,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   menuDataLoading = false;
   resourceType: ResourceType = ResourceType.WORKSPACE;
   userRoles?: UserRole[];
+  helpContent: string;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -57,10 +58,12 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.tabPath = this.getTabPath();
+    this.setHelpContent();
     this.subscriptions.push(
       this.router.events.filter(event => event instanceof NavigationEnd)
         .subscribe(event => {
           this.tabPath = this.getTabPath();
+          this.setHelpContent();
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.displayNavBar = !minimizeChrome;
@@ -190,5 +193,19 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
 
   closeBugReport(): void {
     this.bugReportOpen = false;
+  }
+
+  setHelpContent() {
+    let child = this.route.firstChild;
+    while (child) {
+      if (child.firstChild) {
+        child = child.firstChild;
+      } else if (child.snapshot.data && child.snapshot.data.helpContent) {
+        this.helpContent = child.snapshot.data.helpContent;
+        child = null;
+      } else {
+        child = null;
+      }
+    }
   }
 }

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -38,6 +38,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   resourceType: ResourceType = ResourceType.WORKSPACE;
   userRoles?: UserRole[];
   helpContent: string;
+  hideSidebar = 0;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -64,6 +65,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         .subscribe(event => {
           this.tabPath = this.getTabPath();
           this.setHelpContent();
+          this.hideSidebar++;
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.displayNavBar = !minimizeChrome;

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -206,6 +206,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         this.helpContent = child.snapshot.data.helpContent;
         child = null;
       } else {
+        this.helpContent = null;
         child = null;
       }
     }

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -38,7 +38,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   resourceType: ResourceType = ResourceType.WORKSPACE;
   userRoles?: UserRole[];
   helpContent: string;
-  hideSidebar = 0;
+  sidebarOpen = false;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -65,7 +65,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         .subscribe(event => {
           this.tabPath = this.getTabPath();
           this.setHelpContent();
-          this.hideSidebar++;
+          this.sidebarOpen = false;
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.displayNavBar = !minimizeChrome;
@@ -210,5 +210,9 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         child = null;
       }
     }
+  }
+
+  setSidebarState = (sidebarOpen: boolean) => {
+    this.sidebarOpen = sidebarOpen;
   }
 }

--- a/ui/src/app/services/review-state.service.ts
+++ b/ui/src/app/services/review-state.service.ts
@@ -1,7 +1,7 @@
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
-import {CohortReview, CohortStatus} from 'generated/fetch';
+import {CohortReview, CohortStatus, ParticipantCohortStatus} from 'generated/fetch';
 
 export const initialFilterState = {
   global: {
@@ -96,16 +96,12 @@ export const initialFilterState = {
 
 export const cohortReviewStore = new BehaviorSubject<CohortReview>(undefined);
 export const visitsFilterOptions = new BehaviorSubject<Array<any>>(null);
-export const filterStateStore =
-  new BehaviorSubject<any>(JSON.parse(JSON.stringify(initialFilterState)));
+export const filterStateStore = new BehaviorSubject<any>(JSON.parse(JSON.stringify(initialFilterState)));
 export const vocabOptions = new BehaviorSubject<any>(null);
 export const multiOptions = new BehaviorSubject<any>(null);
+export const participantStore = new BehaviorSubject<ParticipantCohortStatus>(null);
 
-export function getVocabOptions(
-  workspaceNamespace: string,
-  workspaceId: string,
-  cohortReviewId: number
-) {
+export function getVocabOptions(workspaceNamespace: string, workspaceId: string, cohortReviewId: number) {
   const vocabFilters = {source: {}, standard: {}};
   try {
     cohortReviewApi().getVocabularies(workspaceNamespace, workspaceId, cohortReviewId)
@@ -122,5 +118,16 @@ export function getVocabOptions(
   } catch (error) {
     vocabOptions.next(vocabFilters);
     console.error(error);
+  }
+}
+
+export function updateParticipant(participant: ParticipantCohortStatus) {
+  const review = cohortReviewStore.getValue();
+  if (participant && review) {
+    const index = review.participantCohortStatuses.findIndex(p => p.participantId === participant.participantId);
+    if (index !== -1) {
+      review.participantCohortStatuses[index] = participant;
+      cohortReviewStore.next(review);
+    }
   }
 }


### PR DESCRIPTION
- Removes `HelpSidebar` from individual pages and adds it to `WorkspaceWrapperComponent` so it shows on all pages within a workspace (except `InteractiveNotebookComponent`).
- Adds a `helpContent` property to the data for each route with the help sidebar that determines the help tip content.
- Moves handling of participants/annotations for `SidebarContent` component into `review-state.service.ts` instead of using `props`.

@freemabd to deploy and test locally, especially annotations
@NehaBroad for general review, especially changes to workbench code