### PR TITLE
turn down logLevel

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/monitoring/GaugeRecorderService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/GaugeRecorderService.java
@@ -16,7 +16,7 @@ public class GaugeRecorderService {
   private final MonitoringService monitoringService;
 
   // For local debugging, change this to Level.INFO or higher
-  private final Level logLevel = Level.INFO;
+  private final Level logLevel = Level.FINE;
 
   public GaugeRecorderService(
       List<GaugeDataCollector> gaugeDataCollectors, MonitoringService monitoringService) {


### PR DESCRIPTION
We now have enough output from the gauges that it's getting in the way if you're not working directly on instrumentation.