### PR TITLE
[RW-4149][RW-4145][risk=no] Add new tabs and tile behind feature flag in concept search

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/db/model/CommonStorageEnums.java
+++ b/common-api/src/main/java/org/pmiops/workbench/db/model/CommonStorageEnums.java
@@ -22,6 +22,7 @@ public class CommonStorageEnums {
           .put(Domain.VISIT, (short) 7)
           .put(Domain.SURVEY, (short) 8)
           .put(Domain.PERSON, (short) 9)
+          .put(Domain.PHYSICALMEASUREMENT, (short) 10)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -37,6 +38,7 @@ public class CommonStorageEnums {
           .put(Domain.VISIT, "Visit")
           .put(Domain.SURVEY, "Survey")
           .put(Domain.PERSON, "Person")
+          .put(Domain.PHYSICALMEASUREMENT, "Physical Measurement")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -46,7 +46,7 @@ definitions:
   Domain:
     type: string
     description: a domain for concepts corresponding to a table in the OMOP schema
-    enum: &DOMAIN [OBSERVATION, PROCEDURE, DRUG, CONDITION, MEASUREMENT, DEVICE, DEATH, VISIT, SURVEY, PERSON]
+    enum: &DOMAIN [OBSERVATION, PROCEDURE, DRUG, CONDITION, MEASUREMENT, DEVICE, DEATH, VISIT, SURVEY, PERSON, PHYSICALMEASUREMENT]
 
   Surveys:
     type: string

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -114,7 +114,9 @@ const DomainCard: React.FunctionComponent<{conceptDomainInfo: DomainInfo,
 const SurveyCard: React.FunctionComponent<{survey: SurveyModule, browseSurvey: Function}> =
     ({survey, browseSurvey}) => {
       return <DomainCardBase style={{maxHeight: 'auto', width: '11.5rem'}}>
-        <div style={styles.domainBoxHeader} data-test-id='survey-box-name'>{survey.name}</div>
+        <Clickable style={styles.domainBoxHeader}
+          onClick={browseSurvey}
+          data-test-id='survey-box-name'>{survey.name}</Clickable>
         <div style={styles.conceptText}>
           <span style={{fontSize: 30}}>{survey.questionCount}</span> survey questions with
           <div><b>{survey.participantCount}</b> participants</div>
@@ -122,10 +124,39 @@ const SurveyCard: React.FunctionComponent<{survey: SurveyModule, browseSurvey: F
         <div style={{...styles.conceptText, height: '3.5rem'}}>
           {survey.description}
         </div>
-        <Clickable style={{...styles.domainBoxLink}} onClick={browseSurvey}>Browse
-          Survey</Clickable>
+        <Clickable style={{...styles.domainBoxLink}} onClick={browseSurvey}>Browse Survey</Clickable>
       </DomainCardBase>;
     };
+
+// Placeholder version of Physical Measurements card. TODO update styles when api call is ready
+const PhysicalMeasurementsCard: React.FunctionComponent<{physicalMeasurement: DomainInfo, browsePhysicalMeasurements: Function}> =
+    ({physicalMeasurement, browsePhysicalMeasurements}) => {
+      return <DomainCardBase style={{maxHeight: 'auto', width: '11.5rem', opacity: 0.4, cursor: 'not-allowed'}}>
+        <Clickable style={{...styles.domainBoxHeader, cursor: 'not-allowed'}}
+          onClick={browsePhysicalMeasurements}
+          data-test-id='pm-box-name'>{physicalMeasurement.name}</Clickable>
+        <div style={styles.conceptText}>
+          <span style={{fontSize: 30}}>{physicalMeasurement.allConceptCount}</span> physical measurements.
+          <div><b>{physicalMeasurement.participantCount}</b> participants in this domain</div>
+        </div>
+        <div style={{...styles.conceptText, height: 'auto'}}>
+          {physicalMeasurement.description}
+        </div>
+        <Clickable style={{...styles.domainBoxLink, cursor: 'not-allowed'}} onClick={browsePhysicalMeasurements}>
+          Browse Physical Measurements
+        </Clickable>
+      </DomainCardBase>;
+    };
+
+// Stub used to mock Physical Measurements data that will be returned from api call. TODO remove when api call is ready
+const physicalMeasurementsStub = {
+  domain: Domain.MEASUREMENT,
+  name: 'Physical Measurements',
+  description: 'Participants have the option to provide a standard set of physical measurements as part of the enrollment process (“program physical measurements”).',
+  allConceptCount: 0,
+  participantCount: 0,
+  standardConceptCount: 0
+};
 
 interface Props {
   workspace: WorkspaceData;
@@ -145,6 +176,8 @@ interface State { // Browse survey
   conceptDomainCounts: Array<DomainCount>;
   // Array of domains and their metadata
   conceptDomainList: Array<DomainInfo>;
+  // Array of Physical Measurements
+  conceptPhysicalMeasurementsList: Array<any>;
   conceptsSavedText: string;
   // Array of surveys
   conceptSurveysList: Array<SurveyModule>;
@@ -188,6 +221,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
         surveyAddModalOpen: false,
         conceptDomainCounts: [],
         conceptDomainList: [],
+        conceptPhysicalMeasurementsList: [],
         concepts: [],
         conceptsCache: [],
         conceptsSavedText: '',
@@ -240,6 +274,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
           conceptDomainCounts: conceptDomainCounts,
           conceptSurveysList: surveysInfo.items,
           selectedDomain: conceptDomainCounts[0],
+          conceptPhysicalMeasurementsList: [physicalMeasurementsStub]
         });
       } catch (e) {
         console.error(e);
@@ -460,7 +495,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
     }
 
     render() {
-      const {loadingDomains, browsingSurvey, conceptDomainList, conceptSurveysList,
+      const {loadingDomains, browsingSurvey, conceptDomainList, conceptPhysicalMeasurementsList, conceptSurveysList,
         standardConceptsOnly, showSearchError, searching, selectedDomain, conceptAddModalOpen,
         conceptsToAdd, currentSearchString, conceptsSavedText, selectedSurvey, surveyAddModalOpen,
         selectedSurveyQuestions} =
@@ -514,31 +549,40 @@ export const ConceptHomepage = withCurrentWorkspace()(
           {!browsingSurvey && loadingDomains ? <div style={{position: 'relative', minHeight: '10rem'}}><SpinnerOverlay/></div> :
             searching ?
               this.renderConcepts() : !browsingSurvey &&
-                  <div>
-                    <div style={styles.sectionHeader}>
-                      EHR Domain
-                    </div>
-                    <div style={styles.cardList}>
-                    {conceptDomainList.map((domain, i) => {
-                      return <DomainCard conceptDomainInfo={domain}
-                                           standardConceptsOnly={standardConceptsOnly}
-                                           browseInDomain={() => this.browseDomain(domain)}
-                                           key={i} data-test-id='domain-box'/>;
-                    })}
-                    </div>
-                    <div style={styles.sectionHeader}>
-                      Survey Questions
-                    </div>
-                    <div style={styles.cardList}>
-                      {conceptSurveysList.map((surveys) => {
-                        return <SurveyCard survey={surveys} key={surveys.orderNumber}
-                                           browseSurvey={() => {this.setState({
-                                             browsingSurvey: true,
-                                             selectedSurvey: surveys.name
-                                           }); }}/>;
-                      })}
-                     </div>
+                <div>
+                  <div style={styles.sectionHeader}>
+                    EHR Domain
                   </div>
+                  <div style={styles.cardList}>
+                  {conceptDomainList.map((domain, i) => {
+                    return <DomainCard conceptDomainInfo={domain}
+                                         standardConceptsOnly={standardConceptsOnly}
+                                         browseInDomain={() => this.browseDomain(domain)}
+                                         key={i} data-test-id='domain-box'/>;
+                  })}
+                  </div>
+                  <div style={styles.sectionHeader}>
+                    Survey Questions
+                  </div>
+                  <div style={styles.cardList}>
+                    {conceptSurveysList.map((surveys) => {
+                      return <SurveyCard survey={surveys} key={surveys.orderNumber}
+                                         browseSurvey={() => {this.setState({
+                                           browsingSurvey: true,
+                                           selectedSurvey: surveys.name
+                                         }); }}/>;
+                    })}
+                   </div>
+                  <div style={styles.sectionHeader}>
+                    Program Physical Measurements
+                  </div>
+                  <div style={styles.cardList}>
+                    {conceptPhysicalMeasurementsList.map((physicalMeasurement, p) => {
+                      return <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurement} key={p}
+                                         browsePhysicalMeasurements={() => {}}/>; // TODO replace with actual function when api call ready
+                    })}
+                   </div>
+                </div>
           }
           {conceptAddModalOpen &&
             <ConceptAddModal selectedDomain={selectedDomain}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -551,7 +551,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
               this.renderConcepts() : !browsingSurvey &&
                 <div>
                   <div style={styles.sectionHeader}>
-                    EHR Domain
+                    Domains
                   </div>
                   <div style={styles.cardList}>
                   {conceptDomainList.map((domain, i) => {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -164,7 +164,7 @@ const conceptCacheStub = [
     items: []
   },
   {
-    domain: Domain.DEATH, // TODO switch to PM after fix enum issue
+    domain: Domain.PHYSICALMEASUREMENT,
     items: []
   }
 ];
@@ -177,7 +177,7 @@ const domainCountStub = [
     conceptCount: 0
   },
   {
-    domain: Domain.DEATH, // TODO switch to PM after fix enum issue
+    domain: Domain.PHYSICALMEASUREMENT,
     name: 'Physical Measurements',
     conceptCount: 0
   }
@@ -351,16 +351,16 @@ export const ConceptHomepage = withCurrentWorkspace()(
     }
 
     async searchConcepts() {
-      const {standardConceptsOnly, currentSearchString, conceptsCache,
-        selectedDomain, completedDomainSearches} = this.state;
+      const {standardConceptsOnly, currentSearchString, conceptsCache, selectedDomain} = this.state;
       const {namespace, id} = this.props.workspace;
       this.setState({concepts: [], searchLoading: true, searching: true, conceptsToAdd: [],
         selectedConceptDomainMap: new Map<string, number>(), completedDomainSearches: []});
       const standardConceptFilter = standardConceptsOnly ?
         StandardConceptFilter.STANDARDCONCEPTS : StandardConceptFilter.ALLCONCEPTS;
-
-      completedDomainSearches.push(Domain.SURVEY);
-      conceptsCache.forEach(async(cacheItem) => {
+      // TODO switch to empty array when we start actually searching surveys and PM
+      const completedDomainSearches = [Domain.SURVEY, Domain.PHYSICALMEASUREMENT];
+      // TODO remove filter below when we start actually searching surveys and PM
+      conceptsCache.filter(item => ![Domain.SURVEY, Domain.PHYSICALMEASUREMENT].includes(item.domain)).forEach(async(cacheItem) => {
         const activeTabSearch = cacheItem.domain === selectedDomain.domain;
         const resp = await conceptsApi().searchConcepts(namespace, id, {
           query: currentSearchString,

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -58,4 +58,6 @@ export interface Environment {
   enableAccountPages: boolean;
   // Profile changes for CAPS requirements in RW-3441.
   enableProfileCapsFeatures: boolean;
+  // Enable Surveys and Physical Measurements tabs in concept search
+  enableNewConceptTabs: boolean;
 }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -22,4 +22,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: true,
   enableAccountPages: true,
   enableProfileCapsFeatures: true,
+  enableNewConceptTabs: true
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableAccountPages: false,
   enableProfileCapsFeatures: false,
+  enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -24,4 +24,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableAccountPages: false,
   enableProfileCapsFeatures: false,
+  enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -20,4 +20,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableAccountPages: false,
   enableProfileCapsFeatures: false,
+  enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -20,4 +20,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableAccountPages: false,
   enableProfileCapsFeatures: false,
+  enableNewConceptTabs: false
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -18,5 +18,6 @@ export const testEnvironmentBase = {
   inactivityWarningBeforeSeconds: 5 * 60,
   enableHomepageRestyle: true,
   enableProfileCapsFeatures: true,
-  enableAccountPages: true
+  enableAccountPages: true,
+  enableNewConceptTabs: true
 };


### PR DESCRIPTION
** Both items below are feature flagged for local and test environments only
- Add tabs for Surveys and Physical Measurements in concept search ([RW-4149](https://precisionmedicineinitiative.atlassian.net/browse/RW-4149))
- Add Physical Measurements card on Concept homepage ([RW-4145](https://precisionmedicineinitiative.atlassian.net/browse/RW-4151))
<img width="1377" alt="Screen Shot 2019-12-16 at 4 42 22 PM" src="https://user-images.githubusercontent.com/40036095/71001022-02ae7580-20a2-11ea-8c91-aea46bda587b.png">
<img width="1376" alt="Screen Shot 2019-12-16 at 4 42 42 PM" src="https://user-images.githubusercontent.com/40036095/71001034-080bc000-20a2-11ea-88b6-5ade9ab326d2.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
