### PR TITLE
[RISK:NO] Add lastModifiedTime column to User table

### DIFF
--- a/api/db/changelog/db.changelog-111-user-add-column-lastModifiedDate.xml
+++ b/api/db/changelog/db.changelog-111-user-add-column-lastModifiedDate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="nsaxena" id="db.changelog-111-user-add-column-lastModifiedDate">
+    <addColumn tableName="user">
+      <column name="last_modified_time" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -118,6 +118,7 @@
     <include file="changelog/db.changelog-108-user-data-use-agreement.xml"/>
     <include file="changelog/db.changelog-109-dataset-prepackaged-conceptsets-nullConstraint.xml"/>
     <include file="changelog/db.changelog-110-free-credits-days-override.xml"/>
+    <include file="changelog/db.changelog-111-user-add-column-lastModifiedDate.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -569,7 +569,7 @@ public class ProfileController implements ProfileApiDelegate {
     user.setCurrentPosition(updatedProfile.getCurrentPosition());
     user.setAboutYou(updatedProfile.getAboutYou());
     user.setAreaOfResearch(updatedProfile.getAreaOfResearch());
-
+    user.setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()));
     if (updatedProfile.getContactEmail() != null
         && !updatedProfile.getContactEmail().equals(user.getContactEmail())) {
       // See RW-1488.

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -97,6 +97,7 @@ public class DbUser {
   private Timestamp idVerificationBypassTime;
   private Timestamp twoFactorAuthCompletionTime;
   private Timestamp twoFactorAuthBypassTime;
+  private Timestamp lastModifiedTime;
   private DbDemographicSurvey demographicSurvey;
   private DbAddress address;
 
@@ -580,6 +581,15 @@ public class DbUser {
 
   public void setTwoFactorAuthBypassTime(Timestamp twoFactorAuthBypassTime) {
     this.twoFactorAuthBypassTime = twoFactorAuthBypassTime;
+  }
+
+  @Column(name = "last_modified_time")
+  public Timestamp getLastModifiedTime() {
+    return lastModifiedTime;
+  }
+
+  public void setLastModifiedTime(Timestamp lastModifiedTime) {
+    this.lastModifiedTime = lastModifiedTime;
   }
 
   @OneToOne(


### PR DESCRIPTION
lastModifiedTime column is added to the user table to keep track of when any profile changes (institution affiliations etc)  are made to the User. This will be helpful when we export the modified user's information to RDR.