### PR TITLE
[RW-3866][risk=no] Minor UI fixes for concept search

### DIFF
--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -286,7 +286,6 @@ export const ConceptHomepage = withCurrentWorkspace()(
     setConceptsAndVocabularies() {
       const cacheItem = this.state.conceptsCache
         .find(c => c.domain === this.state.selectedDomain.domain);
-      console.log(this.state.conceptsCache);
       this.setState({concepts: cacheItem.items});
     }
 

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -286,6 +286,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
     setConceptsAndVocabularies() {
       const cacheItem = this.state.conceptsCache
         .find(c => c.domain === this.state.selectedDomain.domain);
+      console.log(this.state.conceptsCache);
       this.setState({concepts: cacheItem.items});
     }
 
@@ -294,7 +295,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
         selectedDomain, completedDomainSearches} = this.state;
       const {namespace, id} = this.props.workspace;
       this.setState({concepts: [], searchLoading: true, searching: true, conceptsToAdd: [],
-        selectedConceptDomainMap: new Map<string, number>()});
+        selectedConceptDomainMap: new Map<string, number>(), completedDomainSearches: []});
       const standardConceptFilter = standardConceptsOnly ?
         StandardConceptFilter.STANDARDCONCEPTS : StandardConceptFilter.ALLCONCEPTS;
 
@@ -369,8 +370,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
     }
 
     domainLoading(domain) {
-      return this.state.searchLoading || !this.state.completedDomainSearches
-        .includes(domain.domain);
+      return !this.state.completedDomainSearches.includes(domain.domain);
     }
 
     get noConceptsConstant() {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -370,7 +370,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
     }
 
     domainLoading(domain) {
-      return !this.state.completedDomainSearches.includes(domain.domain);
+      return this.state.searchLoading || !this.state.completedDomainSearches.includes(domain.domain);
     }
 
     get noConceptsConstant() {
@@ -440,9 +440,9 @@ export const ConceptHomepage = withCurrentWorkspace()(
             </FlexColumn>;
           })}
         </FlexRow>
-        <div style={styles.conceptCounts}>
+        {!searchLoading && <div style={styles.conceptCounts}>
           Showing top {concepts.length} of {selectedDomain.conceptCount} {selectedDomain.name}
-        </div>
+        </div>}
         <ConceptTable concepts={concepts}
                       loading={searchLoading}
                       onSelectConcepts={this.selectConcepts.bind(this)}
@@ -513,7 +513,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                              expanded={this.addSurveyToSetText}
                              disable={selectedSurveyQuestions.length === 0}/>
           </div>}
-          {!browsingSurvey && loadingDomains ? <SpinnerOverlay/> :
+          {!browsingSurvey && loadingDomains ? <div style={{position: 'relative', minHeight: '10rem'}}><SpinnerOverlay/></div> :
             searching ?
               this.renderConcepts() : !browsingSurvey &&
                   <div>

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -426,7 +426,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                 {this.domainLoading(domain) ?
                     <Spinner style={{height: '15px', width: '15px'}}/> :
                     <FlexRow style={{justifyContent: 'space-between'}}>
-                      <div>{domain.conceptCount}</div>
+                      <div>{domain.conceptCount.toLocaleString()}</div>
                       {(selectedConceptDomainMap[domain.domain] > 0) &&
                       <div style={styles.selectedConceptsCount} data-test-id='selectedConcepts'>
                         {selectedConceptDomainMap[domain.domain]}
@@ -441,7 +441,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
           })}
         </FlexRow>
         {!searchLoading && <div style={styles.conceptCounts}>
-          Showing top {concepts.length} of {selectedDomain.conceptCount} {selectedDomain.name}
+          Showing top {concepts.length} of {selectedDomain.conceptCount.toLocaleString()} {selectedDomain.name}
         </div>}
         <ConceptTable concepts={concepts}
                       loading={searchLoading}

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -1,6 +1,7 @@
 import {Link} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
+import {SpinnerOverlay} from 'app/components/spinners';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {Concept} from 'generated/fetch/api';
@@ -205,8 +206,8 @@ export class ConceptTable extends React.Component<Props, State> {
   render() {
     const {pageConcepts, pageLoading, selectedConcepts} = this.state;
     const {placeholderValue, loading, reactKey} = this.props;
-    return <div data-test-id='conceptTable' key={reactKey}>
-      <DataTable emptyMessage={loading ? '' : placeholderValue}
+    return <div data-test-id='conceptTable' key={reactKey} style={{position: 'relative', minHeight: '10rem'}}>
+      {loading ? <SpinnerOverlay /> : <DataTable emptyMessage={loading ? '' : placeholderValue}
                  value={pageConcepts} scrollable={true}
                  selection={selectedConcepts} style={{minWidth: 1100}}
                  totalRecords={this.state.totalRecords}
@@ -219,14 +220,14 @@ export class ConceptTable extends React.Component<Props, State> {
                  lazy={true} first={this.state.first}
                  data-test-id='conceptRow'
                  onSelectionChange={e => this.updateSelectedConceptList(e.value)} >
-      <Column bodyStyle={{...styles.colStyle, width: '3rem'}} headerStyle = {{width: '3rem'}}
-              data-test-id='conceptCheckBox' selectionMode='multiple' />
-      <Column bodyStyle={styles.colStyle} field='conceptName' header='Name'
-              data-test-id='conceptName'/>
-      <Column bodyStyle={styles.colStyle} field='conceptCode' header='Code'/>
-      <Column field='vocabularyId' header='Vocabulary' bodyStyle={styles.colStyle} />
-      <Column style={styles.colStyle} field='countValue' header='Count'/>
-    </DataTable>
+        <Column bodyStyle={{...styles.colStyle, width: '3rem'}} headerStyle = {{width: '3rem'}}
+                data-test-id='conceptCheckBox' selectionMode='multiple' />
+        <Column bodyStyle={styles.colStyle} field='conceptName' header='Name'
+                data-test-id='conceptName'/>
+        <Column bodyStyle={styles.colStyle} field='conceptCode' header='Code'/>
+        <Column field='vocabularyId' header='Vocabulary' bodyStyle={styles.colStyle} />
+        <Column style={styles.colStyle} field='countValue' header='Count'/>
+      </DataTable>}
     </div>;
   }
 }

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -10,6 +10,10 @@ import {Column} from 'primereact/column';
 import {DataTable} from 'primereact/datatable';
 import * as React from 'react';
 
+function formatCounts(concept: any) {
+  concept.countValue = concept.countValue.toLocaleString();
+  return concept;
+}
 
 const styles = reactStyles({
   colStyle: {
@@ -119,7 +123,7 @@ export class ConceptTable extends React.Component<Props, State> {
       first: 0,
       totalRecords: props.concepts.length,
       pageNumber: 0,
-      pageConcepts: props.concepts.slice(0, 10)
+      pageConcepts: props.concepts.slice(0, 10).map(formatCounts)
     };
   }
 
@@ -147,7 +151,7 @@ export class ConceptTable extends React.Component<Props, State> {
       // Update pageConcepts only for the first time/page.
       // onPage() will update for the rest of the pages
       if (this.state.pageNumber === 0 ) {
-        this.setState({pageConcepts: nextProps.concepts.slice(0, 10)});
+        this.setState({pageConcepts: nextProps.concepts.slice(0, 10).map(formatCounts)});
       }
     }
   }
@@ -198,7 +202,7 @@ export class ConceptTable extends React.Component<Props, State> {
 
     this.setState({
       first: event.first,
-      pageConcepts: this.props.concepts.slice(startIndex, endIndex),
+      pageConcepts: this.props.concepts.slice(startIndex, endIndex).map(formatCounts),
       pageLoading: false
     });
   }

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -140,15 +140,13 @@ export class ConceptTable extends React.Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps) {
-    if ((nextProps.concepts !==  this.props.concepts)) {
-      if (nextProps.concepts !== this.props.concepts && nextProps.concepts.length > 0 ) {
-        this.setState({totalRecords: nextProps.concepts.length});
+    if (nextProps.concepts !==  this.props.concepts) {
+      this.setState({totalRecords: nextProps.concepts.length});
 
-        // Update pageConcepts only for the first time/page.
-        // onPage() will update for the rest of the pages
-        if (this.state.pageNumber === 0 ) {
-          this.setState({pageConcepts: nextProps.concepts.slice(0, 10)});
-        }
+      // Update pageConcepts only for the first time/page.
+      // onPage() will update for the rest of the pages
+      if (this.state.pageNumber === 0 ) {
+        this.setState({pageConcepts: nextProps.concepts.slice(0, 10)});
       }
     }
   }
@@ -178,7 +176,7 @@ export class ConceptTable extends React.Component<Props, State> {
       }
       words.push(splits[splits.length - 1]);
     }
-    return words.map(word => <span
+    return words.map((word, w) => <span key={w}
       style={matchString.test(word.toLowerCase()) ? styles.highlighted : {}}>
         {word}
       </span>);


### PR DESCRIPTION
- Fixes issue where selecting a domain tab with no results doesn't remove previous rows from the table or show the empty message
- Prevents spinners from overlapping other content and hides results messaging while loading data (eg: 'Showing top 0 of 0 Conditions')
- Format all counts with commas