### PR TITLE
[RW-3602][RISK=NO] Replace uses of AssertJ with Truth

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.sql.Timestamp;
 import java.time.Clock;

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.billing;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -56,23 +56,17 @@ public class FreeTierBillingServiceTest {
 
   private static final double HALF_TOLERANCE_PERCENTAGE = 0.001;
   private static final double DEFAULT_FREE_CREDITS_LIMIT = 1.0;
-  @Autowired
-  BigQueryService bigQueryService;
+  @Autowired BigQueryService bigQueryService;
 
-  @Autowired
-  FreeTierBillingService freeTierBillingService;
+  @Autowired FreeTierBillingService freeTierBillingService;
 
-  @Autowired
-  UserDao userDao;
+  @Autowired UserDao userDao;
 
-  @Autowired
-  NotificationService notificationService;
+  @Autowired NotificationService notificationService;
 
-  @Autowired
-  WorkspaceDao workspaceDao;
+  @Autowired WorkspaceDao workspaceDao;
 
-  @Autowired
-  WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
+  @Autowired WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
 
   private static WorkbenchConfig workbenchConfig;
 
@@ -269,9 +263,7 @@ public class FreeTierBillingServiceTest {
       DbWorkspaceFreeTierUsage usage = workspaceFreeTierUsageDao.findOneByWorkspace(ws);
       assertThat(usage.getUser()).isEqualTo(ws.getCreator());
       assertThat(usage.getWorkspace()).isEqualTo(ws);
-      assertWithinPercentage(usage.getCost(),
-          expectedCosts.get(ws.getWorkspaceId()),
-          0.001);
+      assertWithinPercentage(usage.getCost(), expectedCosts.get(ws.getWorkspaceId()), 0.001);
     }
   }
 
@@ -342,13 +334,13 @@ public class FreeTierBillingServiceTest {
     DbUser user = createUser("test@test.com");
 
     workbenchConfig.billing.defaultFreeCreditsLimit = DEFAULT_FREE_CREDITS_LIMIT;
-    assertCloseEnough(freeTierBillingService.getUserFreeTierLimit(user),
-        DEFAULT_FREE_CREDITS_LIMIT);
+    assertCloseEnough(
+        freeTierBillingService.getUserFreeTierLimit(user), DEFAULT_FREE_CREDITS_LIMIT);
 
     final double fractionalFreeCreditsLimit = 123.456;
     workbenchConfig.billing.defaultFreeCreditsLimit = fractionalFreeCreditsLimit;
-    assertCloseEnough(freeTierBillingService.getUserFreeTierLimit(user),
-        fractionalFreeCreditsLimit);
+    assertCloseEnough(
+        freeTierBillingService.getUserFreeTierLimit(user), fractionalFreeCreditsLimit);
   }
 
   @Test
@@ -360,15 +352,15 @@ public class FreeTierBillingServiceTest {
     final double freeTierCreditsLimitOverride = 100.0;
     user.setFreeTierCreditsLimitOverride(freeTierCreditsLimitOverride);
     user = userDao.save(user);
-    assertCloseEnough(freeTierBillingService.getUserFreeTierLimit(user),
-        freeTierCreditsLimitOverride);
+    assertCloseEnough(
+        freeTierBillingService.getUserFreeTierLimit(user), freeTierCreditsLimitOverride);
 
     double doubleFreeTierCreditsLimitOverride1 = 200.0;
     user.setFreeTierCreditsLimitOverride(doubleFreeTierCreditsLimitOverride1);
     user = userDao.save(user);
 
-    assertCloseEnough(freeTierBillingService.getUserFreeTierLimit(user),
-        doubleFreeTierCreditsLimitOverride1);
+    assertCloseEnough(
+        freeTierBillingService.getUserFreeTierLimit(user), doubleFreeTierCreditsLimitOverride1);
   }
 
   @Test
@@ -383,8 +375,8 @@ public class FreeTierBillingServiceTest {
 
     freeTierBillingService.checkFreeTierBillingUsage();
 
-    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user),
-        SINGLE_WORKSPACE_TEST_COST);
+    assertCloseEnough(
+        freeTierBillingService.getUserCachedFreeTierUsage(user), SINGLE_WORKSPACE_TEST_COST);
 
     createWorkspace(user, "another project");
     Map<String, Double> newCosts = new HashMap<>();
@@ -393,13 +385,12 @@ public class FreeTierBillingServiceTest {
     doReturn(mockBQTableResult(newCosts)).when(bigQueryService).executeQuery(any());
 
     // we have not yet cached the new workspace costs
-    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user),
-        SINGLE_WORKSPACE_TEST_COST);
+    assertCloseEnough(
+        freeTierBillingService.getUserCachedFreeTierUsage(user), SINGLE_WORKSPACE_TEST_COST);
 
     freeTierBillingService.checkFreeTierBillingUsage();
 
-    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user),
-        1100.0);
+    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user), 1100.0);
 
     DbUser user2 = createUser("another user");
     createWorkspace(user2, "project 3");
@@ -408,8 +399,7 @@ public class FreeTierBillingServiceTest {
 
     freeTierBillingService.checkFreeTierBillingUsage();
 
-    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user),
-        1100.0);
+    assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user), 1100.0);
     assertCloseEnough(freeTierBillingService.getUserCachedFreeTierUsage(user2), 999.9);
   }
 
@@ -469,9 +459,8 @@ public class FreeTierBillingServiceTest {
     assertWithinPercentage(actualValue, expectedValue, HALF_TOLERANCE_PERCENTAGE);
   }
 
-  private void assertWithinPercentage(double actualValue,
-      double expectedValue,
-      double percentageDelta) {
+  private void assertWithinPercentage(
+      double actualValue, double expectedValue, double percentageDelta) {
     final double tolerance = percentageDelta * expectedValue * 0.01;
     assertThat(actualValue).isWithin(tolerance).of(expectedValue);
   }

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -390,7 +390,8 @@ public class FreeTierBillingServiceTest {
 
     freeTierBillingService.checkFreeTierBillingUsage();
     final double expectedTotalCachedFreeTierUsage = 1100.0;
-    assertWithinBillingTolerance(freeTierBillingService.getUserCachedFreeTierUsage(user), expectedTotalCachedFreeTierUsage);
+    assertWithinBillingTolerance(
+        freeTierBillingService.getUserCachedFreeTierUsage(user), expectedTotalCachedFreeTierUsage);
 
     final double user2Costs = 999.0;
     DbUser user2 = createUser("another user");
@@ -400,8 +401,10 @@ public class FreeTierBillingServiceTest {
 
     freeTierBillingService.checkFreeTierBillingUsage();
 
-    assertWithinBillingTolerance(freeTierBillingService.getUserCachedFreeTierUsage(user), expectedTotalCachedFreeTierUsage);
-    assertWithinBillingTolerance(freeTierBillingService.getUserCachedFreeTierUsage(user2), user2Costs);
+    assertWithinBillingTolerance(
+        freeTierBillingService.getUserCachedFreeTierUsage(user), expectedTotalCachedFreeTierUsage);
+    assertWithinBillingTolerance(
+        freeTierBillingService.getUserCachedFreeTierUsage(user2), user2Costs);
   }
 
   private TableResult mockBQTableResult(Map<String, Double> costMap) {

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -54,8 +54,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Import(LiquibaseAutoConfiguration.class)
 public class FreeTierBillingServiceTest {
 
-  private static final double HALF_TOLERANCE_PERCENTAGE = 0.001;
-  private static final double DEFAULT_FREE_CREDITS_LIMIT = 1.0;
+  private static final double DEFAULT_PERCENTAGE_TOLERANCE = 0.001;
+
   @Autowired BigQueryService bigQueryService;
 
   @Autowired FreeTierBillingService freeTierBillingService;
@@ -332,10 +332,10 @@ public class FreeTierBillingServiceTest {
   @Test
   public void getUserFreeTierLimit_default() {
     DbUser user = createUser("test@test.com");
-
-    workbenchConfig.billing.defaultFreeCreditsLimit = DEFAULT_FREE_CREDITS_LIMIT;
+    final double initialFreeCreditsLimit = 1.0;
+    workbenchConfig.billing.defaultFreeCreditsLimit = initialFreeCreditsLimit;
     assertCloseEnough(
-        freeTierBillingService.getUserFreeTierLimit(user), DEFAULT_FREE_CREDITS_LIMIT);
+        freeTierBillingService.getUserFreeTierLimit(user), initialFreeCreditsLimit);
 
     final double fractionalFreeCreditsLimit = 123.456;
     workbenchConfig.billing.defaultFreeCreditsLimit = fractionalFreeCreditsLimit;
@@ -456,7 +456,7 @@ public class FreeTierBillingServiceTest {
   }
 
   private void assertCloseEnough(double actualValue, double expectedValue) {
-    assertWithinPercentage(actualValue, expectedValue, HALF_TOLERANCE_PERCENTAGE);
+    assertWithinPercentage(actualValue, expectedValue, DEFAULT_PERCENTAGE_TOLERANCE);
   }
 
   private void assertWithinPercentage(

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortFactoryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortFactoryTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.cohorts;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -256,7 +256,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
+    assertThat(actualIds).containsAllIn(expectedIds);
   }
 
   @Test
@@ -293,7 +293,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
+    assertThat(actualIds).containsAllIn(expectedIds);
 
     DbUser mockUser = mock(DbUser.class);
     doReturn(mockUser).when(mockUserProvider).get();

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -256,7 +256,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAll(expectedIds);
+    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
   }
 
   @Test
@@ -293,7 +293,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAll(expectedIds);
+    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
 
     DbUser mockUser = mock(DbUser.class);
     doReturn(mockUser).when(mockUserProvider).get();
@@ -323,7 +323,7 @@ public class WorkspaceServiceTest {
         recentWorkspaces.stream()
             .map(DbUserRecentWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).contains(1L, 2L);
+    assertThat(actualIds).containsAllOf(1L, 2L);
   }
 
   @Test


### PR DESCRIPTION
The decision was to go with Truth, which means moving out the assertions from AssertJ.

The only place where there might be pain is around the use of `isWithinPercentage()` which has no direct analog. I tried to find a reasonable workaround there.