### PR TITLE
[risk=no] Add prototype scope to static references

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -51,6 +51,7 @@ import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -105,7 +106,7 @@ public class ClusterControllerTest {
   static class Configuration {
 
     @Bean
-    @Scope("prototype")
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public WorkbenchConfig workbenchConfig() {
       return config;
     }
@@ -116,7 +117,7 @@ public class ClusterControllerTest {
     }
 
     @Bean
-    @Scope("prototype")
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser user() {
       return user;
     }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -73,6 +73,7 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -81,6 +82,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -183,6 +185,7 @@ public class CohortReviewControllerTest {
     }
 
     @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser user() {
       return user;
     }


### PR DESCRIPTION
Description:

@jaycarlton pointed me to this flaky test where `CohortReviewControllerTest.getParticipantCohortStatuses()` was failing if you ran it by itself. The fix was easy, we were missing the `@Scope("prototype")` annotation on the provided user. Finding out why the test would only pass in some scenarios took a bit more digging.

**Here's what I found**
With the normal `@Bean` annotation, the bean definitions are executed and cached on every test BEFORE the `@Before` annotation is called.

Mental model of the test setup for EVERY `@Test` method
1. Spring Beans are defined and stored/cached. In our case, defining the User Bean means setting it equal to whatever the static user variable references.
2. `@Before` function is executed
3. `@Test` function is executed 

What this means is that any code that sets up `@Bean` definitions in the `@Before` function will execute AFTER the bean's definition has been fixed.

What ended up happening in our tests is that userProvider would be returning the value that user was set to in the previous test. For most of our tests, this value is the one defined in setup(). But for our very first test, userProvider will return null because that is its initial declared value. 

The flaky test would pass when run with other tests since user is non null as long as it is not the first test to run. If you run the flaky test by itself, userProvider will return null and cause the failing test.

Example pseudocode
```
private static DbUser user = null;

@TestConfiguration
@Bean
static class Configuration {
  Integer num() {
    return user;
  }
}

@Before
public void setup() {
  user = new DbUser(name = "Eric");
}

@Test
public void firstToRun() {
  // userProvider.get() == null
  // user == DbUser("Eric")

  // user is set to DbUser("Eric") since the setup() function runs before this, however,
  // userProvider.get() will fetch null because Spring will define the User Bean BEFORE
  // the setup() function runs and the value of user before setup() is null
}

@Test
public void secondToRun() {
  // userProvider.get() ==  DbUser("Eric")
  // user == DbUser("Eric")

  // userProvider now fetches DbUser("Eric") because Spring will redefine the User Bean
  // before every test. At this point, user refers to DbUser("Eric") so that is the value stored
  // as the User Bean
  
  user = new DbUser(name = "Jay")
}

@Test
public void thirdToRun() {
  // userProvider.get() == DbUser("Jay")
  // user == DbUser("Eric")

  // userProvider now fetches DbUser("Jay") because Spring will again, redefine the User Bean
  // before this test. Since the last thing we did was to set user equal to DbUser(name = "Jay"),
  // that is the value that is stored as the User Bean.
  // However, the user currently references DbUser("Eric") because it was set in the setup() 
  // function
}

@Test
public void fourthToRun() {
  // userProvider.get() == DbUser(name = "Eric")
  // user == DbUser("Eric")
}
```

**What does this mean for us?**
We need to be diligent about using the `@Scope("prototype")` annotation whenever a Bean returns a global variable whose definition could change in setup(). I couldn't think of a more automated/elegant solution than this.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
