### PR TITLE
[RW-4215][risk=no] fixing Map error

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -804,7 +804,11 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   /** Build a map that contains all gender/race/ethnicity names with the concept id as the key. */
   private Map<Long, String> getGenderRaceEthnicityMap() {
     return cbCriteriaDao.findGenderRaceEthnicity().stream()
-        .collect(Collectors.toMap(DbCriteria::getLongConceptId, DbCriteria::getName));
+        .collect(
+            Collectors.toMap(
+                DbCriteria::getLongConceptId,
+                DbCriteria::getName,
+                (oldValue, newValue) -> oldValue));
   }
 
   /**

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -149,7 +149,9 @@ public class CohortReviewControllerTest {
     WHITE("White", 8527),
     MALE("MALE", 8507),
     FEMALE("FEMALE", 8532),
-    NOT_HISPANIC("Not Hispanic or Latino", 38003564);
+    NOT_HISPANIC("Not Hispanic or Latino", 38003564),
+    PREFER_NOT_TO_ANSWER_RACE("I Prefer not to answer", 1177221),
+    PREFER_NOT_TO_ANSWER_ETH("I Prefer not to answer", 1177221);
 
     private final String name;
     private final long conceptId;
@@ -169,7 +171,11 @@ public class CohortReviewControllerTest {
 
     public static Map<Long, String> asMap() {
       return Arrays.stream(TestConcepts.values())
-          .collect(Collectors.toMap(TestConcepts::getConceptId, TestConcepts::getName));
+          .collect(
+              Collectors.toMap(
+                  TestConcepts::getConceptId,
+                  TestConcepts::getName,
+                  (oldValue, newValue) -> oldValue));
     }
   }
 
@@ -246,6 +252,20 @@ public class CohortReviewControllerTest {
             .parentId(1L)
             .conceptId(String.valueOf(TestConcepts.WHITE.conceptId))
             .name(TestConcepts.WHITE.name));
+    cbCriteriaDao.save(
+        new DbCriteria()
+            .domainId(DomainType.PERSON.toString())
+            .type(CriteriaType.RACE.toString())
+            .parentId(1L)
+            .conceptId(String.valueOf(TestConcepts.PREFER_NOT_TO_ANSWER_RACE.conceptId))
+            .name(TestConcepts.PREFER_NOT_TO_ANSWER_RACE.name));
+    cbCriteriaDao.save(
+        new DbCriteria()
+            .domainId(DomainType.PERSON.toString())
+            .type(CriteriaType.RACE.toString())
+            .parentId(1L)
+            .conceptId(String.valueOf(TestConcepts.PREFER_NOT_TO_ANSWER_ETH.conceptId))
+            .name(TestConcepts.PREFER_NOT_TO_ANSWER_ETH.name));
 
     cdrVersion = new DbCdrVersion();
     cdrVersion.setBigqueryDataset("dataSetId");


### PR DESCRIPTION
new demographic data trees have duplicate concept ids in the criteria table and are causing the following error in prod:
`java.lang.IllegalStateException: Duplicate key 1177221 (attempted merging values I prefer not to answer and I prefer not to answer)`