### PR TITLE
[RW-3689][risk=no] Google Analytics Events - Workspaces

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -135,11 +135,11 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "aou-workbench-ui:build"
+            "browserTarget": "aou-workbench-ui:build:dev"
           },
           "configurations": {
             "dev": {
-              "browserTarget": "aou-workbench-ui:build:test"
+              "browserTarget": "aou-workbench-ui:build:dev"
             },
             "local": {
               "browserTarget": "aou-workbench-ui:build:local"

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -122,8 +122,10 @@ export class RenameModal extends React.Component<Props, States> {
       <ModalFooter>
         <Button type='secondary' onClick={() => this.props.onCancel()}>Cancel</Button>
         <TooltipTrigger content={summarizeErrors(errors)}>
-          <Button data-test-id='rename-button' disabled={!!errors || saving}
-            style={{marginLeft: '0.5rem'}} onClick={() => this.onRename()}>
+          <Button data-test-id='rename-button'
+                  disabled={!!errors || saving}
+                  style={{marginLeft: '0.5rem'}}
+                  onClick={() => this.onRename()}>
             Rename {type}
           </Button>
         </TooltipTrigger>

--- a/ui/src/app/components/resource-card-template.tsx
+++ b/ui/src/app/components/resource-card-template.tsx
@@ -65,6 +65,7 @@ interface Props {
   actions: Action[];
   disabled: boolean;
   resourceUrl: string;
+  onNavigate: () => void;
   displayName: string;
   description: string;
   displayDate: string;
@@ -79,10 +80,12 @@ export class ResourceCardTemplate extends React.Component<Props, {}> {
     super(props);
   }
 
+  static defaultProps = {
+    onNavigate: () => {}
+  };
+
   render() {
     return <React.Fragment>
-
-
       <ResourceCardBase style={styles.card}
                         data-test-id='card'>
         <FlexColumn style={{alignItems: 'flex-start'}}>
@@ -115,8 +118,10 @@ export class ResourceCardTemplate extends React.Component<Props, {}> {
                  data-test-id='card-name'
                  href={this.props.resourceUrl}
                  onClick={e => {
+                   this.props.onNavigate();
                    navigateAndPreventDefaultIfNoKeysPressed(e, this.props.resourceUrl);
-                 }}> {this.props.displayName}
+                 }}>
+                {this.props.displayName}
               </a>
             </Clickable>
           </FlexRow>

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -18,11 +18,8 @@ import {CopyRequest, DataSet, RecentResource} from 'generated/fetch';
 
 import {Modal, ModalBody, ModalTitle} from 'app/components/modals';
 import {RenameModal} from 'app/components/rename-modal';
-import {
-  cohortReviewApi,
-  conceptSetsApi,
-  dataSetApi
-} from 'app/services/swagger-fetch-clients';
+import {cohortReviewApi, conceptSetsApi, dataSetApi} from 'app/services/swagger-fetch-clients';
+import {AnalyticsTracker} from 'app/utils/analytics';
 
 const styles = reactStyles({
   card: {
@@ -267,6 +264,7 @@ export class ResourceCard extends React.Component<Props, State> {
         break;
       }
       case ResourceType.DATA_SET: {
+        AnalyticsTracker.DatasetBuilder.Delete();
         dataSetApi().deleteDataSet(
           this.props.resourceCard.workspaceNamespace,
           this.props.resourceCard.workspaceFirecloudName,
@@ -417,6 +415,9 @@ export class ResourceCard extends React.Component<Props, State> {
                    data-test-id='card-name'
                  href={this.getResourceUrl()}
                  onClick={e => {
+                   if (this.resourceType === ResourceType.DATA_SET) {
+                     AnalyticsTracker.DatasetBuilder.OpenEditPage('From Clicking Card');
+                   }
                    navigateAndPreventDefaultIfNoKeysPressed(e, this.getResourceUrl());
                  }}>{this.displayName}
               </a>
@@ -463,7 +464,10 @@ export class ResourceCard extends React.Component<Props, State> {
                           closeFunction={() => this.setState({exportingDataSet: false})}/>}
       {this.state.renaming && this.isDataSet &&
         <RenameModal
-          onRename={(newName, newDescription) => this.receiveDataSetRename(newName, newDescription)}
+          onRename={(newName, newDescription) => {
+            AnalyticsTracker.DatasetBuilder.Rename();
+            this.receiveDataSetRename(newName, newDescription);
+          }}
           type='Dataset'
           onCancel={() => this.cancelRename()}
           oldDescription ={this.props.resourceCard.dataSet.description}

--- a/ui/src/app/components/resources.tsx
+++ b/ui/src/app/components/resources.tsx
@@ -4,6 +4,7 @@ import {Clickable, MenuItem} from 'app/components/buttons';
 import {SnowmanIcon} from 'app/components/icons';
 import {PopupTrigger} from 'app/components/popups';
 import {switchCase} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {ResourceType} from 'app/utils/resourceActions';
 
 export interface ResourceCardMenuProps {
@@ -65,25 +66,37 @@ export class ResourceCardMenu extends React.Component<ResourceCardMenuProps> {
           [ResourceType.DATA_SET, () => {
             return <React.Fragment>
               <MenuItem icon='pencil'
-                        onClick={this.props.onRenameResource}
+                        onClick={() => {
+                          AnalyticsTracker.DatasetBuilder.OpenRenameModal();
+                          this.props.onRenameResource();
+                        }}
                         disabled={!this.props.canEdit}
               >
                 Rename Dataset
               </MenuItem>
               <MenuItem icon='pencil'
-                        onClick={this.props.onEdit}
+                        onClick={() => {
+                          AnalyticsTracker.DatasetBuilder.OpenEditPage('From Card Snowman');
+                          this.props.onEdit();
+                        }}
                         disabled={!this.props.canEdit}
               >
                 Edit
               </MenuItem>
               <MenuItem icon='clipboard'
-                        onClick={this.props.onExportDataSet}
+                        onClick={() => {
+                          AnalyticsTracker.DatasetBuilder.OpenExportModal();
+                          this.props.onExportDataSet();
+                        }}
                         disabled={!this.props.canEdit}
               >
                 Export to Notebook
               </MenuItem>
               <MenuItem icon='trash'
-                        onClick={this.props.onDeleteResource}
+                        onClick={() => {
+                          AnalyticsTracker.DatasetBuilder.OpenDeleteModal();
+                          this.props.onDeleteResource();
+                        }}
                         disabled={!this.props.canDelete}
               >
                 Delete

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -13,6 +13,7 @@ import {notebooksClusterApi} from 'app/services/notebooks-swagger-fetch-clients'
 import {clusterApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {isAbortError} from 'app/utils/errors';
 import {navigate, userProfileStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -265,14 +266,20 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
               </div>) : (
               <div style={{display: 'flex'}}>
                 <div style={this.buttonStyleObj}
-                     onClick={() => { this.startEditMode(); }}>
+                     onClick={() => {
+                       AnalyticsTracker.Notebooks.Edit();
+                       this.startEditMode();
+                     }}>
                   <EditComponentReact enableHoverEffect={false}
                                       disabled={!this.canWrite}
                                       style={styles.navBarIcon}/>
                   Edit {this.notebookInUse && '(In Use)'}
                 </div>
                 <div style={this.buttonStyleObj}
-                     onClick={() => { this.onPlaygroundModeClick(); }}>
+                     onClick={() => {
+                       AnalyticsTracker.Notebooks.Run();
+                       this.onPlaygroundModeClick();
+                     }}>
                   <PlaygroundModeIcon enableHoverEffect={false} disabled={!this.canWrite}
                                       style={styles.navBarIcon}/>
                   Run (Playground Mode)

--- a/ui/src/app/pages/analysis/new-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-notebook-modal.tsx
@@ -13,6 +13,7 @@ import {navigate} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 import {ResourceType} from 'app/utils/resourceActions';
 
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {Workspace} from 'generated/fetch';
 
 export class NewNotebookModal extends React.Component<
@@ -79,8 +80,13 @@ export class NewNotebookModal extends React.Component<
           <Button
             style={{marginLeft: '0.5rem'}}
             disabled={!!errors}
-            onClick={() => this.save()}
-          >Create Notebook</Button>
+            onClick={() => {
+              AnalyticsTracker.Notebooks.Create(Kernels[this.state.kernel]);
+              this.save();
+            }}
+          >
+            Create Notebook
+          </Button>
         </TooltipTrigger>
       </ModalFooter>
     </Modal>;

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -17,6 +17,7 @@ import {WorkspaceData} from 'app/utils/workspace-data';
 
 
 import {NotebookResourceCard} from 'app/pages/analysis/notebook-resource-card';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {FileDetail, WorkspaceAccessLevel} from 'generated/fetch';
 
 const styles = {
@@ -89,7 +90,10 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
           <CardButton
             disabled={!canWrite}
             type='small'
-            onClick={() => this.setState({creating: true})}
+            onClick={() => {
+              AnalyticsTracker.Notebooks.OpenCreateModal();
+              this.setState({creating: true});
+            }}
           >
             Create a<br/>New Notebook
             <ClrIcon shape='plus-circle' size={21} style={{marginTop: 5}} />

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -8,6 +8,7 @@ import {dropNotebookFileSuffix} from 'app/pages/analysis/util';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {formatRecentResourceDisplayDate} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {encodeURIComponentStrict} from 'app/utils/navigation';
 import {ResourceType} from 'app/utils/resourceActions';
 import {CopyRequest, RecentResource} from 'generated/fetch';
@@ -70,6 +71,7 @@ export const NotebookResourceCard = fp.flow(
         icon: 'pencil',
         displayName: 'Rename',
         onClick: () => {
+          AnalyticsTracker.Notebooks.OpenRenameModal();
           this.setState({showRenameModal: true});
         },
         disabled: !this.writePermission,
@@ -77,21 +79,33 @@ export const NotebookResourceCard = fp.flow(
       {
         icon: 'copy',
         displayName: 'Duplicate',
-        onClick: () => this.duplicateNotebook(),
+        onClick: () => {
+          AnalyticsTracker.Notebooks.Duplicate();
+          this.duplicateNotebook();
+        },
         disabled: !this.writePermission,
       },
       {
         icon: 'copy',
         displayName: 'Copy to another Workspace',
-        onClick: () => this.setState({showCopyNotebookModal: true}),
+        onClick: () => {
+          AnalyticsTracker.Notebooks.OpenCopyModal();
+          this.setState({showCopyNotebookModal: true});
+        },
         disabled: false,
       },
       {
         icon: 'trash',
         displayName: 'Delete',
         onClick: () => {
-          this.props.showConfirmDeleteModal(this.displayName,
-            this.resourceType, () => this.deleteNotebook());
+          AnalyticsTracker.Notebooks.OpenDeleteModal();
+          this.props.showConfirmDeleteModal(
+            this.displayName,
+            this.resourceType,
+            () => {
+              AnalyticsTracker.Notebooks.Delete();
+              return this.deleteNotebook();
+            });
         },
         disabled: !this.deletePermission,
       }];
@@ -146,6 +160,8 @@ export const NotebookResourceCard = fp.flow(
   }
 
   copyNotebook(copyRequest: CopyRequest) {
+    AnalyticsTracker.Notebooks.Copy();
+
     return workspacesApi().copyNotebook(
       this.props.resource.workspaceNamespace,
       this.props.resource.workspaceFirecloudName,
@@ -169,7 +185,10 @@ export const NotebookResourceCard = fp.flow(
 
       {this.state.showRenameModal &&
       <RenameModal type={this.resourceType}
-                   onRename={(newName) => this.renameNotebook(newName)}
+                   onRename={(newName) => {
+                     AnalyticsTracker.Notebooks.Rename();
+                     this.renameNotebook(newName);
+                   }}
                    onCancel={() => this.setState({showRenameModal: false})}
                    hideDescription={true}
                    oldName={this.props.resource.notebook.name}
@@ -181,6 +200,7 @@ export const NotebookResourceCard = fp.flow(
         actions={this.actions}
         disabled={false} // Notebook Cards are always at least readable
         resourceUrl={this.resourceUrl}
+        onNavigate={() => AnalyticsTracker.Notebooks.Preview()}
         displayName={this.displayName}
         description={''}
         displayDate={formatRecentResourceDisplayDate(this.props.resource.modifiedTime)}

--- a/ui/src/app/pages/data/data-page.tsx
+++ b/ui/src/app/pages/data/data-page.tsx
@@ -12,6 +12,7 @@ import {CohortResourceCard} from 'app/pages/data/cohort/cohort-resource-card';
 import {cohortReviewApi, cohortsApi, conceptSetsApi, dataSetApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {navigate} from 'app/utils/navigation';
 import {
   convertToResources,
@@ -227,6 +228,7 @@ export const DataPage = withCurrentWorkspace()(class extends React.Component<
               style={{...styles.resourceTypeButton, ...styles.resourceTypeButtonLast}}
               disabled={!writePermission}
               onClick={() => {
+                AnalyticsTracker.DatasetBuilder.OpenCreatePage();
                 navigate(['workspaces', namespace, id, 'data', 'data-sets']);
               }}>
               <div style={styles.cardHeader}>

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -29,6 +29,7 @@ import {
   withUrlParams,
   withUserProfile
 } from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {currentWorkspaceStore, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {ResourceType} from 'app/utils/resourceActions';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -974,12 +975,19 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                 </div>
               </div>
               </FlexColumn>
-              <Clickable data-test-id='preview-button' style={{
-                marginTop: '0.5rem',
-                cursor: this.disableSave() ? 'not-allowed' : 'pointer', height: '1.8rem',
-                width: '6.5rem', color: this.disableSave() ? colorWithWhiteness(colors.dark, 0.6) :
-                  colors.accent}} disabled={this.disableSave()}
-                onClick={() => this.getPreviewList()}>
+              <Clickable data-test-id='preview-button'
+                         style={{
+                           marginTop: '0.5rem',
+                           cursor: this.disableSave() ? 'not-allowed' : 'pointer',
+                           height: '1.8rem',
+                           width: '6.5rem',
+                           color: this.disableSave() ? colorWithWhiteness(colors.dark, 0.6) : colors.accent
+                         }}
+                         disabled={this.disableSave()}
+                         onClick={() => {
+                           AnalyticsTracker.DatasetBuilder.ViewPreviewTable();
+                           this.getPreviewList();
+                         }}>
                   View Preview Table
               </Clickable>
             </div>

--- a/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
@@ -13,6 +13,7 @@ import {encodeURIComponentStrict, navigateByUrl} from 'app/utils/navigation';
 
 
 import {appendNotebookFileSuffix} from 'app/pages/analysis/util';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {DataSet, DataSetRequest, FileDetail, KernelTypeEnum} from 'generated/fetch';
 
 interface Props {
@@ -173,7 +174,12 @@ class ExportDataSetModal extends React.Component<
       <ModalTitle>Export {dataSet.name} to Notebook</ModalTitle>
       <ModalBody>
         <Button data-test-id='code-preview-button'
-                onClick={() => this.setState({seePreview: !seePreview})}>
+                onClick={() => {
+                  if (!seePreview) {
+                    AnalyticsTracker.DatasetBuilder.SeeCodePreview();
+                  }
+                  this.setState({seePreview: !seePreview});
+                }}>
           {seePreview ? 'Hide Preview' : 'See Code Preview'}
         </Button>
         {seePreview && <React.Fragment>
@@ -225,8 +231,13 @@ class ExportDataSetModal extends React.Component<
           Cancel
         </Button>
         <TooltipTrigger content={summarizeErrors(errors)}>
-          <Button type='primary' data-test-id='save-data-set'
-                  disabled={errors || loading} onClick={() => this.exportDataSet()}>
+          <Button type='primary'
+                  data-test-id='save-data-set'
+                  disabled={errors || loading}
+                  onClick={() => {
+                    AnalyticsTracker.DatasetBuilder.Export(this.state.kernelType);
+                    this.exportDataSet();
+                  }}>
             Export and Open
           </Button>
         </TooltipTrigger>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -26,6 +26,7 @@ import {environment} from 'environments/environment';
 import {
   Profile,
 } from 'generated/fetch';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 export const styles = reactStyles({
   bottomBanner: {
@@ -436,7 +437,10 @@ export const Homepage = withUserProfile()(class extends React.Component<
                       <FlexRow style={{paddingTop: '2rem'}}>
                         <div style={styles.contentWrapperLeft}>
                           <div style={styles.mainHeaderToDelete}>Researcher Workbench</div>
-                          <CardButton onClick={() => navigate(['workspaces/build'])}
+                          <CardButton onClick={() => {
+                                        AnalyticsTracker.Workspaces.OpenCreatePage();
+                                        navigate(['workspaces/build'])
+                                      }}
                                       style={{margin: '1.9rem 106px 0 3%'}}>
                             Create a <br/> New Workspace
                             <ClrIcon shape='plus-circle' style={{height: '32px', width: '32px'}}/>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -22,11 +22,11 @@ import {getRegistrationTasksMap, RegistrationDashboard} from 'app/pages/homepage
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {environment} from 'environments/environment';
 import {
   Profile,
 } from 'generated/fetch';
-import {AnalyticsTracker} from "app/utils/analytics";
 
 export const styles = reactStyles({
   bottomBanner: {
@@ -438,9 +438,9 @@ export const Homepage = withUserProfile()(class extends React.Component<
                         <div style={styles.contentWrapperLeft}>
                           <div style={styles.mainHeaderToDelete}>Researcher Workbench</div>
                           <CardButton onClick={() => {
-                                        AnalyticsTracker.Workspaces.OpenCreatePage();
-                                        navigate(['workspaces/build'])
-                                      }}
+                            AnalyticsTracker.Workspaces.OpenCreatePage();
+                            navigate(['workspaces/build']);
+                          }}
                                       style={{margin: '1.9rem 106px 0 3%'}}>
                             Create a <br/> New Workspace
                             <ClrIcon shape='plus-circle' style={{height: '32px', width: '32px'}}/>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -324,7 +324,10 @@ export const Homepage = withUserProfile()(class extends React.Component<
                                     size={30}
                                     className={'is-solid'}
                                     style={{color: colors.accent, marginLeft: '1rem', cursor: 'pointer'}}
-                                    onClick={() => navigate(['workspaces/build'])}
+                                    onClick={() => {
+                                      AnalyticsTracker.Workspaces.OpenCreatePage();
+                                      navigate(['workspaces/build']);
+                                    }}
                                   />
                                 </FlexRow>
                                 <span

--- a/ui/src/app/pages/workspace/new-workspace-button.tsx
+++ b/ui/src/app/pages/workspace/new-workspace-button.tsx
@@ -4,6 +4,7 @@ import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {navigate} from 'app/utils/navigation';
 import * as React from 'react';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 const styles = reactStyles({
   addCard: {
@@ -12,7 +13,11 @@ const styles = reactStyles({
 });
 
 export const NewWorkspaceButton = () =>
-  <CardButton onClick={() => navigate(['workspaces/build'])}  style={styles.addCard}>
+  <CardButton onClick={() => {
+                AnalyticsTracker.Workspaces.OpenCreatePage();
+                navigate(['workspaces/build'])
+              }}
+              style={styles.addCard}>
     Create a <br/> New Workspace
     <ClrIcon shape='plus-circle' style={{height: '32px', width: '32px'}}/>
   </CardButton>;

--- a/ui/src/app/pages/workspace/new-workspace-button.tsx
+++ b/ui/src/app/pages/workspace/new-workspace-button.tsx
@@ -2,9 +2,9 @@ import {CardButton} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {navigate} from 'app/utils/navigation';
 import * as React from 'react';
-import {AnalyticsTracker} from "app/utils/analytics";
 
 const styles = reactStyles({
   addCard: {
@@ -14,9 +14,9 @@ const styles = reactStyles({
 
 export const NewWorkspaceButton = () =>
   <CardButton onClick={() => {
-                AnalyticsTracker.Workspaces.OpenCreatePage();
-                navigate(['workspaces/build'])
-              }}
+    AnalyticsTracker.Workspaces.OpenCreatePage();
+    navigate(['workspaces/build']);
+  }}
               style={styles.addCard}>
     Create a <br/> New Workspace
     <ClrIcon shape='plus-circle' style={{height: '32px', width: '32px'}}/>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -15,7 +15,7 @@ import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {displayDate, reactStyles} from 'app/utils';
-import {triggerEvent} from 'app/utils/analytics';
+import {AnalyticsTracker, triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore, navigate} from 'app/utils/navigation';
 import {ResourceType} from 'app/utils/resourceActions';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
@@ -78,26 +78,42 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
     content={
       <React.Fragment>
         <MenuItem icon='copy'
-                  onClick={() => {navigate([wsPathPrefix, 'duplicate']); }}>
+                  onClick={() => {
+                    AnalyticsTracker.Workspaces.OpenDuplicatePage('Tile');
+                    navigate([wsPathPrefix, 'duplicate']); }
+                  }>
           Duplicate
         </MenuItem>
         <TooltipTrigger content={<div>Requires Write Permission</div>}
                         disabled={WorkspacePermissionsUtil.canWrite(accessLevel)}>
           <MenuItem icon='pencil'
-                    onClick={() => {navigate([wsPathPrefix, 'edit']); }}
+                    onClick={() => {
+                      AnalyticsTracker.Workspaces.OpenEditPage('Tile');
+                      navigate([wsPathPrefix, 'edit']); }
+                    }
                     disabled={!WorkspacePermissionsUtil.canWrite(accessLevel)}>
             Edit
           </MenuItem>
         </TooltipTrigger>
         <TooltipTrigger content={<div data-test-id='workspace-share-disabled-tooltip'>Requires Owner Permission</div>}
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
-          <MenuItem icon='pencil' onClick={onShare} disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
+          <MenuItem icon='pencil'
+                    onClick={() => {
+                      AnalyticsTracker.Workspaces.OpenShareModal('Tile');
+                      onShare();
+                    }}
+                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
             Share
           </MenuItem>
         </TooltipTrigger>
         <TooltipTrigger content={<div>Requires Owner Permission</div>}
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
-          <MenuItem icon='trash' onClick={onDelete} disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
+          <MenuItem icon='trash'
+                    onClick={() => {
+                      AnalyticsTracker.Workspaces.OpenDeleteModal('Tile');
+                      onDelete();
+                    }}
+                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
             Delete
           </MenuItem>
         </TooltipTrigger>
@@ -296,7 +312,10 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
       <ConfirmDeleteModal data-test-id='confirm-delete-modal'
                           resourceType={ResourceType.WORKSPACE}
                           resourceName={workspace.name}
-                          receiveDelete={() => {this.deleteWorkspace(); }}
+                          receiveDelete={() => {
+                            AnalyticsTracker.Workspaces.Delete();
+                            this.deleteWorkspace();
+                          }}
                           closeFunction={() => {this.setState({confirmDeleting: false}); }}/>}
       {sharing && <WorkspaceShare data-test-id='workspace-share-modal'
                                   workspace={workspace}

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -79,7 +79,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
       <React.Fragment>
         <MenuItem icon='copy'
                   onClick={() => {
-                    AnalyticsTracker.Workspaces.OpenDuplicatePage('Tile');
+                    AnalyticsTracker.Workspaces.OpenDuplicatePage('Card');
                     navigate([wsPathPrefix, 'duplicate']); }
                   }>
           Duplicate
@@ -88,7 +88,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
                         disabled={WorkspacePermissionsUtil.canWrite(accessLevel)}>
           <MenuItem icon='pencil'
                     onClick={() => {
-                      AnalyticsTracker.Workspaces.OpenEditPage('Tile');
+                      AnalyticsTracker.Workspaces.OpenEditPage('Card');
                       navigate([wsPathPrefix, 'edit']); }
                     }
                     disabled={!WorkspacePermissionsUtil.canWrite(accessLevel)}>
@@ -99,7 +99,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='pencil'
                     onClick={() => {
-                      AnalyticsTracker.Workspaces.OpenShareModal('Tile');
+                      AnalyticsTracker.Workspaces.OpenShareModal('Card');
                       onShare();
                     }}
                     disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
@@ -110,7 +110,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='trash'
                     onClick={() => {
-                      AnalyticsTracker.Workspaces.OpenDeleteModal('Tile');
+                      AnalyticsTracker.Workspaces.OpenDeleteModal('Card');
                       onDelete();
                     }}
                     disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -533,6 +533,18 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       return fp.includes(populationEnum, this.state.workspace.researchPurpose.populationDetails);
     }
 
+    onSaveClick() {
+      if (this.isMode(WorkspaceEditMode.Create)) {
+        AnalyticsTracker.Workspaces.Create();
+      } else if (this.isMode(WorkspaceEditMode.Duplicate)) {
+        AnalyticsTracker.Workspaces.Duplicate();
+      } else if (this.isMode(WorkspaceEditMode.Edit)) {
+        AnalyticsTracker.Workspaces.Edit();
+      }
+
+      this.saveWorkspace();
+    }
+
     async saveWorkspace() {
       try {
         this.setState({loading: true});
@@ -907,16 +919,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
               </ul>
             } disabled={!errors}>
               <Button type='primary'
-                      onClick={() => {
-                        if (this.isMode(WorkspaceEditMode.Create)) {
-                          AnalyticsTracker.Workspaces.Create();
-                        } else if (this.isMode(WorkspaceEditMode.Duplicate)) {
-                          AnalyticsTracker.Workspaces.Duplicate();
-                        } else if (this.isMode(WorkspaceEditMode.Edit)) {
-                          AnalyticsTracker.Workspaces.Edit();
-                        }
-                        this.saveWorkspace();
-                      }}
+                      onClick={() => this.onSaveClick()}
                       disabled={errors || this.state.loading}
                       data-test-id='workspace-save-btn'>
                 {this.renderButtonText()}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -908,7 +908,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             } disabled={!errors}>
               <Button type='primary'
                       onClick={() => {
-                        AnalyticsTracker.Workspaces.Create();
+                        if (this.isMode(WorkspaceEditMode.Create)) {
+                          AnalyticsTracker.Workspaces.Create();
+                        } else if (this.isMode(WorkspaceEditMode.Duplicate)) {
+                          AnalyticsTracker.Workspaces.Duplicate();
+                        } else if (this.isMode(WorkspaceEditMode.Edit)) {
+                          AnalyticsTracker.Workspaces.Edit();
+                        }
                         this.saveWorkspace()}}
                       disabled={errors || this.state.loading}
                       data-test-id='workspace-save-btn'>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -19,6 +19,7 @@ import {ArchivalStatus, CdrVersion, CdrVersionListResponse, DataAccessLevel, Spe
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import * as validate from 'validate.js';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 export const ResearchPurposeDescription =
   <div style={{display: 'inline'}}>The <i>All of Us</i> Research Program requires each user
@@ -627,11 +628,6 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       });
     }
 
-    isEmpty(parent, field) {
-      const fieldValue = parent[field];
-      return !fieldValue || fieldValue === '';
-    }
-
     isMode(mode) {
       return this.props.routeConfigData.mode === mode;
     }
@@ -910,7 +906,10 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                 {errors.diseaseOfFocus && <div>You must specify a disease of focus</div>}
               </ul>
             } disabled={!errors}>
-              <Button type='primary' onClick={() => this.saveWorkspace()}
+              <Button type='primary'
+                      onClick={() => {
+                        AnalyticsTracker.Workspaces.Create();
+                        this.saveWorkspace()}}
                       disabled={errors || this.state.loading}
                       data-test-id='workspace-save-btn'>
                 {this.renderButtonText()}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -13,13 +13,13 @@ import {TwoColPaddedTable} from 'app/components/tables';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, sliceByHalfLength, withCdrVersions, withCurrentWorkspace, withRouteConfigData} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {reportError} from 'app/utils/errors';
 import {currentWorkspaceStore, navigate, nextWorkspaceWarmupStore, serverConfigStore} from 'app/utils/navigation';
 import {ArchivalStatus, CdrVersion, CdrVersionListResponse, DataAccessLevel, SpecificPopulationEnum, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import * as validate from 'validate.js';
-import {AnalyticsTracker} from "app/utils/analytics";
 
 export const ResearchPurposeDescription =
   <div style={{display: 'inline'}}>The <i>All of Us</i> Research Program requires each user
@@ -915,7 +915,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                         } else if (this.isMode(WorkspaceEditMode.Edit)) {
                           AnalyticsTracker.Workspaces.Edit();
                         }
-                        this.saveWorkspace()}}
+                        this.saveWorkspace();
+                      }}
                       disabled={errors || this.state.loading}
                       data-test-id='workspace-save-btn'>
                 {this.renderButtonText()}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -11,6 +11,7 @@ import {WorkspaceAccessLevel} from 'generated';
 
 import * as fp from 'lodash/fp';
 import * as React from 'react';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 
 const styles = reactStyles({
@@ -100,14 +101,20 @@ export const WorkspaceNavBarReact = fp.flow(
           <div style={styles.dropdownHeader}>Workspace Actions</div>
           <MenuItem
             icon='copy'
-            onClick={() => NavStore.navigate(['/workspaces', namespace, id, 'duplicate'])}>
+            onClick={() => {
+              AnalyticsTracker.Workspaces.OpenDuplicatePage();
+              NavStore.navigate(['/workspaces', namespace, id, 'duplicate']);
+            }}>
             Duplicate
           </MenuItem>
           <MenuItem
             icon='pencil'
             tooltip={isNotOwner && 'Requires owner permission'}
             disabled={isNotOwner}
-            onClick={() => NavStore.navigate(['/workspaces', namespace, id, 'edit'])}
+            onClick={() => {
+              AnalyticsTracker.Workspaces.OpenEditPage();
+              NavStore.navigate(['/workspaces', namespace, id, 'edit']);
+            }}
           >
             Edit
           </MenuItem>
@@ -115,14 +122,20 @@ export const WorkspaceNavBarReact = fp.flow(
             icon='share'
             tooltip={isNotOwner && 'Requires owner permission'}
             disabled={isNotOwner}
-            onClick={() => shareFunction()}>
+            onClick={() => {
+              AnalyticsTracker.Workspaces.OpenShareModal();
+              shareFunction();
+            }}>
             Share
           </MenuItem>
           <MenuItem
             icon='trash'
             tooltip={isNotOwner && 'Requires owner permission'}
             disabled={isNotOwner}
-            onClick={() => deleteFunction()}>
+            onClick={() => {
+              AnalyticsTracker.Workspaces.OpenDeleteModal();
+              deleteFunction();
+            }}>
             Delete
           </MenuItem>
         </React.Fragment>

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -9,9 +9,9 @@ import {withCurrentWorkspace, withUrlParams} from 'app/utils/index';
 import {NavStore} from 'app/utils/navigation';
 import {WorkspaceAccessLevel} from 'generated';
 
+import {AnalyticsTracker} from 'app/utils/analytics';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {AnalyticsTracker} from "app/utils/analytics";
 
 
 const styles = reactStyles({

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -24,7 +24,7 @@ import {Button} from 'app/components/buttons';
 import {ClrIcon, InfoIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
-import {AnalyticsTracker} from "app/utils/analytics";
+import {AnalyticsTracker} from 'app/utils/analytics';
 
 const styles = reactStyles( {
   tooltipLabel: {
@@ -432,7 +432,7 @@ export const WorkspaceShare = withCurrentWorkspace()(class extends React.Compone
             <Button type='primary' data-test-id='save' disabled={!this.hasPermission}
                     onClick={() => {
                       AnalyticsTracker.Workspaces.Share();
-                      this.save()
+                      this.save();
                     }}>Save</Button>
         </ModalFooter>
       </Modal>}

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -24,6 +24,7 @@ import {Button} from 'app/components/buttons';
 import {ClrIcon, InfoIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 const styles = reactStyles( {
   tooltipLabel: {
@@ -429,7 +430,10 @@ export const WorkspaceShare = withCurrentWorkspace()(class extends React.Compone
             <Button type='link' style={{marginRight: '.8rem', border: 'none'}}
                     onClick={() => this.onCancel()}>Cancel</Button>
             <Button type='primary' data-test-id='save' disabled={!this.hasPermission}
-                    onClick={() => this.save()}>Save</Button>
+                    onClick={() => {
+                      AnalyticsTracker.Workspaces.Share();
+                      this.save()
+                    }}>Save</Button>
         </ModalFooter>
       </Modal>}
       {!this.state.workspaceFound && <div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -15,6 +15,7 @@ import {
 import {ResourceType} from 'app/utils/resourceActions';
 
 import {UserRole, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
+import {AnalyticsTracker} from "app/utils/analytics";
 
 @Component({
   styleUrls: ['../../../styles/buttons.css',
@@ -158,6 +159,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   }
 
   receiveDelete(): void {
+    AnalyticsTracker.Workspaces.Delete();
     this.delete(this.workspace);
   }
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -14,8 +14,8 @@ import {
 } from 'app/utils/navigation';
 import {ResourceType} from 'app/utils/resourceActions';
 
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {UserRole, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
-import {AnalyticsTracker} from "app/utils/analytics";
 
 @Component({
   styleUrls: ['../../../styles/buttons.css',

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -30,7 +30,9 @@ export function triggerEvent(
 }
 
 enum ANALYTICS_CATEGORIES {
-  WORKSPACES = 'Workspaces'
+  WORKSPACES = 'Workspaces',
+  DATASET_BUILDER = 'Dataset Builder',
+  NOTEBOOKS = 'Notebooks'
 }
 
 export const AnalyticsTracker = {
@@ -45,6 +47,36 @@ export const AnalyticsTracker = {
     Share: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Share', getCurrentPageLabel()),
     OpenDeleteModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Delete Modal', getCurrentPageLabel(suffix)),
     Delete: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Delete', getCurrentPageLabel())
+  },
+  DatasetBuilder: {
+    OpenCreatePage: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Create Page'),
+    Save: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Save'),
+    SaveAndAnalyze: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Save and Analyze', suffix),
+    OpenEditPage: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Edit Page', suffix),
+    Update: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Update'),
+    UpdateAndAnalyze: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Update and Analyze', suffix),
+    SeeCodePreview: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'See Code Preview'),
+    OpenRenameModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Rename Modal'),
+    Rename: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Rename'),
+    OpenExportModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Export Modal'),
+    Export: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Export', suffix),
+    OpenDeleteModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Delete Modal'),
+    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Delete'),
+    ViewPreviewTable: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'View Preview Table')
+  },
+  Notebooks: {
+    OpenCreateModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Create Modal'),
+    Create: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Create', suffix),
+    OpenRenameModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Rename Modal'),
+    Rename: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Rename'),
+    Duplicate: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Duplicate'),
+    OpenCopyModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Copy Modal'),
+    Copy: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Copy'),
+    OpenDeleteModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Delete Modal'),
+    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Delete'),
+    Preview: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Preview'),
+    Edit: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Edit'),
+    Run: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Run (Playground Mode)')
   }
 };
 

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -32,18 +32,33 @@ export function triggerEvent(
 export const AnalyticsTracker = {
   Workspaces: {
     OpenCreatePage: () => triggerEvent('Workspaces', 'Open Create Page', getCurrentPageLabel()),
-    Create: () => triggerEvent('Workspaces', 'Create')
-  }
+    Create: () => triggerEvent('Workspaces', 'Create'),
+    OpenDuplicatePage: (suffix = '') => triggerEvent('Workspaces', 'Open Duplicate Page', getCurrentPageLabel(suffix)),
+    Duplicate: () => triggerEvent('Workspaces', 'Duplicate'),
+    OpenEditPage: (suffix = '') => triggerEvent('Workspaces', 'Open Edit Page', getCurrentPageLabel(suffix)),
+    Edit: () => triggerEvent('Workspaces', 'Edit'),
+    OpenShareModal: (suffix = '') => triggerEvent('Workspaces', 'Open Share Modal', getCurrentPageLabel(suffix)),
+    Share: () => triggerEvent('Workspaces', 'Share', getCurrentPageLabel()),
+    OpenDeleteModal: (suffix = '') => triggerEvent('Workspaces', 'Open Delete Modal', getCurrentPageLabel(suffix)),
+    Delete: () => triggerEvent('Workspaces', 'Delete', getCurrentPageLabel())
+  },
+
 };
 
-function getCurrentPageLabel() {
+function getCurrentPageLabel(suffix = '') {
+  let prefix;
+
   if (window.location.pathname === '/') {
-    return 'From Home Page';
+    prefix = 'From Home Page';
   } else if (window.location.pathname === '/workspaces') {
-    return 'From Workspace List Page';
+    prefix = 'From Workspace List Page';
+  } else if (window.location.pathname.match(/\/workspaces\/.*/) !== null) {
+    prefix = 'From Workspace Page';
   } else {
-    return 'Unknown Label: ' + window.location.pathname;
+    prefix = 'Unknown Label: ' + window.location.pathname;
   }
+
+  return `${prefix} (${suffix})`;
 }
 
 enum UserAuthState {

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -61,7 +61,7 @@ function getCurrentPageLabel(suffix = '') {
     prefix = 'Unknown Label: ' + window.location.pathname;
   }
 
-  return `${prefix} (${suffix})`;
+  return suffix ? `${prefix} (${suffix})` : prefix;
 }
 
 enum UserAuthState {

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -29,20 +29,23 @@ export function triggerEvent(
   }
 }
 
+enum ANALYTICS_CATEGORIES {
+  WORKSPACES = 'Workspaces'
+}
+
 export const AnalyticsTracker = {
   Workspaces: {
-    OpenCreatePage: () => triggerEvent('Workspaces', 'Open Create Page', getCurrentPageLabel()),
-    Create: () => triggerEvent('Workspaces', 'Create'),
-    OpenDuplicatePage: (suffix = '') => triggerEvent('Workspaces', 'Open Duplicate Page', getCurrentPageLabel(suffix)),
-    Duplicate: () => triggerEvent('Workspaces', 'Duplicate'),
-    OpenEditPage: (suffix = '') => triggerEvent('Workspaces', 'Open Edit Page', getCurrentPageLabel(suffix)),
-    Edit: () => triggerEvent('Workspaces', 'Edit'),
-    OpenShareModal: (suffix = '') => triggerEvent('Workspaces', 'Open Share Modal', getCurrentPageLabel(suffix)),
-    Share: () => triggerEvent('Workspaces', 'Share', getCurrentPageLabel()),
-    OpenDeleteModal: (suffix = '') => triggerEvent('Workspaces', 'Open Delete Modal', getCurrentPageLabel(suffix)),
-    Delete: () => triggerEvent('Workspaces', 'Delete', getCurrentPageLabel())
-  },
-
+    OpenCreatePage: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Create Page', getCurrentPageLabel()),
+    Create: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Create'),
+    OpenDuplicatePage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Duplicate Page', getCurrentPageLabel(suffix)),
+    Duplicate: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Duplicate'),
+    OpenEditPage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Edit Page', getCurrentPageLabel(suffix)),
+    Edit: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Edit'),
+    OpenShareModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Share Modal', getCurrentPageLabel(suffix)),
+    Share: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Share', getCurrentPageLabel()),
+    OpenDeleteModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Delete Modal', getCurrentPageLabel(suffix)),
+    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Delete', getCurrentPageLabel())
+  }
 };
 
 function getCurrentPageLabel(suffix = '') {

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -29,6 +29,23 @@ export function triggerEvent(
   }
 }
 
+export const AnalyticsTracker = {
+  Workspaces: {
+    OpenCreatePage: () => triggerEvent('Workspaces', 'Open Create Page', getCurrentPageLabel()),
+    Create: () => triggerEvent('Workspaces', 'Create')
+  }
+};
+
+function getCurrentPageLabel() {
+  if (window.location.pathname === '/') {
+    return 'From Home Page';
+  } else if (window.location.pathname === '/workspaces') {
+    return 'From Workspace List Page';
+  } else {
+    return 'Unknown Label: ' + window.location.pathname;
+  }
+}
+
 enum UserAuthState {
   LOGGED_IN = 'Logged in',
   LOGGED_OUT = 'Logged out'

--- a/ui/src/environments/environment.localtest.ts
+++ b/ui/src/environments/environment.localtest.ts
@@ -6,5 +6,6 @@ import {testEnvironmentBase} from 'environments/test-env-base';
 export const environment: Environment = {
   ...testEnvironmentBase,
   displayTag: 'Local->Test',
-  debug: true
+  debug: true,
+  gaId: 'UA-112406425-5'
 };


### PR DESCRIPTION
Dev Notes
- I tried to trigger the event as close to the onClick as much as possible
- I wanted to centralize the logic so there's a single place to look at what events we're tracking
- The `getCurrentPageLabel()` bit might be controversial but I felt like it was the cleanest way to infer where we currently are on the page. The traditional way passing the info down through props/args would have resulted in a *lot* of new info being shuttled around. 

Things I learned
- One form of Google Analytics tracking is firing “Events”.  “Events” have three levels specificity of Category, Action, and Label. See https://support.google.com/analytics/answer/1033068#Anatomy
- As it applies to our application, I view “Category” as a product area, “Action” as a verb that the user would do, “Label” as miscellaneous info. For my Events, I used “Label” as a way to distinguish between different ways a user can get perform the same action.  
- One way to test Google Analytics Events is to view the Network tab in the developer console. Look for a request going out to Google and view its query params to verify that the Category/Action/Label you wanted is there.
- Request access from Greg Jordan and/or file a PD ticket
- There is a Google Analytics project per environment.
- The project that it’s going to is specified by the `gaId` in the front end environment variables.
- The Google Analytics console will show you which GA IDs map to which project/environment.
- **Developing locally will send events to the TEST environment, not local. This is probably due to the fact that local development uses the `test-env-base` for most of its config.
- Data Studio is report generator that uses data from Google Analytics. They are two separate products with separate access controls.
- Google Analytics reports take 24-48 hours to update
- They offer a real time report that is useful for testing but only shows Event Category, and Event Action. Event Label is missing
- **Google Analytics will not record events unless you create a filter to include your requests. The default is to ignore all incoming requests unless there’s a filter to allow it through. I had to change the test environment’s filter to include localhost hostnames. 
- We have two versions of the homepage right now. Make sure changes go to both.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
