### PR TITLE
[RW-3650][risk=no] Add label support to our core CheckBox class and add type-safety and unit tests.

### DIFF
--- a/ui/src/app/components/inputs.spec.tsx
+++ b/ui/src/app/components/inputs.spec.tsx
@@ -1,33 +1,44 @@
-import {EnzymeAdapter, mount, shallow, ShallowWrapper} from 'enzyme';
+import {
+  EnzymeAdapter,
+  mount,
+  ReactWrapper,
+  shallow,
+  ShallowWrapper,
+} from 'enzyme';
 import * as React from 'react';
 
 import {CheckBox} from './inputs';
 
-function findInput(wrapper: ShallowWrapper): ShallowWrapper {
+function findInput(wrapper: (ShallowWrapper|ReactWrapper)): (ShallowWrapper|ReactWrapper) {
   return wrapper.find('input[type="checkbox"]').first();
 }
 
-function clickCheckbox(wrapper: ShallowWrapper) {
+function clickCheckbox(wrapper: (ShallowWrapper|ReactWrapper)) {
   const currentChecked = findInput(wrapper).prop('checked');
   findInput(wrapper).simulate('change', {target: {checked: !currentChecked}});
 }
 
 describe('inputs', () => {
-  it('handles click with manageOwnState', () => {
+  it('click causes DOM checked state to change', () => {
     // When the checkbox manages its own state, a click should cause the input
     // to change.
-    const wrapper = shallow(<CheckBox label='asdf' manageOwnState={true} />);
+    const wrapper = shallow(<CheckBox label='asdf' />);
     expect(findInput(wrapper).prop('checked')).toEqual(false);
     clickCheckbox(wrapper);
     wrapper.update();
     expect(findInput(wrapper).prop('checked')).toEqual(true);
   });
 
+  it('uses "checked" to set initial state', () => {
+    const wrapper = shallow(<CheckBox checked={true} />);
+    expect(findInput(wrapper).prop('checked')).toEqual(true);
+  });
+
   it('uses props only when manageOwnState=false', () => {
-    // This is the more common pattern used throughout the RW codebase, where
+    // This pattern is disfavored but still exists in the RW codebase, where
     // the caller of CheckBox provides "checked" as a prop and handles updates
     // by reacting to onChange callbacks.
-    const wrapper = shallow(<CheckBox checked={true}/>);
+    const wrapper = mount(<CheckBox checked={true} manageOwnState={false}/>);
     expect(findInput(wrapper).prop('checked')).toEqual(true);
     // A user click shouldn't directly affect the checked state.
     clickCheckbox(wrapper);

--- a/ui/src/app/components/inputs.spec.tsx
+++ b/ui/src/app/components/inputs.spec.tsx
@@ -1,0 +1,56 @@
+import {EnzymeAdapter, mount, shallow, ShallowWrapper} from 'enzyme';
+import * as React from 'react';
+
+import {CheckBox} from './inputs';
+
+function findInput(wrapper: ShallowWrapper): ShallowWrapper {
+  return wrapper.find('input[type="checkbox"]').first();
+}
+
+function clickCheckbox(wrapper: ShallowWrapper) {
+  const currentChecked = findInput(wrapper).prop('checked');
+  findInput(wrapper).simulate('change', {target: {checked: !currentChecked}});
+}
+
+describe('inputs', () => {
+  it('handles click with manageOwnState', () => {
+    // When the checkbox manages its own state, a click should cause the input
+    // to change.
+    const wrapper = shallow(<CheckBox label='asdf' manageOwnState={true} />);
+    expect(findInput(wrapper).prop('checked')).toEqual(false);
+    clickCheckbox(wrapper);
+    wrapper.update();
+    expect(findInput(wrapper).prop('checked')).toEqual(true);
+  });
+
+  it('uses props only when manageOwnState=false', () => {
+    // This is the more common pattern used throughout the RW codebase, where
+    // the caller of CheckBox provides "checked" as a prop and handles updates
+    // by reacting to onChange callbacks.
+    const wrapper = shallow(<CheckBox checked={true}/>);
+    expect(findInput(wrapper).prop('checked')).toEqual(true);
+    // A user click shouldn't directly affect the checked state.
+    clickCheckbox(wrapper);
+    expect(findInput(wrapper).prop('checked')).toEqual(true);
+    // Changing the props will change the checked state.
+    wrapper.setProps({checked: false} as any);
+    expect(findInput(wrapper).prop('checked')).toEqual(false);
+  });
+
+  it('calls onChange with target checked state', () => {
+    let checked = null;
+    const wrapper = shallow(<CheckBox onChange={(value) => checked = value}/>);
+    clickCheckbox(wrapper);
+    expect(checked).toEqual(true);
+  });
+
+  it('renders with plain-text label', () => {
+    const wrapper = mount(<CheckBox label='hello'/>);
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('renders with HTML label', () => {
+    const wrapper = mount(<CheckBox label={(<span>Hello, <i>world</i></span>)}/>);
+    expect(wrapper).toBeTruthy();
+  });
+});

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -177,7 +177,6 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
   };
 
   handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    console.log('change', e.target.checked, this.props);
     if (this.props.manageOwnState) {
       // We only track state internally if props aren't being used to render
       // the checkbox value.

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -164,17 +164,23 @@ interface CheckBoxState {
 }
 
 export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
+  static defaultProps: CheckBoxProps = {
+    checked: false,
+    manageOwnState: true
+  };
+
+  uniqueId?: string = null;
+
   constructor(props: CheckBoxProps) {
     super(props);
     this.state = {
       checked: props.checked
     };
-  }
 
-  static defaultProps: CheckBoxProps = {
-    checked: false,
-    manageOwnState: true
-  };
+    if (!props.id) {
+      this.uniqueId = fp.uniqueId('checkbox');
+    }
+  }
 
   handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (this.props.manageOwnState) {
@@ -191,12 +197,10 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
       checked, disabled, label, labelStyle, onChange, manageOwnState, style, wrapperStyle,
       ...otherProps
     } = this.props;
-    const uniqueId = fp.uniqueId('checkbox');
-
     const maybeDisabledOverrides = disabled ? styles.disabledStyle : {};
 
     const input = <input
-      id={uniqueId}
+      id={this.props.id ? this.props.id : this.uniqueId}
       type='checkbox'
       checked={manageOwnState ? this.state.checked : checked}
       disabled={disabled}
@@ -206,7 +210,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
     />;
     if (label) {
       return <span style={wrapperStyle}>{input}
-        <label htmlFor={uniqueId}
+        <label htmlFor={this.props.id ? this.props.id : this.uniqueId}
                style={{...styles.checkboxLabel,
                  ...labelStyle,
                  ...maybeDisabledOverrides}}>{label}</label>

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -177,9 +177,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
       checked: props.checked
     };
 
-    if (!props.id) {
-      this.uniqueId = fp.uniqueId('checkbox');
-    }
+    this.uniqueId = props.id || fp.uniqueId('checkbox');
   }
 
   handleChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -200,7 +198,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
     const maybeDisabledOverrides = disabled ? styles.disabledStyle : {};
 
     const input = <input
-      id={this.props.id ? this.props.id : this.uniqueId}
+      id={this.uniqueId}
       type='checkbox'
       checked={manageOwnState ? this.state.checked : checked}
       disabled={disabled}
@@ -210,7 +208,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
     />;
     if (label) {
       return <span style={wrapperStyle}>{input}
-        <label htmlFor={this.props.id ? this.props.id : this.uniqueId}
+        <label htmlFor={this.uniqueId}
                style={{...styles.checkboxLabel,
                  ...labelStyle,
                  ...maybeDisabledOverrides}}>{label}</label>

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -18,6 +18,20 @@ export const styles = {
     borderColor: colors.success
   },
 
+  checkbox: {
+    cursor: 'pointer',
+    verticalAlign: 'middle'
+  },
+
+  checkboxLabel: {
+    cursor: 'pointer',
+    verticalAlign: 'middle'
+  },
+
+  disabledStyle: {
+    cursor: 'default'
+  },
+
   error: {
     padding: '0 0.5rem',
     fontWeight: 600,
@@ -119,13 +133,90 @@ export const RadioButton = ({ onChange, ...props }) => {
   />;
 };
 
-export const CheckBox = ({onChange, ...props}) => {
-  return <input
-    type='checkbox'
-    onChange={onChange ? (e => onChange(e.target.checked)) : undefined}
-    {...props}
-  />;
-};
+interface CheckBoxProps {
+  // Whether the checkbox should be checked. If manageOwnState is false, the
+  // checkbox will always be rendered with the value of this prop. If
+  // manageOwnState is true, this prop controls only the initial value.
+  checked?: boolean;
+  // Whether the checkbox is rendered in a disabled state.
+  disabled?: boolean;
+  id?: string;
+  // An optional label to show alongside the input. Can be a plain string or
+  // any React node.
+  label?: React.ReactNode;
+  // Styles to apply to the label element. Only relevant when label is non-null.
+  labelStyle?: React.CSSProperties;
+  // Indicates whether the CheckBox should be responsible for managing its own
+  // state. When false, the HTML input will always be rendered with the value of
+  // the passed 'checked' prop.
+  manageOwnState: boolean;
+  // Callback called when the user clicks the checkbox or label, containing the
+  // new checked value.
+  onChange?: (boolean) => void;
+  // Styles for the <input> checkbox component.
+  style?: React.CSSProperties;
+  // If the label is non-empty, styles to be applied to the <span> wrapper.
+  wrapperStyle?: React.CSSProperties;
+}
+
+interface CheckBoxState {
+  checked: boolean;
+}
+
+export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
+  constructor(props: CheckBoxProps) {
+    super(props);
+    this.state = {
+      checked: props.checked
+    };
+  }
+
+  static defaultProps: CheckBoxProps = {
+    checked: false,
+    manageOwnState: true
+  };
+
+  handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    console.log('change', e.target.checked, this.props);
+    if (this.props.manageOwnState) {
+      // We only track state internally if props aren't being used to render
+      // the checkbox value.
+      this.setState({checked: !this.state.checked});
+    }
+    if (this.props.onChange) {
+      this.props.onChange(e.target.checked);
+    }
+  }
+  render() {
+    const {
+      checked, disabled, label, labelStyle, onChange, manageOwnState, style, wrapperStyle,
+      ...otherProps
+    } = this.props;
+    const uniqueId = fp.uniqueId('checkbox');
+
+    const maybeDisabledOverrides = disabled ? styles.disabledStyle : {};
+
+    const input = <input
+      id={uniqueId}
+      type='checkbox'
+      checked={manageOwnState ? this.state.checked : checked}
+      disabled={disabled}
+      onChange={e => this.handleChange(e)}
+      style={{...styles.checkbox, ...style, ...maybeDisabledOverrides}}
+      {...otherProps}
+    />;
+    if (label) {
+      return <span style={wrapperStyle}>{input}
+        <label htmlFor={uniqueId}
+               style={{...styles.checkboxLabel,
+                 ...labelStyle,
+                 ...maybeDisabledOverrides}}>{label}</label>
+      </span>;
+    } else {
+      return input;
+    }
+  }
+}
 
 export const Select = ({value, options, onChange, ...props}) => {
   return <RSelect

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -20,14 +20,14 @@ export const TwoColPaddedTable = ({style = {}, header = false, headerLeft = '',
   headerRight = '', cellWidth = {left: '50%', right: '50%'}, contentLeft, contentRight}) => {
   return <FlexColumn style={{...style}}>
     {header &&
-      <FlexRow key='header' style={{height: '100%'}}>
-        <PaddedTableCell key='header_l' left={true} leftWidth={cellWidth.left}
+      <FlexRow style={{height: '100%'}}>
+        <PaddedTableCell left={true} leftWidth={cellWidth.left}
                          content={<strong>{headerLeft}</strong>}/>
-        <PaddedTableCell key='header_r' left={false} rightWidth={cellWidth.right}
+        <PaddedTableCell left={false} rightWidth={cellWidth.right}
                          content={<strong>{headerRight}</strong>}/>
       </FlexRow>}
     {contentLeft.map((c, i) =>
-      <FlexRow key={i}>
+      <FlexRow>
         <PaddedTableCell key={i + '_l'} left={true} content={c}
                          leftWidth={cellWidth.left}/>
         {contentRight.length >= i + 1 &&

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -20,14 +20,14 @@ export const TwoColPaddedTable = ({style = {}, header = false, headerLeft = '',
   headerRight = '', cellWidth = {left: '50%', right: '50%'}, contentLeft, contentRight}) => {
   return <FlexColumn style={{...style}}>
     {header &&
-      <FlexRow style={{height: '100%'}}>
-        <PaddedTableCell left={true} leftWidth={cellWidth.left}
+      <FlexRow key='header' style={{height: '100%'}}>
+        <PaddedTableCell key='header_l' left={true} leftWidth={cellWidth.left}
                          content={<strong>{headerLeft}</strong>}/>
-        <PaddedTableCell left={false} rightWidth={cellWidth.right}
+        <PaddedTableCell key='header_r' left={false} rightWidth={cellWidth.right}
                          content={<strong>{headerRight}</strong>}/>
       </FlexRow>}
     {contentLeft.map((c, i) =>
-      <FlexRow>
+      <FlexRow key={i}>
         <PaddedTableCell key={i + '_l'} left={true} content={c}
                          leftWidth={cellWidth.left}/>
         {contentRight.length >= i + 1 &&

--- a/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
+++ b/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
@@ -27,10 +27,9 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
     };
   }
 
-  toggleChecked() {
-    const newState = !this.state.checked;
-    this.setState({checked: newState});
-    Cookies.set(ConfirmPlaygroundModeModal.DO_NOT_SHOW_AGAIN, String(newState));
+  toggleChecked(checked: boolean) {
+    this.setState({checked: checked});
+    Cookies.set(ConfirmPlaygroundModeModal.DO_NOT_SHOW_AGAIN, String(checked));
   }
 
   render() {
@@ -45,7 +44,7 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
       <ModalFooter style={{alignItems: 'center'}}>
         <CheckBox id='show-again-checkbox'
                   checked={this.state.checked}
-                  onChange={() => { this.toggleChecked(); }} />
+                  onChange={(checked) => { this.toggleChecked(checked); }} />
         <label htmlFor='show-again-checkbox'
                style={{marginLeft: '8px', marginRight: 'auto', color: colors.primary}}>
           Don't show again

--- a/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
+++ b/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
@@ -27,7 +27,7 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
     };
   }
 
-  toggleChecked(checked: boolean) {
+  handleCheckboxCHange(checked: boolean) {
     this.setState({checked: checked});
     Cookies.set(ConfirmPlaygroundModeModal.DO_NOT_SHOW_AGAIN, String(checked));
   }
@@ -44,7 +44,7 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
       <ModalFooter style={{alignItems: 'center'}}>
         <CheckBox id='show-again-checkbox'
                   checked={this.state.checked}
-                  onChange={(checked) => { this.toggleChecked(checked); }} />
+                  onChange={(checked) => { this.handleCheckboxCHange(checked); }} />
         <label htmlFor='show-again-checkbox'
                style={{marginLeft: '8px', marginRight: 'auto', color: colors.primary}}>
           Don't show again

--- a/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
+++ b/ui/src/app/pages/analysis/confirm-playground-mode-modal.tsx
@@ -27,7 +27,7 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
     };
   }
 
-  handleCheckboxCHange(checked: boolean) {
+  handleCheckboxChange(checked: boolean) {
     this.setState({checked: checked});
     Cookies.set(ConfirmPlaygroundModeModal.DO_NOT_SHOW_AGAIN, String(checked));
   }
@@ -44,7 +44,7 @@ export class ConfirmPlaygroundModeModal extends React.Component<Props, State> {
       <ModalFooter style={{alignItems: 'center'}}>
         <CheckBox id='show-again-checkbox'
                   checked={this.state.checked}
-                  onChange={(checked) => { this.handleCheckboxCHange(checked); }} />
+                  onChange={(checked) => { this.handleCheckboxChange(checked); }} />
         <label htmlFor='show-again-checkbox'
                style={{marginLeft: '8px', marginRight: 'auto', color: colors.primary}}>
           Don't show again

--- a/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
@@ -203,6 +203,7 @@ const AnnotationItem = fp.flow(
         />;
       case AnnotationType.BOOLEAN:
         return <CheckBox
+          manageOwnState={false}
           checked={value}
           onChange={v => this.save(v)}
           disabled={disabled}

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -126,8 +126,8 @@ describe('ConceptHomepage', () => {
     const wrapper = mount(<ConceptHomepage />);
     await waitOneTickAndUpdate(wrapper);
 
-    wrapper.find('[data-test-id="standardConceptsCheckBox"]').first()
-      .simulate('change', { target: { checked: true } });
+    wrapper.find('[data-test-id="standardConceptsCheckBox"] input').first()
+      .simulate('change', { target: { checked: false } });
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -511,14 +511,13 @@ export const ConceptHomepage = withCurrentWorkspace()(
                   <ClrIcon shape='times-circle' style={styles.clearSearchIcon}/>
               </Clickable>}
               <CheckBox checked={standardConceptsOnly}
+                        label='Standard concepts only'
+                        labelStyle={{marginLeft: '0.2rem'}}
                         data-test-id='standardConceptsCheckBox'
                         style={{marginLeft: '0.5rem', height: '16px', width: '16px'}}
-                        onChange={() => this.setState({
-                          standardConceptsOnly: !standardConceptsOnly
+                        onChange={(checked) => this.setState({
+                          standardConceptsOnly: checked
                         })}/>
-              <label style={{marginLeft: '0.2rem'}}>
-                Standard concepts only
-              </label>
             </div>
             {showSearchError &&
             <AlertDanger style={{width: '64.3%', marginLeft: '1%',

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -913,6 +913,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                     <BoxHeader step='3' header='Select Values' subHeader='Columns'>
                     <div style={styles.selectAllContainer}>
                       <CheckBox style={{height: 17, width: 17}}
+                                manageOwnState={false}
                                 disabled={fp.isEmpty(valueSets)}
                                 data-test-id='select-all'
                                 onChange={() => this.selectAllValues()}

--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -180,8 +180,8 @@ class NewDataSetModal extends React.Component<Props, State> {
     }
   }
 
-  changeExportToNotebook() {
-    this.setState({exportToNotebook: !this.state.exportToNotebook});
+  changeExportToNotebook(checked: boolean) {
+    this.setState({exportToNotebook: checked});
   }
 
   onSaveClick() {
@@ -282,8 +282,8 @@ class NewDataSetModal extends React.Component<Props, State> {
         <div style={{display: 'flex', alignItems: 'center', marginTop: '1rem'}}>
           <CheckBox style={{height: 17, width: 17}}
                     data-test-id='export-to-notebook'
-                    onChange={() => this.changeExportToNotebook()}
-                    checked={this.state.exportToNotebook} />
+                    onChange={(checked) => this.changeExportToNotebook(checked)}
+                    checked={false} />
           <div style={{marginLeft: '.5rem',
             color: colors.primary}}>Export to notebook</div>
         </div>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -31,7 +31,9 @@ const styles = {
     fontFamily: 'Montserrat',
     fontSize: '14px',
     fontWeight: 400,
-  }
+  },
+  checkboxWrapper: {display: 'flex', width: '9rem', marginBottom: '0.5rem', marginTop: '0.3rem'},
+  checkboxLabel: {paddingLeft: '0.5rem', paddingRight: '0.5rem'}
 };
 
 export const DropDownSection = (props) => {
@@ -40,16 +42,6 @@ export const DropDownSection = (props) => {
               value={props.value}
               onChange={(e) => props.onChange(e.value)}/>
   </Section>;
-};
-
-export const CheckBoxWithLabel = (props) => {
-  return <div style={{display: 'flex', width: '9rem', marginBottom: '0.5rem'}}>
-    <CheckBox style={{marginTop: '0.3rem'}}
-              checked={props.checked} onChange={(value) => props.onChange(value)}/>
-    <div style={{paddingLeft: '0.5rem', paddingRight: '0.5rem'}}>
-      <label style={{...styles.questionLabel, ...props.style}}>{props.label}</label>
-    </div>
-  </div>;
 };
 
 export interface AccountCreationSurveyProps {
@@ -114,6 +106,7 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     // Toggle Includes removes the element if it already exist and adds if not
     const attributeList = toggleIncludes(value, this.state.profile.demographicSurvey[attribute]);
     this.setState(fp.set(['profile', 'demographicSurvey', attribute], attributeList));
+    console.log(this.state);
   }
 
   toggleDisability(value) {
@@ -139,9 +132,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='1. Race'>
         <div style={{display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap'}}>
           {AccountCreationOptions.race.map((race) => {
-            return <CheckBoxWithLabel attribute='race' label={race.label}
-                                      onChange={(value) => this.updateList('race', race.value)}
-                                      value={race.value}/>; })
+            return <CheckBox label={race.label}
+                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
+                             onChange={(value) => this.updateList('race', race.value)}
+                             />; })
           }
         </div>
       </Section>
@@ -155,9 +149,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='3. Gender'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.gender.map((gender) => {
-            return <CheckBoxWithLabel attribute='gender'
-                                      onChange={(value) => this.updateList('gender', gender.value)}
-                                      label={gender.label} value={gender.value}/>;
+            return <CheckBox label={gender.label}
+                        onChange={(value) => this.updateList('gender', gender.value)}
+                        wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
+                        />;
           })
           }
         </FlexRow>
@@ -166,9 +161,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='4. Sex at birth'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexAtBirth.map((sexAtBirth) => {
-            return <CheckBoxWithLabel attribute='sexAtBirth'
-                                      onChange={(value) => this.updateList('sexAtBirth', sexAtBirth.value)}
-                                      label={sexAtBirth.label} value={sexAtBirth.value}/>;
+            return <CheckBox label={sexAtBirth.label}
+                             onChange={(value) => this.updateList('sexAtBirth', sexAtBirth.value)}
+                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
+            />;
           })
           }
         </FlexRow>
@@ -177,9 +173,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='5. Sexual Orientation'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexualOrientation.map((sexualOrientation) => {
-            return <CheckBoxWithLabel attribute='sexualOrientation'
-                                      onChange={(value) => this.updateList('sexualOrientation', sexualOrientation.value)}
-                                      label={sexualOrientation.label} value={sexualOrientation.value}/>;
+            return <CheckBox label={sexualOrientation.label}
+                             onChange={(value) => this.updateList('sexualOrientation', sexualOrientation.value)}
+                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
+            />;
           })
           }
         </FlexRow>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -25,15 +25,16 @@ import {AccountCreationOptions} from './account-creation-options';
 
 
 const styles = {
-  questionLabel: {
-    width: 76,
+  checkbox: {marginTop: '0.3rem'},
+  checkboxWrapper: {display: 'flex', width: '9rem', marginBottom: '0.5rem'},
+  checkboxLabel: {
     color: colors.primary,
     fontFamily: 'Montserrat',
     fontSize: '14px',
     fontWeight: 400,
-  },
-  checkboxWrapper: {display: 'flex', width: '9rem', marginBottom: '0.5rem', marginTop: '0.3rem'},
-  checkboxLabel: {paddingLeft: '0.5rem', paddingRight: '0.5rem'}
+    paddingLeft: '0.5rem',
+    paddingRight: '0.5rem'
+  }
 };
 
 export const DropDownSection = (props) => {
@@ -116,6 +117,14 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     this.setState(fp.set(['profile', 'demographicSurvey', attribute], value));
   }
 
+  createOptionCheckbox(checkboxLabel: string, optionKey: string, optionValue: any) {
+    return <CheckBox label={checkboxLabel}
+                     style={styles.checkbox}
+                     wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
+                     onChange={(value) => this.updateList(optionKey, optionValue)}
+    />;
+  }
+
   render() {
     const {profile: {demographicSurvey}} = this.state;
     return <div style={{marginTop: '1rem', paddingLeft: '3rem'}}>
@@ -131,11 +140,8 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='1. Race'>
         <div style={{display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap'}}>
           {AccountCreationOptions.race.map((race) => {
-            return <CheckBox label={race.label}
-                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
-                             onChange={(value) => this.updateList('race', race.value)}
-                             />; })
-          }
+            return this.createOptionCheckbox(race.label, 'race', race.value);
+          })}
         </div>
       </Section>
 
@@ -148,34 +154,23 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='3. Gender'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.gender.map((gender) => {
-            return <CheckBox label={gender.label}
-                        onChange={(value) => this.updateList('gender', gender.value)}
-                        wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
-                        />;
-          })
-          }
+            return this.createOptionCheckbox(gender.label, 'gender', gender.value);
+          })}
         </FlexRow>
       </Section>
       {/*Sex at birth section*/}
       <Section header='4. Sex at birth'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexAtBirth.map((sexAtBirth) => {
-            return <CheckBox label={sexAtBirth.label}
-                             onChange={(value) => this.updateList('sexAtBirth', sexAtBirth.value)}
-                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
-            />;
-          })
-          }
+            return this.createOptionCheckbox(sexAtBirth.label, 'sexAtBirth', sexAtBirth.value);
+          })}
         </FlexRow>
       </Section>
       {/*Sexual orientation section*/}
       <Section header='5. Sexual Orientation'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexualOrientation.map((sexualOrientation) => {
-            return <CheckBox label={sexualOrientation.label}
-                             onChange={(value) => this.updateList('sexualOrientation', sexualOrientation.value)}
-                             wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
-            />;
+            return this.createOptionCheckbox(sexualOrientation.label, 'sexualOrientation', sexualOrientation.value);
           })
           }
         </FlexRow>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -106,7 +106,6 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     // Toggle Includes removes the element if it already exist and adds if not
     const attributeList = toggleIncludes(value, this.state.profile.demographicSurvey[attribute]);
     this.setState(fp.set(['profile', 'demographicSurvey', attribute], attributeList));
-    console.log(this.state);
   }
 
   toggleDisability(value) {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -308,8 +308,10 @@ export const WorkspaceEditSection = (props) => {
 
 export const WorkspaceCategory = (props) => {
   return <div style={...fp.merge(styles.categoryRow, props.style)}>
-    <CheckBox style={styles.checkboxStyle} checked={!!props.value}
-      onChange={e => props.onChange(e)}/>
+    <CheckBox id={props.uniqueId}
+              style={styles.checkboxStyle}
+              checked={!!props.value}
+              onChange={e => props.onChange(e)}/>
     <FlexColumn style={{marginTop: '-0.2rem'}}>
       <label style={styles.shortDescription} htmlFor={props.uniqueId}>
         {props.shortDescription}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -532,7 +532,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
     specificPopulationCheckboxSelected(populationEnum): boolean {
-      return !!fp.includes(populationEnum, this.state.workspace.researchPurpose.populationDetails);
+      return fp.includes(populationEnum, this.state.workspace.researchPurpose.populationDetails);
     }
 
     onSaveClick() {
@@ -744,9 +744,11 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <FlexColumn style={{flex: '1 1 0'}}>
               {ResearchPurposeItems.slice(0, sliceByHalfLength(ResearchPurposeItems))
                 .map((rp, i) =>
-                  <WorkspaceCategory shortDescription={rp.shortDescription} key={i}
+                  <WorkspaceCategory
+                    shortDescription={rp.shortDescription}
+                    key={i}
                     longDescription={rp.longDescription}
-                     uniqueId={rp.uniqueId}
+                    uniqueId={rp.uniqueId}
                     value={this.state.workspace.researchPurpose[rp.shortName]}
                     onChange={v => this.updateResearchPurpose(rp.shortName, v)}
                     children={rp.shortName === 'diseaseFocusedResearch' ?
@@ -755,9 +757,11 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <FlexColumn style={{flex: '1 1 0'}}>
               {ResearchPurposeItems.slice(sliceByHalfLength(ResearchPurposeItems))
                 .map((rp, i) =>
-                  <WorkspaceCategory shortDescription={rp.shortDescription}
-                    longDescription={rp.longDescription} key={i}
-                                     uniqueId={rp.uniqueId}
+                  <WorkspaceCategory
+                    shortDescription={rp.shortDescription}
+                    longDescription={rp.longDescription}
+                    key={i}
+                    uniqueId={rp.uniqueId}
                     value={this.state.workspace.researchPurpose[rp.shortName]}
                     onChange={v => this.updateResearchPurpose(rp.shortName, v)}
                     children={rp.shortName === 'otherPurpose' ?


### PR DESCRIPTION
I ended up digging into the checkbox issue a bit more on Friday. I think this is the most balanced approach to fixing the issue. The crux of the matter is this: should a checkbox manage its own checked state, or should it always blindly render the value passed in via props?

After taking stock of existing usage in the Workbench, I realized that in most scenarios, it's fine to allow checkboxes manage their own state. Wrapping components can pass in the initial value, and listen for changes by providing an .onChange(checked) prop.

In one or two use cases, though, we seem to be expecting the checkbox to always render the value passed in via props. The wrapping component implements the toggling behavior by listening to onChange events, updating its own state, and using that state variable to pass into the CheckBox's 'props'. This pattern should be disfavored, since it causes wrapping components to effectively re-implement the checkbox toggling logic.

I also took the opportunity to add type-safe props and state to the CheckBox component, and a couple unit tests. It's a bit scary that, across our whole codebase, our core UI components have the least type-safety and unit testing. This makes it hard to safely improve or refactor our UI over time, so I'd like to (very incrementally) add these over time.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally