### PR TITLE
[risk=no][RW-4238]Update yarn.lock for Node 12 compatibility on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See https://docs.docker.com/docker-for-mac/#advanced for screenshots and instruc
 For local development, also install:
 
   * [yarn](https://yarnpkg.com/lang/en/docs/install/#mac-stable)
-  * [Node.js](https://nodejs.org/en/)
+  * [Node.js](https://nodejs.org/en/) >= 8.  Currently known to work up to 12.16.
   * [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
 After you've installed `gcloud`, login using your `pmi-ops` account:

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3762,19 +3762,12 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.2.2, fsevents@^1.2.7:
+fsevents@^1.2.2, fsevents@^1.2.3, fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
-
-fsevents@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
-  dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
 
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.12"
@@ -6013,7 +6006,7 @@ nan@^2.10.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
 
-nan@^2.12.1, nan@^2.9.2:
+nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
 
@@ -6158,21 +6151,6 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Description:
`yarn install` failed on my Mac after upgrading to Node 12.

Problem and Solution:
The transitive dependency `fsevents` added Node 12 compatibility in version 1.2.9, and we call for an earlier version in yarn.lock.  I edited `yarn.lock` to remove the entry for the older fsevents and ran `yarn install` to upgrade.  That resolved the issue.

Previous attempts:
TIL about the "resolutions" section of packages.json which helps force version numbers of transitive dependencies.  Ensuring that fsevents would not attempt to install a version before 1.2.8 resolved my problem.   However!  resolutions has an unfortunate bug: it can override the "optional" flag in some cases.  Since fsevents is a Mac-only optional build dependency, this had the side effect of preventing builds on Linux, which is what CircleCI runs.  

Steps to the solution:
https://github.com/fsevents/fsevents/issues/278
https://github.com/yarnpkg/yarn/issues/2051
https://gitmemory.com/issue/yarnpkg/yarn/6040/492049907
https://github.com/paulmillr/chokidar/issues/836

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
