### PR TITLE
[no ticket][risk=no] Improve trace method name & labels for inbound API spans

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
@@ -10,14 +10,13 @@ import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
+import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import io.swagger.annotations.ApiOperation;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.firecloud.FirecloudApiClientTracer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +63,8 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
     // methodName is the method name defined in our Swagger YAML.
     // Example: Recv.syncBillingProjectStatus
     HandlerMethod method = (HandlerMethod) handler;
-    SpanBuilder requestSpanBuilder = tracer.spanBuilder(method.getMethod().getName()).setSpanKind(Span.Kind.SERVER);
+    SpanBuilder requestSpanBuilder =
+        tracer.spanBuilder(method.getMethod().getName()).setSpanKind(Span.Kind.SERVER);
     if (workbenchConfigProvider.get().server.traceAllRequests) {
       requestSpanBuilder.setSampler(Samplers.alwaysSample());
     }
@@ -72,16 +72,26 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
 
     // Log some additional key-value attributes, which will be visible in the details pane on
     // Stackdriver.
-    tracer.getCurrentSpan().putAttribute("aou-env", AttributeValue.stringAttributeValue(
-        workbenchConfigProvider.get().server.shortName));
-    tracer.getCurrentSpan().putAttribute("method", AttributeValue.stringAttributeValue(request.getMethod()));
-    tracer.getCurrentSpan().putAttribute("path", AttributeValue.stringAttributeValue(request.getRequestURI()));
+    tracer
+        .getCurrentSpan()
+        .putAttribute(
+            "aou-env",
+            AttributeValue.stringAttributeValue(workbenchConfigProvider.get().server.shortName));
+    tracer
+        .getCurrentSpan()
+        .putAttribute("method", AttributeValue.stringAttributeValue(request.getMethod()));
+    tracer
+        .getCurrentSpan()
+        .putAttribute("path", AttributeValue.stringAttributeValue(request.getRequestURI()));
     ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);
     if (apiOp != null) {
-      tracer.getCurrentSpan().putAttribute("description", AttributeValue.stringAttributeValue(
-          apiOp.notes()
-      ));
-      tracer.getCurrentSpan().putAttribute("responseType", AttributeValue.stringAttributeValue(apiOp.response().toString()));
+      tracer
+          .getCurrentSpan()
+          .putAttribute("description", AttributeValue.stringAttributeValue(apiOp.notes()));
+      tracer
+          .getCurrentSpan()
+          .putAttribute(
+              "responseType", AttributeValue.stringAttributeValue(apiOp.response().toString()));
     }
 
     // Store the span as a payload within our request so we can close the span on completion.

--- a/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
@@ -1,8 +1,11 @@
 package org.pmiops.workbench.interceptors;
 
+import com.google.api.client.http.HttpMethods;
 import io.opencensus.common.Scope;
 import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
 import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
@@ -13,10 +16,14 @@ import java.util.logging.Logger;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.swagger.annotations.ApiOperation;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.firecloud.FirecloudApiClientTracer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 // Interceptor to create a trace of the lifecycle of api calls.
@@ -45,20 +52,39 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    // OPTIONS methods requests don't need traces.
+    if (request.getMethod().equals(HttpMethods.OPTIONS)) {
+      return true;
+    }
 
-    SpanBuilder requestSpanBuilder =
-        tracer.spanBuilder(
-            String.format(
-                "%s/%s%s",
-                workbenchConfigProvider.get().server.shortName,
-                request.getMethod(),
-                request.getRequestURI()));
-
+    // Create a new scoped span, which will set the span context for any other traces created
+    // from within this request-handling thread.
+    //
+    // This span will end up in Stackdriver with the name format like "Recv.[methodName]" where
+    // methodName is the method name defined in our Swagger YAML.
+    // Example: Recv.syncBillingProjectStatus
+    HandlerMethod method = (HandlerMethod) handler;
+    SpanBuilder requestSpanBuilder = tracer.spanBuilder(method.getMethod().getName()).setSpanKind(Span.Kind.SERVER);
     if (workbenchConfigProvider.get().server.traceAllRequests) {
       requestSpanBuilder.setSampler(Samplers.alwaysSample());
     }
-
     Scope requestSpan = requestSpanBuilder.startScopedSpan();
+
+    // Log some additional key-value attributes, which will be visible in the details pane on
+    // Stackdriver.
+    tracer.getCurrentSpan().putAttribute("aou-env", AttributeValue.stringAttributeValue(
+        workbenchConfigProvider.get().server.shortName));
+    tracer.getCurrentSpan().putAttribute("method", AttributeValue.stringAttributeValue(request.getMethod()));
+    tracer.getCurrentSpan().putAttribute("path", AttributeValue.stringAttributeValue(request.getRequestURI()));
+    ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);
+    if (apiOp != null) {
+      tracer.getCurrentSpan().putAttribute("description", AttributeValue.stringAttributeValue(
+          apiOp.notes()
+      ));
+      tracer.getCurrentSpan().putAttribute("responseType", AttributeValue.stringAttributeValue(apiOp.response().toString()));
+    }
+
+    // Store the span as a payload within our request so we can close the span on completion.
     request.setAttribute(TRACE_ATTRIBUTE_KEY, requestSpan);
     return true;
   }
@@ -67,6 +93,8 @@ public class TracingInterceptor extends HandlerInterceptorAdapter {
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {
-    ((Scope) request.getAttribute(TRACE_ATTRIBUTE_KEY)).close();
+    if (request.getAttribute(TRACE_ATTRIBUTE_KEY) != null) {
+      ((Scope) request.getAttribute(TRACE_ATTRIBUTE_KEY)).close();
+    }
   }
 }


### PR DESCRIPTION
Dev notes

* This PR makes some small changes / additions to our tracing code to improve the readability of spans representing incoming AoU API calls.
* The changes mostly improve the way we extract information from Swagger-generated API methods and whatnot.
* One potentially controversial change: the "Test" prefix is gone from the span name. I realized that treating it as a label probably made more sense.
* I coded this one rainy Friday afternoon several weeks back... it's been sitting in a local branch since then and I finally had a chance to wrap it into shape. It's super low-priority.

Before:
<img width="691" alt="Screen Shot 2019-12-03 at 9 58 26 PM" src="https://user-images.githubusercontent.com/51842/70112723-504bcc80-1624-11ea-9642-89bf211cde0d.png">
<img width="348" alt="Screen Shot 2019-12-03 at 9 58 31 PM" src="https://user-images.githubusercontent.com/51842/70112729-5346bd00-1624-11ea-96c2-a6708be2cdc2.png">

After:
<img width="789" alt="Screen Shot 2019-12-03 at 9 57 41 PM" src="https://user-images.githubusercontent.com/51842/70112737-5772da80-1624-11ea-8b5d-65905b76cdc6.png">
<img width="515" alt="Screen Shot 2019-12-03 at 9 57 52 PM" src="https://user-images.githubusercontent.com/51842/70112743-5e015200-1624-11ea-907f-c54bc05a98ab.png">

(Note: the "Recv" prefix is auto-added by Stackdriver when the span type is set to Span.Kind.SERVER, see [code](https://github.com/census-instrumentation/opencensus-go/commit/b8f3b913f034c5682f7255d5d51efb6f151fb09b))

---
**PR checklist**

- [x] I have run and tested this change locally