### PR TITLE
[RISK=MEDIUM][no ticket] Add default value to user creation date and last modified time

### DIFF
--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -6,18 +6,12 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
     <addColumn tableName="user">
-      <column name="creation_time" type="datetime">
+      <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false" />
       </column>
-      <column name="last_modified_time" type="datetime">
+      <column name="last_modified_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false"/>
       </column>
     </addColumn>
-  </changeSet>
-  <changeSet id="update creation time" author="nsaxena">
-    <sql>update user set creation_time = first_sign_in_time</sql>
-  </changeSet>
-  <changeSet id="update modified time" author="nsaxena">
-    <sql>update user set last_modified_time = first_sign_in_time</sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -11,11 +11,11 @@
       </not>
     </preConditions>
     <addColumn tableName="user">
-      <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
-        <constraints nullable="false" />
+      <column name="creation_time" type="datetime">
+        <constraints nullable="true" />
       </column>
-      <column name="last_modified_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
-        <constraints nullable="false" />
+      <column name="last_modified_time" type="datetime" defaultValueDate="CURRENT_TIMESTAMP">
+        <constraints nullable="false"/>
       </column>
     </addColumn>
   </changeSet>

--- a/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
+++ b/api/db/changelog/db.changelog-115-addColumn-user-create-modified.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified">
+  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified-with-null-constraint-and-default">
     <addColumn tableName="user">
       <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false" />

--- a/api/db/changelog/db.changelog-116-drop-user-creation-modified.xml
+++ b/api/db/changelog/db.changelog-116-drop-user-creation-modified.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="nsaxena" id="db.changelog-116-drop-user-creation-modified">
+    <preConditions onFail="MARK_RAN" >       
+      <columnExists tableName="user" columnName="creation_time" />
+    </preConditions>
+    <dropColumn columnName="creation_time" tableName="user"/>
+    <dropColumn columnName="last_modified_time" tableName="user"/>
+  </changeSet>
+</databaseChangeLog>    

--- a/api/db/changelog/db.changelog-117-add-user-creation-modified-column-again.xml
+++ b/api/db/changelog/db.changelog-117-add-user-creation-modified-column-again.xml
@@ -4,12 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="nsaxena" id="db.changelog-115-addColumn-user-create-modified-with-null-constraint-and-default">
-    <preConditions onFail="MARK_RAN" > 
-      <not>         
-        <columnExists tableName="user" columnName="creation_time" />
-      </not>
-    </preConditions>
+  <changeSet author="nsaxena" id="db.changelog-117-add-user-creation-modified-column-again">
     <addColumn tableName="user">
       <column name="creation_time" type="datetime" defaultValueDate="1970-01-01 00:00:00">
         <constraints nullable="false" />
@@ -19,4 +14,4 @@
       </column>
     </addColumn>
   </changeSet>
-</databaseChangeLog>
+</databaseChangeLog>    

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -123,6 +123,8 @@
     <include file="changelog/db.changelog-113-user-demographics-updates.xml"/>
     <include file="changelog/db.changelog-114-workspace-last-export-date.xml"/>
     <include file="changelog/db.changelog-115-addColumn-user-create-modified.xml"/>
+    <include file="changelog/db.changelog-116-drop-user-creation-modified.xml"/>
+    <include file="changelog/db.changelog-117-add-user-creation-modified-column-again.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
This PR has 3 database script file:

1) 115 : Skip if USER TABLE have creation_time and last_modfied_time COLUMNS already else create the two columns with
- creation_time with not null 
-  last_modified_time with null constraint. and default value as current_timestamp
2) 116: DROP column creation_time and  LAST_MODIFIED_TIME if they exist in USER else skip
3) 117: Add columns creation_time and  LAST_MODIFIED_TIME  again with null constraints and defaultdate as 1970 Jan 1

The reason for three scripts are as follows:

1) Date with null constraint cannot be updated later with another default value as it starts giving liquibase base exception 
_liquibase.exception.LiquibaseException: Unexpected error running Liquibase: Data truncation: Incorrect datetime value: '0000-00-00 00:00:00' for column 'creation_time' at row 1 [Failed SQL: ALTER TABLE workbench.user ADD creation_time datetime NOT NULL, ADD last_modified_time datetime NOT NULL]_
2) On test 115 has already run and we do not have permission to ALTER table hence the rollback script ran partially removing the entry from DATABASECHANGELOG but unable to alter table hence we are rerunning 115 with preCondition to ignore onFail
3) Since test already has the columns we want to Default value too and we cannot add default values tag 116 will drop them (if they exist) and 117 will add proper values