### PR TITLE
[RISK=LOW][No ticket] Removing null constraint from User table column creation and modified time 

### DIFF
--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -7,17 +7,11 @@
   <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
     <addColumn tableName="user">
       <column name="creation_time" type="datetime">
-        <constraints nullable="false" />
+        <constraints nullable="true" />
       </column>
       <column name="last_modified_time" type="datetime">
-        <constraints nullable="false"/>
+        <constraints nullable="true"/>
       </column>
     </addColumn>
-  </changeSet>
-  <changeSet id="update creation time" author="nsaxena">
-    <sql>update user set creation_time = first_sign_in_time</sql>
-  </changeSet>
-  <changeSet id="update modified time" author="nsaxena">
-    <sql>update user set last_modified_time = first_sign_in_time</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -9,9 +9,12 @@
       <column name="creation_time" type="datetime">
         <constraints nullable="true" />
       </column>
-      <column name="last_modified_time" type="datetime">
+      <column name="last_modified_time" type="datetime" defaultValueDate="CURRENT_TIMESTAMP">
         <constraints nullable="true"/>
       </column>
     </addColumn>
+  </changeSet>
+  <changeSet id="update modified time" author="nsaxena">
+    <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -10,7 +10,7 @@
         <constraints nullable="true" />
       </column>
       <column name="last_modified_time" type="datetime" defaultValueDate="CURRENT_TIMESTAMP">
-        <constraints nullable="true"/>
+        <constraints nullable="false"/>
       </column>
     </addColumn>
   </changeSet>

--- a/api/src/main/java/org/pmiops/workbench/db/dao/RdrExportDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/RdrExportDao.java
@@ -12,7 +12,7 @@ public interface RdrExportDao extends CrudRepository<DbRdrExport, Long> {
       nativeQuery = true,
       value =
           "select u.user_id from user u LEFT JOIN rdr_export rdr on"
-              + " u.user_id = rdr.export_id and rdr.entity_type = 1 where u.last_modified_time is null or "
+              + " u.user_id = rdr.export_id and rdr.entity_type = 1 where "
               + "u.last_modified_time > rdr.last_Export_date or rdr.export_id is null")
   List<BigInteger> findDbUserIdsToExport();
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/RdrExportDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/RdrExportDao.java
@@ -12,7 +12,7 @@ public interface RdrExportDao extends CrudRepository<DbRdrExport, Long> {
       nativeQuery = true,
       value =
           "select u.user_id from user u LEFT JOIN rdr_export rdr on"
-              + " u.user_id = rdr.export_id and rdr.entity_type = 1 where "
+              + " u.user_id = rdr.export_id and rdr.entity_type = 1 where u.last_modified_time is null or "
               + "u.last_modified_time > rdr.last_Export_date or rdr.export_id is null")
   List<BigInteger> findDbUserIdsToExport();
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -386,6 +386,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
     dbUser.setDataUseAgreementCompletionTime(timestamp);
     dbUser.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
+    dbUser.setLastModifiedTime(timestamp);
     return userDao.save(dbUser);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -379,9 +379,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
     DbUserDataUseAgreement dataUseAgreement = new DbUserDataUseAgreement();
     dataUseAgreement.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
-    dataUseAgreement.setUserId(user.getUserId());
-    dataUseAgreement.setUserFamilyName(user.getFamilyName());
-    dataUseAgreement.setUserGivenName(user.getGivenName());
+    dataUseAgreement.setUserId(dbUser.getUserId());
+    dataUseAgreement.setUserFamilyName(dbUser.getFamilyName());
+    dataUseAgreement.setUserGivenName(dbUser.getGivenName());
     dataUseAgreement.setUserInitials(initials);
     dataUseAgreement.setCompletionTime(timestamp);
     userDataUseAgreementDao.save(dataUseAgreement);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -374,26 +374,26 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       DbUser dbUser, Integer dataUseAgreementSignedVersion, String initials) {
 
     return updateUserWithRetries(
-            (user) -> {
-              // FIXME: this should not be hardcoded
-              if (dataUseAgreementSignedVersion != CURRENT_DATA_USE_AGREEMENT_VERSION) {
-                throw new BadRequestException("Data Use Agreement Version is not up to date");
-              }
-              final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-              DbUserDataUseAgreement dataUseAgreement = new DbUserDataUseAgreement();
-              dataUseAgreement.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
-              dataUseAgreement.setUserId(user.getUserId());
-              dataUseAgreement.setUserFamilyName(user.getFamilyName());
-              dataUseAgreement.setUserGivenName(user.getGivenName());
-              dataUseAgreement.setUserInitials(initials);
-              dataUseAgreement.setCompletionTime(timestamp);
-              userDataUseAgreementDao.save(dataUseAgreement);
-              // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
-              user.setDataUseAgreementCompletionTime(timestamp);
-              user.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
-              return user;
-            },
-            dbUser);
+        (user) -> {
+          // FIXME: this should not be hardcoded
+          if (dataUseAgreementSignedVersion != CURRENT_DATA_USE_AGREEMENT_VERSION) {
+            throw new BadRequestException("Data Use Agreement Version is not up to date");
+          }
+          final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
+          DbUserDataUseAgreement dataUseAgreement = new DbUserDataUseAgreement();
+          dataUseAgreement.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
+          dataUseAgreement.setUserId(user.getUserId());
+          dataUseAgreement.setUserFamilyName(user.getFamilyName());
+          dataUseAgreement.setUserGivenName(user.getGivenName());
+          dataUseAgreement.setUserInitials(initials);
+          dataUseAgreement.setCompletionTime(timestamp);
+          userDataUseAgreementDao.save(dataUseAgreement);
+          // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
+          user.setDataUseAgreementCompletionTime(timestamp);
+          user.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
+          return user;
+        },
+        dbUser);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -372,22 +372,21 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   @Override
   public DbUser submitDataUseAgreement(
       DbUser dbUser, Integer dataUseAgreementSignedVersion, String initials) {
-
+    // FIXME: this should not be hardcoded
+    if (dataUseAgreementSignedVersion != CURRENT_DATA_USE_AGREEMENT_VERSION) {
+      throw new BadRequestException("Data Use Agreement Version is not up to date");
+    }
+    final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
+    DbUserDataUseAgreement dataUseAgreement = new DbUserDataUseAgreement();
+    dataUseAgreement.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
+    dataUseAgreement.setUserId(user.getUserId());
+    dataUseAgreement.setUserFamilyName(user.getFamilyName());
+    dataUseAgreement.setUserGivenName(user.getGivenName());
+    dataUseAgreement.setUserInitials(initials);
+    dataUseAgreement.setCompletionTime(timestamp);
+    userDataUseAgreementDao.save(dataUseAgreement);
     return updateUserWithRetries(
         (user) -> {
-          // FIXME: this should not be hardcoded
-          if (dataUseAgreementSignedVersion != CURRENT_DATA_USE_AGREEMENT_VERSION) {
-            throw new BadRequestException("Data Use Agreement Version is not up to date");
-          }
-          final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
-          DbUserDataUseAgreement dataUseAgreement = new DbUserDataUseAgreement();
-          dataUseAgreement.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);
-          dataUseAgreement.setUserId(user.getUserId());
-          dataUseAgreement.setUserFamilyName(user.getFamilyName());
-          dataUseAgreement.setUserGivenName(user.getGivenName());
-          dataUseAgreement.setUserInitials(initials);
-          dataUseAgreement.setCompletionTime(timestamp);
-          userDataUseAgreementDao.save(dataUseAgreement);
           // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
           user.setDataUseAgreementCompletionTime(timestamp);
           user.setDataUseAgreementSignedVersion(dataUseAgreementSignedVersion);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -133,6 +133,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     while (true) {
       dbUser = userModifier.apply(dbUser);
       updateDataAccessLevel(dbUser);
+      Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+      dbUser.setLastModifiedTime(now);
       try {
         return userDao.save(dbUser);
       } catch (ObjectOptimisticLockingFailureException e) {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -158,7 +158,8 @@ public class RdrExportServiceImpl implements RdrExportService {
     RdrResearcher researcher = new RdrResearcher();
     researcher.setUserId((int) dbUser.getUserId());
     // RDR will start accepting null creation Time and later once workbench works on story
-    // https://precisionmedicineinitiative.atlassian.net/browse/RW-3741 RDR will create API to backfill data
+    // https://precisionmedicineinitiative.atlassian.net/browse/RW-3741 RDR will create API to
+    // backfill data
     if (null != researcher.getCreationTime()) {
       researcher.setCreationTime(dbUser.getCreationTime().toLocalDateTime().atOffset(offset));
     }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -157,8 +157,17 @@ public class RdrExportServiceImpl implements RdrExportService {
   private RdrResearcher toRdrResearcher(DbUser dbUser) {
     RdrResearcher researcher = new RdrResearcher();
     researcher.setUserId((int) dbUser.getUserId());
-    researcher.setCreationTime(dbUser.getCreationTime().toLocalDateTime().atOffset(offset));
-    researcher.setModifiedTime(dbUser.getLastModifiedTime().toLocalDateTime().atOffset(offset));
+    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+    if (null != researcher.getCreationTime()) {
+      researcher.setCreationTime(dbUser.getCreationTime().toLocalDateTime().atOffset(offset));
+    } else {
+      researcher.setCreationTime(OffsetDateTime.now());
+    }
+    if (null != researcher.getModifiedTime()) {
+      researcher.setModifiedTime(dbUser.getLastModifiedTime().toLocalDateTime().atOffset(offset));
+    } else {
+      researcher.setModifiedTime(OffsetDateTime.now());
+    }
     researcher.setGivenName(dbUser.getGivenName());
     researcher.setFamilyName(dbUser.getFamilyName());
     if (dbUser.getAddress() != null) {
@@ -259,10 +268,11 @@ public class RdrExportServiceImpl implements RdrExportService {
     Map<String, FirecloudWorkspaceAccessEntry> aclMap = firecloudResponse.getAcl();
     aclMap.forEach(
         (email, access) -> {
-          RdrWorkspaceUser workspaceUderMap = new RdrWorkspaceUser();
-          workspaceUderMap.setUserId((int) userDao.findUserByUsername(email).getUserId());
-          workspaceUderMap.setRole(RdrWorkspaceUser.RoleEnum.fromValue(access.getAccessLevel()));
-          rdrWorkspace.addWorkspaceUsersItem(workspaceUderMap);
+          RdrWorkspaceUser workspaceUserMap = new RdrWorkspaceUser();
+          workspaceUserMap.setUserId((int) userDao.findUserByUsername(email).getUserId());
+          workspaceUserMap.setRole(RdrWorkspaceUser.RoleEnum.fromValue(access.getAccessLevel()));
+          workspaceUserMap.setStatus(RdrWorkspaceUser.StatusEnum.fromValue("ACTIVE"));
+          rdrWorkspace.addWorkspaceUsersItem(workspaceUserMap);
         });
 
     return rdrWorkspace;

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -157,7 +157,6 @@ public class RdrExportServiceImpl implements RdrExportService {
   private RdrResearcher toRdrResearcher(DbUser dbUser) {
     RdrResearcher researcher = new RdrResearcher();
     researcher.setUserId((int) dbUser.getUserId());
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     if (null != researcher.getCreationTime()) {
       researcher.setCreationTime(dbUser.getCreationTime().toLocalDateTime().atOffset(offset));
     } else {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -157,10 +157,10 @@ public class RdrExportServiceImpl implements RdrExportService {
   private RdrResearcher toRdrResearcher(DbUser dbUser) {
     RdrResearcher researcher = new RdrResearcher();
     researcher.setUserId((int) dbUser.getUserId());
+    // RDR will start accepting null creation Time and later once workbench works on story
+    // https://precisionmedicineinitiative.atlassian.net/browse/RW-3741 RDR will create API to backfill data
     if (null != researcher.getCreationTime()) {
       researcher.setCreationTime(dbUser.getCreationTime().toLocalDateTime().atOffset(offset));
-    } else {
-      researcher.setCreationTime(OffsetDateTime.now());
     }
     researcher.setModifiedTime(dbUser.getLastModifiedTime().toLocalDateTime().atOffset(offset));
 

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -162,11 +162,8 @@ public class RdrExportServiceImpl implements RdrExportService {
     } else {
       researcher.setCreationTime(OffsetDateTime.now());
     }
-    if (null != researcher.getModifiedTime()) {
-      researcher.setModifiedTime(dbUser.getLastModifiedTime().toLocalDateTime().atOffset(offset));
-    } else {
-      researcher.setModifiedTime(OffsetDateTime.now());
-    }
+    researcher.setModifiedTime(dbUser.getLastModifiedTime().toLocalDateTime().atOffset(offset));
+
     researcher.setGivenName(dbUser.getGivenName());
     researcher.setFamilyName(dbUser.getFamilyName());
     if (dbUser.getAddress() != null) {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -270,7 +270,6 @@ public class RdrExportServiceImpl implements RdrExportService {
           RdrWorkspaceUser workspaceUserMap = new RdrWorkspaceUser();
           workspaceUserMap.setUserId((int) userDao.findUserByUsername(email).getUserId());
           workspaceUserMap.setRole(RdrWorkspaceUser.RoleEnum.fromValue(access.getAccessLevel()));
-          workspaceUserMap.setStatus(RdrWorkspaceUser.StatusEnum.fromValue("ACTIVE"));
           rdrWorkspace.addWorkspaceUsersItem(workspaceUserMap);
         });
 


### PR DESCRIPTION
This will remove the not null constrain on the  columns creation and last_modified_time as well as removing the default values.

The reason behind this is that rather than populating creation_time with first_sign_in (which can be null as well as incorrect) or the current date time, we will spend effort in trying to find ways to populate the column with close to actual creation_date time for existing user (maybe checking when the got the email for registration or other way). In order to do that its better to have the values as null so it will be easier to find users that needs updating.

There is another ticket that is going to take care of populating the correct creation and last_modified_time for existing users https://precisionmedicineinitiative.atlassian.net/browse/RW-4278