### PR TITLE
[RW-4226][RISK=no] Use descriptive, unique-per-instance MonitoredResource specification

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -54,7 +54,8 @@
     "projectId": "all-of-us-workbench-test",
     "shortName": "Local",
     "oauthClientId": "602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com",
-    "traceAllRequests": true
+    "traceAllRequests": true,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "loginUrl": "http:\/\/localhost:4200/login",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -56,7 +56,8 @@
     "projectId": "all-of-us-rw-perf",
     "shortName": "Perf",
     "oauthClientId": "63939010390-aj0r8hro7r8lkt7a45gissu3m73ietl2.apps.googleusercontent.com",
-    "traceAllRequests": true
+    "traceAllRequests": true,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-perf.appspot.com/login",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -53,7 +53,8 @@
     "projectId": "all-of-us-rw-prod",
     "shortName": "Prod",
     "oauthClientId": "684273740878-d7i68in5d9hqr6n9mfvrdh53snekp79f.apps.googleusercontent.com",
-    "traceAllRequests": false
+    "traceAllRequests": false,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "adminIdVerification": "support@researchallofus.org",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -53,7 +53,8 @@
     "projectId": "all-of-us-rw-stable",
     "shortName": "Stable",
     "oauthClientId": "56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com",
-    "traceAllRequests": false
+    "traceAllRequests": false,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-stable.appspot.com/login",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -53,7 +53,8 @@
     "projectId": "all-of-us-rw-staging",
     "shortName": "Staging",
     "oauthClientId": "657299777109-kvb5qafr70bl01i6bnpgsiq5nt6v1o8u.apps.googleusercontent.com",
-    "traceAllRequests": false
+    "traceAllRequests": false,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-rw-staging.appspot.com/login",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -54,7 +54,8 @@
     "projectId": "all-of-us-workbench-test",
     "shortName": "Test",
     "oauthClientId": "602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com",
-    "traceAllRequests": true
+    "traceAllRequests": true,
+    "appEngineLocationId": "us-central"
   },
   "admin": {
     "loginUrl": "https:\/\/all-of-us-workbench-test.appspot.com/login",

--- a/api/src/main/java/org/pmiops/workbench/appengine/AppEngineMetadataSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/appengine/AppEngineMetadataSpringConfiguration.java
@@ -1,0 +1,15 @@
+package org.pmiops.workbench.appengine;
+
+import com.google.appengine.api.modules.ModulesService;
+import com.google.appengine.api.modules.ModulesServiceFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppEngineMetadataSpringConfiguration {
+
+  @Bean
+  ModulesService getModulesService() {
+    return ModulesServiceFactory.getModulesService();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -49,8 +49,7 @@ public class StackdriverStatsExporterService {
   public void createAndRegister() {
     if (!initialized) {
       try {
-        final StackdriverStatsConfiguration configuration =
-            makeStackdriverStatsConfiguration();
+        final StackdriverStatsConfiguration configuration = makeStackdriverStatsConfiguration();
         StackdriverStatsExporter.createAndRegister(configuration);
         logger.info(
             String.format(

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -1,11 +1,19 @@
 package org.pmiops.workbench.monitoring;
 
+import com.google.api.MonitoredResource;
+import com.google.appengine.api.modules.ModulesException;
+import com.google.appengine.api.modules.ModulesService;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Provider;
+import javax.swing.text.html.Option;
+import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.springframework.stereotype.Service;
 
@@ -15,15 +23,25 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class StackdriverStatsExporterService {
+
   private static final Logger logger =
       Logger.getLogger(StackdriverStatsExporterService.class.getName());
   private static final String STACKDRIVER_CUSTOM_METRICS_DOMAIN_NAME = "custom.googleapis.com";
+  private static final String MONITORED_RESOURCE_TYPE = "generic_node";
+  private static final String PROJECT_ID_LABEL = "project_id";
+  private static final String LOCATION_LABEL = "location";
+  private static final String NAMESPACE_LABEL = "namespace";
+  private static final String NODE_ID_LABEL = "node_id";
+  public static final String UNKNOWN_LOCATION = "global";
 
   private boolean initialized;
   private Provider<WorkbenchConfig> workbenchConfigProvider;
+  private ModulesService modulesService;
 
-  public StackdriverStatsExporterService(Provider<WorkbenchConfig> workbenchConfigProvider) {
+  public StackdriverStatsExporterService(Provider<WorkbenchConfig> workbenchConfigProvider,
+      ModulesService modulesService) {
     this.workbenchConfigProvider = workbenchConfigProvider;
+    this.modulesService = modulesService;
     this.initialized = false;
   }
 
@@ -34,17 +52,57 @@ public class StackdriverStatsExporterService {
   public void createAndRegister() {
     if (!initialized) {
       try {
+        final String projectId = workbenchConfigProvider.get().server.projectId;
         final StackdriverStatsConfiguration configuration =
             StackdriverStatsConfiguration.builder()
                 .setMetricNamePrefix(buildMetricNamePrefix())
-                .setProjectId(workbenchConfigProvider.get().server.projectId)
+                .setProjectId(projectId)
+                .setMonitoredResource(makeMonitoredResource(projectId))
                 .build();
         StackdriverStatsExporter.createAndRegister(configuration);
+        logger.info(String.format("Configured StackDriver exports with configuration:\n%s",
+            configuration.toString()));
         initialized = true;
       } catch (IOException e) {
         logger.log(Level.WARNING, "Failed to initialize global StackdriverStatsExporter.", e);
       }
     }
+  }
+
+  private Optional<String> getOptionalFromThrowable(Supplier<String> extractor) {
+    Optional<String> result = Optional.empty();
+    try {
+      result = Optional.of(extractor.get());
+    } catch (RuntimeException e) {
+      logger.log(Level.INFO, "Failed to retrieve String ", e);
+    }
+    return result;
+  }
+
+  private MonitoredResource makeMonitoredResource(String projectId) {
+    final MonitoredResource.Builder resultBuilder = MonitoredResource.newBuilder()
+        .setType(MONITORED_RESOURCE_TYPE)
+        .putLabels(PROJECT_ID_LABEL, projectId)
+        .putLabels(LOCATION_LABEL, UNKNOWN_LOCATION);
+    getCurrentModule().ifPresent(m -> resultBuilder.putLabels(NAMESPACE_LABEL, m));
+    getInstanceId().ifPresent(id -> resultBuilder.putLabels(NODE_ID_LABEL, id));
+
+    return resultBuilder.build();
+  }
+
+  private Optional<String> getCurrentModule() {
+    return getOptionalFromThrowable(modulesService::getCurrentModule);
+//    Optional<String> result = Optional.empty();
+//    try {
+//      result = Optional.of(modulesService.getCurrentModule());
+//    } catch (IllegalStateException e) {
+//      logger.log(Level.INFO, "AppEngine Module not available", e);
+//    }
+//    return result;
+  }
+
+  private Optional<String> getInstanceId() {
+    return getOptionalFromThrowable(modulesService::getCurrentInstanceId);
   }
 
   private String buildMetricNamePrefix() {

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
@@ -20,14 +20,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.ServerConfig;
 import org.pmiops.workbench.monitoring.views.MonitoringViews;
 import org.pmiops.workbench.monitoring.views.OpenCensusStatsViewInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
@@ -45,17 +45,7 @@ public class MonitoringServiceTest {
   @TestConfiguration
   @Import({MonitoringServiceImpl.class})
   @MockBean({ViewManager.class, StatsRecorder.class, StackdriverStatsExporterService.class})
-  static class Configuration {
-    @Bean
-    public WorkbenchConfig workbenchConfig() {
-      final WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      // Nothing should show up in any Metrics backend for these tests.
-      workbenchConfig.server = new ServerConfig();
-      workbenchConfig.server.shortName = "unit-test";
-      workbenchConfig.server.projectId = "fake-project";
-      return workbenchConfig;
-    }
-  }
+  static class Configuration {}
 
   @Before
   public void setup() {

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -48,23 +48,25 @@ public class StackdriverStatsExporterServiceTest {
   public void testMakeConfiguration() {
     doReturn(FOUND_NODE_ID).when(mockModulesService).getCurrentInstanceId();
 
-    StackdriverStatsConfiguration statsConfiguration = exporterService.makeStackdriverStatsConfiguration();
+    StackdriverStatsConfiguration statsConfiguration =
+        exporterService.makeStackdriverStatsConfiguration();
     assertThat(statsConfiguration.getProjectId()).isEqualTo(PROJECT_ID);
-    assertThat(statsConfiguration.getMetricNamePrefix()).isEqualTo("custom.googleapis.com/unit-test/");
+    assertThat(statsConfiguration.getMetricNamePrefix())
+        .isEqualTo("custom.googleapis.com/unit-test/");
 
     final MonitoredResource monitoredResource = statsConfiguration.getMonitoredResource();
     assertThat(monitoredResource.getType()).isEqualTo("generic_node");
 
-    final Map<String,String> labelToValue = monitoredResource.getLabelsMap();
+    final Map<String, String> labelToValue = monitoredResource.getLabelsMap();
     assertThat(statsConfiguration.getMonitoredResource().getLabelsMap()).isNotEmpty();
     assertThat(labelToValue.get("node_id")).isEqualTo(FOUND_NODE_ID);
   }
 
-
   @Test
   public void testMakeMonitoredResource_noInstanceIdAvailable() {
     doThrow(ModulesException.class).when(mockModulesService).getCurrentInstanceId();
-    final MonitoredResource monitoredResource = exporterService.makeStackdriverStatsConfiguration().getMonitoredResource();
+    final MonitoredResource monitoredResource =
+        exporterService.makeStackdriverStatsConfiguration().getMonitoredResource();
     assertThat(monitoredResource.getLabelsMap().get("node_id")).isNotEmpty();
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -1,0 +1,70 @@
+package org.pmiops.workbench.monitoring;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import com.google.api.MonitoredResource;
+import com.google.appengine.api.modules.ModulesException;
+import com.google.appengine.api.modules.ModulesService;
+import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.ServerConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class StackdriverStatsExporterServiceTest {
+
+  private static final String PROJECT_ID = "fake-project";
+  private static final String FOUND_NODE_ID = "node-11001001";
+  @Autowired private ModulesService mockModulesService;
+  @Autowired private StackdriverStatsExporterService exporterService;
+
+  @TestConfiguration
+  @Import(StackdriverStatsExporterService.class)
+  @MockBean(ModulesService.class)
+  static class Configuration {
+    @Bean
+    public WorkbenchConfig workbenchConfig() {
+      final WorkbenchConfig workbenchConfig = new WorkbenchConfig();
+      // Nothing should show up in any Metrics backend for these tests.
+      workbenchConfig.server = new ServerConfig();
+      workbenchConfig.server.shortName = "unit-test";
+      workbenchConfig.server.projectId = PROJECT_ID;
+      workbenchConfig.server.appEngineLocationId = "moon-luna-1";
+      return workbenchConfig;
+    }
+  }
+
+  @Test
+  public void testMakeConfiguration() {
+    doReturn(FOUND_NODE_ID).when(mockModulesService).getCurrentInstanceId();
+
+    StackdriverStatsConfiguration statsConfiguration = exporterService.makeStackdriverStatsConfiguration();
+    assertThat(statsConfiguration.getProjectId()).isEqualTo(PROJECT_ID);
+    assertThat(statsConfiguration.getMetricNamePrefix()).isEqualTo("custom.googleapis.com/unit-test/");
+
+    final MonitoredResource monitoredResource = statsConfiguration.getMonitoredResource();
+    assertThat(monitoredResource.getType()).isEqualTo("generic_node");
+
+    final Map<String,String> labelToValue = monitoredResource.getLabelsMap();
+    assertThat(statsConfiguration.getMonitoredResource().getLabelsMap()).isNotEmpty();
+    assertThat(labelToValue.get("node_id")).isEqualTo(FOUND_NODE_ID);
+  }
+
+
+  @Test
+  public void testMakeMonitoredResource_noInstanceIdAvailable() {
+    doThrow(ModulesException.class).when(mockModulesService).getCurrentInstanceId();
+    final MonitoredResource monitoredResource = exporterService.makeStackdriverStatsConfiguration().getMonitoredResource();
+    assertThat(monitoredResource.getLabelsMap().get("node_id")).isNotEmpty();
+  }
+}

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -143,6 +143,7 @@ public class WorkbenchConfig {
     // Controls whether all api requests are traced and sent to Stackdriver tracing, or
     // whether we only trace at the default frequency.
     public boolean traceAllRequests;
+    public String appEngineLocationId;
   }
 
   public static class AdminConfig {


### PR DESCRIPTION
We need to use the `generic_node` [MonitoredResource](https://cloud.google.com/logging/docs/api/v2/resource-list) type since we run on AppEngine and can have multiple nodes writing at once.

Since we don't have a namespace, I chose the short name of the environment. For the instanceId, sometimes we get an exception saying it's not available, and I just use a GUID for that. This hopefully only happens on local, but we're more concerned with avoiding hitting the rate limits when we have escalated instance counts than with debugging performance of particular instances at the moment.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
