### PR TITLE
[RW-3998][risk=low] Reject previews of large notebooks, add preview page error handling

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageService.java
@@ -43,9 +43,11 @@ public interface CloudStorageService {
   GoogleCredential getGarbageCollectionServiceAccountCredentials(String garbageCollectionEmail)
       throws IOException;
 
-  JSONObject getFileAsJson(String bucketName, String fileName);
-
   Map<String, String> getMetadata(String bucketName, String objectPath);
+
+  Blob getBlob(String bucketName, String objectPath);
+
+  JSONObject readBlobAsJson(Blob blob);
 
   void deleteBlob(BlobId blobId);
 

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageServiceImpl.java
@@ -78,12 +78,9 @@ public class CloudStorageServiceImpl implements CloudStorageService {
     return configProvider.get().googleCloudStorageService.emailImagesBucketName;
   }
 
-  private String readToString(String bucketName, String objectPath) {
-    return new String(getBlob(bucketName, objectPath).getContent()).trim();
-  }
-
   // wrapper for storage.get() which throws NotFoundException instead of NullPointerException
-  private Blob getBlob(String bucketName, String objectPath) {
+  @Override
+  public Blob getBlob(String bucketName, String objectPath) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
     Blob result = storage.get(bucketName, objectPath);
     if (result == null) {
@@ -125,8 +122,12 @@ public class CloudStorageServiceImpl implements CloudStorageService {
     return getCredentialsBucketJSON("elastic-cloud.json");
   }
 
+  private String readBlobAsString(Blob blob) {
+    return new String(blob.getContent()).trim();
+  }
+
   private String readCredentialsBucketString(String objectPath) {
-    return readToString(getCredentialsBucketName(), objectPath);
+    return readBlobAsString(getBlob(getCredentialsBucketName(), objectPath));
   }
 
   private GoogleCredential getCredential(final String objectPath) throws IOException {
@@ -162,8 +163,8 @@ public class CloudStorageServiceImpl implements CloudStorageService {
   }
 
   @Override
-  public JSONObject getFileAsJson(String bucketName, String fileName) {
-    return new JSONObject(readToString(bucketName, fileName));
+  public JSONObject readBlobAsJson(Blob blob) {
+    return new JSONObject(readBlobAsString(blob));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -29,6 +29,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class NotebooksServiceImpl implements NotebooksService {
 
+  // Experimentally determined that generating the preview HTML for a >11MB notebook results in
+  // OOMs on a default F1 240MB GAE task. OOMs may still occur during concurrent requests. If this
+  // issue persists, we can move preview processing onto the client (calling Calhoun), or fully
+  // client-side (using a client-side notebook renderer).
   private static final long MAX_NOTEBOOK_READ_SIZE_BYTES = 5 * 1000 * 1000; // 5MB
   private static final PolicyFactory PREVIEW_SANITIZER =
       Sanitizers.FORMATTING
@@ -54,6 +58,7 @@ public class NotebooksServiceImpl implements NotebooksService {
                   // <pre> is not included in the prebuilt sanitizers; it is used for monospace code
                   // block formatting
                   .allowElements("style", "pre")
+
                   // Allow id/class in order to interact with the style tag.
                   .allowAttributes("id", "class")
                   .globally()
@@ -186,6 +191,11 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public JSONObject getNotebookContents(String bucketName, String notebookName) {
+    Blob blob = getBlobWithSizeConstraint(bucketName, notebookName);
+    return cloudStorageService.readBlobAsJson(blob);
+  }
+
+  private Blob getBlobWithSizeConstraint(String bucketName, String notebookName) {
     Blob blob =
         cloudStorageService.getBlob(
             bucketName, "notebooks/".concat(NotebooksService.withNotebookExtension(notebookName)));
@@ -194,7 +204,7 @@ public class NotebooksServiceImpl implements NotebooksService {
           String.format(
               "target notebook is too large to process @ %.2fMB", ((double) blob.getSize()) / 1e6));
     }
-    return cloudStorageService.readBlobAsJson(blob);
+    return blob;
   }
 
   @Override
@@ -214,12 +224,12 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getWorkspace()
             .getBucketName();
 
+    Blob blob = getBlobWithSizeConstraint(bucketName, notebookName);
     // We need to send a byte array so the ApiClient attaches the body as is instead
     // of serializing it through Gson which it will do for Strings.
     // The default Gson serializer does not work since it strips out some null fields
-    // which are needed for nbconvert
-    byte[] contents = getNotebookContents(bucketName, notebookName).toString().getBytes();
-    return PREVIEW_SANITIZER.sanitize(fireCloudService.staticNotebooksConvert(contents));
+    // which are needed for nbconvert. Skip the JSON conversion here to reduce memory overhead.
+    return PREVIEW_SANITIZER.sanitize(fireCloudService.staticNotebooksConvert(blob.getContent()));
   }
 
   private GoogleCloudLocators getNotebookLocators(

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.Blob;
 import java.time.Clock;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -136,7 +135,7 @@ public class NotebooksServiceImplTest {
     when(firecloudService.getWorkspace(any(), any()))
         .thenReturn(
             new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
+    when(mockBlob.getContent()).thenReturn("{}".getBytes());
     when(cloudStorageService.getBlob(any(), any())).thenReturn(mockBlob);
-    when(cloudStorageService.readBlobAsJson(mockBlob)).thenReturn(new JSONObject());
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceImplTest.java
@@ -1,15 +1,21 @@
 package org.pmiops.workbench.notebooks;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.storage.Blob;
 import java.time.Clock;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
@@ -47,16 +53,28 @@ public class NotebooksServiceImplTest {
     }
   }
 
+  @Mock private Blob mockBlob;
   @Autowired private NotebooksService notebooksService;
   @Autowired private FireCloudService firecloudService;
   @Autowired private CloudStorageService cloudStorageService;
 
   @Test
+  public void testGetReadOnlyHtml_tooBig() {
+    when(mockBlob.getSize()).thenReturn(50L * 1000 * 1000); // 50MB
+    stubNotebookToJson();
+
+    try {
+      notebooksService.getReadOnlyHtml("", "", "").getBytes();
+      fail("expected 412 exception");
+    } catch (FailedPreconditionException e) {
+      // expected
+    }
+    verify(firecloudService, never()).staticNotebooksConvert(any());
+  }
+
+  @Test
   public void testGetReadOnlyHtml_basicContent() {
-    when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(
-            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
-    when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
+    stubNotebookToJson();
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<html><body><div>asdf</div></body></html>");
 
@@ -67,10 +85,7 @@ public class NotebooksServiceImplTest {
 
   @Test
   public void testGetReadOnlyHtml_scriptSanitization() {
-    when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(
-            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
-    when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
+    stubNotebookToJson();
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<html><script>window.alert('hacked');</script></html>");
 
@@ -81,10 +96,7 @@ public class NotebooksServiceImplTest {
 
   @Test
   public void testGetReadOnlyHtml_styleSanitization() {
-    when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(
-            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
-    when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
+    stubNotebookToJson();
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn(
             "<STYLE type=\"text/css\">BODY{background:url(\"javascript:alert('XSS')\")} div {color: 'red'}</STYLE>\n");
@@ -101,11 +113,7 @@ public class NotebooksServiceImplTest {
 
   @Test
   public void testGetReadOnlyHtml_allowsDataImage() {
-    when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(
-            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
-    when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
-
+    stubNotebookToJson();
     String dataUri = "data:image/png;base64,MTIz";
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<img src=\"" + dataUri + "\" />\n");
@@ -116,14 +124,19 @@ public class NotebooksServiceImplTest {
 
   @Test
   public void testGetReadOnlyHtml_disallowsRemoteImage() {
-    when(firecloudService.getWorkspace(any(), any()))
-        .thenReturn(
-            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
-    when(cloudStorageService.getFileAsJson(any(), any())).thenReturn(new JSONObject());
+    stubNotebookToJson();
     when(firecloudService.staticNotebooksConvert(any()))
         .thenReturn("<img src=\"https://eviltrackingpixel.com\" />\n");
 
     String html = new String(notebooksService.getReadOnlyHtml("", "", "").getBytes());
     assertThat(html).doesNotContain("eviltrackingpixel.com");
+  }
+
+  private void stubNotebookToJson() {
+    when(firecloudService.getWorkspace(any(), any()))
+        .thenReturn(
+            new FirecloudWorkspaceResponse().workspace(new FirecloudWorkspace().bucketName("bkt")));
+    when(cloudStorageService.getBlob(any(), any())).thenReturn(mockBlob);
+    when(cloudStorageService.readBlobAsJson(mockBlob)).thenReturn(new JSONObject());
   }
 }

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -299,13 +299,13 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
         case PreviewErrorMode.NONE:
           return (<SpinnerOverlay/>);
         case PreviewErrorMode.INVALID:
-          return (<div style={{...styles.previewMessageBase, ...styles.previewInvalid}}>{previewErrorMessage}</div>)
+          return (<div style={{...styles.previewMessageBase, ...styles.previewInvalid}}>{previewErrorMessage}</div>);
         case PreviewErrorMode.ERROR:
           return (<div style={{...styles.previewMessageBase, ...styles.previewError}}>
             <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid'
                      shape='exclamation-triangle' size='30'/>
             {previewErrorMessage}
-          </div>)
+          </div>);
       }
     }
 

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -65,6 +65,31 @@ const styles = reactStyles({
     position: 'absolute',
     border: 0
   },
+  previewMessageBase: {
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    marginTop: '56px'
+  },
+  previewInvalid: {
+    color: colorWithWhiteness(colors.dark, .6),
+    fontSize: '18px',
+    fontWeight: 600,
+    lineHeight: '32px',
+    maxWidth: '840px',
+    textAlign: 'center'
+  },
+  previewError: {
+    background: colors.warning,
+    border: '1px solid #ebafa6',
+    borderRadius: '5px',
+    color: colors.white,
+    display: 'flex',
+    fontSize: '14px',
+    fontWeight: 500,
+    maxWidth: '550px',
+    padding: '8px',
+    textAlign: 'left'
+  },
   rotate: {
     animation: 'rotation 2s infinite linear'
   }
@@ -83,6 +108,14 @@ interface State {
   showInUseModal: boolean;
   showPlaygroundModeModal: boolean;
   userRequestedExecutableNotebook: boolean;
+  previewErrorMode: PreviewErrorMode;
+  previewErrorMessage: string;
+}
+
+enum PreviewErrorMode {
+  NONE = 'none',
+  INVALID = 'invalid',
+  ERROR = 'error'
 }
 
 export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace())(
@@ -100,6 +133,8 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
         showInUseModal: false,
         showPlaygroundModeModal: false,
         userRequestedExecutableNotebook: false,
+        previewErrorMode: PreviewErrorMode.NONE,
+        previewErrorMessage: ''
       };
     }
 
@@ -108,6 +143,16 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
 
       workspacesApi().readOnlyNotebook(ns, wsid, nbName).then(html => {
         this.setState({html: html.html});
+      }).catch((e) => {
+        let previewErrorMode = PreviewErrorMode.ERROR;
+        let previewErrorMessage = 'Failed to render preview due to an unknown error, ' +
+            'please try reloading or opening the notebook in edit or playground mode.';
+        if (e.status === 412) {
+          previewErrorMode = PreviewErrorMode.INVALID;
+          previewErrorMessage = 'Notebook is too large to display in preview mode, please use edit mode or ' +
+              'playground mode to view this notebook.';
+        }
+        this.setState({previewErrorMode, previewErrorMessage});
       });
 
       workspacesApi().getNotebookLockingMetadata(ns, wsid, nbName).then((resp) => {
@@ -245,13 +290,31 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
       }
     }
 
+    private renderPreviewContents() {
+      const {html, previewErrorMode, previewErrorMessage} = this.state;
+      if (html) {
+        return (<iframe id='notebook-frame' style={styles.previewFrame} srcDoc={html}/>);
+      }
+      switch (previewErrorMode) {
+        case PreviewErrorMode.NONE:
+          return (<SpinnerOverlay/>);
+        case PreviewErrorMode.INVALID:
+          return (<div style={{...styles.previewMessageBase, ...styles.previewInvalid}}>{previewErrorMessage}</div>)
+        case PreviewErrorMode.ERROR:
+          return (<div style={{...styles.previewMessageBase, ...styles.previewError}}>
+            <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid'
+                     shape='exclamation-triangle' size='30'/>
+            {previewErrorMessage}
+          </div>)
+      }
+    }
+
     render() {
       const {
-        html,
         lastLockedBy,
         showInUseModal,
         showPlaygroundModeModal,
-        userRequestedExecutableNotebook
+        userRequestedExecutableNotebook,
       } = this.state;
       return (
         <div>
@@ -288,9 +351,7 @@ export const InteractiveNotebook = fp.flow(withUrlParams(), withCurrentWorkspace
             }
           </div>
           <div style={styles.previewDiv}>
-            {html ?
-              (<iframe id='notebook-frame' style={styles.previewFrame} srcDoc={html}/>) :
-              (<SpinnerOverlay/>)}
+            {this.renderPreviewContents()}
           </div>
           {showPlaygroundModeModal &&
             <ConfirmPlaygroundModeModal


### PR DESCRIPTION
5MB is chosen as the cutoff here. From manual testing, I found that with our current GAE task configuration, previews would start failing around ~10MB. I couldn't find any good tooling for analyzing memory use on GAE Java servers, there is probably room for improvement here. It is possible that we are still susceptible to OOMs from concurrent preview requests on a single server with this approach.

Too large error:
![image](https://user-images.githubusercontent.com/822298/70399921-b053c180-19dc-11ea-9386-dfc88304235f.png)

Unexpected error:
![image](https://user-images.githubusercontent.com/822298/70399916-a8941d00-19dc-11ea-9246-5fc756fdf1b0.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
