### PR TITLE
[RW-4302][risk=no] moving cloud cdr versions.

### DIFF
--- a/api/config/cdr_versions_perf.json
+++ b/api/config/cdr_versions_perf.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,7 @@
     "creationTime": "2018-09-20 00:00:01Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -9,7 +9,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_2"
+    "cdrDbName": "synth_r_2020q1_1"
   },
   {
     "cdrVersionId": 2,
@@ -57,6 +57,6 @@
     "creationTime": "2019-10-21 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 242299,
-    "cdrDbName": "r_2019q4_3"
+    "cdrDbName": "r_2020q1_1"
   }
 ]

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -9,7 +9,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -22,7 +22,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -34,7 +34,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -47,7 +47,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -9,7 +9,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -22,7 +22,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -34,7 +34,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -47,7 +47,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,7 @@
     "creationTime": "2018-09-20 00:00:01Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2019q3_3",
+    "cdrDbName": "synth_r_2020q1_1",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]


### PR DESCRIPTION
move cloud cdr versions in config files
**cdr_versions_test.json** 
synth_r_2019q3_3 -> synth_r_2020q1_1
**cdr_versions_staging.json**
synth_r_2019q3_3 -> synth_r_2020q1_1
**cdr_versions_stable.json**
synth_r_2019q3_3 -> synth_r_2020q1_1
**cdr_versions_perf.json**
synth_r_2019q3_3 -> synth_r_2020q1_1
**cdr_versions_prod.json**
synth_r_2019q3_2 -> synth_r_2020q1_1
r_2019q4_3 -> r_2020q1_1