### PR TITLE
[RISK=NO][NO ticket] Split changeSet for user column and update statements

### DIFF
--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -4,14 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
-    <addColumn tableName="user">
-      <column name="creation_time" type="datetime">
-        <constraints nullable="false" />
-      </column>
-      <column name="last_modified_time" type="datetime">
-        <constraints nullable="false"/>
-      </column>
-    </addColumn>
+  <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
+  	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
+    <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -6,7 +6,7 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
   	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
-  	<sql>ALTER TABLE user MODIFY COLUMN last_modified_time DEFAULT CURRENT_TIMESTAMP()</sql>
+  	<sql>ALTER TABLE user MODIFY COLUMN last_modified_time timestamp DEFAULT CURRENT_TIMESTAMP()</sql>
     <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -6,7 +6,7 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
   	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
-  	<addDefaultValue columnDataType="datetime" columnName="last_modified_time" defaultValueDate="CURRENT_TIMESTAMP" tableName="user"/>
+  	<addDefaultValue columnName="last_modified_time" defaultValueDate="CURRENT_TIMESTAMP" tableName="user"/>
     <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -6,7 +6,7 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
   	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
-  	<sql>ALTER TABLE user MODIFY COLUMN last_modified_time timestamp DEFAULT CURRENT_TIMESTAMP()</sql>
+  	<sql>ALTER TABLE user MODIFY COLUMN last_modified_time DEFAULT CURRENT_TIMESTAMP()</sql>
     <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -6,6 +6,7 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
   	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
+  	<addDefaultValue columnDataType="datetime" columnName="last_modified_time" defaultValueDate="CURRENT_TIMESTAMP" tableName="user"/>
     <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
+++ b/api/db/changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml
@@ -6,7 +6,7 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-116-drop-not-null-constraint-user-creation-date">
   	<dropNotNullConstraint columnDataType="datetime" columnName="creation_time" tableName="user"/>
-  	<addDefaultValue columnName="last_modified_time" defaultValueDate="CURRENT_TIMESTAMP" tableName="user"/>
+  	<sql>ALTER TABLE user MODIFY COLUMN last_modified_time timestamp DEFAULT CURRENT_TIMESTAMP()</sql>
     <sql>update user set last_modified_time = first_sign_in_time where first_sign_in_time is not null</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -123,6 +123,7 @@
     <include file="changelog/db.changelog-113-user-demographics-updates.xml"/>
     <include file="changelog/db.changelog-114-workspace-last-export-date.xml"/>
     <include file="changelog/db.changelog-115-addColumn-user-create-modified.xml"/>
+    <include file="changelog/db.changelog-116-drop-not-null-constraint-user-creation-date.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -268,6 +268,7 @@ public class RdrExportServiceImpl implements RdrExportService {
           RdrWorkspaceUser workspaceUserMap = new RdrWorkspaceUser();
           workspaceUserMap.setUserId((int) userDao.findUserByUsername(email).getUserId());
           workspaceUserMap.setRole(RdrWorkspaceUser.RoleEnum.fromValue(access.getAccessLevel()));
+          workspaceUserMap.setStatus(RdrWorkspaceUser.StatusEnum.ACTIVE);
           rdrWorkspace.addWorkspaceUsersItem(workspaceUserMap);
         });
 


### PR DESCRIPTION
The test build were failing since there were 2 changesets in file db.changelog-115-addColumn-user-create-modified.xml and the one to create creation-date and last_modified_time with null constraint had already been run.

This PR will split and create a new changeSet :
1) To remove null constraint from creation_Date
2) run update sql that will populate last_modified_time to first_sign_in if its not null else have a default value of today's date

Liquibase has an issue, using<addDefaultValue for setting date to current_timestamp doesnt work
since it generates

ALTER TABLE <tablename> ALTER columnName SET DEFAULT NOW() which is incorrect

https://forum.liquibase.org/topic/mysql-timestamp-default-value-should-use-modify-instead-of-alter