### PR TITLE
[RW-3331][risk=no] Disable defunct BigQuery audit cron for now

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
@@ -95,7 +95,7 @@ public class OfflineAuditController implements OfflineAuditApiDelegate {
         tableSuffixes.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")));
   }
 
-  // TODO(RW-3331): Update this method to handle VPC-SC CDRs.
+  // TODO(RW-3331): Update this method to handle VPC-SC CDRs and re-enable the cron if still needed.
   @Override
   public ResponseEntity<AuditBigQueryResponse> auditBigQuery() {
     // We expect to only see queries run within Firecloud AoU projects, or for administrative

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
@@ -95,6 +95,7 @@ public class OfflineAuditController implements OfflineAuditApiDelegate {
         tableSuffixes.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")));
   }
 
+  // TODO(RW-3331): Update this method to handle VPC-SC CDRs.
   @Override
   public ResponseEntity<AuditBigQueryResponse> auditBigQuery() {
     // We expect to only see queries run within Firecloud AoU projects, or for administrative

--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -1,9 +1,4 @@
 cron:
-- description: 'daily BigQuery audit job'
-  url: /v1/cron/auditBigQuery
-  schedule: every 24 hours
-  timezone: UTC
-  target: api
 - description: 'Periodic notebook cluster checks'
   url: /v1/cron/checkClusters
   schedule: every 3 hours


### PR DESCRIPTION
This cron needs to be updated or deleted to handle VPC-SC.

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
