### PR TITLE
Add admin delete clusters in project endpoint

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditor.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditor.java
@@ -1,0 +1,5 @@
+package org.pmiops.workbench.actionaudit.auditors;
+
+public interface ClusterAuditor {
+  void fireDeleteClustersInProject(String projectId);
+}

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditor.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditor.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.actionaudit.auditors;
 
+import java.util.List;
+
 public interface ClusterAuditor {
-  void fireDeleteClustersInProject(String projectId);
+  void fireDeleteClustersInProject(String projectId, List<String> clusterNames);
 }

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
@@ -1,0 +1,47 @@
+package org.pmiops.workbench.actionaudit.auditors;
+
+import org.pmiops.workbench.actionaudit.ActionAuditEvent;
+import org.pmiops.workbench.actionaudit.ActionAuditService;
+import org.pmiops.workbench.actionaudit.ActionType;
+import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.actionaudit.TargetType;
+import org.pmiops.workbench.actionaudit.targetproperties.AccountTargetProperty;
+import org.pmiops.workbench.actionaudit.targetproperties.values.AccountDisabledStatus;
+import org.pmiops.workbench.db.model.DbUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Provider;
+import java.time.Clock;
+
+@Service
+public class ClusterAuditorImpl implements ClusterAuditor {
+  private ActionAuditService actionAuditService;
+  private Clock clock;
+  private Provider<DbUser> adminDbUserProvider;
+
+  @Autowired
+  public ClusterAuditorImpl(
+      ActionAuditService actionAuditService,
+      Clock clock,
+      Provider<DbUser> adminDbUserProvider) {
+    this.actionAuditService = actionAuditService;
+    this.clock = clock;
+    this.adminDbUserProvider = adminDbUserProvider;
+  }
+
+  @Override
+  public void fireDeleteClustersInProject(String projectId) {
+    actionAuditService.send(
+        ActionAuditEvent.builder()
+            .timestamp(clock.millis())
+            .agentType(AgentType.ADMINISTRATOR)
+            .agentId(adminDbUserProvider.get().getUserId())
+            .agentEmailMaybe(adminDbUserProvider.get().getUsername())
+            .actionType(ActionType.DELETE)
+            .targetType(TargetType.NOTEBOOK_SERVER)
+            .targetPropertyMaybe(projectId)
+            .build());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
@@ -1,47 +1,53 @@
 package org.pmiops.workbench.actionaudit.auditors;
 
+import java.time.Clock;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
 import org.pmiops.workbench.actionaudit.ActionAuditEvent;
 import org.pmiops.workbench.actionaudit.ActionAuditService;
 import org.pmiops.workbench.actionaudit.ActionType;
 import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.actionaudit.TargetType;
-import org.pmiops.workbench.actionaudit.targetproperties.AccountTargetProperty;
-import org.pmiops.workbench.actionaudit.targetproperties.values.AccountDisabledStatus;
 import org.pmiops.workbench.db.model.DbUser;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-
-import javax.inject.Provider;
-import java.time.Clock;
 
 @Service
 public class ClusterAuditorImpl implements ClusterAuditor {
+  private Provider<String> actionIdProvider;
   private ActionAuditService actionAuditService;
   private Clock clock;
   private Provider<DbUser> adminDbUserProvider;
 
   @Autowired
   public ClusterAuditorImpl(
+      Provider<String> actionIdProvider,
       ActionAuditService actionAuditService,
       Clock clock,
       Provider<DbUser> adminDbUserProvider) {
+    this.actionIdProvider = actionIdProvider;
     this.actionAuditService = actionAuditService;
     this.clock = clock;
     this.adminDbUserProvider = adminDbUserProvider;
   }
 
   @Override
-  public void fireDeleteClustersInProject(String projectId) {
+  public void fireDeleteClustersInProject(String projectId, List<String> clusterNames) {
     actionAuditService.send(
-        ActionAuditEvent.builder()
-            .timestamp(clock.millis())
-            .agentType(AgentType.ADMINISTRATOR)
-            .agentId(adminDbUserProvider.get().getUserId())
-            .agentEmailMaybe(adminDbUserProvider.get().getUsername())
-            .actionType(ActionType.DELETE)
-            .targetType(TargetType.NOTEBOOK_SERVER)
-            .targetPropertyMaybe(projectId)
-            .build());
+        clusterNames.stream()
+            .map(
+                clusterName ->
+                    ActionAuditEvent.builder()
+                        .timestamp(clock.millis())
+                        .agentType(AgentType.ADMINISTRATOR)
+                        .agentId(adminDbUserProvider.get().getUserId())
+                        .agentEmailMaybe(adminDbUserProvider.get().getUsername())
+                        .actionType(ActionType.DELETE)
+                        .newValueMaybe(clusterName)
+                        .targetType(TargetType.NOTEBOOK_SERVER)
+                        .targetPropertyMaybe(projectId)
+                        .build())
+            .collect(Collectors.toList()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -136,7 +136,9 @@ public class ClusterController implements ClusterApiDelegate {
             .filter(
                 cluster ->
                     clusterNamesToDelete.getClustersToDelete() == null
-                        || clusterNamesToDelete.getClustersToDelete().contains(cluster.getClusterName()))
+                        || clusterNamesToDelete
+                            .getClustersToDelete()
+                            .contains(cluster.getClusterName()))
             .collect(Collectors.toList());
 
     clustersToDelete.forEach(
@@ -157,7 +159,9 @@ public class ClusterController implements ClusterApiDelegate {
             .filter(
                 cluster ->
                     clusterNamesToDelete.getClustersToDelete() == null
-                        || clusterNamesToDelete.getClustersToDelete().contains(cluster.getClusterName()))
+                        || clusterNamesToDelete
+                            .getClustersToDelete()
+                            .contains(cluster.getClusterName()))
             .collect(Collectors.toList());
     List<ClusterStatus> acceptableStates =
         ImmutableList.of(ClusterStatus.DELETED, ClusterStatus.DELETING, ClusterStatus.ERROR);

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.json.JSONObject;
+import org.pmiops.workbench.actionaudit.auditors.ClusterAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -87,6 +88,7 @@ public class ClusterController implements ClusterApiDelegate {
             return allOfUsCluster;
           };
 
+  private final ClusterAuditor clusterAuditor;
   private final LeonardoNotebooksClient leonardoNotebooksClient;
   private final Provider<DbUser> userProvider;
   private final WorkspaceService workspaceService;
@@ -99,6 +101,7 @@ public class ClusterController implements ClusterApiDelegate {
 
   @Autowired
   ClusterController(
+      ClusterAuditor clusterAuditor,
       LeonardoNotebooksClient leonardoNotebooksClient,
       Provider<DbUser> userProvider,
       WorkspaceService workspaceService,
@@ -108,6 +111,7 @@ public class ClusterController implements ClusterApiDelegate {
       UserRecentResourceService userRecentResourceService,
       UserDao userDao,
       Clock clock) {
+    this.clusterAuditor = clusterAuditor;
     this.leonardoNotebooksClient = leonardoNotebooksClient;
     this.userProvider = userProvider;
     this.workspaceService = workspaceService;
@@ -125,6 +129,7 @@ public class ClusterController implements ClusterApiDelegate {
     if (billingProjectId == null) {
       throw new BadRequestException("Must specify billing project");
     }
+    clusterAuditor.fireDeleteClustersInProject(billingProjectId);
 
     leonardoNotebooksClient
         .listClustersByProjectAsAdmin(billingProjectId)

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -45,6 +45,7 @@ public final class DbStorageEnums {
           .put(Authority.ACCESS_CONTROL_ADMIN, (short) 2)
           .put(Authority.FEATURED_WORKSPACE_ADMIN, (short) 3)
           .put(Authority.COMMUNICATIONS_ADMIN, (short) 4)
+          .put(Authority.SECURITY_ADMIN, (short) 5)
           .build();
 
   public static Authority authorityFromStorage(Short authority) {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -37,7 +37,6 @@ public interface LeonardoNotebooksClient {
   /** Gets information about a notebook cluster */
   Cluster getCluster(String googleProject, String clusterName) throws WorkbenchException;
 
-
   /** Send files over to notebook Cluster */
   void localize(String googleProject, String clusterName, Map<String, String> fileList)
       throws WorkbenchException;

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -1,8 +1,10 @@
 package org.pmiops.workbench.notebooks;
 
+import java.util.List;
 import java.util.Map;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.notebooks.model.Cluster;
+import org.pmiops.workbench.notebooks.model.ListClusterResponse;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 
 /**
@@ -10,6 +12,11 @@ import org.pmiops.workbench.notebooks.model.StorageLink;
  * for internal use.
  */
 public interface LeonardoNotebooksClient {
+  List<ListClusterResponse> listClustersByProject(String googleProject);
+
+  /** lists all notebook clusters as the appengine SA, to be used only for admin operations */
+  List<ListClusterResponse> listClustersByProjectAsAdmin(String googleProject);
+
   /**
    * Creates a notebooks cluster owned by the current authenticated user.
    *
@@ -24,8 +31,12 @@ public interface LeonardoNotebooksClient {
   /** Deletes a notebook cluster */
   void deleteCluster(String googleProject, String clusterName) throws WorkbenchException;
 
+  /** Deletes a notebook cluster as the appengine SA, to be used only for admin operations */
+  void deleteClusterAsAdmin(String googleProject, String clusterName) throws WorkbenchException;
+
   /** Gets information about a notebook cluster */
   Cluster getCluster(String googleProject, String clusterName) throws WorkbenchException;
+
 
   /** Send files over to notebook Cluster */
   void localize(String googleProject, String clusterName, Map<String, String> fileList)

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -51,7 +51,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   @Autowired
   public LeonardoNotebooksClientImpl(
       @Qualifier(NotebooksConfig.USER_CLUSTER_API) Provider<ClusterApi> clusterApiProvider,
-      @Qualifier(NotebooksConfig.SERVICE_CLUSTER_API) Provider<ClusterApi> serviceClusterApiProvider,
+      @Qualifier(NotebooksConfig.SERVICE_CLUSTER_API)
+          Provider<ClusterApi> serviceClusterApiProvider,
       Provider<NotebooksApi> notebooksApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       Provider<DbUser> userProvider,

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -538,6 +538,32 @@ paths:
 
   # Notebook clusters ####################################################################
 
+  /v1/admin/security/clusters/{billingProjectId}/delete-clusters:
+    post:
+      summary: Pause all clusters in a project
+      description: >
+        An admin gated endpoint that deletes all clusters in a given billing project.
+      operationId: deleteClustersInProject
+      tags:
+        - cluster
+      parameters:
+        - in: path
+          name: billingProjectId
+          description: The unique identifier of the Google Billing Project containing the clusters
+          required: true
+          type: string
+      responses:
+        200:
+          description: Clusters paused
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ListClusterResponse'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
   /v1/clusters/{billingProjectId}/{workspaceFirecloudName}:
     get:
       summary: List available notebook clusters
@@ -565,7 +591,7 @@ paths:
         200:
           description: Available clusters
           schema:
-            $ref: '#/definitions/ClusterListResponse'
+            $ref: '#/definitions/DefaultClusterResponse'
         500:
           description: Internal Error
           schema:
@@ -2332,7 +2358,8 @@ definitions:
       DEVELOPER,
       ACCESS_CONTROL_ADMIN,
       FEATURED_WORKSPACE_ADMIN,
-      COMMUNICATIONS_ADMIN
+      COMMUNICATIONS_ADMIN,
+      SECURITY_ADMIN
     ]
 
   PageVisit:
@@ -3634,13 +3661,43 @@ definitions:
         format: int64
         description: Milliseconds since the UNIX epoch.
 
-  ClusterListResponse:
+  DefaultClusterResponse:
     type: object
     required:
       - defaultCluster
     properties:
       defaultCluster:
         $ref: "#/definitions/Cluster"
+
+  ListClusterResponse:
+    description: Limited set of responses for a cluster. This is a subset of options in a full cluster, copied from the Leonardo swagger
+    required:
+      - clusterName
+      - googleProject
+      - status
+      - createdDate
+      - labels
+      - dateAccessed
+    properties:
+      clusterName:
+        type: string
+        description: The user-supplied name for the cluster
+      googleProject:
+        type: string
+        description: The Google Project used to create the cluster
+      status:
+        $ref: "#/definitions/ClusterStatus"
+      createdDate:
+        type: string
+        description: The date and time the cluster was created, in ISO-8601 format
+      labels:
+        type: object
+        description: The labels to be placed on the cluster. Of type Map[String,String]
+      dateAccessed:
+        type: string
+        description: |
+          The date and time the cluster was last accessed, in ISO-8601 format.
+          Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
 
   ClusterLocalizeRequest:
     type: object

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -540,7 +540,7 @@ paths:
 
   /v1/admin/security/clusters/{billingProjectId}/delete-clusters:
     post:
-      summary: Pause all clusters in a project
+      summary: Delete all clusters in a project
       description: >
         An admin gated endpoint that deletes all clusters in a given billing project.
       operationId: deleteClustersInProject
@@ -552,9 +552,15 @@ paths:
           description: The unique identifier of the Google Billing Project containing the clusters
           required: true
           type: string
+        - in: body
+          name: clustersToDelete
+          description: A list of names of clusters to delete. To delete all clusters, use an empty object (e.g., {})
+          required: true
+          schema:
+            $ref: '#/definitions/ListClusterDeleteRequest'
       responses:
         200:
-          description: Clusters paused
+          description: Clusters deleted
           schema:
             type: array
             items:
@@ -3698,6 +3704,14 @@ definitions:
         description: |
           The date and time the cluster was last accessed, in ISO-8601 format.
           Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
+
+  ListClusterDeleteRequest:
+    type: object
+    properties:
+      clustersToDelete:
+        type: array
+        items:
+          type: string
 
   ClusterLocalizeRequest:
     type: object

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -540,9 +540,9 @@ paths:
 
   /v1/admin/security/clusters/{billingProjectId}/delete-clusters:
     post:
-      summary: Delete all clusters in a project
+      summary: Delete specified (or all if no specified list) clusters in a project
       description: >
-        An admin gated endpoint that deletes all clusters in a given billing project.
+        An admin gated endpoint that deletes given clusters in a given billing project.
       operationId: deleteClustersInProject
       tags:
         - cluster

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -554,7 +554,8 @@ paths:
           type: string
         - in: body
           name: clustersToDelete
-          description: A list of names of clusters to delete. To delete all clusters, use an empty object (e.g., {})
+          description: A list of names of clusters to delete. To delete all clusters, use an empty object, without
+            providing a list property at all (e.g., {}) An empty list will delete no clusters.
           required: true
           schema:
             $ref: '#/definitions/ListClusterDeleteRequest'

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -595,7 +595,7 @@ paths:
           type: string
       responses:
         200:
-          description: Available clusters
+          description: The users cluster
           schema:
             $ref: '#/definitions/DefaultClusterResponse'
         500:

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorTest.java
@@ -1,0 +1,89 @@
+package org.pmiops.workbench.actionaudit.auditors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.pmiops.workbench.actionaudit.ActionAuditEvent;
+import org.pmiops.workbench.actionaudit.ActionAuditService;
+import org.pmiops.workbench.actionaudit.ActionType;
+import org.pmiops.workbench.db.model.DbUser;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class ClusterAuditorTest {
+  private DbUser user1;
+  private static final long Y2K_EPOCH_MILLIS =
+      Instant.parse("2000-01-01T00:00:00.00Z").toEpochMilli();
+  private static final String ACTION_ID = "58cbae08-447f-499f-95b9-7bdedc955f4d";
+  private static final String BILLING_PROJECT_ID = "all-of-us-yjty";
+  private static final List<String> CLUSTER_NAMES =
+      ImmutableList.of("all-of-us-1", "all-of-us-2", "all-of-us-3");
+
+  private ClusterAuditor clusterAuditor;
+
+  @Captor private ArgumentCaptor<Collection<ActionAuditEvent>> eventCollectionCaptor;
+
+  @Mock private Provider<String> mockActionIdProvider;
+  @Mock private ActionAuditService mockActionAuditService;
+  @Mock private Clock mockClock;
+  @Mock private Provider<DbUser> mockUserProvider;
+
+  @TestConfiguration
+  @MockBean(value = {ActionAuditService.class})
+  static class Configuration {}
+
+  @Before
+  public void setUp() {
+    user1 = new DbUser();
+    user1.setUserId(101L);
+    user1.setUsername("fflinstone@slate.com");
+    user1.setGivenName("Fred");
+    user1.setFamilyName("Flintstone");
+    doReturn(user1).when(mockUserProvider).get();
+    clusterAuditor =
+        new ClusterAuditorImpl(
+            mockActionIdProvider, mockActionAuditService, mockClock, mockUserProvider);
+
+    doReturn(Y2K_EPOCH_MILLIS).when(mockClock).millis();
+    doReturn(ACTION_ID).when(mockActionIdProvider).get();
+  }
+
+  @Test
+  public void testFireDeleteClustersInProject() {
+    clusterAuditor.fireDeleteClustersInProject(BILLING_PROJECT_ID, CLUSTER_NAMES);
+    verify(mockActionAuditService).send(eventCollectionCaptor.capture());
+    Collection<ActionAuditEvent> eventsSent = eventCollectionCaptor.getValue();
+    assertThat(eventsSent).hasSize(3);
+    Optional<ActionAuditEvent> firstEvent = eventsSent.stream().findFirst();
+    assertThat(firstEvent.isPresent()).isTrue();
+    assertThat(firstEvent.map(ActionAuditEvent::getActionType).orElse(null))
+        .isEqualTo(ActionType.DELETE);
+    assertThat(firstEvent.map(ActionAuditEvent::getTargetPropertyMaybe).orElse(null))
+        .isEqualTo(BILLING_PROJECT_ID);
+    assertThat(firstEvent.map(ActionAuditEvent::getNewValueMaybe).orElse(null))
+        .isEqualTo(CLUSTER_NAMES.get(0));
+    assertThat(
+            eventsSent.stream()
+                .map(ActionAuditEvent::getActionType)
+                .collect(Collectors.toSet())
+                .size())
+        .isEqualTo(1);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorTest.java
@@ -70,7 +70,7 @@ public class ClusterAuditorTest {
     clusterAuditor.fireDeleteClustersInProject(BILLING_PROJECT_ID, CLUSTER_NAMES);
     verify(mockActionAuditService).send(eventCollectionCaptor.capture());
     Collection<ActionAuditEvent> eventsSent = eventCollectionCaptor.getValue();
-    assertThat(eventsSent).hasSize(3);
+    assertThat(eventsSent).hasSize(CLUSTER_NAMES.size());
     Optional<ActionAuditEvent> firstEvent = eventsSent.stream().findFirst();
     assertThat(firstEvent.isPresent()).isTrue();
     assertThat(firstEvent.map(ActionAuditEvent::getActionType).orElse(null))

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.pmiops.workbench.actionaudit.auditors.ClusterAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -49,7 +50,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterConfig;
-import org.pmiops.workbench.model.ClusterListResponse;
 import org.pmiops.workbench.model.ClusterLocalizeRequest;
 import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
@@ -101,6 +101,7 @@ public class ClusterControllerTest {
   @TestConfiguration
   @Import({ClusterController.class, UserServiceImpl.class})
   @MockBean({
+    ClusterAuditor.class,
     FireCloudService.class,
     LeonardoNotebooksClient.class,
     WorkspaceService.class,
@@ -137,6 +138,7 @@ public class ClusterControllerTest {
 
   @Captor private ArgumentCaptor<Map<String, String>> mapCaptor;
 
+  @Autowired ClusterAuditor clusterAuditor;
   @Autowired LeonardoNotebooksClient notebookService;
   @Autowired FireCloudService fireCloudService;
   @Autowired UserDao userDao;
@@ -150,7 +152,6 @@ public class ClusterControllerTest {
   private org.pmiops.workbench.notebooks.model.ListClusterResponse testFcClusterListResponse;
 
   private Cluster testCluster;
-  private ListClusterResponse testClusterListResponse;
   private DbWorkspace testWorkspace;
 
   @Before
@@ -197,12 +198,6 @@ public class ClusterControllerTest {
             .clusterName(getClusterName())
             .clusterNamespace(BILLING_PROJECT_ID)
             .status(ClusterStatus.DELETING)
-            .createdDate(createdDate);
-    testClusterListResponse =
-        new ListClusterResponse()
-            .clusterName(getClusterName())
-            .googleProject(BILLING_PROJECT_ID)
-            .status(ClusterStatus.RUNNING)
             .createdDate(createdDate);
 
     testWorkspace = new DbWorkspace();

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -272,7 +272,13 @@ public class ClusterControllerTest {
         .when(notebookService)
         .deleteClusterAsAdmin(BILLING_PROJECT_ID, getClusterName());
 
-    assertThat(clusterController.deleteClustersInProject(BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(ImmutableList.of(testFcCluster.getClusterName()))).getBody())
+    assertThat(
+            clusterController
+                .deleteClustersInProject(
+                    BILLING_PROJECT_ID,
+                    new ListClusterDeleteRequest()
+                        .clustersToDelete(ImmutableList.of(testFcCluster.getClusterName())))
+                .getBody())
         .isEqualTo(
             ImmutableList.of(
                 new ListClusterResponse()

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -54,6 +54,7 @@ import org.pmiops.workbench.model.ClusterLocalizeRequest;
 import org.pmiops.workbench.model.ClusterLocalizeResponse;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.ListClusterDeleteRequest;
 import org.pmiops.workbench.model.ListClusterResponse;
 import org.pmiops.workbench.model.UpdateClusterConfigRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -271,7 +272,7 @@ public class ClusterControllerTest {
         .when(notebookService)
         .deleteClusterAsAdmin(BILLING_PROJECT_ID, getClusterName());
 
-    assertThat(clusterController.deleteClustersInProject(BILLING_PROJECT_ID).getBody())
+    assertThat(clusterController.deleteClustersInProject(BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(ImmutableList.of(testFcCluster.getClusterName()))).getBody())
         .isEqualTo(
             ImmutableList.of(
                 new ListClusterResponse()

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -260,21 +260,25 @@ public class ClusterControllerTest {
   public void testDeleteClustersInProject() throws Exception {
     when(notebookService.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
         .thenReturn(ImmutableList.of(testFcClusterListResponse));
-    Mockito.doAnswer(new Answer<Void>() {
-      public Void answer(InvocationOnMock invocation) {
-        testFcClusterListResponse.setStatus(org.pmiops.workbench.notebooks.model.ClusterStatus.DELETING);
-        return null;
-      }
-    }).when(notebookService).deleteClusterAsAdmin(BILLING_PROJECT_ID, getClusterName());
+    Mockito.doAnswer(
+            new Answer<Void>() {
+              public Void answer(InvocationOnMock invocation) {
+                testFcClusterListResponse.setStatus(
+                    org.pmiops.workbench.notebooks.model.ClusterStatus.DELETING);
+                return null;
+              }
+            })
+        .when(notebookService)
+        .deleteClusterAsAdmin(BILLING_PROJECT_ID, getClusterName());
 
-    assertThat(
-        clusterController
-            .deleteClustersInProject(BILLING_PROJECT_ID)
-            .getBody())
-        .isEqualTo(ImmutableList.of(new ListClusterResponse()
-            .clusterName(testCluster.getClusterName())
-            .createdDate(testCluster.getCreatedDate())
-            .status(ClusterStatus.DELETING).googleProject(testCluster.getClusterNamespace())));
+    assertThat(clusterController.deleteClustersInProject(BILLING_PROJECT_ID).getBody())
+        .isEqualTo(
+            ImmutableList.of(
+                new ListClusterResponse()
+                    .clusterName(testCluster.getClusterName())
+                    .createdDate(testCluster.getCreatedDate())
+                    .status(ClusterStatus.DELETING)
+                    .googleProject(testCluster.getClusterNamespace())));
   }
 
   @Test

--- a/ui/src/testing/stubs/cluster-api-stub.ts
+++ b/ui/src/testing/stubs/cluster-api-stub.ts
@@ -1,10 +1,10 @@
 import {
   Cluster,
   ClusterApi,
-  ClusterListResponse,
   ClusterLocalizeRequest,
   ClusterLocalizeResponse,
   ClusterStatus,
+  DefaultClusterResponse,
 } from 'generated/fetch';
 
 export class ClusterApiStub extends ClusterApi {
@@ -20,8 +20,8 @@ export class ClusterApiStub extends ClusterApi {
     };
   }
 
-  listClusters(extraHttpRequestParams?: any): Promise<ClusterListResponse> {
-    return new Promise<ClusterListResponse>(resolve => {
+  listClusters(extraHttpRequestParams?: any): Promise<DefaultClusterResponse> {
+    return new Promise<DefaultClusterResponse>(resolve => {
       console.log(this.cluster);
       resolve({defaultCluster: this.cluster});
     });

--- a/ui/src/testing/stubs/cluster-service-stub.ts
+++ b/ui/src/testing/stubs/cluster-service-stub.ts
@@ -2,10 +2,10 @@ import {Observable} from 'rxjs/Observable';
 
 import {
   Cluster,
-  ClusterListResponse,
   ClusterLocalizeRequest,
   ClusterLocalizeResponse,
-  ClusterStatus
+  ClusterStatus,
+  DefaultClusterResponse,
 } from 'generated';
 
 export class ClusterServiceStub {
@@ -21,8 +21,8 @@ export class ClusterServiceStub {
     };
   }
 
-  listClusters(extraHttpRequestParams?: any): Observable<ClusterListResponse> {
-    return new Observable<ClusterListResponse>(observer => {
+  listClusters(extraHttpRequestParams?: any): Observable<DefaultClusterResponse> {
+    return new Observable<DefaultClusterResponse>(observer => {
       setTimeout(() => {
         observer.next({defaultCluster: this.cluster});
         observer.complete();


### PR DESCRIPTION
Description:
This adds an endpoint which allows security admins to delete all clusters in a project. We went with delete because Leonardo doesn't currently allow for stopping clusters as a project owner, just deleting them.

Manual test on local included:
Deleting current user's cluster as that user.
Deleting another user's cluster as one user, in a workspace the user does not have access to. 

I would love some thoughts on the unit tests here, because I am unsure where the cost/benefit lands for amount of unit tests. (The one I wrote just basically verifies that it hits Leo)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
