### PR TITLE
[RW-4091][RISK=NO] Correct exportRDR cron URL

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -264,7 +264,8 @@ public class RdrExportServiceImpl implements RdrExportService {
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     Map<String, FirecloudWorkspaceAccessEntry> aclMap = firecloudResponse.getAcl();
 
-    // Since the USERS cannot be deleted from workbench yet, hence sending the the status of COLLABORATOR as ACTIVE
+    // Since the USERS cannot be deleted from workbench yet, hence sending the the status of
+    // COLLABORATOR as ACTIVE
     aclMap.forEach(
         (email, access) -> {
           RdrWorkspaceUser workspaceUserMap = new RdrWorkspaceUser();

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -263,11 +263,14 @@ public class RdrExportServiceImpl implements RdrExportService {
         fireCloudService.getWorkspaceAcl(
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     Map<String, FirecloudWorkspaceAccessEntry> aclMap = firecloudResponse.getAcl();
+
+    // Since the USERS cannot be deleted from workbench yet, hence sending the the status of COLLABORATOR as ACTIVE
     aclMap.forEach(
         (email, access) -> {
           RdrWorkspaceUser workspaceUserMap = new RdrWorkspaceUser();
           workspaceUserMap.setUserId((int) userDao.findUserByUsername(email).getUserId());
           workspaceUserMap.setRole(RdrWorkspaceUser.RoleEnum.fromValue(access.getAccessLevel()));
+          workspaceUserMap.setStatus(RdrWorkspaceUser.StatusEnum.ACTIVE);
           rdrWorkspace.addWorkspaceUsersItem(workspaceUserMap);
         });
 

--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -55,7 +55,7 @@ cron:
   timezone: UTC
   target: api
 - description: 'Export user and workspace data to RDR'
-  url: /v1/cron/exportToRDR
+  url: /v1/cron/exportToRdr
   schedule: every 24 hours
   timezone: UTC
   target: api

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchLocationConfigService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchLocationConfigService.java
@@ -23,8 +23,8 @@ public class WorkbenchLocationConfigService {
    */
   public String getCloudTaskLocationId() {
     String appEngineLocationId = workbenchConfig.get().server.appEngineLocationId;
-    if (appEngineLocationId == "us-central") return "us-central1";
-    else if (appEngineLocationId == "europe-west") return "europe-west1";
+    if (appEngineLocationId.equals("us-central")) return "us-central1";
+    else if (appEngineLocationId.equals("europe-west")) return "europe-west1";
     return appEngineLocationId;
   }
 }


### PR DESCRIPTION
While testing i saw the following (silly) errors:
1) Cron yaml url doesnt case match the entry in workbench.yaml
2) String Equal was using == rather than .equal because of which the correct location was not being send.
3) Send Workspace Collaborators Status as ACTIVE to RDR 