### PR TITLE
[RISK=NO][No ticket]Add default value to creation_Time

### DIFF
--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -6,18 +6,12 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
     <addColumn tableName="user">
-      <column name="creation_time" type="datetime">
+      <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false" />
       </column>
-      <column name="last_modified_time" type="datetime">
+      <column name="last_modified_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false"/>
       </column>
     </addColumn>
-  </changeSet>
-  <changeSet id="update creation time" author="nsaxena">
-    <sql>update user set creation_time = first_sign_in_time</sql>
-  </changeSet>
-  <changeSet id="update modified time" author="nsaxena">
-    <sql>update user set last_modified_time = first_sign_in_time</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
+  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified-with-null-constraint-and-default">
     <addColumn tableName="user">
       <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false" />


### PR DESCRIPTION
This PR will add default values 'Jan 1 1970' TO user column creation_time and last_modified_time. 

In order for this to reflect on test i will rollback changes for existing 115 as well as remove the entry from databasechangelog in just this case