### PR TITLE
[RW-3428][risk=no] Apply stricter frame-ancestors to static UI resources

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -12,7 +12,7 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
-    Content-Security-Policy: "default-src 'none'; report-uri /content-security-report"
+    Content-Security-Policy: "default-src 'none'; frame-ancestors 'none'; report-uri /content-security-report"
 - url: /.*
   static_files: dist/index.html
   upload: dist/index.html


### PR DESCRIPTION
This should have no bearing on security or the application; it is just to satisfy AppScan alerts.

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
