### PR TITLE
[RW-3988][Risk=no] Srubenst/preview data time formatting

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -15,6 +15,8 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -422,8 +424,7 @@ public class DataSetController implements DataSetApiDelegate {
               value -> {
                 if (!value.equals(EMPTY_CELL_MARKER)) {
                   Double fieldValue = Double.parseDouble(value);
-                  // Bigquery returns time values in seconds, rather than in milliseconds.
-                  queryValues.add(dateFormat.format(new Date(fieldValue.longValue() * 1000)));
+                  queryValues.add(dateFormat.format(Date.from(Instant.ofEpochSecond(fieldValue.longValue()))));
                 } else {
                   queryValues.add(value);
                 }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -16,7 +16,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -424,7 +423,8 @@ public class DataSetController implements DataSetApiDelegate {
               value -> {
                 if (!value.equals(EMPTY_CELL_MARKER)) {
                   Double fieldValue = Double.parseDouble(value);
-                  queryValues.add(dateFormat.format(Date.from(Instant.ofEpochSecond(fieldValue.longValue()))));
+                  queryValues.add(
+                      dateFormat.format(Date.from(Instant.ofEpochSecond(fieldValue.longValue()))));
                 } else {
                   queryValues.add(value);
                 }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -417,7 +416,6 @@ public class DataSetController implements DataSetApiDelegate {
     if (field.getType() == LegacySQLTypeName.TIMESTAMP) {
       List<String> queryValues = new ArrayList<>();
       DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STRING);
-      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       previewValue
           .getQueryValue()
           .forEach(

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -416,13 +417,15 @@ public class DataSetController implements DataSetApiDelegate {
     if (field.getType() == LegacySQLTypeName.TIMESTAMP) {
       List<String> queryValues = new ArrayList<>();
       DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STRING);
+      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       previewValue
           .getQueryValue()
           .forEach(
               value -> {
                 if (!value.equals(EMPTY_CELL_MARKER)) {
                   Double fieldValue = Double.parseDouble(value);
-                  queryValues.add(dateFormat.format(new Date(fieldValue.longValue())));
+                  // Bigquery returns time values in seconds, rather than in milliseconds.
+                  queryValues.add(dateFormat.format(new Date(fieldValue.longValue() * 1000)));
                 } else {
                   queryValues.add(value);
                 }


### PR DESCRIPTION
During the workshop, we realized all the dates in the preview table in dataset builder were very close to the Linux Epoch. When I poked around locally, the values from the API seemed to be similarly incorrect. When looking at the values side by side with something that would be pointing to a date similar to what we might expect, it looked like they might be off by a factor of 1000. Ariel and I determined BQ was likely returning data in seconds rather than milliseconds.

Tested manually and it looks fine