### PR TITLE
[RW-4236][risk=no] - adding counts for PM and Surveys

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.pmiops.workbench.api.BigQueryBaseTest;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.api.BigQueryTestService;
+import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
@@ -42,6 +43,8 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
   @Autowired private SurveyModuleDao surveyModuleDao;
 
+  @Autowired private CBCriteriaDao cbCriteriaDao;
+
   @Autowired private BigQueryService bigQueryService;
 
   @Autowired private CdrBigQuerySchemaConfigService cdrBigQuerySchemaConfigService;
@@ -55,7 +58,8 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
-    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService =
+        new ConceptService(conceptDao, domainInfoDao, surveyModuleDao, cbCriteriaDao);
     conceptBigQueryService =
         new ConceptBigQueryService(bigQueryService, cdrBigQuerySchemaConfigService, conceptService);
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.pmiops.workbench.api.BigQueryBaseTest;
 import org.pmiops.workbench.api.BigQueryTestService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
+import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
@@ -101,6 +102,8 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
 
   @Autowired private ParticipantCohortStatusDao participantCohortStatusDao;
 
+  @Autowired private CBCriteriaDao cbCriteriaDao;
+
   @Autowired private FieldSetQueryBuilder fieldSetQueryBuilder;
 
   @Autowired private AnnotationQueryBuilder annotationQueryBuilder;
@@ -162,7 +165,8 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
     participantCohortStatusDao.save(
         makeStatus(cohortReview.getCohortReviewId(), 2L, CohortStatus.EXCLUDED));
 
-    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService =
+        new ConceptService(conceptDao, domainInfoDao, surveyModuleDao, cbCriteriaDao);
 
     this.cohortMaterializationService =
         new CohortMaterializationService(

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -15,7 +15,7 @@ import org.pmiops.workbench.concept.ConceptService.ConceptIds;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService.ConceptColumns;
 import org.pmiops.workbench.model.SurveyAnswerResponse;
-import org.pmiops.workbench.model.SurveyQuestionsResponse;
+import org.pmiops.workbench.model.SurveyQuestions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -126,8 +126,8 @@ public class ConceptBigQueryService {
     return QueryJobConfiguration.newBuilder(finalSql).setUseLegacySql(false).build();
   }
 
-  public List<SurveyQuestionsResponse> getSurveyQuestions(String surveyName) {
-    List<SurveyQuestionsResponse> responseList = new ArrayList<>();
+  public List<SurveyQuestions> getSurveyQuestions(String surveyName) {
+    List<SurveyQuestions> responseList = new ArrayList<>();
 
     TableResult result =
         bigQueryService.executeQuery(
@@ -138,8 +138,7 @@ public class ConceptBigQueryService {
             surveyValue -> {
               String question = surveyValue.get(0).getValue().toString();
               Long concept_id = Long.parseLong(surveyValue.get(1).getValue().toString());
-              responseList.add(
-                  new SurveyQuestionsResponse().question(question).conceptId(concept_id));
+              responseList.add(new SurveyQuestions().question(question).conceptId(concept_id));
             });
     return responseList;
   }

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -59,10 +59,14 @@ public class ConceptService {
 
   // Used for tests
   public ConceptService(
-      ConceptDao conceptDao, DomainInfoDao domainInfoDao, SurveyModuleDao surveyModuleDao) {
+      ConceptDao conceptDao,
+      DomainInfoDao domainInfoDao,
+      SurveyModuleDao surveyModuleDao,
+      CBCriteriaDao cbCriteriaDao) {
     this.conceptDao = conceptDao;
     this.domainInfoDao = domainInfoDao;
     this.surveyModuleDao = surveyModuleDao;
+    this.cbCriteriaDao = cbCriteriaDao;
   }
 
   public static String modifyMultipleMatchKeyword(String query) {

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
@@ -44,6 +45,7 @@ public class ConceptService {
   @Autowired private ConceptDao conceptDao;
   @Autowired private DomainInfoDao domainInfoDao;
   @Autowired private SurveyModuleDao surveyModuleDao;
+  @Autowired private CBCriteriaDao cbCriteriaDao;
   public static final String STANDARD_CONCEPTS = "STANDARD_CONCEPTS";
   public static final String STANDARD_CONCEPT_CODE = "S";
   public static final String CLASSIFICATION_CONCEPT_CODE = "C";
@@ -116,12 +118,24 @@ public class ConceptService {
     return domainInfoDao.findAllMatchConceptCounts(matchExp);
   }
 
+  public DbDomainInfo findPhysicalMeasurementConceptCounts(String matchExp) {
+    return domainInfoDao.findPhysicalMeasurementConceptCounts(matchExp);
+  }
+
   public List<DbDomainInfo> getStandardConceptCounts(String matchExp) {
     return domainInfoDao.findStandardConceptCounts(matchExp);
   }
 
   public List<DbSurveyModule> getSurveyInfo() {
     return surveyModuleDao.findByParticipantCountNotOrderByOrderNumberAsc(0L);
+  }
+
+  public long findSurveyCountByTerm(String matchExp) {
+    return cbCriteriaDao.findSurveyCountByTerm(matchExp);
+  }
+
+  public long findSurveyCountBySurveyName(String surveyName) {
+    return cbCriteriaDao.findSurveyCountBySurveyName(surveyName);
   }
 
   public Slice<DbConcept> searchConcepts(

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -521,6 +521,9 @@ definitions:
           The domain for the concepts returned (e.g. OBSERVATION, DRUG). Note that this may map
           to multiple domain ID values in OMOP.
         $ref: "#/definitions/Domain"
+      surveyName:
+        description: The name of the survey clicked
+        type: string
       maxResults:
         type: integer
         format: int32
@@ -543,6 +546,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Concept"
+      questions:
+        type: "array"
+        items:
+          $ref: "#/definitions/SurveyQuestions"
       domainCounts:
         type: "array"
         items:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1900,7 +1900,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/SurveyQuestionsResponse"
+              $ref: "#/definitions/SurveyQuestions"
 
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/surveyAnswer:
     get:
@@ -3248,7 +3248,7 @@ definitions:
         items:
           $ref: "#/definitions/SurveyModule"
 
-  SurveyQuestionsResponse:
+  SurveyQuestions:
     type: object
     properties:
       question:

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -201,7 +201,7 @@ public class ConceptsControllerTest {
       new DbDomainInfo()
           .domainEnum(Domain.SURVEY)
           .domainId("Survey")
-          .name("SURVEY")
+          .name("Surveys")
           .description("SURVEY")
           .conceptId(CONCEPT_4.getConceptId())
           .participantCount(0)

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
@@ -196,6 +197,17 @@ public class ConceptsControllerTest {
           .standardConceptCount(3)
           .allConceptCount(4);
 
+  private static final DbDomainInfo SURVEY_DOMAIN =
+      new DbDomainInfo()
+          .domainEnum(Domain.SURVEY)
+          .domainId("Survey")
+          .name("SURVEY")
+          .description("SURVEY")
+          .conceptId(CONCEPT_4.getConceptId())
+          .participantCount(0)
+          .standardConceptCount(0)
+          .allConceptCount(0);
+
   private static final String WORKSPACE_NAMESPACE = "ns";
   private static final String WORKSPACE_NAME = "name";
   private static final String USER_EMAIL = "bob@gmail.com";
@@ -226,6 +238,7 @@ public class ConceptsControllerTest {
   @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private ConceptBigQueryService conceptBigQueryService;
   @Autowired private DomainInfoDao domainInfoDao;
+  @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired FireCloudService fireCloudService;
   @Autowired UserDao userDao;
   @Mock Provider<DbUser> userProvider;
@@ -238,7 +251,8 @@ public class ConceptsControllerTest {
     // Injecting ConceptsController and ConceptService doesn't work well without using
     // SpringBootTest, which causes problems with CdrDbConfig. Just construct the service and
     // controller directly.
-    ConceptService conceptService = new ConceptService(conceptDao, domainInfoDao, surveyModuleDao);
+    ConceptService conceptService =
+        new ConceptService(conceptDao, domainInfoDao, surveyModuleDao, cbCriteriaDao);
     conceptsController =
         new ConceptsController(conceptService, conceptBigQueryService, workspaceService);
 
@@ -323,7 +337,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, false),
             toDomainCount(DRUG_DOMAIN, false),
             toDomainCount(MEASUREMENT_DOMAIN, false),
-            toDomainCount(PROCEDURE_DOMAIN, false)),
+            toDomainCount(PROCEDURE_DOMAIN, false),
+            toDomainCount(SURVEY_DOMAIN, false)),
         ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5, CLIENT_CONCEPT_3, CLIENT_CONCEPT_1));
   }
 
@@ -346,7 +361,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, true),
             toDomainCount(DRUG_DOMAIN, true),
             toDomainCount(MEASUREMENT_DOMAIN, true),
-            toDomainCount(PROCEDURE_DOMAIN, true)),
+            toDomainCount(PROCEDURE_DOMAIN, true),
+            toDomainCount(SURVEY_DOMAIN, true)),
         ImmutableList.of(CLIENT_CONCEPT_5, CLIENT_CONCEPT_1));
   }
 
@@ -369,7 +385,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, true),
             toDomainCount(DRUG_DOMAIN, true),
             toDomainCount(MEASUREMENT_DOMAIN, true),
-            toDomainCount(PROCEDURE_DOMAIN, true)),
+            toDomainCount(PROCEDURE_DOMAIN, true),
+            toDomainCount(SURVEY_DOMAIN, true)),
         ImmutableList.of(CLIENT_CONCEPT_5, CLIENT_CONCEPT_1));
   }
 
@@ -515,7 +532,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, 2),
             toDomainCount(DRUG_DOMAIN, 0),
             toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0)),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)),
         ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5));
   }
 
@@ -536,7 +554,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, 1),
             toDomainCount(DRUG_DOMAIN, 0),
             toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0)),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)),
         ImmutableList.of(CLIENT_CONCEPT_4));
   }
 
@@ -591,7 +610,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, 1),
             toDomainCount(DRUG_DOMAIN, 0),
             toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0)),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)),
         ImmutableList.of(CLIENT_CONCEPT_5));
   }
 
@@ -612,7 +632,8 @@ public class ConceptsControllerTest {
             toDomainCount(CONDITION_DOMAIN, 2),
             toDomainCount(DRUG_DOMAIN, 0),
             toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0)),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)),
         ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5));
   }
 
@@ -636,7 +657,8 @@ public class ConceptsControllerTest {
             // Although it doesn't match the domain filter, we still include the measurement concept
             // in domain counts
             toDomainCount(MEASUREMENT_DOMAIN, 1),
-            toDomainCount(PROCEDURE_DOMAIN, 0)),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)),
         ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5, CLIENT_CONCEPT_3, CLIENT_CONCEPT_1));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -33,6 +33,7 @@ public class CBCriteriaDaoTest {
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
   private DbCriteria surveyCriteria;
+  private DbCriteria questionCriteria;
   private DbCriteria sourceCriteria;
   private DbCriteria standardCriteria;
   private DbCriteria icd9Criteria;
@@ -52,7 +53,19 @@ public class CBCriteriaDaoTest {
                 .subtype(CriteriaSubType.SURVEY.toString())
                 .group(false)
                 .standard(false)
-                .selectable(true));
+                .selectable(true)
+                .name("The Basics"));
+    questionCriteria =
+        cbCriteriaDao.save(
+            new DbCriteria()
+                .domainId(DomainType.SURVEY.toString())
+                .type(CriteriaType.PPI.toString())
+                .subtype(CriteriaSubType.QUESTION.toString())
+                .group(false)
+                .standard(false)
+                .selectable(true)
+                .parentId(surveyCriteria.getId())
+                .synonyms("test"));
     sourceCriteria =
         cbCriteriaDao.save(
             new DbCriteria()
@@ -331,5 +344,15 @@ public class CBCriteriaDaoTest {
     assertEquals(DomainType.SURVEY.toString(), option.getDomain());
     assertEquals("PPI", option.getType());
     assertFalse(option.getStandard());
+  }
+
+  @Test
+  public void findSurveyCountByTerm() {
+    assertEquals(1, cbCriteriaDao.findSurveyCountByTerm("test"));
+  }
+
+  @Test
+  public void findSurveyCountBySurveyName() {
+    assertEquals(1, cbCriteriaDao.findSurveyCountBySurveyName("The Basics"));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
@@ -88,9 +88,10 @@ public class DomainInfoDaoTest {
   @Test
   public void findByOrderByDomainId() {
     List<DbDomainInfo> infos = domainInfoDao.findByOrderByDomainId();
-    assertEquals(2, infos.size());
+    assertEquals(3, infos.size());
     assertEquals(domainInfoCondition, infos.get(0));
     assertEquals(domainInfoObservation, infos.get(1));
+    assertEquals(domainInfoPM, infos.get(2));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
@@ -22,6 +22,7 @@ public class DomainInfoDaoTest {
   @Autowired private ConceptDao conceptDao;
   private DbDomainInfo domainInfoObservation;
   private DbDomainInfo domainInfoCondition;
+  private DbDomainInfo domainInfoPM;
 
   @Before
   public void setUp() {
@@ -40,6 +41,14 @@ public class DomainInfoDaoTest {
             .count(100L)
             .sourceCountValue(122L)
             .standardConcept("S")
+            .conceptName("name"));
+    conceptDao.save(
+        new DbConcept()
+            .conceptId(3L)
+            .domainId("Measurement")
+            .count(200L)
+            .sourceCountValue(127L)
+            .vocabularyId("PPI")
             .conceptName("name"));
     domainInfoObservation =
         domainInfoDao.save(
@@ -63,6 +72,17 @@ public class DomainInfoDaoTest {
                 .allConceptCount(0)
                 .standardConceptCount(0)
                 .participantCount(0));
+    domainInfoPM =
+        domainInfoDao.save(
+            new DbDomainInfo()
+                .conceptId(0L)
+                .domain((short) 10)
+                .domainId("Physical Measurements")
+                .name("Physical Measurements")
+                .description("descr")
+                .allConceptCount(33)
+                .standardConceptCount(0)
+                .participantCount(453542));
   }
 
   @Test
@@ -87,5 +107,11 @@ public class DomainInfoDaoTest {
     assertEquals(2, infos.size());
     assertEquals(domainInfoCondition.allConceptCount(1), infos.get(0));
     assertEquals(domainInfoObservation.allConceptCount(1), infos.get(1));
+  }
+
+  @Test
+  public void findPhysicalMeasurementConceptCounts() {
+    DbDomainInfo info = domainInfoDao.findPhysicalMeasurementConceptCounts("name");
+    assertEquals(domainInfoPM.allConceptCount(1), info);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -236,4 +236,21 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select distinct domain_id as domain, type, is_standard as standard from cb_criteria order by domain, type, is_standard",
       nativeQuery = true)
   List<DbMenuOption> findMenuOptions();
+
+  @Query(
+      value =
+          "select count(c) "
+              + "from DbCriteria c "
+              + "where domainId = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
+              + "and match(synonyms, :term) > 0")
+  long findSurveyCountByTerm(@Param("term") String term);
+
+  @Query(
+      value =
+          "select count(*) "
+              + "from cb_criteria "
+              + "where domain_id = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
+              + "and parent_id in (select id from cb_criteria where domain_id = 'SURVEY' and type = 'PPI' and name = :surveyName)",
+      nativeQuery = true)
+  long findSurveyCountBySurveyName(@Param("surveyName") String surveyName);
 }

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -28,7 +28,7 @@ import {
   DomainInfo,
   StandardConceptFilter,
   SurveyModule,
-  SurveyQuestionsResponse,
+  SurveyQuestions,
 } from 'generated/fetch';
 import {Key} from 'ts-key-enum';
 import {SurveyDetails} from './survey-details';
@@ -156,15 +156,6 @@ const conceptCacheStub = [
   }
 ];
 
-// Stub used to display placeholder tabs in concept search
-const domainCountStub = [
-  {
-    domain: Domain.SURVEY,
-    name: 'Surveys',
-    conceptCount: 0
-  }
-];
-
 interface Props {
   workspace: WorkspaceData;
 }
@@ -203,7 +194,7 @@ interface State { // Browse survey
   // Name of the survey selected
   selectedSurvey: string;
   // Array of survey questions selected to be added to concept set
-  selectedSurveyQuestions: Array<SurveyQuestionsResponse>;
+  selectedSurveyQuestions: Array<SurveyQuestions>;
   // Show if a search error occurred
   showSearchError: boolean;
   // Only search on standard concepts
@@ -270,7 +261,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
         }));
         if (environment.enableNewConceptTabs) {
           conceptsCache = [...conceptsCache, ...conceptCacheStub];
-          conceptDomainCounts = [...conceptDomainCounts, ...domainCountStub];
+          conceptDomainCounts = [...conceptDomainCounts];
         } else {
           conceptsCache = conceptsCache.filter(item => item.domain !== Domain.PHYSICALMEASUREMENT);
           conceptDomainCounts = conceptDomainCounts.filter(item => item.domain !== Domain.PHYSICALMEASUREMENT);
@@ -357,7 +348,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
         cacheItem.items = resp.items;
         this.setState({completedDomainSearches: completedDomainSearches});
         if (activeTabSearch) {
-          const conceptDomainCounts = environment.enableNewConceptTabs ? [...resp.domainCounts, ...domainCountStub]
+          const conceptDomainCounts = environment.enableNewConceptTabs ? [...resp.domainCounts]
             : resp.domainCounts.filter(item => item.domain !== Domain.PHYSICALMEASUREMENT);
           this.setState({
             searchLoading: false,

--- a/ui/src/app/pages/data/concept/concept-survey-add-modal.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-survey-add-modal.spec.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {ConceptSetsApi, Domain, SurveyQuestionsResponse, Surveys} from 'generated/fetch';
+import {ConceptSetsApi, Domain, SurveyQuestions, Surveys} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {ConceptStubVariables} from 'testing/stubs/concepts-api-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {ConceptSurveyAddModal} from './concept-survey-add-modal';
 
-const surveyList: Array<SurveyQuestionsResponse> = [{
+const surveyList: Array<SurveyQuestions> = [{
   question: 'Lifestyle',
   conceptId: 5
 }];

--- a/ui/src/app/pages/data/concept/concept-survey-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-survey-add-modal.tsx
@@ -14,7 +14,7 @@ import {
   ConceptSet,
   CreateConceptSetRequest,
   Domain,
-  SurveyQuestionsResponse,
+  SurveyQuestions,
   Surveys,
   UpdateConceptSetRequest
 } from 'generated/fetch';
@@ -34,7 +34,7 @@ const styles = reactStyles({
 export const ConceptSurveyAddModal = withCurrentWorkspace()
 (class extends React.Component<{
   workspace: WorkspaceData,
-  selectedSurvey: Array<SurveyQuestionsResponse>,
+  selectedSurvey: Array<SurveyQuestions>,
   onSave: Function,
   onClose: Function,
   surveyName: string

--- a/ui/src/app/pages/data/concept/survey-details.tsx
+++ b/ui/src/app/pages/data/concept/survey-details.tsx
@@ -5,13 +5,13 @@ import {conceptsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {SurveyAnswerResponse, SurveyQuestionsResponse} from 'generated/fetch';
+import {SurveyAnswerResponse, SurveyQuestions} from 'generated/fetch';
 import {Column} from 'primereact/column';
 import {DataTable} from 'primereact/datatable';
 import * as React from 'react';
 
 interface SurveyDetails {
-  question: SurveyQuestionsResponse;
+  question: SurveyQuestions;
   answer: Array<SurveyAnswerResponse>;
 }
 
@@ -58,7 +58,7 @@ interface State {
   expandedRows: Array<any>;
   loading: boolean;
   seeMyAnswers: Array<boolean>;
-  selectedQuestions: Array<SurveyQuestionsResponse>;
+  selectedQuestions: Array<SurveyQuestions>;
   surveyList: Array<SurveyDetails>;
 }
 


### PR DESCRIPTION
Concept set builder now implements tab counts for PM and Surveys. 
All domains including Surveys in concept set builder will use ConceptsController.searchConcepts 

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
