### PR TITLE
[RW-4007][RISK=NO] Login Auditing

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/adapters/ProfileAuditAdapter.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/adapters/ProfileAuditAdapter.kt
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.actionaudit.adapters
 
+import org.pmiops.workbench.db.model.DbUser
 import org.pmiops.workbench.model.Profile
 
 interface ProfileAuditAdapter : AuditAdapter<Profile> {
@@ -8,4 +9,6 @@ interface ProfileAuditAdapter : AuditAdapter<Profile> {
     fun fireUpdateAction(previousProfile: Profile, updatedProfile: Profile)
 
     fun fireDeleteAction(userId: Long, userEmail: String)
+
+    fun fireLoginAction(dbUser: DbUser)
 }

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/adapters/ProfileAuditAdapterImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/adapters/ProfileAuditAdapterImpl.kt
@@ -104,6 +104,26 @@ constructor(
         }
     }
 
+    override fun fireLoginAction(dbUser: DbUser) {
+        try {
+            actionAuditService.send(ActionAuditEvent(
+                    timestamp = clock.millis(),
+                    actionId = actionIdProvider.get(),
+                    actionType = ActionType.LOGIN,
+                    agentType = AgentType.USER,
+                    agentId = dbUser.userId,
+                    agentEmailMaybe = dbUser.email,
+                    targetType = TargetType.WORKBENCH,
+                    targetIdMaybe = null,
+                    targetPropertyMaybe = null,
+                    previousValueMaybe = null,
+                    newValueMaybe = null
+            ))
+        } catch (e: java.lang.RuntimeException) {
+            logAndSwallow(e)
+        }
+    }
+
     private fun logAndSwallow(e: RuntimeException) {
         actionAuditService.logRuntimeException(logger, e)
     }


### PR DESCRIPTION
The closest thing we have right now to a "login event" is the `getMe()` method on the `v1/profile` endpoint. This works to catch logins, but also captures profile display actions.

As of right now, we think this is better than nothing. The extra events are during a session anyway, and shouldn't lead to wildly inaccurate conclusions.