### PR TITLE
[no ticket][risk=no] Use same metric names for all environments

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -102,9 +102,10 @@ public class StackdriverStatsExporterService {
   }
 
   /**
-   * Stackdriver instances have very long, random ID strings. When running locally, however,
-   * the ModulesService throws an exception, so we need to assign non-conflicting and non-repeating
-   * ID strings.
+   * Stackdriver instances have very long, random ID strings. When running locally, however, the
+   * ModulesService throws an exception, so we need to assign non-conflicting and non-repeating ID
+   * strings.
+   *
    * @return
    */
   private String makeRandomNodeId() {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -24,12 +24,13 @@ public class StackdriverStatsExporterService {
 
   private static final Logger logger =
       Logger.getLogger(StackdriverStatsExporterService.class.getName());
-  private static final String STACKDRIVER_CUSTOM_METRICS_DOMAIN_NAME = "custom.googleapis.com";
+  private static final String STACKDRIVER_CUSTOM_METRICS_PREFIX = "custom.googleapis.com/";
   private static final String MONITORED_RESOURCE_TYPE = "generic_node";
   private static final String PROJECT_ID_LABEL = "project_id";
   private static final String LOCATION_LABEL = "location";
   private static final String NAMESPACE_LABEL = "namespace";
   private static final String NODE_ID_LABEL = "node_id";
+  public static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
 
   private boolean initialized;
   private Provider<WorkbenchConfig> workbenchConfigProvider;
@@ -65,7 +66,7 @@ public class StackdriverStatsExporterService {
   @VisibleForTesting
   public StackdriverStatsConfiguration makeStackdriverStatsConfiguration() {
     return StackdriverStatsConfiguration.builder()
-        .setMetricNamePrefix(buildMetricNamePrefix())
+        .setMetricNamePrefix(STACKDRIVER_CUSTOM_METRICS_PREFIX)
         .setProjectId(getProjectId())
         .setMonitoredResource(makeMonitoredResource())
         .build();
@@ -100,13 +101,14 @@ public class StackdriverStatsExporterService {
     }
   }
 
+  /**
+   * Stackdriver instances have very long, random ID strings. When running locally, however,
+   * the ModulesService throws an exception, so we need to assign non-conflicting and non-repeating
+   * ID strings.
+   * @return
+   */
   private String makeRandomNodeId() {
-    return UUID.randomUUID().toString();
-  }
-
-  private String buildMetricNamePrefix() {
-    return String.format(
-        "%s/%s/", STACKDRIVER_CUSTOM_METRICS_DOMAIN_NAME, getEnvironmentShortName());
+    return UNKNOWN_INSTANCE_PREFIX + UUID.randomUUID().toString();
   }
 
   @NotNull

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -51,8 +51,7 @@ public class StackdriverStatsExporterServiceTest {
     StackdriverStatsConfiguration statsConfiguration =
         exporterService.makeStackdriverStatsConfiguration();
     assertThat(statsConfiguration.getProjectId()).isEqualTo(PROJECT_ID);
-    assertThat(statsConfiguration.getMetricNamePrefix())
-        .isEqualTo("custom.googleapis.com/");
+    assertThat(statsConfiguration.getMetricNamePrefix()).isEqualTo("custom.googleapis.com/");
 
     final MonitoredResource monitoredResource = statsConfiguration.getMonitoredResource();
     assertThat(monitoredResource.getType()).isEqualTo("generic_node");

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -52,7 +52,7 @@ public class StackdriverStatsExporterServiceTest {
         exporterService.makeStackdriverStatsConfiguration();
     assertThat(statsConfiguration.getProjectId()).isEqualTo(PROJECT_ID);
     assertThat(statsConfiguration.getMetricNamePrefix())
-        .isEqualTo("custom.googleapis.com/unit-test/");
+        .isEqualTo("custom.googleapis.com/");
 
     final MonitoredResource monitoredResource = statsConfiguration.getMonitoredResource();
     assertThat(monitoredResource.getType()).isEqualTo("generic_node");


### PR DESCRIPTION
The `MonitoredResource` structure now contains information on our environment and project, so we don't need to keep any of that in the metric names as we had originally. Additionally, project-level information is already in place in the `StackdriverStatsConfiguration` object. Using these mechanisms should be a better experience for automation, as we're working with metadata directly instead of pulling it out of a longer string.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
