### PR TITLE
[risk=low][RW-4231]Use dockerhub jupyter and welder images

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -13,7 +13,8 @@
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -12,7 +12,8 @@
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -12,7 +12,8 @@
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "015EAA-E95687-1F8614",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -12,7 +12,8 @@
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -12,7 +12,8 @@
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -13,7 +13,8 @@
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.6"
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.8",
+    "welderDockerImage": "broadinstitute/welder-server:60e28bc"
   },
   "billing": {
     "accountId": "014D91-FCB792-33D2C0",

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -104,6 +104,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                     Optional.ofNullable(clusterOverride.machineType)
                         .orElse(config.firecloud.clusterDefaultMachineType)))
         .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
+        .welderDockerImage(workbenchConfigProvider.get().firecloud.welderDockerImage)
         .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -103,7 +103,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                 .masterMachineType(
                     Optional.ofNullable(clusterOverride.machineType)
                         .orElse(config.firecloud.clusterDefaultMachineType)))
-        .jupyterDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
+        .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
         .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
   }
 

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1439,7 +1439,9 @@ definitions:
         default: false
       customClusterEnvironmentVariables:
         type: object
-        description: Optional environment variables to be set on the cluster.
+        description: A collection of key/value pairs of environment variable names and their desired value to be set in the cluster.
+        additionalProperties:
+          type: string
 
   ClusterError:
     description: 'Errors encountered on cluster create'

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1375,14 +1375,6 @@ definitions:
       userJupyterExtensionConfig:
         $ref: "#/definitions/UserJupyterExtensionConfig"
         description: Jupyter extensions to be installed in the notebook
-      jupyterExtensionUri:
-        type: string
-        description: |
-          Optional bucket URI or URL to an archive containing Jupyter notebook extension files, or
-          a .js file.
-          The archive must be in tar.gz format, must not include a parent directory, and
-          must have an entry point named 'main'. For more information on notebook extensions,
-          see http://jupyter-notebook.readthedocs.io/en/latest/extending/frontend_extensions.html.
       jupyterUserScriptUri:
         type: string
         description: |
@@ -1426,9 +1418,14 @@ definitions:
       defaultClientId:
         type: string
         description: The default Google Client ID.
-      jupyterDockerImage:
+      toolDockerImage:
         type: string
-        description: The Jupyter docker image to install. May be Dockerhub or GCR. If not set, then a default Jupyter image will be installed.
+        description: The tool docker image to install. May be Dockerhub or GCR. If not set, a default Jupyter image will be installed.
+      welderDockerImage:
+        type: string
+        description: |
+          The Welder docker image to install. Only takes effect if the tool being installed supports welder.
+          May be Dockerhub or GCR. If not set, then a default Welder image will be installed.
       scopes:
         type: array
         items:
@@ -1442,10 +1439,7 @@ definitions:
         default: false
       customClusterEnvironmentVariables:
         type: object
-        description: A collection of key/value pairs of environment variable names and their desired value to be set in the cluster.
-        additionalProperties:
-          type: string
-
+        description: Optional environment variables to be set on the cluster.
 
   ClusterError:
     description: 'Errors encountered on cluster create'

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -109,8 +109,10 @@ public class WorkbenchConfig {
     public String vpcServicePerimeterName;
     // The length of our API HTTP client timeouts to firecloud
     public Integer timeoutInSeconds;
-    // The image in GCR that we use for our jupyter dockers
+    // The docker image that we use for our jupyter images
     public String jupyterDockerImage;
+    // The docker image that we use for our welder images
+    public String welderDockerImage;
   }
 
   public static class AuthConfig {


### PR DESCRIPTION
Description:
Tested by deploying a notebook with these images and running the Notebook Tester workspace's notebooks.
Confirmed that the cluster is using these images by querying Leonardo.

Cluster creation time does not appear to be meaningfully affected.  Translated "timings" at the end of dataproc-initialization-script-0_output : 

GCR run 1: 18:21:18 to 18:23:28
GCR run 2: 18:33:37 to 18:35:46
GCR run 3: 18:47:57 to 18:50:03
Dockerhub run 1: 19:12:44 to 19:15:16
Dockerhub run 2: 16:50:55 to 16:52:57
Dockerhub run 3: 17:07:38 to 17:09:49

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
