### PR TITLE
[RW-4072][risk=no] Include users without workspaces in user data export

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -172,7 +172,8 @@ public class ExportWorkspaceData {
           FirecloudTransforms.extractAclResponse(
                   workspacesApi.getWorkspaceAcl(
                       workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
-              .entrySet().stream()
+              .entrySet()
+              .stream()
               .map(entry -> entry.getKey() +  " (" + entry.getValue().getAccessLevel() + ")")
               .collect(Collectors.joining("\n")));
     } catch (ApiException e) {

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -132,7 +132,8 @@ public class ExportWorkspaceData {
 
       List<WorkspaceExportRow> rows = new ArrayList<>();
 
-      Set<DbUser> usersWithoutWorkspaces = Streams.stream(userDao.findAll()).collect(Collectors.toSet());
+      Set<DbUser> usersWithoutWorkspaces =
+          Streams.stream(userDao.findAll()).collect(Collectors.toSet());
 
       for (DbWorkspace workspace : this.workspaceDao.findAll()) {
         rows.add(toWorkspaceExportRow(workspace));
@@ -172,9 +173,8 @@ public class ExportWorkspaceData {
           FirecloudTransforms.extractAclResponse(
                   workspacesApi.getWorkspaceAcl(
                       workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
-              .entrySet()
-              .stream()
-              .map(entry -> entry.getKey() +  " (" + entry.getValue().getAccessLevel() + ")")
+              .entrySet().stream()
+              .map(entry -> entry.getKey() + " (" + entry.getValue().getAccessLevel() + ")")
               .collect(Collectors.joining("\n")));
     } catch (ApiException e) {
       row.setCollaborators("Error: Not Found");
@@ -220,7 +220,8 @@ public class ExportWorkspaceData {
     WorkspaceExportRow row = new WorkspaceExportRow();
     row.setCreatorContactEmail(user.getContactEmail());
     row.setCreatorUsername(user.getEmail());
-    row.setCreatorFirstSignIn(user.getFirstSignInTime() == null ? "" : dateFormat.format(user.getFirstSignInTime()));
+    row.setCreatorFirstSignIn(
+        user.getFirstSignInTime() == null ? "" : dateFormat.format(user.getFirstSignInTime()));
     row.setCreatorRegistrationState(user.getDataAccessLevelEnum().toString());
 
     return row;


### PR DESCRIPTION
Description:

- Adds Users w/o workspaces to the workspace export tool

- Add access level to the collaborators column

Things I learned
- Spring Dao `findAll` will return an iterable.  This can be easily converted to a stream (and then into Java collections) using Guavas `Streams.stream(iterable)`.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
