### PR TITLE
[RW-4109][Risk=no] Add spinner to delete modal

### DIFF
--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -358,7 +358,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                             this.setState({error: false})}>Close</Button>
               </ModalFooter>
           </Modal>}
-          {removingConcepts && <Modal>
+          {removingConcepts && <Modal loading={removeSubmitting}>
             <ModalTitle>Are you sure you want to remove {this.selectedConceptsCount}
             {this.selectedConceptsCount > 1 ? ' concepts' : ' concept'} from this set?</ModalTitle>
             <ModalFooter>


### PR DESCRIPTION
Description:
This PR adds a loading spinner to the concept delete modal in concept sets. I left the disabled state on the buttons because I wasn't sure what our pattern was around that, and it seemed like the smallest change. This addresses 4109, because we could not reproduce the users original bug, this is the approach from product to try to make what is happening more visible. 

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
