### PR TITLE
[RW-2840][risk=no] Use AppIdentityService to generate service-backed credentials

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -390,6 +390,8 @@ dependencies {
   compile 'com.google.cloud:google-cloud-bigquery:1.51.0'
   compile 'com.google.cloud:google-cloud-storage:1.51.0'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.3'
+  compile 'com.google.auth:google-auth-library-oauth2-http:0.19.0'
+  compile 'com.google.auth:google-auth-library-appengine:0.19.0'
   compile 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1'
 
   compile "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"

--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -20,16 +20,16 @@ public class ServiceAccounts {
   /**
    * Returns an appropriate set of backend service credentials with the given set of scopes.
    *
-   * This method uses AppIdentityService to return an instance of scoped AppEngineCredentials when
-   * running in an App Engine environment.
+   * <p>This method uses AppIdentityService to return an instance of scoped AppEngineCredentials
+   * when running in an App Engine environment.
    *
-   * Unfortunately, if we use GoogleCredentials.getApplicationDefault() from
-   * within an App Engine environment, the returned credentials will be an instance of
-   * ComputeEngineCredentials, which doesn't support scoped access tokens. Frustratingly, the call
-   * to .createScoped will silently proceed by doing nothing -- meaning we only learn about the
-   * error once an attempt to use these credentials fails in a downstream service due to bad scopes.
+   * <p>Unfortunately, if we use GoogleCredentials.getApplicationDefault() from within an App Engine
+   * environment, the returned credentials will be an instance of ComputeEngineCredentials, which
+   * doesn't support scoped access tokens. Frustratingly, the call to .createScoped will silently
+   * proceed by doing nothing -- meaning we only learn about the error once an attempt to use these
+   * credentials fails in a downstream service due to bad scopes.
    *
-   * See https://github.com/googleapis/google-auth-library-java/issues/272 and
+   * <p>See https://github.com/googleapis/google-auth-library-java/issues/272 and
    * https://github.com/googleapis/google-auth-library-java/issues/172 for reference; this seems to
    * be a common pain point for users of the com.google.auth.oauth2 library.
    *
@@ -48,11 +48,11 @@ public class ServiceAccounts {
       // out locally and it *seemed* to work, but it needs a bit more careful vetting.
       return GoogleCredentials.getApplicationDefault().createScoped(scopes);
     } else {
-    AppIdentityService appIdentityService = AppIdentityServiceFactory.getAppIdentityService();
-    return AppEngineCredentials.newBuilder()
-        .setScopes(scopes)
-        .setAppIdentityService(appIdentityService)
-        .build();
+      AppIdentityService appIdentityService = AppIdentityServiceFactory.getAppIdentityService();
+      return AppEngineCredentials.newBuilder()
+          .setScopes(scopes)
+          .setAppIdentityService(appIdentityService)
+          .build();
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.firecloud;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
@@ -58,9 +57,7 @@ public class FireCloudConfig {
   public ApiClient allOfUsApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = buildApiClient(workbenchConfig);
     try {
-      apiClient.setAccessToken(
-          ServiceAccounts.getScopedAccessToken(
-              GoogleCredentials.getApplicationDefault(), BILLING_SCOPES));
+      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES));
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.notebooks;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
@@ -43,9 +42,7 @@ public class NotebooksConfig {
   public ApiClient workbenchServiceAccountClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = buildApiClient(workbenchConfig);
     try {
-      apiClient.setAccessToken(
-          ServiceAccounts.getScopedAccessToken(
-              GoogleCredentials.getApplicationDefault(), NOTEBOOK_SCOPES));
+      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(NOTEBOOK_SCOPES));
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }


### PR DESCRIPTION
After #2962 merged, we started seeing 401 errors in test when creating a new workspace.

I tracked this down to an issue where the newer GoogleCredentials library doesn't do what I was expecting when calling GoogleCredentials.getApplicationDefault(). See the new comments on the ServiceAccounts method which describes the issue in some detail.

This PR essentially brings back the logic to switch how we generate scoped service credentials based on the operating environment: if App Engine, use the AppIdentityService; if development, use ADCs. This method is called by a couple config classes for APIs which use our service identity to call downstream APIs.

---
**PR checklist**

- [X] I have run and tested this change locally