### PR TITLE
[RW-4235][risk=no] Log when a user observes a held notebook lock

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -703,6 +703,22 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       }
     }
 
+    // If a lock is held by another user, log this to establish a rough estimate of how often
+    // locked notebooks are encountered. Note that this only covers locks encountered from the
+    // Workbench - any Jupyter UI-based lock detection does not touch this code path.
+    String currentUsername = userProvider.get().getUsername();
+    if (response.getLockExpirationTime() == null
+        || response.getLastLockedBy() == null
+        || response.getLockExpirationTime() < clock.millis()
+        || response.getLastLockedBy().equals(currentUsername)) {
+      log.info(String.format("user '%s' observed notebook available for editing", currentUsername));
+    } else {
+      log.info(
+          String.format(
+              "user '%s' observed notebook locked by '%s'",
+              currentUsername, response.getLastLockedBy()));
+    }
+
     return ResponseEntity.ok(response);
   }
 


### PR DESCRIPTION
Description:
This was requested to establish a rough estimate of the effect of how often users are affect by notebook locking.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
