### PR TITLE
[RW-2695][risk=moderate] AoU workspace owners are now billing project owners instead of users

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -740,6 +740,16 @@ task loadDataDictionary(type: JavaExec) {
   }
 }
 
+// See project.rb command: backfill-billing-project-users
+task backfillBillingProjectOwners(type: JavaExec) {
+  classpath = sourceSets.tools.runtimeClasspath
+  main = "org.pmiops.workbench.tools.BackfillBillingProjectOwners"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -740,7 +740,7 @@ task loadDataDictionary(type: JavaExec) {
   }
 }
 
-// See project.rb command: backfill-billing-project-users
+// See project.rb command: backfill-billing-project-owners
 task backfillBillingProjectOwners(type: JavaExec) {
   classpath = sourceSets.tools.runtimeClasspath
   main = "org.pmiops.workbench.tools.BackfillBillingProjectOwners"

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -7,6 +7,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -142,7 +143,9 @@ public class BillingGarbageCollectionService {
       garbageCollectionCredentials.refresh();
 
       fireCloudService.removeOwnerFromBillingProject(
-          projectName, appEngineSA, garbageCollectionCredentials.getAccessToken().getTokenValue());
+          projectName,
+          appEngineSA,
+          Optional.of(garbageCollectionCredentials.getAccessToken().getTokenValue()));
     } catch (final ExecutionException e) {
       final String msg =
           String.format(

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -250,7 +250,7 @@ public class BillingProjectBufferService implements GaugeDataCollector {
   public DbBillingProjectBufferEntry assignBillingProject(DbUser dbUser) {
     DbBillingProjectBufferEntry bufferEntry = consumeBufferEntryForAssignment();
 
-    fireCloudService.addUserToBillingProject(
+    fireCloudService.addOwnerToBillingProject(
         dbUser.getUsername(), bufferEntry.getFireCloudProjectName());
     bufferEntry.setStatusEnum(BufferEntryStatus.ASSIGNED, this::getCurrentTimestamp);
     bufferEntry.setAssignedUser(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -50,28 +50,19 @@ public interface FireCloudService {
   /** Get Billing Project Status */
   FirecloudBillingProjectStatus getBillingProjectStatus(String projectName);
 
-  /** Adds the specified user to the specified billing project. */
-  void addUserToBillingProject(String email, String projectName);
-
-  /**
-   * Removes the specified user from the specified billing project.
-   *
-   * <p>Only used for errored billing projects
-   */
-  void removeUserFromBillingProject(String email, String projectName);
-
   /** Adds the specified user as an owner to the specified billing project. */
   void addOwnerToBillingProject(String ownerEmail, String projectName);
 
   /**
    * Removes the specified user as an owner from the specified billing project. Since FireCloud
    * users cannot remove themselves, we need to supply the credential of a different user which will
-   * retain ownership to make the call
+   * retain ownership to make the call.
    *
-   * <p>Only used for billing project garbage collection
+   * <p>The call is made by the SA by default. An optional callerAccessToken can be passed in to use
+   * that as the caller instead.
    */
   void removeOwnerFromBillingProject(
-      String projectName, String ownerEmailToRemove, String callerAccessToken);
+      String projectName, String ownerEmailToRemove, Optional<String> callerAccessToken);
 
   /** Creates a new FC workspace. */
   FirecloudWorkspace createWorkspace(String projectName, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -65,7 +65,6 @@ public class FireCloudServiceImpl implements FireCloudService {
   private static final String MEMBER_ROLE = "member";
   private static final String STATUS_SUBSYSTEMS_KEY = "systems";
 
-  private static final String USER_FC_ROLE = "user";
   private static final String OWNER_FC_ROLE = "owner";
   private static final String THURLOE_STATUS_NAME = "Thurloe";
   private static final String SAM_STATUS_NAME = "Sam";

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -401,13 +401,14 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
             String.format(
                 "removing user '%s' from billing project '%s'",
                 email, workspace.getWorkspaceNamespace()));
-        fireCloudService.removeUserFromBillingProject(email, workspace.getWorkspaceNamespace());
+        fireCloudService.removeOwnerFromBillingProject(
+            email, workspace.getWorkspaceNamespace(), Optional.empty());
       } else if (!FC_OWNER_ROLE.equals(fromAccess) && WorkspaceAccessLevel.OWNER == toAccess) {
         log.info(
             String.format(
                 "adding user '%s' to billing project '%s'",
                 email, workspace.getWorkspaceNamespace()));
-        fireCloudService.addUserToBillingProject(email, workspace.getWorkspaceNamespace());
+        fireCloudService.addOwnerToBillingProject(email, workspace.getWorkspaceNamespace());
       }
     }
 

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -191,6 +191,40 @@ paths:
               - email
               - profile
 
+  /api/billing/{projectId}/members:
+    get:
+      responses:
+        200:
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/RawlsBillingProjectMember'
+        403:
+          description: You must be a project owner to view the members of a project
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: list members of billing project the caller owns
+      parameters:
+        - in: path
+          description: Project ID
+          name: projectId
+          required: true
+          type: string
+      tags:
+        - billing
+      summary: list members of billing project the caller owns
+      operationId: listBillingProjectMembers
+      security:
+        - googleoauth:
+            - openid
+            - email
+            - profile
+
   /api/billing/{projectId}/googleRole/{role}/{email}:
     put:
       responses:
@@ -1203,6 +1237,19 @@ definitions:
         description: the users or groups who were not found
         items:
           $ref: '#/definitions/WorkspaceACLUpdate'
+
+  RawlsBillingProjectMember:
+    description: an element of a list of project users and their role
+    required:
+      - email
+      - role
+    properties:
+      email:
+        type: string
+        description: the email of the user
+      role:
+        type: string
+        description: the role of the user in the project
 
   WorkspaceAccessEntry:
     description: ''

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -191,40 +191,6 @@ paths:
               - email
               - profile
 
-  /api/billing/{projectId}/members:
-    get:
-      responses:
-        200:
-          description: Success
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/RawlsBillingProjectMember'
-        403:
-          description: You must be a project owner to view the members of a project
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        500:
-          description: Rawls Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-      description: list members of billing project the caller owns
-      parameters:
-        - in: path
-          description: Project ID
-          name: projectId
-          required: true
-          type: string
-      tags:
-        - billing
-      summary: list members of billing project the caller owns
-      operationId: listBillingProjectMembers
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
-
   /api/billing/{projectId}/googleRole/{role}/{email}:
     put:
       responses:
@@ -1237,19 +1203,6 @@ definitions:
         description: the users or groups who were not found
         items:
           $ref: '#/definitions/WorkspaceACLUpdate'
-
-  RawlsBillingProjectMember:
-    description: an element of a list of project users and their role
-    required:
-      - email
-      - role
-    properties:
-      email:
-        type: string
-        description: the email of the user
-      role:
-        type: string
-        description: the role of the user in the project
 
   WorkspaceAccessEntry:
     description: ''

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,8 +65,6 @@ public class AuthDomainControllerTest {
   public void setUp() {
     DbUser adminUser = new DbUser();
     adminUser.setUserId(0L);
-    doNothing().when(fireCloudService).addUserToBillingProject(any(), any());
-    doNothing().when(fireCloudService).removeUserFromBillingProject(any(), any());
     when(fireCloudService.createGroup(any())).thenReturn(new FirecloudManagedGroupWithMembers());
     when(userProvider.get()).thenReturn(adminUser);
     WorkbenchConfig config = new WorkbenchConfig();

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -440,7 +440,7 @@ public class BillingProjectBufferServiceTest {
 
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> secondCaptor = ArgumentCaptor.forClass(String.class);
-    verify(mockFireCloudService).addUserToBillingProject(captor.capture(), secondCaptor.capture());
+    verify(mockFireCloudService).addOwnerToBillingProject(captor.capture(), secondCaptor.capture());
     String invokedEmail = captor.getValue();
     String invokedProjectName = secondCaptor.getValue();
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
@@ -1835,9 +1836,10 @@ public class WorkspacesControllerTest {
     workspacesController.shareWorkspace(
         workspace.getNamespace(), workspace.getName(), shareWorkspaceRequest);
     verify(fireCloudService, times(1))
-        .addUserToBillingProject(ownerUser.getUsername(), workspace.getNamespace());
-    verify(fireCloudService, never()).addUserToBillingProject(eq(writerUser.getUsername()), any());
-    verify(fireCloudService, never()).removeUserFromBillingProject(any(), any());
+        .addOwnerToBillingProject(ownerUser.getUsername(), workspace.getNamespace());
+    verify(fireCloudService, never()).addOwnerToBillingProject(eq(writerUser.getUsername()), any());
+    verify(fireCloudService, never())
+        .removeOwnerFromBillingProject(any(), any(), eq(Optional.empty()));
   }
 
   @Test
@@ -1884,10 +1886,11 @@ public class WorkspacesControllerTest {
     workspacesController.shareWorkspace(
         workspace.getNamespace(), workspace.getName(), shareWorkspaceRequest);
     verify(fireCloudService, times(1))
-        .removeUserFromBillingProject(ownerUser.getUsername(), workspace.getNamespace());
+        .removeOwnerFromBillingProject(
+            ownerUser.getUsername(), workspace.getNamespace(), eq(Optional.empty()));
     verify(fireCloudService, never())
-        .removeUserFromBillingProject(eq(writerUser.getUsername()), any());
-    verify(fireCloudService, never()).addUserToBillingProject(any(), any());
+        .removeOwnerFromBillingProject(eq(writerUser.getUsername()), any(), eq(Optional.empty()));
+    verify(fireCloudService, never()).addOwnerToBillingProject(any(), any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1887,7 +1887,7 @@ public class WorkspacesControllerTest {
         workspace.getNamespace(), workspace.getName(), shareWorkspaceRequest);
     verify(fireCloudService, times(1))
         .removeOwnerFromBillingProject(
-            ownerUser.getUsername(), workspace.getNamespace(), eq(Optional.empty()));
+            ownerUser.getUsername(), workspace.getNamespace(), Optional.empty());
     verify(fireCloudService, never())
         .removeOwnerFromBillingProject(eq(writerUser.getUsername()), any(), eq(Optional.empty()));
     verify(fireCloudService, never()).addOwnerToBillingProject(any(), any());

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
@@ -6,6 +6,7 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.cli.CommandLine;
@@ -15,6 +16,7 @@ import org.apache.commons.cli.Options;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+import org.pmiops.workbench.firecloud.model.FirecloudRawlsBillingProjectMember;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACL;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
@@ -90,6 +92,33 @@ public class BackfillBillingProjectOwners {
       String billingProjectPrefix,
       boolean dryRun)
       throws ApiException {
+
+    String projectId = "aou-rw-test-858a2a6d";
+    String user = "ericsong@fake-research-aou.org";
+
+    FirecloudWorkspaceResponse resp = workspacesApi.getWorkspace(projectId, "break", FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS);
+    Map<String, FirecloudWorkspaceAccessEntry> acl = extractAclResponse(workspacesApi.getWorkspaceAcl(resp.getWorkspace().getNamespace(), resp.getWorkspace().getName()));
+
+    log.info("Before anything");
+    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
+      log.info(member.toString());
+    }
+
+    log.info("After adding owner");
+    billingApi.removeUserFromBillingProject(projectId, "user", user);
+    billingApi.addUserToBillingProject(projectId, "owner", user);
+    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
+      log.info(member.toString());
+    }
+
+    log.info("Removing owner");
+    billingApi.removeUserFromBillingProject(projectId, "owner", user);
+
+    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
+      log.info(member.toString());
+    }
+
+    /*
     int userUpgrades = 0;
     for (FirecloudWorkspaceResponse resp :
         workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS)) {
@@ -132,6 +161,7 @@ public class BackfillBillingProjectOwners {
     }
 
     dryLog(dryRun, String.format("added %d users as billing project owners", userUpgrades));
+     */
   }
 
   @Bean

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
@@ -6,7 +6,6 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.cli.CommandLine;
@@ -16,7 +15,6 @@ import org.apache.commons.cli.Options;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
-import org.pmiops.workbench.firecloud.model.FirecloudRawlsBillingProjectMember;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACL;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
@@ -92,33 +90,6 @@ public class BackfillBillingProjectOwners {
       String billingProjectPrefix,
       boolean dryRun)
       throws ApiException {
-
-    String projectId = "aou-rw-test-858a2a6d";
-    String user = "ericsong@fake-research-aou.org";
-
-    FirecloudWorkspaceResponse resp = workspacesApi.getWorkspace(projectId, "break", FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS);
-    Map<String, FirecloudWorkspaceAccessEntry> acl = extractAclResponse(workspacesApi.getWorkspaceAcl(resp.getWorkspace().getNamespace(), resp.getWorkspace().getName()));
-
-    log.info("Before anything");
-    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
-      log.info(member.toString());
-    }
-
-    log.info("After adding owner");
-    billingApi.removeUserFromBillingProject(projectId, "user", user);
-    billingApi.addUserToBillingProject(projectId, "owner", user);
-    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
-      log.info(member.toString());
-    }
-
-    log.info("Removing owner");
-    billingApi.removeUserFromBillingProject(projectId, "owner", user);
-
-    for (FirecloudRawlsBillingProjectMember member : billingApi.listBillingProjectMembers("aou-rw-test-858a2a6d")) {
-      log.info(member.toString());
-    }
-
-    /*
     int userUpgrades = 0;
     for (FirecloudWorkspaceResponse resp :
         workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS)) {
@@ -161,7 +132,6 @@ public class BackfillBillingProjectOwners {
     }
 
     dryLog(dryRun, String.format("added %d users as billing project owners", userUpgrades));
-     */
   }
 
   @Bean

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillBillingProjectOwners.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
  * Backfill script for granting the billing project owner role to all AoU owners (corresponding to
  * Firecloud OWNER access).
  *
- * <p>For http://broad.io/1ppw, collaborators need to be either writers or billing project users in
+ * <p>For http://broad.io/1ppw, collaborators need to be either writers or billing project owners in
  * order to launch clusters within shared billing projects, see RW-3009 and RW-3188 for details.
  *
  * <p>The original iteration of this file was used to backfill the billing project user role to all


### PR DESCRIPTION
Description:
We are increasing the scope of the AoU workspace owner (also the Firecloud project owner) to grant the owner role on the corresponding billing project. This grant takes place on new workspace creation as well as workspace sharing. Ownership is removed if a user is removed as an owner from a billing project.

This PR also adds a project.rb command which will backfill all existing workspace owners as billing project owners. This is an adaptation of the backfill billing project users script. The most notable changes are

- Granting "owner" instead of "user"
- Not skipping over workspace creators

Running the dry-run version of the script on stable results in 468 calls
`INFO: [DRY RUN] Would have... added 468 users as billing project owners` 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
