### PR TITLE
[RW-3973][RW-4078][risk=low]Update jupyter docker to terra-jupyter-gatk:0.0.6

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -13,7 +13,7 @@
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "015EAA-E95687-1F8614",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -13,7 +13,7 @@
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.3"
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",


### PR DESCRIPTION
Description:
Certain R packages could not be installed due to outdated libraries, and we no longer populate the environment variable WORKSPACE_BUCKET.
Solution: use the latest version of terra-docker-gatk as our docker image, which includes an updated R build and restores WORKSPACE_BUCKET.

PR to update terra-docker-r with the fix to RW-3973: https://github.com/DataBiosphere/terra-docker/pull/54
PR to update terra-docker-gatk to include the fixed terra-docker-r: https://github.com/DataBiosphere/terra-docker/pull/60
PR to update all terra docker images with the fix to RW-4078: https://github.com/DataBiosphere/terra-docker/pull/63
Jenkins-triggered PR to push the [docker image](https://us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6) to GCR: https://github.com/DataBiosphere/leonardo/pull/1161

Manual testing framework proposal: https://docs.google.com/document/d/1mrjZh5ktQXgPhAh1cfyxkoIti9uPVqfdcZJUQiB_0mo/edit#
Test steps:
* Open a Workspace in a Local API running with this branch.  Hit Reset Notebook Server if you have an existing cluster, in order to recreate it with the new image.
* While that is recreating, open the [Notebook Functional Testing Workspace](https://all-of-us-workbench-test.appspot.com/workspaces/aou-rw-test-646cf54c/notebooktesting) in Test and download the R and Python notebooks locally (from Edit mode)
* Upload these notebooks to your Local environment by:
** Open or create a new notebook and go to Edit mode
** Click the Jupyter logo to enter the Jupyter file manager
** navigate to workspace/name_of_workspace in the Jupyter file manager
** upload the two notebooks 
** run them and observe that these two bugs are fixed
** TODO: a much better process! https://precisionmedicineinitiative.atlassian.net/browse/RW-3249

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
