### PR TITLE
[risk=low] CommandLineToolConfig restructuring for CLI bean isolation

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
@@ -47,8 +47,6 @@ import org.springframework.retry.backoff.ThreadWaitSleeper;
 @EntityScan("org.pmiops.workbench.db.model")
 // Scan the google module, for CloudStorageService and DirectoryService beans.
 @ComponentScan("org.pmiops.workbench.google")
-// Scan the FireCloud module, for FireCloudService bean.
-@ComponentScan("org.pmiops.workbench.firecloud")
 // Scan the ServiceAccounts class, but exclude other classes in auth (since they
 // bring in JPA-related beans, which include a whole bunch of other deps that are
 // more complicated than we need for now).

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
@@ -15,15 +15,11 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.ConfigDao;
 import org.pmiops.workbench.db.model.DbConfig;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Configuration;
 
-@SpringBootApplication
-@EnableJpaRepositories("org.pmiops.workbench.db.dao")
-@EntityScan("org.pmiops.workbench.db.model")
+@Configuration
 /**
  * Command-line tool to load a WorkbenchConfig or CdrBigQuerySchemaConfig from a local file and
  * store it in the MySQL database for the current environment.
@@ -103,6 +99,9 @@ public class ConfigLoader {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(ConfigLoader.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(ConfigLoader.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ConfigLoader.java
@@ -15,7 +15,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.ConfigDao;
 import org.pmiops.workbench.db.model.DbConfig;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -99,9 +98,6 @@ public class ConfigLoader {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(ConfigLoader.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(ConfigLoader.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -43,7 +43,6 @@ import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
@@ -79,7 +78,6 @@ public class ExportWorkspaceData {
 
   @Primary
   @Bean
-  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
   WorkspacesApi workspaceApi(WorkbenchConfig config) throws IOException {
     return new ServiceAccountAPIClientFactory(config.firecloud.baseUrl).workspacesApi();

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -22,6 +23,7 @@ import org.springframework.context.annotation.Configuration;
  * domain-wide delegation to make FireCloud API calls impersonating other users.
  */
 @Configuration
+@ComponentScan("org.pmiops.workbench.firecloud")
 public class FetchFireCloudUserProfile {
   private static final Logger log =
       Logger.getLogger(org.pmiops.workbench.tools.FetchFireCloudUserProfile.class.getName());

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -58,9 +57,6 @@ public class FetchFireCloudUserProfile {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(FetchFireCloudUserProfile.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(FetchFireCloudUserProfile.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -11,11 +11,9 @@ import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * A tool that takes an AoU username (e.g. gjordan) and fetches the FireCloud profile associated
@@ -24,10 +22,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * <p>This is intended mostly for demonstration / testing purposes, to show how we leverage
  * domain-wide delegation to make FireCloud API calls impersonating other users.
  */
-@SpringBootApplication
-// Load the DBA and DB model classes required for UserDao.
-@EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
-@EntityScan("org.pmiops.workbench.db.model")
+@Configuration
 public class FetchFireCloudUserProfile {
   private static final Logger log =
       Logger.getLogger(org.pmiops.workbench.tools.FetchFireCloudUserProfile.class.getName());
@@ -63,6 +58,9 @@ public class FetchFireCloudUserProfile {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(FetchFireCloudUserProfile.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(FetchFireCloudUserProfile.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -13,7 +13,6 @@ import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -77,9 +76,6 @@ public class FetchWorkspaceDetails {
   }
 
   public static void main(String[] args) {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(FetchWorkspaceDetails.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(FetchWorkspaceDetails.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -13,11 +13,9 @@ import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * A tool that takes a Workspace namespace / Firecloud Project ID and returns details for any
@@ -25,9 +23,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  *
  * <p>Details currently include... - Name - Creator Email - Collaborator Emails and Access Levels
  */
-@SpringBootApplication
-@EnableJpaRepositories({"org.pmiops.workbench.db.dao"})
-@EntityScan("org.pmiops.workbench.db.model")
+@Configuration
 public class FetchWorkspaceDetails {
 
   private static final Logger log = Logger.getLogger(FetchWorkspaceDetails.class.getName());
@@ -81,6 +77,9 @@ public class FetchWorkspaceDetails {
   }
 
   public static void main(String[] args) {
-    new SpringApplicationBuilder(FetchWorkspaceDetails.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(FetchWorkspaceDetails.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/LoadDataDictionary.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/LoadDataDictionary.java
@@ -19,18 +19,14 @@ import org.pmiops.workbench.db.dao.DataDictionaryEntryDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
-@EnableJpaRepositories("org.pmiops.workbench")
-@EntityScan("org.pmiops.workbench")
+@Configuration
 public class LoadDataDictionary {
 
   private static final Logger logger = Logger.getLogger(LoadDataDictionary.class.getName());
@@ -134,6 +130,9 @@ public class LoadDataDictionary {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(LoadDataDictionary.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(LoadDataDictionary.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/LoadDataDictionary.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/LoadDataDictionary.java
@@ -19,7 +19,6 @@ import org.pmiops.workbench.db.dao.DataDictionaryEntryDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
@@ -130,9 +129,6 @@ public class LoadDataDictionary {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(LoadDataDictionary.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(LoadDataDictionary.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -31,9 +31,6 @@ import org.springframework.context.annotation.Configuration;
  * ManageClusters is an operational utility for interacting with the Leonardo Notebook clusters
  * available to the application default user. This should generally be used while authorized as the
  * App Engine default service account for a given environment.
- *
- * <p>Note: If this utility later needs database access, replace @Configuration
- * with @SpringBootApplication.
  */
 @Configuration
 public class ManageClusters {
@@ -184,6 +181,9 @@ public class ManageClusters {
   }
 
   public static void main(String[] args) throws Exception {
+    // This tool doesn't currently need database access, so it doesn't extend the
+    // CommandLineToolConfig. To add database access, extend from that config and update project.rb
+    // to ensure a Cloud SQL proxy is available when this command is run.
     new SpringApplicationBuilder(ManageClusters.class).web(false).run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
@@ -9,7 +9,6 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.Authority;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -93,9 +92,6 @@ public class SetAuthority {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(SetAuthority.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(SetAuthority.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
@@ -9,18 +9,14 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.Authority;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * See api/project.rb set-authority. Adds or removes authorities (permissions) from users in the db.
  */
-@SpringBootApplication
-@EnableJpaRepositories("org.pmiops.workbench.db.dao")
-@EntityScan("org.pmiops.workbench.db.model")
+@Configuration
 public class SetAuthority {
 
   private static final Logger log = Logger.getLogger(SetAuthority.class.getName());
@@ -97,6 +93,9 @@ public class SetAuthority {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(SetAuthority.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(SetAuthority.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateCdrVersions.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateCdrVersions.java
@@ -19,19 +19,15 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.model.ArchivalStatus;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * See api/project.rb update-cdr-versions. Reads CDR versions from a JSON file and updates the
  * database to match.
  */
-@SpringBootApplication
-@EnableJpaRepositories("org.pmiops.workbench.db.dao")
-@EntityScan("org.pmiops.workbench.db.model")
+@Configuration
 public class UpdateCdrVersions {
 
   private static final Logger logger = Logger.getLogger(UpdateCdrVersions.class.getName());
@@ -137,6 +133,9 @@ public class UpdateCdrVersions {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(UpdateCdrVersions.class).web(false).run(args);
+    new SpringApplicationBuilder(CommandLineToolConfig.class)
+        .child(UpdateCdrVersions.class)
+        .web(false)
+        .run(args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateCdrVersions.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateCdrVersions.java
@@ -19,7 +19,6 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.model.ArchivalStatus;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -133,9 +132,6 @@ public class UpdateCdrVersions {
   }
 
   public static void main(String[] args) throws Exception {
-    new SpringApplicationBuilder(CommandLineToolConfig.class)
-        .child(UpdateCdrVersions.class)
-        .web(false)
-        .run(args);
+    CommandLineToolConfig.runCommandLine(UpdateCdrVersions.class, args);
   }
 }


### PR DESCRIPTION
- `@SpringBootApplication` is an alias for 3 annotations, one of which was problematic:
  - `@Configuration` (effectively: this class can declare beans)
  - `@EnableAutoconfiguration` (import basic Spring modules, e.g. JPA, REST stuff, Liquibase)
  -  :warning: `@ComponentScan` (start grabbing all beans indiscriminately from the current source tree rooted at this package)
- ComponentScan had the side effect of muddling up all tool bean configs (including everything in every CLI tool) in the source directory into the same context, this was unexpected and undesirable.
- For a given CLI tool, in addition to that tool's `@Configuration`, the only thing we actually wanted to scan was the `CommandLineToolConfig`, which now needs to be explicitly brought in
- Also switch to a parent/child relationship, which may allow for easier overrides of particular bean declarations. `@Import`ing `CommandLineToolConfig` would have also worked.
  - **Note:** Parent/child contexts exhibit what I'd call "early binding" behavior. This means once you're injecting a bean that is sourced from the parent context, all dependencies for that bean can only be produced by the parent context. For example, if I got a `WorkspaceService` from the parent context (which depends on `WorkspacesApi`), as a child I'm not allowed to patch in my own custom `WorkspacesApi` override - to do that I'd need to provide my on `WorkspaceService` as well. If this proves to be undesirable, we can simply union the contexts as was done previously.

In particular, this article was highly relevant: https://www.blackpepper.co.uk/blog/a-modular-architecture-with-spring-boot

Example code in this PR shows a failing Bean in tool B (loadDataDictionary) coexisting with tool A (setAuthority). On master, this would cause tool A to fail.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
