### PR TITLE
[RW-4073][risk=no] Remove unneeded cohort store references

### DIFF
--- a/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
+++ b/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
@@ -10,7 +10,7 @@ import {cohortReviewStore} from 'app/services/review-state.service';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import {reactStyles, ReactWrapperBase, summarizeErrors, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
-import {currentCohortStore, navigate} from 'app/utils/navigation';
+import {navigate} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {Cohort} from 'generated/fetch';
 import {CohortReview} from 'generated/fetch';
@@ -50,17 +50,17 @@ const styles = reactStyles({
 });
 
 interface Props {
-  created: Function;
   canceled: Function;
+  cohort: Cohort;
+  created: Function;
   workspace: WorkspaceData;
 }
 
 interface State {
-  cohort: Cohort;
-  review: CohortReview;
   create: boolean;
   creating: boolean;
   numberOfParticipants: string;
+  review: CohortReview;
 }
 
 export const CreateReviewModal = withCurrentWorkspace()(
@@ -69,11 +69,10 @@ export const CreateReviewModal = withCurrentWorkspace()(
     constructor(props: any) {
       super(props);
       this.state = {
-        review: cohortReviewStore.getValue(),
-        cohort: currentCohortStore.getValue(),
         create: true,
         creating: false,
         numberOfParticipants: '',
+        review: cohortReviewStore.getValue()
       };
     }
 
@@ -83,8 +82,8 @@ export const CreateReviewModal = withCurrentWorkspace()(
 
     createReview() {
       this.setState({creating: true});
-      const {workspace: {cdrVersionId, id, namespace}} = this.props;
-      const {cohort, numberOfParticipants} = this.state;
+      const {cohort, workspace: {cdrVersionId, id, namespace}} = this.props;
+      const {numberOfParticipants} = this.state;
       const request = {size: parseInt(numberOfParticipants, 10)};
 
       cohortReviewApi().createCohortReview(namespace, id, cohort.id, +cdrVersionId, request)
@@ -101,7 +100,8 @@ export const CreateReviewModal = withCurrentWorkspace()(
     }
 
     render() {
-      const {cohort, creating, numberOfParticipants, review} = this.state;
+      const {cohort} = this.props;
+      const {creating, numberOfParticipants, review} = this.state;
       const max = Math.min(this.state.review.matchedParticipantCount, 10000);
       const errors = validate({numberOfParticipants}, {
         numberOfParticipants: {
@@ -161,8 +161,9 @@ export const CreateReviewModal = withCurrentWorkspace()(
 })
 export class CreateReviewModalComponent extends ReactWrapperBase {
   @Input('canceled') canceled: Props['canceled'];
+  @Input('cohort') cohort: Props['cohort'];
   @Input('created') created: Props['created'];
   constructor() {
-    super(CreateReviewModal, ['canceled', 'created']);
+    super(CreateReviewModal, ['canceled', 'cohort', 'created']);
   }
 }

--- a/ui/src/app/pages/data/cohort-review/detail-header.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-header.component.tsx
@@ -4,7 +4,7 @@ import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, summarizeErrors, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
-import {currentCohortStore, currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
+import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 
 import {
@@ -375,7 +375,7 @@ export const DetailHeader = withCurrentWorkspace()(
         isFirstParticipant,
         isLastParticipant
       } = this.state;
-      const cohort = currentCohortStore.getValue();
+      const review = cohortReviewStore.getValue();
       const errors = validate({ageMin, ageMax, dateMin, dateMax}, {
         ageMin: {
           numericality: {
@@ -409,8 +409,8 @@ export const DetailHeader = withCurrentWorkspace()(
           onClick={() => this.backToTable()}>
           Back to review set
         </button>
-        <h4 style={styles.title}>{cohort.name}</h4>
-        <div style={styles.description}>{cohort.description}</div>
+        <h4 style={styles.title}>{review.cohortName}</h4>
+        <div style={styles.description}>{review.description}</div>
         {errors && <div className='error-messages'>
           <ValidationError>
             {summarizeErrors(errors && (

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -7,9 +7,9 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {DetailHeader} from 'app/pages/data/cohort-review/detail-header.component';
 import {DetailTabs} from 'app/pages/data/cohort-review/detail-tabs.component';
 import {cohortReviewStore, getVocabOptions, participantStore, vocabOptions} from 'app/services/review-state.service';
-import {cohortReviewApi, cohortsApi} from 'app/services/swagger-fetch-clients';
+import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import {ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
-import {currentCohortStore, urlParamsStore} from 'app/utils/navigation';
+import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ParticipantCohortStatus, SortOrder} from 'generated/fetch';
 
@@ -32,22 +32,13 @@ export const DetailPage = withCurrentWorkspace()(
     async componentDidMount() {
       const {workspace: {cdrVersionId, id, namespace}} = this.props;
       const {ns, wsid, cid} = urlParamsStore.getValue();
-      const promises = [];
       if (!cohortReviewStore.getValue()) {
-        promises.push(
-          cohortReviewApi().getParticipantCohortStatuses(ns, wsid, cid, +cdrVersionId, {
-            page: 0,
-            pageSize: 25,
-            sortOrder: SortOrder.Asc,
-            filters: {items: []}
-          }).then(review => cohortReviewStore.next(review))
-        );
-      }
-      if (!currentCohortStore.getValue()) {
-        promises.push(cohortsApi().getCohort(ns, wsid, cid).then(cohort => currentCohortStore.next(cohort)));
-      }
-      if (promises.length) {
-        await Promise.all(promises);
+        await cohortReviewApi().getParticipantCohortStatuses(ns, wsid, cid, +cdrVersionId, {
+          page: 0,
+          pageSize: 25,
+          sortOrder: SortOrder.Asc,
+          filters: {items: []}
+        }).then(review => cohortReviewStore.next(review));
       }
       this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(params => !!params.pid)

--- a/ui/src/app/pages/data/cohort-review/table-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/table-page.tsx
@@ -9,12 +9,12 @@ import {Button} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortReviewStore, filterStateStore, getVocabOptions, multiOptions, vocabOptions} from 'app/services/review-state.service';
-import {cohortBuilderApi, cohortReviewApi, cohortsApi} from 'app/services/swagger-fetch-clients';
+import {cohortBuilderApi, cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {datatableStyles} from 'app/styles/datatable';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
-import {currentCohortStore, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
+import {navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   CohortStatus,
@@ -253,11 +253,8 @@ export const ParticipantsTable = withCurrentWorkspace()(
       const {filters} = this.state;
       const {cdrVersionId} = this.props.workspace;
       const promises = [];
-      const {ns, wsid, cid} = urlParamsStore.getValue();
+      const {ns, wsid} = urlParamsStore.getValue();
       const review = cohortReviewStore.getValue();
-      if (!currentCohortStore.getValue()) {
-        promises.push(cohortsApi().getCohort(ns, wsid, cid).then(cohort => currentCohortStore.next(cohort)));
-      }
       if (!review) {
         promises.push(
           this.getParticipantStatuses().then(rev => {
@@ -569,7 +566,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
     render() {
       const {loading, page, sortField, sortOrder, total} = this.state;
       const data = loading ? null : this.state.data;
-      const cohort = currentCohortStore.getValue();
+      const review = cohortReviewStore.getValue();
       const start = page * rows;
       let pageReportTemplate;
       if (data !== null) {
@@ -606,7 +603,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
       });
       return <div style={styles.review}>
         <style>{datatableStyles}</style>
-        {!!cohort && <React.Fragment>
+        {!!review && <React.Fragment>
           <button
             style={styles.backBtn}
             type='button'
@@ -614,7 +611,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
             Back to cohort
           </button>
           <h4 style={styles.title}>
-            Review Sets for {cohort.name}
+            Review Sets for {review.cohortName}
             <Button
               style={{float: 'right', height: '1.3rem'}}
               disabled={!data}
@@ -623,7 +620,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
             </Button>
           </h4>
           <div style={styles.description}>
-            {cohort.description}
+            {review.description}
           </div>
           <DataTable
             style={styles.table}

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -7,7 +7,7 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {cohortsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
-import {currentCohortStore, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
+import {navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {Cohort} from 'generated/fetch';
 import * as React from 'react';
@@ -77,30 +77,22 @@ const CohortActions = withCurrentWorkspace()(
   class extends React.Component<Props, State> {
     constructor(props: any) {
       super(props);
-      this.state = {cohort: currentCohortStore.getValue(), cohortLoading: false};
+      this.state = {cohort: undefined, cohortLoading: false};
     }
 
     componentDidMount(): void {
-      const {cohort} = this.state;
-      if (!cohort) {
-        const cid = urlParamsStore.getValue().cid;
-        this.setState({cohortLoading: true});
-        if (cid) {
-          const {namespace, id} = this.props.workspace;
-          cohortsApi().getCohort(namespace, id, cid).then(c => {
-            if (c) {
-              currentCohortStore.next(c);
-              this.setState({cohort: c, cohortLoading: false});
-            } else {
-              navigate(['workspaces', namespace, id, 'data', 'cohorts']);
-            }
-          });
-        }
+      const cid = urlParamsStore.getValue().cid;
+      this.setState({cohortLoading: true});
+      if (cid) {
+        const {namespace, id} = this.props.workspace;
+        cohortsApi().getCohort(namespace, id, cid).then(c => {
+          if (c) {
+            this.setState({cohort: c, cohortLoading: false});
+          } else {
+            navigate(['workspaces', namespace, id, 'data', 'cohorts']);
+          }
+        });
       }
-    }
-
-    componentWillUnmount(): void {
-      currentCohortStore.next(undefined);
     }
 
     navigateTo(action: string): void {


### PR DESCRIPTION
Fixes issue where previous cohort is still loaded in `currentCohortStore` if the user goes directly from cohort review to building a new cohort.