### PR TITLE
[RW-4233][risk=no] adding PM and Surveys to concept search

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -443,7 +443,7 @@ where d.domain_id = c.domain_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.domain_info\` d
 set d.all_concept_count = c.all_concept_count, d.standard_concept_count = c.standard_concept_count from
-(SELECT count(distinct concept_id) as all_concept_count, 0 as standard_concept_count
+(SELECT count(distinct concept_id) as all_concept_count, SUM(CASE WHEN c.standard_concept IN ('S', 'C') THEN 1 ELSE 0 END) as standard_concept_count
 FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
 WHERE vocabulary_id = 'PPI'
 AND domain_id = 'Measurement'

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -446,7 +446,8 @@ set d.all_concept_count = c.all_concept_count, d.standard_concept_count = c.stan
 (SELECT count(distinct concept_id) as all_concept_count, 0 as standard_concept_count
 FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
 WHERE vocabulary_id = 'PPI'
-AND domain_id = 'Measurement') c
+AND domain_id = 'Measurement'
+AND concept_class_id = 'Clinical Observation') c
 where d.domain = 8"
 
 # Set participant counts for Condition domain
@@ -499,7 +500,8 @@ WHERE measurement_source_concept_id IN (
 SELECT concept_id
 FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
 WHERE vocabulary_id = 'PPI'
-AND domain_id = 'Measurement')) as r
+AND domain_id = 'Measurement'
+AND concept_class_id = 'Clinical Observation')) as r
 where d.domain = 8"
 
 ##########################################

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -177,7 +177,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
       Iterable<DbConcept> concepts = conceptDao.findAll(conceptSet.getConceptIds());
       result.setConcepts(
           Streams.stream(concepts)
-              .map(ConceptsController.TO_CLIENT_CONCEPT)
+              .map(ConceptsController::toClientConcept)
               .sorted(CONCEPT_NAME_ORDERING)
               .collect(Collectors.toList()));
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.model.StandardConceptFilter.ALL_CONCEPTS;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
@@ -102,7 +104,7 @@ public class ConceptsController implements ConceptsApiDelegate {
   private void addDomainCounts(SearchConceptsRequest request, ConceptListResponse response) {
     if (request.getIncludeDomainCounts()) {
       StandardConceptFilter standardConceptFilter = request.getStandardConceptFilter();
-      boolean allConcepts = standardConceptFilter == StandardConceptFilter.ALL_CONCEPTS;
+      boolean allConcepts = standardConceptFilter == ALL_CONCEPTS;
       DbDomainInfo pmDomainInfo = null;
       String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery());
       List<DbDomainInfo> allDbDomainInfos = conceptService.getAllDomainsOrderByDomainId();
@@ -110,11 +112,11 @@ public class ConceptsController implements ConceptsApiDelegate {
           matchExp == null ? allDbDomainInfos : new ArrayList<>();
       if (matchingDbDomainInfos.isEmpty()) {
         matchingDbDomainInfos =
-            allConcepts
-                ? conceptService.getAllConceptCounts(matchExp)
-                : conceptService.getStandardConceptCounts(matchExp);
+            conceptService.getConceptCounts(matchExp, request.getStandardConceptFilter().name());
         if (allConcepts) {
-          pmDomainInfo = conceptService.findPhysicalMeasurementConceptCounts(matchExp);
+          pmDomainInfo =
+              conceptService.findPhysicalMeasurementConceptCounts(
+                  matchExp, request.getStandardConceptFilter().name());
         }
       }
       Map<Domain, DbDomainInfo> domainCountMap =
@@ -168,7 +170,7 @@ public class ConceptsController implements ConceptsApiDelegate {
 
     ConceptListResponse response = new ConceptListResponse();
     if (request.getDomain().equals(Domain.SURVEY)) {
-      if (StandardConceptFilter.ALL_CONCEPTS.equals(request.getStandardConceptFilter())) {
+      if (ALL_CONCEPTS.equals(request.getStandardConceptFilter())) {
         Slice<DbCriteria> questionList =
             conceptService.searchSurveys(
                 request.getQuery(),

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.api;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -166,16 +167,20 @@ public class ConceptsController implements ConceptsApiDelegate {
 
     ConceptListResponse response = new ConceptListResponse();
     if (request.getDomain().equals(Domain.SURVEY)) {
-      Slice<DbCriteria> questionList =
-          conceptService.searchSurveys(
-              request.getQuery(),
-              request.getSurveyName(),
-              maxResults,
-              (request.getPageNumber() == null) ? 0 : request.getPageNumber());
-      response.setQuestions(
-          questionList.getContent().stream()
-              .map(this::toClientSurveyQuestions)
-              .collect(Collectors.toList()));
+      if (StandardConceptFilter.ALL_CONCEPTS.equals(request.getStandardConceptFilter())) {
+        Slice<DbCriteria> questionList =
+            conceptService.searchSurveys(
+                request.getQuery(),
+                request.getSurveyName(),
+                maxResults,
+                (request.getPageNumber() == null) ? 0 : request.getPageNumber());
+        response.setQuestions(
+            questionList.getContent().stream()
+                .map(this::toClientSurveyQuestions)
+                .collect(Collectors.toList()));
+      } else {
+        response.setQuestions(Collections.EMPTY_LIST);
+      }
     } else {
       Slice<DbConcept> concepts =
           conceptService.searchConcepts(

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
@@ -150,7 +149,7 @@ public class ConceptsController implements ConceptsApiDelegate {
           new DomainCount()
               .domain(Domain.SURVEY)
               .conceptCount(conceptCount)
-              .name(StringUtils.capitalize(Domain.SURVEY.toString().toLowerCase()).concat("s")));
+              .name(CommonStorageEnums.domainToDomainId(Domain.SURVEY).concat("s")));
     }
   }
 
@@ -187,7 +186,9 @@ public class ConceptsController implements ConceptsApiDelegate {
               (request.getPageNumber() == null) ? 0 : request.getPageNumber());
       if (concepts != null) {
         response.setItems(
-            concepts.getContent().stream().map(this::toClientConcept).collect(Collectors.toList()));
+            concepts.getContent().stream()
+                .map(ConceptsController::toClientConcept)
+                .collect(Collectors.toList()));
       }
     }
 
@@ -196,7 +197,7 @@ public class ConceptsController implements ConceptsApiDelegate {
     return ResponseEntity.ok(response);
   }
 
-  private Concept toClientConcept(DbConcept concept) {
+  public static Concept toClientConcept(DbConcept concept) {
     return new Concept()
         .conceptClassId(concept.getConceptClassId())
         .conceptCode(concept.getConceptCode())

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -6,11 +6,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.cdr.model.DbConcept;
+import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.concept.ConceptService;
@@ -42,21 +42,6 @@ public class ConceptsController implements ConceptsApiDelegate {
   private final ConceptService conceptService;
   private final ConceptBigQueryService conceptBigQueryService;
   private final WorkspaceService workspaceService;
-
-  static final Function<DbConcept, Concept> TO_CLIENT_CONCEPT =
-      (concept) ->
-          new Concept()
-              .conceptClassId(concept.getConceptClassId())
-              .conceptCode(concept.getConceptCode())
-              .conceptName(concept.getConceptName())
-              .conceptId(concept.getConceptId())
-              .countValue(concept.getCountValue())
-              .domainId(concept.getDomainId())
-              .prevalence(concept.getPrevalence())
-              .standardConcept(
-                  ConceptService.STANDARD_CONCEPT_CODE.equals(concept.getStandardConcept()))
-              .vocabularyId(concept.getVocabularyId())
-              .conceptSynonyms(concept.getSynonyms());
 
   @Autowired
   public ConceptsController(
@@ -158,8 +143,8 @@ public class ConceptsController implements ConceptsApiDelegate {
       if (allConcepts) {
         conceptCount =
             matchExp == null
-                ? conceptService.findSurveyCountBySurveyName(request.getSurveyName())
-                : conceptService.findSurveyCountByTerm(matchExp);
+                ? conceptService.countSurveyByName(request.getSurveyName())
+                : conceptService.countSurveyBySearchTerm(matchExp);
       }
       response.addDomainCountsItem(
           new DomainCount()
@@ -182,9 +167,16 @@ public class ConceptsController implements ConceptsApiDelegate {
 
     ConceptListResponse response = new ConceptListResponse();
     if (request.getDomain().equals(Domain.SURVEY)) {
-      List<SurveyQuestions> surveyQuestionList =
-          conceptBigQueryService.getSurveyQuestions(request.getSurveyName());
-      response.setQuestions(surveyQuestionList);
+      Slice<DbCriteria> questionList =
+          conceptService.searchSurveys(
+              request.getQuery(),
+              request.getSurveyName(),
+              maxResults,
+              (request.getPageNumber() == null) ? 0 : request.getPageNumber());
+      response.setQuestions(
+          questionList.getContent().stream()
+              .map(this::toClientSurveyQuestions)
+              .collect(Collectors.toList()));
     } else {
       Slice<DbConcept> concepts =
           conceptService.searchConcepts(
@@ -195,12 +187,32 @@ public class ConceptsController implements ConceptsApiDelegate {
               (request.getPageNumber() == null) ? 0 : request.getPageNumber());
       if (concepts != null) {
         response.setItems(
-            concepts.getContent().stream().map(TO_CLIENT_CONCEPT).collect(Collectors.toList()));
+            concepts.getContent().stream().map(this::toClientConcept).collect(Collectors.toList()));
       }
     }
 
     // TODO: consider doing these queries in parallel
     addDomainCounts(request, response);
     return ResponseEntity.ok(response);
+  }
+
+  private Concept toClientConcept(DbConcept concept) {
+    return new Concept()
+        .conceptClassId(concept.getConceptClassId())
+        .conceptCode(concept.getConceptCode())
+        .conceptName(concept.getConceptName())
+        .conceptId(concept.getConceptId())
+        .countValue(concept.getCountValue())
+        .domainId(concept.getDomainId())
+        .prevalence(concept.getPrevalence())
+        .standardConcept(ConceptService.STANDARD_CONCEPT_CODE.equals(concept.getStandardConcept()))
+        .vocabularyId(concept.getVocabularyId())
+        .conceptSynonyms(concept.getSynonyms());
+  }
+
+  private SurveyQuestions toClientSurveyQuestions(DbCriteria dbCriteria) {
+    return new SurveyQuestions()
+        .conceptId(dbCriteria.getLongConceptId())
+        .question(dbCriteria.getName());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.api;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,7 +142,9 @@ public class ConceptsController implements ConceptsApiDelegate {
       if (allConcepts) {
         conceptCount =
             matchExp == null
-                ? conceptService.countSurveyByName(request.getSurveyName())
+                ? request.getSurveyName() == null
+                    ? conceptService.countSurveys()
+                    : conceptService.countSurveyByName(request.getSurveyName())
                 : conceptService.countSurveyBySearchTerm(matchExp);
       }
       response.addDomainCountsItem(
@@ -178,8 +179,6 @@ public class ConceptsController implements ConceptsApiDelegate {
             questionList.getContent().stream()
                 .map(this::toClientSurveyQuestions)
                 .collect(Collectors.toList()));
-      } else {
-        response.setQuestions(Collections.EMPTY_LIST);
       }
     } else {
       Slice<DbConcept> concepts =

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -246,7 +246,7 @@ public class DataSetController implements DataSetApiDelegate {
       Iterable<DbConcept> concepts = conceptDao.findAll(conceptSet.getConceptIds());
       result.setConcepts(
           StreamSupport.stream(concepts.spliterator(), false)
-              .map(ConceptsController.TO_CLIENT_CONCEPT)
+              .map(ConceptsController::toClientConcept)
               .collect(Collectors.toList()));
     }
     return result;

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -156,7 +156,11 @@ public class ConceptService {
   }
 
   public Slice<DbConcept> searchConcepts(
-      String query, String standardConceptFilter, List<String> domainIds, int limit, int page) {
+      String query,
+      String standardConceptFilter,
+      ImmutableList<String> domainIds,
+      int limit,
+      int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
     ImmutableList<String> conceptTypes = getConceptTypes(standardConceptFilter);

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -169,7 +169,7 @@ public class ConceptService {
 
   public Slice<DbCriteria> searchSurveys(String query, String surveyName, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
-    Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
+    Pageable pageable = new PageRequest(page, limit, new Sort(Direction.ASC, "id"));
     return StringUtils.isBlank(keyword)
         ? cbCriteriaDao.findSurveysByName(surveyName, pageable)
         : cbCriteriaDao.findSurveys(keyword, pageable);

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -123,16 +123,20 @@ public class ConceptService {
     return domainInfoDao.findByOrderByDomainId();
   }
 
-  public List<DbDomainInfo> getAllConceptCounts(String matchExp) {
-    return domainInfoDao.findAllMatchConceptCounts(matchExp);
+  public List<DbDomainInfo> getConceptCounts(String matchExp, String standardConceptFilter) {
+    return domainInfoDao.findConceptCounts(matchExp, getConceptTypes(standardConceptFilter));
   }
 
-  public DbDomainInfo findPhysicalMeasurementConceptCounts(String matchExp) {
-    return domainInfoDao.findPhysicalMeasurementConceptCounts(matchExp);
+  public DbDomainInfo findPhysicalMeasurementConceptCounts(
+      String matchExp, String standardConceptFilter) {
+    return domainInfoDao.findPhysicalMeasurementConceptCounts(
+        matchExp, getConceptTypes(standardConceptFilter));
   }
 
-  public List<DbDomainInfo> getStandardConceptCounts(String matchExp) {
-    return domainInfoDao.findStandardConceptCounts(matchExp);
+  private List<String> getConceptTypes(String standardConceptFilter) {
+    return STANDARD_CONCEPTS.equals(standardConceptFilter)
+        ? STANDARD_CONCEPT_CODES
+        : ALL_CONCEPT_CODES;
   }
 
   public List<DbSurveyModule> getSurveyInfo() {
@@ -155,10 +159,7 @@ public class ConceptService {
       String query, String standardConceptFilter, List<String> domainIds, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
-    List<String> conceptTypes =
-        STANDARD_CONCEPTS.equals(standardConceptFilter)
-            ? STANDARD_CONCEPT_CODES
-            : ALL_CONCEPT_CODES;
+    List<String> conceptTypes = getConceptTypes(standardConceptFilter);
     if (domainIds.contains(CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT))) {
       ImmutableList domains =
           ImmutableList.of(CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT));

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -147,6 +147,10 @@ public class ConceptService {
     return cbCriteriaDao.countSurveyByName(surveyName);
   }
 
+  public long countSurveys() {
+    return cbCriteriaDao.countSurveys();
+  }
+
   public Slice<DbConcept> searchConcepts(
       String query, String standardConceptFilter, List<String> domainIds, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
@@ -156,10 +160,12 @@ public class ConceptService {
             ? STANDARD_CONCEPT_CODES
             : ALL_CONCEPT_CODES;
     if (domainIds.contains(CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT))) {
+      ImmutableList domains =
+          ImmutableList.of(CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT));
       return StringUtils.isBlank(keyword)
-          ? conceptDao.findConcepts(conceptTypes, domainIds, VOCAB_ID, CONCEPT_CLASS_ID, pageable)
+          ? conceptDao.findConcepts(conceptTypes, domains, VOCAB_ID, CONCEPT_CLASS_ID, pageable)
           : conceptDao.findConcepts(
-              keyword, conceptTypes, domainIds, VOCAB_ID, CONCEPT_CLASS_ID, pageable);
+              keyword, conceptTypes, domains, VOCAB_ID, CONCEPT_CLASS_ID, pageable);
     } else {
       return StringUtils.isBlank(keyword)
           ? conceptDao.findConcepts(conceptTypes, domainIds, pageable)
@@ -170,9 +176,12 @@ public class ConceptService {
   public Slice<DbCriteria> searchSurveys(String query, String surveyName, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.ASC, "id"));
-    return StringUtils.isBlank(keyword)
-        ? cbCriteriaDao.findSurveysByName(surveyName, pageable)
-        : cbCriteriaDao.findSurveys(keyword, pageable);
+    if (StringUtils.isBlank(keyword)) {
+      return StringUtils.isBlank(surveyName)
+          ? cbCriteriaDao.findSurveys(pageable)
+          : cbCriteriaDao.findSurveysByName(surveyName, pageable);
+    }
+    return cbCriteriaDao.findSurveys(keyword, pageable);
   }
 
   public ConceptIds classifyConceptIds(Set<Long> conceptIds) {

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -55,9 +55,9 @@ public class ConceptService {
   public static final String STANDARD_CONCEPT_CODE = "S";
   public static final String CLASSIFICATION_CONCEPT_CODE = "C";
   public static final String EMPTY_CONCEPT_CODE = "";
-  public static final List<String> STANDARD_CONCEPT_CODES =
+  public static final ImmutableList<String> STANDARD_CONCEPT_CODES =
       ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE);
-  public static final List<String> ALL_CONCEPT_CODES =
+  public static final ImmutableList<String> ALL_CONCEPT_CODES =
       ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE, EMPTY_CONCEPT_CODE);
 
   public ConceptService() {}
@@ -133,7 +133,7 @@ public class ConceptService {
         matchExp, getConceptTypes(standardConceptFilter));
   }
 
-  private List<String> getConceptTypes(String standardConceptFilter) {
+  private ImmutableList<String> getConceptTypes(String standardConceptFilter) {
     return STANDARD_CONCEPTS.equals(standardConceptFilter)
         ? STANDARD_CONCEPT_CODES
         : ALL_CONCEPT_CODES;
@@ -159,7 +159,7 @@ public class ConceptService {
       String query, String standardConceptFilter, List<String> domainIds, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
-    List<String> conceptTypes = getConceptTypes(standardConceptFilter);
+    ImmutableList<String> conceptTypes = getConceptTypes(standardConceptFilter);
     if (domainIds.contains(CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT))) {
       ImmutableList domains =
           ImmutableList.of(CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT));

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -352,7 +352,20 @@ public class CBCriteriaDaoTest {
   }
 
   @Test
+  public void findSurveys() {
+    PageRequest page = new PageRequest(0, 10);
+    assertEquals(questionCriteria, cbCriteriaDao.findSurveys("test", page).getContent().get(0));
+  }
+
+  @Test
   public void countSurveyByName() {
     assertEquals(1, cbCriteriaDao.countSurveyByName("The Basics"));
+  }
+
+  @Test
+  public void findSurveysByName() {
+    PageRequest page = new PageRequest(0, 10);
+    assertEquals(
+        questionCriteria, cbCriteriaDao.findSurveysByName("The Basics", page).getContent().get(0));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -347,12 +347,12 @@ public class CBCriteriaDaoTest {
   }
 
   @Test
-  public void findSurveyCountByTerm() {
-    assertEquals(1, cbCriteriaDao.findSurveyCountByTerm("test"));
+  public void countSurveyBySearchTerm() {
+    assertEquals(1, cbCriteriaDao.countSurveyBySearchTerm("test"));
   }
 
   @Test
-  public void findSurveyCountBySurveyName() {
-    assertEquals(1, cbCriteriaDao.findSurveyCountBySurveyName("The Basics"));
+  public void countSurveyByName() {
+    assertEquals(1, cbCriteriaDao.countSurveyByName("The Basics"));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -368,4 +368,15 @@ public class CBCriteriaDaoTest {
     assertEquals(
         questionCriteria, cbCriteriaDao.findSurveysByName("The Basics", page).getContent().get(0));
   }
+
+  @Test
+  public void findSurveysNoSurveyName() {
+    PageRequest page = new PageRequest(0, 10);
+    assertEquals(questionCriteria, cbCriteriaDao.findSurveys(page).getContent().get(0));
+  }
+
+  @Test
+  public void countSurveys() {
+    assertEquals(1, cbCriteriaDao.countSurveys());
+  }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DomainInfoDaoTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.cdr.dao;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +49,9 @@ public class DomainInfoDaoTest {
             .domainId("Measurement")
             .count(200L)
             .sourceCountValue(127L)
+            .standardConcept("")
             .vocabularyId("PPI")
+            .conceptClassId("Clinical Observation")
             .conceptName("name"));
     domainInfoObservation =
         domainInfoDao.save(
@@ -96,23 +99,25 @@ public class DomainInfoDaoTest {
 
   @Test
   public void findStandardConceptCounts() {
-    List<DbDomainInfo> infos = domainInfoDao.findStandardConceptCounts("name");
+    List<DbDomainInfo> infos = domainInfoDao.findConceptCounts("name", ImmutableList.of("S", "C"));
     assertEquals(2, infos.size());
-    assertEquals(domainInfoCondition.standardConceptCount(1), infos.get(0));
-    assertEquals(domainInfoObservation.standardConceptCount(1), infos.get(1));
+    assertEquals(domainInfoCondition.standardConceptCount(1).allConceptCount(1), infos.get(0));
+    assertEquals(domainInfoObservation.standardConceptCount(1).allConceptCount(1), infos.get(1));
   }
 
   @Test
   public void findAllMatchConceptCounts() {
-    List<DbDomainInfo> infos = domainInfoDao.findAllMatchConceptCounts("name");
+    List<DbDomainInfo> infos =
+        domainInfoDao.findConceptCounts("name", ImmutableList.of("S", "C", ""));
     assertEquals(2, infos.size());
-    assertEquals(domainInfoCondition.allConceptCount(1), infos.get(0));
-    assertEquals(domainInfoObservation.allConceptCount(1), infos.get(1));
+    assertEquals(domainInfoCondition.allConceptCount(1).standardConceptCount(1), infos.get(0));
+    assertEquals(domainInfoObservation.allConceptCount(1).standardConceptCount(1), infos.get(1));
   }
 
   @Test
   public void findPhysicalMeasurementConceptCounts() {
-    DbDomainInfo info = domainInfoDao.findPhysicalMeasurementConceptCounts("name");
-    assertEquals(domainInfoPM.allConceptCount(1), info);
+    DbDomainInfo info =
+        domainInfoDao.findPhysicalMeasurementConceptCounts("name", ImmutableList.of("S", "C", ""));
+    assertEquals(domainInfoPM.allConceptCount(1).standardConceptCount(1), info);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -256,19 +256,17 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select count(*) "
-              + "from cb_criteria "
-              + "where domain_id = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
-              + "and parent_id in (select id from cb_criteria where domain_id = 'SURVEY' and type = 'PPI' and name = :surveyName)",
-      nativeQuery = true)
+          "select count(c) "
+              + "from DbCriteria c "
+              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
+              + "and c.parentId in (select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName)")
   long countSurveyByName(@Param("surveyName") String surveyName);
 
   @Query(
       value =
-          "select * "
-              + "from cb_criteria "
-              + "where domain_id = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
-              + "and parent_id in (select id from cb_criteria where domain_id = 'SURVEY' and type = 'PPI' and name = :surveyName)",
-      nativeQuery = true)
+          "select c "
+              + "from DbCriteria c "
+              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
+              + "and c.parentId in (select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName)")
   Page<DbCriteria> findSurveysByName(@Param("surveyName") String surveyName, Pageable page);
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -269,4 +269,18 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
               + "and c.parentId in (select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName)")
   Page<DbCriteria> findSurveysByName(@Param("surveyName") String surveyName, Pageable page);
+
+  @Query(
+      value =
+          "select c "
+              + "from DbCriteria c "
+              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
+  Page<DbCriteria> findSurveys(Pageable page);
+
+  @Query(
+      value =
+          "select count(c) "
+              + "from DbCriteria c "
+              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
+  long countSurveys();
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
@@ -243,7 +244,15 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "from DbCriteria c "
               + "where domainId = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
               + "and match(synonyms, :term) > 0")
-  long findSurveyCountByTerm(@Param("term") String term);
+  long countSurveyBySearchTerm(@Param("term") String term);
+
+  @Query(
+      value =
+          "select c "
+              + "from DbCriteria c "
+              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
+              + "and match(c.synonyms, :term) > 0")
+  Page<DbCriteria> findSurveys(@Param("term") String term, Pageable page);
 
   @Query(
       value =
@@ -252,5 +261,14 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where domain_id = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
               + "and parent_id in (select id from cb_criteria where domain_id = 'SURVEY' and type = 'PPI' and name = :surveyName)",
       nativeQuery = true)
-  long findSurveyCountBySurveyName(@Param("surveyName") String surveyName);
+  long countSurveyByName(@Param("surveyName") String surveyName);
+
+  @Query(
+      value =
+          "select * "
+              + "from cb_criteria "
+              + "where domain_id = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
+              + "and parent_id in (select id from cb_criteria where domain_id = 'SURVEY' and type = 'PPI' and name = :surveyName)",
+      nativeQuery = true)
+  Page<DbCriteria> findSurveysByName(@Param("surveyName") String surveyName, Pageable page);
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.cdr.dao;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.springframework.data.domain.Page;
@@ -26,7 +27,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.standardConcept IN (?2) "
               + "and c.domainId in (?3)")
   Page<DbConcept> findConcepts(
-      String matchExp, List<String> conceptTypes, List<String> domainIds, Pageable page);
+      String matchExp, ImmutableList<String> conceptTypes, List<String> domainIds, Pageable page);
 
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
@@ -42,7 +43,8 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
               + "and c.domainId in (?2)")
-  Page<DbConcept> findConcepts(List<String> conceptTypes, List<String> domainIds, Pageable page);
+  Page<DbConcept> findConcepts(
+      ImmutableList<String> conceptTypes, List<String> domainIds, Pageable page);
 
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
@@ -66,7 +68,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.conceptClassId = ?5")
   Page<DbConcept> findConcepts(
       String matchExp,
-      List<String> conceptTypes,
+      ImmutableList<String> conceptTypes,
       List<String> domainIds,
       String vocabularyId,
       String conceptClassId,
@@ -91,7 +93,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.vocabularyId = ?3 "
               + "and c.conceptClassId = ?4")
   Page<DbConcept> findConcepts(
-      List<String> conceptTypes,
+      ImmutableList<String> conceptTypes,
       List<String> domainIds,
       String vocabularyId,
       String conceptClassId,

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.cdr.dao;
 
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +26,10 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.standardConcept IN (?2) "
               + "and c.domainId in (?3)")
   Page<DbConcept> findConcepts(
-      String matchExp, ImmutableList<String> conceptTypes, List<String> domainIds, Pageable page);
+      String matchExp,
+      ImmutableList<String> conceptTypes,
+      ImmutableList<String> domainIds,
+      Pageable page);
 
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
@@ -44,7 +46,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.standardConcept IN (?1) "
               + "and c.domainId in (?2)")
   Page<DbConcept> findConcepts(
-      ImmutableList<String> conceptTypes, List<String> domainIds, Pageable page);
+      ImmutableList<String> conceptTypes, ImmutableList<String> domainIds, Pageable page);
 
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
@@ -69,7 +71,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
   Page<DbConcept> findConcepts(
       String matchExp,
       ImmutableList<String> conceptTypes,
-      List<String> domainIds,
+      ImmutableList<String> domainIds,
       String vocabularyId,
       String conceptClassId,
       Pageable page);
@@ -94,7 +96,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.conceptClassId = ?4")
   Page<DbConcept> findConcepts(
       ImmutableList<String> conceptTypes,
-      List<String> domainIds,
+      ImmutableList<String> domainIds,
       String vocabularyId,
       String conceptClassId,
       Pageable page);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -43,4 +43,57 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and c.standardConcept IN (?1) "
               + "and c.domainId in (?2)")
   Page<DbConcept> findConcepts(List<String> conceptTypes, List<String> domainIds, Pageable page);
+
+  /**
+   * Return standard or all concepts in each vocabulary for the specified domain matching the
+   * specified expression, matching concept name, synonym, ID, or code.
+   *
+   * @param matchExp SQL MATCH expression to match concept name or synonym
+   * @param conceptTypes can be 'S', 'C' or ''
+   * @param domainIds domain IDs to use when filtering concepts
+   * @param vocabularyId vocabulary id type to search
+   * @param conceptClassId concept class id type to search
+   * @return per-vocabulary concept counts
+   */
+  @Query(
+      value =
+          "select distinct c from DbConcept c "
+              + "where (c.countValue > 0 or c.sourceCountValue > 0) "
+              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
+              + "and c.standardConcept IN (?2) "
+              + "and c.domainId in (?3) "
+              + "and c.vocabularyId = ?4 "
+              + "and c.conceptClassId = ?5")
+  Page<DbConcept> findConcepts(
+      String matchExp,
+      List<String> conceptTypes,
+      List<String> domainIds,
+      String vocabularyId,
+      String conceptClassId,
+      Pageable page);
+
+  /**
+   * Return standard or all concepts in each vocabulary for the specified domain matching the
+   * specified expression, matching concept name, synonym, ID, or code.
+   *
+   * @param conceptTypes can be 'S', 'C' or ''
+   * @param domainIds domain IDs to use when filtering concepts
+   * @param vocabularyId vocabulary id type to search
+   * @param conceptClassId concept class id type to search
+   * @return per-vocabulary concept counts
+   */
+  @Query(
+      value =
+          "select distinct c from DbConcept c "
+              + "where (c.countValue > 0 or c.sourceCountValue > 0) "
+              + "and c.standardConcept IN (?1) "
+              + "and c.domainId in (?2) "
+              + "and c.vocabularyId = ?3 "
+              + "and c.conceptClassId = ?4")
+  Page<DbConcept> findConcepts(
+      List<String> conceptTypes,
+      List<String> domainIds,
+      String vocabularyId,
+      String conceptClassId,
+      Pageable page);
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
@@ -22,15 +22,15 @@ public interface DomainInfoDao extends CrudRepository<DbDomainInfo, Long> {
       value =
           "select new DbDomainInfo(\n"
               + "d.domain, d.domainId, d.name, d.description,\n"
-              + "d.conceptId, 0L, COUNT(*), d.participantCount)\n"
+              + "d.conceptId, COUNT(*), COUNT(*), d.participantCount)\n"
               + "from DbDomainInfo d\n"
               + "join DbConcept c ON d.domainId = c.domainId\n"
-              + "where c.countValue > 0 \n"
-              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 and\n"
-              + "c.standardConcept IN ('S', 'C')\n"
+              + "where (c.countValue > 0 or c.sourceCountValue > 0)\n"
+              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
+              + "and c.standardConcept IN (?2)\n"
               + "group by d.domain, d.domainId, d.name, d.description, d.conceptId\n"
               + "order by d.domainId")
-  List<DbDomainInfo> findStandardConceptCounts(String matchExpression);
+  List<DbDomainInfo> findConceptCounts(String matchExpression, List<String> conceptTypes);
 
   /**
    * Returns domain metadata and concept counts for domains, matching only PM concepts by name,
@@ -44,37 +44,19 @@ public interface DomainInfoDao extends CrudRepository<DbDomainInfo, Long> {
       value =
           "select new DbDomainInfo(\n"
               + "d.domain, d.domainId, d.name, d.description,\n"
-              + "d.conceptId, COUNT(*), 0L, d.participantCount)\n"
+              + "d.conceptId, COUNT(*), COUNT(*), d.participantCount)\n"
               + "from DbDomainInfo d\n"
               + "join DbConcept c ON 'Measurement' = c.domainId\n"
-              + "where c.vocabularyId = 'PPI'\n"
+              + "where (c.countValue > 0 or c.sourceCountValue > 0)\n"
+              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0\n"
+              + "and c.vocabularyId = 'PPI'\n"
               + "and d.domain = 10\n"
-              + "and c.sourceCountValue > 0\n"
-              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0\n"
+              + "and c.conceptClassId = 'Clinical Observation'\n"
+              + "and c.standardConcept IN (?2)\n"
               + "group by d.domain, d.domainId, d.name, d.description, d.conceptId\n"
               + "order by d.domainId")
-  DbDomainInfo findPhysicalMeasurementConceptCounts(String matchExpression);
-
-  /**
-   * Returns domain metadata and concept counts for domains, matching both standard and non-standard
-   * concepts by name, code, or concept ID. allConceptCount is populated; standardConceptCount are
-   * not needed and set to zero.
-   *
-   * @param matchExpression a boolean full text match expression based on the user's query; see
-   *     https://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
-   */
-  @Query(
-      value =
-          "select new DbDomainInfo(\n"
-              + "d.domain, d.domainId, d.name, d.description,\n"
-              + "d.conceptId, COUNT(*), 0L, d.participantCount)\n"
-              + "from DbDomainInfo d\n"
-              + "join DbConcept c ON d.domainId = c.domainId\n"
-              + "where (c.countValue > 0 or c.sourceCountValue > 0) \n"
-              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0\n"
-              + "group by d.domain, d.domainId, d.name, d.description, d.conceptId\n"
-              + "order by d.domainId")
-  List<DbDomainInfo> findAllMatchConceptCounts(String matchExpression);
+  DbDomainInfo findPhysicalMeasurementConceptCounts(
+      String matchExpression, List<String> conceptTypes);
 
   List<DbDomainInfo> findByOrderByDomainId();
 }

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -12,13 +12,7 @@ import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, summarizeErrors, withCurrentWorkspace} from 'app/utils';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {
-  Concept,
-  ConceptSet,
-  CreateConceptSetRequest,
-  DomainCount,
-  UpdateConceptSetRequest
-} from 'generated/fetch';
+import {Concept, ConceptSet, CreateConceptSetRequest, CriteriaType, Domain, DomainCount, UpdateConceptSetRequest} from 'generated/fetch';
 import {validate} from 'validate.js';
 
 const styles = reactStyles({
@@ -31,6 +25,16 @@ const styles = reactStyles({
   }
 });
 
+const filterConcepts = (concepts: any[], domain: Domain) => {
+  if (domain === Domain.PHYSICALMEASUREMENT) {
+    return concepts.filter(concept => concept.domainId === fp.capitalize(Domain[Domain.MEASUREMENT])
+      && concept.vocabularyId === CriteriaType[CriteriaType.PPI]);
+  } else if (domain === Domain.SURVEY) {
+    return concepts.filter(concept => !!concept.question);
+  } else {
+    return concepts.filter(concept => concept.domainId === fp.capitalize(Domain[domain]));
+  }
+};
 
 export const ConceptAddModal = withCurrentWorkspace()
 (class extends React.Component<{
@@ -66,13 +70,12 @@ export const ConceptAddModal = withCurrentWorkspace()
       name: '',
       saving: false,
       selectedSet: null,
-      selectedConceptsInDomain: props.selectedConcepts
-          .filter((concept: Concept) =>
-              concept.domainId === fp.capitalize(props.selectedDomain.domain))
+      selectedConceptsInDomain: filterConcepts(props.selectedConcepts, props.selectedDomain.domain)
     };
   }
 
   componentDidMount() {
+    console.log(this.props);
     this.getExistingConceptSets();
   }
 
@@ -130,7 +133,7 @@ export const ConceptAddModal = withCurrentWorkspace()
       const conceptSet: ConceptSet = {
         name: name,
         description: newSetDescription,
-        domain: selectedDomain.domain
+        domain: selectedDomain.domain === Domain.PHYSICALMEASUREMENT ? Domain.MEASUREMENT : selectedDomain.domain
       };
       const request: CreateConceptSetRequest = {
         conceptSet: conceptSet,

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -103,8 +103,8 @@ describe('ConceptHomepage', () => {
       );
     });
 
-    // Test that it makes a call for each domain
-    expect(spy).toHaveBeenCalledTimes(DomainStubVariables.STUB_DOMAINS.length);
+    // Test that it makes a call for each domain. Adding 1 to the length since currently we manually add surveys to conceptsCache on init
+    expect(spy).toHaveBeenCalledTimes(DomainStubVariables.STUB_DOMAINS.length + 1);
 
     // Test that it switches to the table view
     expect(wrapper.find('[data-test-id="conceptTable"]').length).toBeGreaterThan(0);

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -337,7 +337,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
       // TODO switch to empty array when we start actually searching surveys and PM
       const completedDomainSearches = [Domain.SURVEY];
       // TODO remove filter below when we start actually searching surveys and PM
-      conceptsCache.filter(item => ![Domain.SURVEY].includes(item.domain)).forEach(async(cacheItem) => {
+      conceptsCache.forEach(async(cacheItem) => {
         selectedConceptDomainMap[cacheItem.domain] = [];
         const activeTabSearch = cacheItem.domain === selectedDomain.domain;
         const resp = await conceptsApi().searchConcepts(namespace, id, {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -343,7 +343,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
           maxResults: this.MAX_CONCEPT_FETCH
         });
         completedDomainSearches.push(cacheItem.domain);
-        cacheItem.items = cacheItem.domain === Domain.SURVEY ? resp.questions : resp.items;
+        cacheItem.items = cacheItem.domain === Domain.SURVEY ? resp.questions || [] : resp.items;
         this.setState({completedDomainSearches: completedDomainSearches});
         if (activeTabSearch) {
           const conceptDomainCounts = environment.enableNewConceptTabs ? [...resp.domainCounts]
@@ -351,8 +351,8 @@ export const ConceptHomepage = withCurrentWorkspace()(
           this.setState({
             searchLoading: false,
             conceptDomainCounts: conceptDomainCounts,
-            selectedDomain: resp.domainCounts
-              .find(domainCount => domainCount.domain === cacheItem.domain)});
+            selectedDomain: resp.domainCounts.find(domainCount => domainCount.domain === cacheItem.domain)
+          });
           this.setConceptsAndVocabularies();
         }
       });
@@ -473,6 +473,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
             Showing top {concepts.length} {selectedDomain.name}
           </div>}
           <ConceptTable concepts={concepts}
+                        domain={selectedDomain.domain}
                         loading={searchLoading}
                         onSelectConcepts={this.selectConcepts.bind(this)}
                         placeholderValue={this.noConceptsConstant}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -382,12 +382,11 @@ export const ConceptHomepage = withCurrentWorkspace()(
       });
     }
 
-    browseDomain(domain: DomainInfo) {
+    browseDomain(domain?: DomainInfo) {
       const {conceptDomainCounts} = this.state;
-      this.setState({browsingSurvey: false, currentSearchString: '',
-        selectedDomain: conceptDomainCounts
-          .find(domainCount => domainCount.domain === domain.domain)},
-        this.searchConcepts);
+      const selectedDomain = !domain ? {domain: Domain.SURVEY, name: 'Surveys', conceptCount: 0}
+        : conceptDomainCounts.find(domainCount => domainCount.domain === domain.domain)
+      this.setState({browsingSurvey: false, currentSearchString: '', selectedDomain: selectedDomain}, this.searchConcepts);
     }
 
     browseSurvey(surveyName) {
@@ -562,11 +561,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                   </div>
                   <div style={styles.cardList}>
                     {conceptSurveysList.map((surveys) => {
-                      return <SurveyCard survey={surveys} key={surveys.orderNumber}
-                                         browseSurvey={() => {this.setState({
-                                           browsingSurvey: true,
-                                           selectedSurvey: surveys.name
-                                         }); }}/>;
+                      return <SurveyCard survey={surveys} key={surveys.orderNumber} browseSurvey={() => this.browseDomain()} />;
                     })}
                    </div>
                   {environment.enableNewConceptTabs && <React.Fragment>

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -322,6 +322,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
             </div>
             {!!conceptSet.concepts ?
             <ConceptTable concepts={conceptSet.concepts} loading={loading}
+                          domain={conceptSet.domain}
                           reactKey={conceptSet.domain.toString()}
                           onSelectConcepts={this.onSelectConcepts.bind(this)}
                           placeholderValue={'No Concepts Found'}

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -5,6 +5,7 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
+import {Domain} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {Column} from 'primereact/column';
 import {DataTable} from 'primereact/datatable';
@@ -158,6 +159,7 @@ export class SynonymsObject extends React.Component<{}, SynonymsObjectState> {
 
 interface Props {
   concepts: any[];
+  domain: Domain;
   loading: boolean;
   onSelectConcepts: Function;
   placeholderValue: string;
@@ -225,6 +227,7 @@ export class ConceptTable extends React.Component<Props, State> {
 
   componentWillReceiveProps(nextProps) {
     if ((nextProps.concepts !==  this.props.concepts)) {
+      console.log(nextProps);
       if (nextProps.concepts !== this.props.concepts && nextProps.concepts.length > 0 ) {
         this.setState({totalRecords: nextProps.concepts.length});
       }
@@ -290,8 +293,7 @@ export class ConceptTable extends React.Component<Props, State> {
   }
 
   renderColumns() {
-    const {concepts} = this.props;
-    const isSurvey = !!concepts && !!concepts.length && !!concepts[0].question;
+    const {domain} = this.props;
     const columns = [
       {
         bodyStyle: {...styles.colStyle, textAlign: 'center'},
@@ -302,7 +304,7 @@ export class ConceptTable extends React.Component<Props, State> {
         selectionMode: 'multiple',
         testId: 'conceptCheckBox'
       },
-      ...(isSurvey ? surveyColumns : domainColumns)
+      ...(domain === Domain.SURVEY ? surveyColumns : domainColumns)
     ];
     return columns.map((col, c) => <Column
       bodyStyle={col.bodyStyle}

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -5,6 +5,7 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
+import {environment} from 'environments/environment';
 import {Domain} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {Column} from 'primereact/column';
@@ -303,7 +304,7 @@ export class ConceptTable extends React.Component<Props, State> {
         selectionMode: 'multiple',
         testId: 'conceptCheckBox'
       },
-      ...(domain === Domain.SURVEY ? surveyColumns : domainColumns)
+      ...(domain === Domain.SURVEY && environment.enableNewConceptTabs ? surveyColumns : domainColumns)
     ];
     return columns.map((col, c) => <Column
       bodyStyle={col.bodyStyle}

--- a/ui/src/testing/stubs/concepts-api-stub.ts
+++ b/ui/src/testing/stubs/concepts-api-stub.ts
@@ -132,6 +132,14 @@ export class DomainStubVariables {
       standardConceptCount: 50,
       allConceptCount: 65,
       participantCount: 200
+    },
+    {
+      domain: Domain.SURVEY,
+      name: 'Survey',
+      description: 'The Surveys Stub',
+      standardConceptCount: 4,
+      allConceptCount: 43,
+      participantCount: 150
     }
   ];
 }


### PR DESCRIPTION
adding PM and Surveys to concept search. This PR includes changes for:

- make-bq-data.sh - update standard concept counts for measurements
- ConceptsController - converting TO_CLIENT_CONCEPT function to a regular method and updating   search to include PM/Survey
- ConceptService - updating service to include PM/Survey calls
- CbCriteriaDao - implemented survey db calls here to allow proper ordering of questions
- ConceptDao - Implemented PM db calls here
- DomainInfoDao - added source/standard checks and implemented call for PM