### PR TITLE
[risk=no]Upgrade vulnerable serialize-javascript

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -114,6 +114,7 @@
     "react-select": "^3.0.8",
     "react-switch": "^4.1.0",
     "rxjs": "^5.5.6",
+    "serialize-javascript": "^2.1.1",
     "stackdriver-errors-js": "^0.4.0",
     "stacktrace-js": "^2.0.0",
     "ts-jest": "^23.10.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7802,6 +7802,11 @@ serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
 
+serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"


### PR DESCRIPTION
Description:
Upgrade serialize-javascript to 2.1.1 or higher, as alerted [here](https://github.com/all-of-us/workbench/network/alert/ui/yarn.lock/serialize-javascript/open) 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
