### PR TITLE
[no ticket][risk=low] Fix js error with 204 from status alert

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/StatusAlertController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/StatusAlertController.java
@@ -31,7 +31,7 @@ public class StatusAlertController implements StatusAlertApiDelegate {
               .link(dbStatusAlert.getLink());
       return ResponseEntity.ok(statusAlert);
     } else {
-      return ResponseEntity.noContent().build();
+      return ResponseEntity.ok(new StatusAlert());
     }
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -125,9 +125,6 @@ paths:
             A status alert information object.
           schema:
             $ref: "#/definitions/StatusAlert"
-        204:
-          description: >
-            There are no status alerts at this point in time.
 
     # User methods ########################################################################
 


### PR DESCRIPTION
When there was no status alert in the DB, we were getting a JS error because the Swagger autogen client side code was trying to parse json out of the response (which doesn't exist in a 204). I guess 204s are Bad. We send back an empty StatusAlert object now.