### PR TITLE
[RW-3870][Risk=no] Add DUA tests

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -241,8 +241,18 @@ public class ProfileControllerTest {
   @Test
   public void testSubmitDataUseAgreement_success() throws Exception {
     createUser();
-    assertThat(profileController.submitDataUseAgreement(DUA_VERSION, "NIH").getStatusCode())
+    DbUser dbUser = userProvider.get();
+    String duaInitials = "NIH";
+    assertThat(profileController.submitDataUseAgreement(DUA_VERSION, duaInitials).getStatusCode())
         .isEqualTo(HttpStatus.OK);
+    List<DbUserDataUseAgreement> dbUserDataUseAgreementList =
+        userDataUseAgreementDao.findByUserIdOrderByCompletionTimeDesc(dbUser.getUserId());
+    assertThat(dbUserDataUseAgreementList.size()).isEqualTo(1);
+    DbUserDataUseAgreement dbUserDataUseAgreement = dbUserDataUseAgreementList.get(0);
+    assertThat(dbUserDataUseAgreement.getUserFamilyName()).isEqualTo(dbUser.getFamilyName());
+    assertThat(dbUserDataUseAgreement.getUserGivenName()).isEqualTo(dbUser.getGivenName());
+    assertThat(dbUserDataUseAgreement.getUserInitials()).isEqualTo(duaInitials);
+    assertThat(dbUserDataUseAgreement.getDataUseAgreementSignedVersion()).isEqualTo(DUA_VERSION);
   }
 
   @Test

--- a/ui/src/app/pages/profile/data-use-agreement-panel.tsx
+++ b/ui/src/app/pages/profile/data-use-agreement-panel.tsx
@@ -84,9 +84,9 @@ export function getDataUseAgreementWidget(submitting, initialWork,
       </div>
     </div>
     <label>Authorized Demonstration User Name</label>
-    <DuaTextInput disabled value={this.props.profileState.profile.username}/>
+    <DuaTextInput disabled data-test-id='dua-username-input' value={this.props.profileState.profile.username}/>
     <label>Contact Email</label>
-    <DuaTextInput disabled value={this.props.profileState.profile.contactEmail}/>
+    <DuaTextInput disabled data-test-id='dua-contact-email-input' value={this.props.profileState.profile.contactEmail}/>
     <label>Date</label>
     <DuaTextInput type='text' disabled value={new Date().toLocaleDateString()}/>
     <TooltipTrigger content={errors && <div>

--- a/ui/src/app/pages/profile/data-use-agreement.spec.tsx
+++ b/ui/src/app/pages/profile/data-use-agreement.spec.tsx
@@ -18,6 +18,25 @@ describe('DataUseAgreement', () => {
     expect(wrapper).toBeTruthy();
   });
 
+  it('should not allow DataUseAgreement without identical initials', () => {
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
+
+    // fill required fields
+    wrapper.find('[data-test-id="dua-name-input"]')
+      .simulate('change', {target: {value: 'Fake Name'}});
+    // add initials to just one initials input field.
+    wrapper.find('[data-test-id="dua-initials-input"]').first().simulate('change', {target: {value: 'XX'}});
+
+    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
+
+    wrapper.find('[data-test-id="dua-initials-input"]').forEach((node, index) => {
+      node.simulate('change', {target: {value: 'X' + index.toString()}});
+    });
+
+    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
+  });
+
   it('should submit DataUseAgreement acceptance with version number', () => {
     const wrapper = component();
     const spy = jest.spyOn(profileApi(), 'submitDataUseAgreement');

--- a/ui/src/app/pages/profile/data-use-agreement.spec.tsx
+++ b/ui/src/app/pages/profile/data-use-agreement.spec.tsx
@@ -1,16 +1,28 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 
-import {profileApi, registerApiClient} from 'app/services/swagger-fetch-clients';
 import {DataUseAgreement} from 'app/pages/profile/data-use-agreement';
-import {ProfileApi} from 'generated/fetch';
-import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
+import {profileApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {userProfileStore} from 'app/utils/navigation';
+import {Profile, ProfileApi} from 'generated/fetch';
+import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
+import {waitOneTickAndUpdate} from "../../../testing/react-test-helpers";
 
 describe('DataUseAgreement', () => {
+  const reload = jest.fn();
+  const updateCache = jest.fn();
+  const profile = ProfileStubVariables.PROFILE_STUB as unknown as Profile;
+
   const component = () => mount(<DataUseAgreement/>);
 
   beforeEach(() => {
     registerApiClient(ProfileApi, new ProfileApiStub());
+    reload.mockImplementation(async () => {
+      const newProfile = await profileApi().getMe();
+      userProfileStore.next({profile: newProfile, reload, updateCache});
+    });
+
+    userProfileStore.next({profile, reload, updateCache});
   });
 
   it('should render', () => {
@@ -23,19 +35,36 @@ describe('DataUseAgreement', () => {
     expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
 
     // fill required fields
+    wrapper.find('[data-test-id="dua-initials-input"]').forEach((node, index) => {
+      node.simulate('change', {target: {value: 'X' + index.toString()}});
+    });
+    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
+  });
+
+  it('should not allow DataUseAgreement with only one field populated', () => {
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
+
+    // fill required fields
     wrapper.find('[data-test-id="dua-name-input"]')
       .simulate('change', {target: {value: 'Fake Name'}});
     // add initials to just one initials input field.
     wrapper.find('[data-test-id="dua-initials-input"]').first().simulate('change', {target: {value: 'XX'}});
 
     expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
-
-    wrapper.find('[data-test-id="dua-initials-input"]').forEach((node, index) => {
-      node.simulate('change', {target: {value: 'X' + index.toString()}});
-    });
-
-    expect(wrapper.find('[data-test-id="submit-dua-button"]').prop('disabled')).toBeTruthy();
   });
+
+  it('should populate username and name from the profile automatically', async() => {
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="dua-name-input"]').props().value)
+      .toBe(ProfileStubVariables.PROFILE_STUB.givenName + ' ' + ProfileStubVariables.PROFILE_STUB.familyName);
+    expect(wrapper.find('[data-test-id="dua-contact-email-input"]').props().value)
+      .toBe(ProfileStubVariables.PROFILE_STUB.contactEmail);
+    expect(wrapper.find('[data-test-id="dua-username-input"]').props().value)
+      .toBe(ProfileStubVariables.PROFILE_STUB.username);
+
+  })
 
   it('should submit DataUseAgreement acceptance with version number', () => {
     const wrapper = component();


### PR DESCRIPTION
I decided there were two major tests missing. One to verify the saving of DUA information, and the other test to verify initials all need to be correct on the front end to save. 