### PR TITLE
[no ticket][risk=no] Add keys for flex row entries to suppress React errors

### DIFF
--- a/ui/src/app/components/resource-card-template.tsx
+++ b/ui/src/app/components/resource-card-template.tsx
@@ -99,9 +99,8 @@ export class ResourceCardTemplate extends React.Component<Props, {}> {
                 <React.Fragment>
                   {this.props.actions.map((action, i) => {
                     return (
-                      <TooltipTrigger content={action.hoverText}>
+                      <TooltipTrigger key={i} content={action.hoverText}>
                         <MenuItem
-                          key={i}
                           icon={action.icon}
                           onClick={() => action.onClick()}
                           disabled={action.disabled}>

--- a/ui/src/app/components/tables.tsx
+++ b/ui/src/app/components/tables.tsx
@@ -20,14 +20,14 @@ export const TwoColPaddedTable = ({style = {}, header = false, headerLeft = '',
   headerRight = '', cellWidth = {left: '50%', right: '50%'}, contentLeft, contentRight}) => {
   return <FlexColumn style={{...style}}>
     {header &&
-      <FlexRow style={{height: '100%'}}>
-        <PaddedTableCell left={true} leftWidth={cellWidth.left}
+      <FlexRow key='header' style={{height: '100%'}}>
+        <PaddedTableCell key='header_l' left={true} leftWidth={cellWidth.left}
                          content={<strong>{headerLeft}</strong>}/>
-        <PaddedTableCell left={false} rightWidth={cellWidth.right}
+        <PaddedTableCell key='header_r' left={false} rightWidth={cellWidth.right}
                          content={<strong>{headerRight}</strong>}/>
       </FlexRow>}
     {contentLeft.map((c, i) =>
-      <FlexRow>
+      <FlexRow key={i}>
         <PaddedTableCell key={i + '_l'} left={true} content={c}
                          leftWidth={cellWidth.left}/>
         {contentRight.length >= i + 1 &&

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -112,8 +112,9 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
           </CardButton>
         </TooltipTrigger>
         <div style={{display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start' }}>
-          {notebookList.map(notebook => {
+          {notebookList.map((notebook, index) => {
             return <NotebookResourceCard
+              key={index}
               resource={convertToResource(notebook, namespace, id, al, ResourceType.NOTEBOOK)}
               existingNameList={notebookNameList}
               onUpdate={() => this.loadNotebooks()}

--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -438,7 +438,7 @@ export const NotebookRedirect = fp.flow(withUserProfile(), withCurrentWorkspace(
             <Button type='secondary' onClick={() => window.history.back()}>Cancel</Button>
           </div>
           <div style={{display: 'flex', flexDirection: 'row', marginTop: '1rem'}}>
-            {Array.from(progressCardStates, ([key, index]) => {
+            {Array.from(progressCardStates, ([key, _], index) => {
               return <ProgressCard key={index} progressState={progress} cardState={key}
                                    creatingNewNotebook={creatingNewNotebook} progressComplete={progressComplete}/>;
             })}

--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -438,8 +438,8 @@ export const NotebookRedirect = fp.flow(withUserProfile(), withCurrentWorkspace(
             <Button type='secondary' onClick={() => window.history.back()}>Cancel</Button>
           </div>
           <div style={{display: 'flex', flexDirection: 'row', marginTop: '1rem'}}>
-            {Array.from(progressCardStates, ([key, _]) => {
-              return <ProgressCard progressState={progress} cardState={key}
+            {Array.from(progressCardStates, ([key, index]) => {
+              return <ProgressCard key={index} progressState={progress} cardState={key}
                                    creatingNewNotebook={creatingNewNotebook} progressComplete={progressComplete}/>;
             })}
           </div>

--- a/ui/src/app/pages/homepage/recent-workspaces.tsx
+++ b/ui/src/app/pages/homepage/recent-workspaces.tsx
@@ -55,7 +55,7 @@ export const RecentWorkspaces = withUserProfile()
             {
               this.state.recentWorkspaces.map(recentWorkspace => {
                 return <WorkspaceCard
-                  key={recentWorkspace.workspace.name}
+                  key={recentWorkspace.workspace.namespace}
                   userEmail={this.props.profileState.profile.username}
                   workspace={recentWorkspace.workspace}
                   accessLevel={recentWorkspace.accessLevel}

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -727,7 +727,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           <FlexColumn style={{...styles.asideContainer, marginTop: '21.8rem', height: '15rem'}}>
             <div style={styles.asideHeader}><i>All of Us</i> participants are most interested in knowing:</div>
             <ul style={styles.asideList}>
-              {researchPurposeList.map(value => <li style={styles.asideText}>{value}</li>)}
+              {researchPurposeList.map((value, index) => <li key={index} style={styles.asideText}>{value}</li>)}
             </ul>
           </FlexColumn>
         </FlexColumn>

--- a/ui/src/app/pages/workspace/workspace-list.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.tsx
@@ -117,7 +117,7 @@ export const WorkspaceList = withUserProfile()
                 <NewWorkspaceButton />
                 {workspaceList.map(wp => {
                   return <WorkspaceCard
-                    key={wp.workspace.name}
+                    key={wp.workspace.namespace}
                     workspace={wp.workspace}
                     accessLevel={wp.accessLevel}
                     userEmail={profile.username}


### PR DESCRIPTION
I ran into this while working through https://github.com/all-of-us/workbench/pull/2973. React items that show up in a list need to have unique keys, otherwise React will complain. I'm not sure if it has any functional impact, but the console warnings went away once I added these keys.

---
**PR checklist**

- [n/a] This PR includes appropriate unit tests
- [yes] I have run and tested this change locally
