### PR TITLE
[risk=low][RW-4241] Install a specific version of reticulate to avoid a kernel-crashing bug

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -523,7 +523,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     switch (kernelTypeEnum) {
       case R:
         prerequisites =
-            // RW-4241 workaround: update when the Jupyter image with the reticulate fix is fully rolled out
+            // RW-4241 workaround: update when the Jupyter image with the reticulate fix is fully
+            // rolled out
             "require(devtools)\n"
                 + "devtools::install_github(\"rstudio/reticulate\", ref=\"00172079\")\n"
                 + "library(reticulate)\n"

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -523,7 +523,9 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     switch (kernelTypeEnum) {
       case R:
         prerequisites =
-            "if(! \"reticulate\" %in% installed.packages()) { install.packages(\"reticulate\") }\n"
+            // RW-4241 workaround: update when the Jupyter image with the reticulate fix is fully rolled out
+            "require(devtools)\n"
+                + "devtools::install_github(\"rstudio/reticulate\", ref=\"00172079\")\n"
                 + "library(reticulate)\n"
                 + "pd <- reticulate::import(\"pandas\")";
         break;

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -720,7 +720,8 @@ public class DataSetControllerTest {
     String prefix = "dataset_00000000_condition_";
     assertThat(response.getCode())
         .isEqualTo(
-            "if(! \"reticulate\" %in% installed.packages()) { install.packages(\"reticulate\") }\n"
+            "require(devtools)\n"
+                + "devtools::install_github(\"rstudio/reticulate\", ref=\"00172079\")\n"
                 + "library(reticulate)\n"
                 + "pd <- reticulate::import(\"pandas\")\n\n"
                 + "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n"


### PR DESCRIPTION
Choose a version of Reticulate which includes this PR: https://github.com/rstudio/reticulate/pull/699

This is a temporary solution.  A longer-term fix is described here: https://docs.google.com/document/d/10FPO4fIAjGZUsLf1EKhDsUwS7afUMWBxsNR5KhSkLq4/edit#

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
