### PR TITLE
[risk=no] moving domainInfoDao and surveyModuleDao into the ConceptService

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -15,6 +15,8 @@ import org.pmiops.workbench.api.BigQueryBaseTest;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.api.BigQueryTestService;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
+import org.pmiops.workbench.cdr.dao.DomainInfoDao;
+import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
@@ -40,6 +42,10 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
   @Autowired private ConceptDao conceptDao;
 
+  @Autowired private DomainInfoDao domainInfoDao;
+
+  @Autowired private SurveyModuleDao surveyModuleDao;
+
   @Autowired private BigQueryService bigQueryService;
 
   @Autowired private CdrBigQuerySchemaConfigService cdrBigQuerySchemaConfigService;
@@ -53,7 +59,8 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
-    ConceptService conceptService = new ConceptService(entityManager, conceptDao);
+    ConceptService conceptService =
+        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
     conceptBigQueryService =
         new ConceptBigQueryService(bigQueryService, cdrBigQuerySchemaConfigService, conceptService);
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -5,8 +5,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,8 +36,6 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
   @Autowired private TestWorkbenchConfig testWorkbenchConfig;
 
-  @PersistenceContext private EntityManager entityManager;
-
   @Autowired private ConceptDao conceptDao;
 
   @Autowired private DomainInfoDao domainInfoDao;
@@ -59,8 +55,7 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
-    ConceptService conceptService =
-        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
     conceptBigQueryService =
         new ConceptBigQueryService(bigQueryService, cdrBigQuerySchemaConfigService, conceptService);
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -27,6 +27,8 @@ import org.pmiops.workbench.api.BigQueryBaseTest;
 import org.pmiops.workbench.api.BigQueryTestService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
+import org.pmiops.workbench.cdr.dao.DomainInfoDao;
+import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
@@ -95,6 +97,10 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
 
   @Autowired private ConceptDao conceptDao;
 
+  @Autowired private DomainInfoDao domainInfoDao;
+
+  @Autowired private SurveyModuleDao surveyModuleDao;
+
   @PersistenceContext private EntityManager entityManager;
 
   @Autowired private ParticipantCohortStatusDao participantCohortStatusDao;
@@ -160,7 +166,8 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
     participantCohortStatusDao.save(
         makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
 
-    ConceptService conceptService = new ConceptService(entityManager, conceptDao);
+    ConceptService conceptService =
+        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
 
     this.cohortMaterializationService =
         new CohortMaterializationService(

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,8 +99,6 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
 
   @Autowired private SurveyModuleDao surveyModuleDao;
 
-  @PersistenceContext private EntityManager entityManager;
-
   @Autowired private ParticipantCohortStatusDao participantCohortStatusDao;
 
   @Autowired private FieldSetQueryBuilder fieldSetQueryBuilder;
@@ -166,8 +162,7 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
     participantCohortStatusDao.save(
         makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
 
-    ConceptService conceptService =
-        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
 
     this.cohortMaterializationService =
         new CohortMaterializationService(

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -4,8 +4,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
@@ -43,9 +41,6 @@ public class ConceptService {
     }
   }
 
-  @PersistenceContext(unitName = "cdr")
-  private EntityManager entityManager;
-
   @Autowired private ConceptDao conceptDao;
   @Autowired private DomainInfoDao domainInfoDao;
   @Autowired private SurveyModuleDao surveyModuleDao;
@@ -62,11 +57,7 @@ public class ConceptService {
 
   // Used for tests
   public ConceptService(
-      EntityManager entityManager,
-      ConceptDao conceptDao,
-      DomainInfoDao domainInfoDao,
-      SurveyModuleDao surveyModuleDao) {
-    this.entityManager = entityManager;
+      ConceptDao conceptDao, DomainInfoDao domainInfoDao, SurveyModuleDao surveyModuleDao) {
     this.conceptDao = conceptDao;
     this.domainInfoDao = domainInfoDao;
     this.surveyModuleDao = surveyModuleDao;

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -8,7 +8,11 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
+import org.pmiops.workbench.cdr.dao.DomainInfoDao;
+import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cdr.model.DbConcept;
+import org.pmiops.workbench.cdr.model.DbDomainInfo;
+import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,12 +23,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ConceptService {
-
-  public enum SearchType {
-    CONCEPT_SEARCH,
-    SURVEY_COUNTS,
-    DOMAIN_COUNTS;
-  }
 
   public static class ConceptIds {
 
@@ -49,6 +47,8 @@ public class ConceptService {
   private EntityManager entityManager;
 
   @Autowired private ConceptDao conceptDao;
+  @Autowired private DomainInfoDao domainInfoDao;
+  @Autowired private SurveyModuleDao surveyModuleDao;
   public static final String STANDARD_CONCEPTS = "STANDARD_CONCEPTS";
   public static final String STANDARD_CONCEPT_CODE = "S";
   public static final String CLASSIFICATION_CONCEPT_CODE = "C";
@@ -61,12 +61,18 @@ public class ConceptService {
   public ConceptService() {}
 
   // Used for tests
-  public ConceptService(EntityManager entityManager, ConceptDao conceptDao) {
+  public ConceptService(
+      EntityManager entityManager,
+      ConceptDao conceptDao,
+      DomainInfoDao domainInfoDao,
+      SurveyModuleDao surveyModuleDao) {
     this.entityManager = entityManager;
     this.conceptDao = conceptDao;
+    this.domainInfoDao = domainInfoDao;
+    this.surveyModuleDao = surveyModuleDao;
   }
 
-  public static String modifyMultipleMatchKeyword(String query, SearchType searchType) {
+  public static String modifyMultipleMatchKeyword(String query) {
     // This function modifies the keyword to match all the words if multiple words are present(by
     // adding + before each word to indicate match that matching each word is essential)
     if (query == null || query.trim().isEmpty()) {
@@ -93,23 +99,7 @@ public class ConceptService {
           if (key.length() < 3) {
             temp.add(key);
           } else {
-            // Only in the case of calling this method from getDomainSearchResults to fetch survey
-            // counts add wildcard* search.
-            // The survey view angular code fetches all the results of each survey module and then
-            // checks if the search text is present in the concept name / stratum4 of achilles
-            // results using regex test.
-            // Without this the number of results for search smoke would be 6 while also the actual
-            // results would be 12 as smoking, smoked (smoke*) are considered.
-            // Changing this would address the search count discrepancy for survey results. If *
-            // wildcard is added to all search types, source vocabulary code match on 507 fetches
-            // all the results matching 507*. (which is not desired to show the source / standard
-            // code mapping)
-            // So added different search type for each purpose
-            if (searchType == SearchType.SURVEY_COUNTS) {
-              temp.add(new String("+" + key + "*"));
-            } else {
-              temp.add(toAdd);
-            }
+            temp.add(toAdd);
           }
         }
       }
@@ -123,9 +113,29 @@ public class ConceptService {
     return query2.toString();
   }
 
+  public List<DbDomainInfo> getDomainInfo() {
+    return domainInfoDao.findByOrderByDomainId();
+  }
+
+  public List<DbDomainInfo> getAllDomainsOrderByDomainId() {
+    return domainInfoDao.findByOrderByDomainId();
+  }
+
+  public List<DbDomainInfo> getAllConceptCounts(String matchExp) {
+    return domainInfoDao.findAllMatchConceptCounts(matchExp);
+  }
+
+  public List<DbDomainInfo> getStandardConceptCounts(String matchExp) {
+    return domainInfoDao.findStandardConceptCounts(matchExp);
+  }
+
+  public List<DbSurveyModule> getSurveyInfo() {
+    return surveyModuleDao.findByParticipantCountNotOrderByOrderNumberAsc(0L);
+  }
+
   public Slice<DbConcept> searchConcepts(
       String query, String standardConceptFilter, List<String> domainIds, int limit, int page) {
-    final String keyword = modifyMultipleMatchKeyword(query, SearchType.CONCEPT_SEARCH);
+    final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
     List<String> conceptTypes =
         STANDARD_CONCEPTS.equals(standardConceptFilter)

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -242,14 +242,10 @@ public class ConceptsControllerTest {
     // Injecting ConceptsController and ConceptService doesn't work well without using
     // SpringBootTest, which causes problems with CdrDbConfig. Just construct the service and
     // controller directly.
-    ConceptService conceptService = new ConceptService(entityManager, conceptDao);
+    ConceptService conceptService =
+        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
     conceptsController =
-        new ConceptsController(
-            conceptService,
-            conceptBigQueryService,
-            workspaceService,
-            domainInfoDao,
-            surveyModuleDao);
+        new ConceptsController(conceptService, conceptBigQueryService, workspaceService);
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Provider;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -233,8 +231,6 @@ public class ConceptsControllerTest {
   @Mock Provider<DbUser> userProvider;
   @Autowired SurveyModuleDao surveyModuleDao;
 
-  @PersistenceContext private EntityManager entityManager;
-
   private ConceptsController conceptsController;
 
   @Before
@@ -242,8 +238,7 @@ public class ConceptsControllerTest {
     // Injecting ConceptsController and ConceptService doesn't work well without using
     // SpringBootTest, which causes problems with CdrDbConfig. Just construct the service and
     // controller directly.
-    ConceptService conceptService =
-        new ConceptService(entityManager, conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
     conceptsController =
         new ConceptsController(conceptService, conceptBigQueryService, workspaceService);
 


### PR DESCRIPTION
This PR moves the following daos into the ConceptService used by the ConceptsController. This moves all database interaction from the ConceptsController into the service layer.

- DomainInfoDao
- SurveyModuleDao

Also, removing entityManager since it's no longer referenced.