### PR TITLE
[RW-4279][RW-4293][Risk=low] Add db fields for demographic survey

### DIFF
--- a/api/db/changelog/db.changelog-120-update-demographics.xml
+++ b/api/db/changelog/db.changelog-120-update-demographics.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="srubenst" id="db.changelog-120-update-demographics">
+    <dropTable tableName="demographic_survey_sexual_orientation"/>
+    <dropTable tableName="demographic_survey_gender"/>
+    <addColumn tableName="user">
+      <column name="professional_url" type="varchar(255)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="demographic_survey">
+      <column name="identifies_as_lgbtq" type="boolean">
+        <constraints nullable="true"/>
+      </column>
+      <column name="lgbtq_identity" type="varchar(255)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-120-update-demographics.xml
+++ b/api/db/changelog/db.changelog-120-update-demographics.xml
@@ -14,7 +14,7 @@
       <column name="identifies_as_lgbtq" type="boolean">
         <constraints nullable="true"/>
       </column>
-      <column name="lgbtq_identity" type="varchar(255)">
+      <column name="lgbtq_identity" type="text">
         <constraints nullable="true"/>
       </column>
     </addColumn>

--- a/api/db/changelog/db.changelog-120-update-demographics.xml
+++ b/api/db/changelog/db.changelog-120-update-demographics.xml
@@ -5,8 +5,6 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="srubenst" id="db.changelog-120-update-demographics">
-    <dropTable tableName="demographic_survey_sexual_orientation"/>
-    <dropTable tableName="demographic_survey_gender"/>
     <addColumn tableName="user">
       <column name="professional_url" type="varchar(255)">
         <constraints nullable="true"/>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -127,6 +127,7 @@
     <include file="changelog/db.changelog-117-add-user-creation-modified-column-again.xml"/>
     <include file="changelog/db.changelog-118-add-billing-account-to-workspaces.xml"/>
     <include file="changelog/db.changelog-119-drop-billing-account-name.xml"/>
+    <include file="changelog/db.changelog-120-update-demographics.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -150,15 +150,13 @@ public class ProfileController implements ProfileApiDelegate {
                     demographicSurvey.getDisability() ? Disability.TRUE : Disability.FALSE);
               if (demographicSurvey.getEducation() != null)
                 result.setEducationEnum(demographicSurvey.getEducation());
-              if (demographicSurvey.getGender() != null)
-                result.setGenderEnum(demographicSurvey.getGender());
+              result.setIdentifiesAsLgbtq(demographicSurvey.getIdentifiesAsLgbtq());
+              result.setLgbtqIdentity(demographicSurvey.getLgbtqIdentity());
               if (demographicSurvey.getDisability() != null)
                 result.setDisabilityEnum(
                     demographicSurvey.getDisability() ? Disability.TRUE : Disability.FALSE);
               if (demographicSurvey.getSexAtBirth() != null)
                 result.setSexAtBirthEnum(demographicSurvey.getSexAtBirth());
-              if (demographicSurvey.getSexualOrientation() != null)
-                result.setSexualOrientationEnum(demographicSurvey.getSexualOrientation());
               if (demographicSurvey.getYearOfBirth() != null)
                 result.setYear_of_birth(demographicSurvey.getYearOfBirth().intValue());
               return result;
@@ -355,6 +353,7 @@ public class ProfileController implements ProfileApiDelegate {
             request.getProfile().getCurrentPosition(),
             request.getProfile().getOrganization(),
             request.getProfile().getAreaOfResearch(),
+            request.getProfile().getProfessionalUrl(),
             request.getProfile().getDegrees(),
             FROM_CLIENT_ADDRESS.apply(request.getProfile().getAddress()),
             FROM_CLIENT_DEMOGRAPHIC_SURVEY.apply(request.getProfile().getDemographicSurvey()),
@@ -561,6 +560,7 @@ public class ProfileController implements ProfileApiDelegate {
     user.setAboutYou(updatedProfile.getAboutYou());
     user.setAreaOfResearch(updatedProfile.getAreaOfResearch());
     user.setLastModifiedTime(now);
+    user.setProfessionalUrl(updatedProfile.getProfessionalUrl());
     if (updatedProfile.getContactEmail() != null
         && !updatedProfile.getContactEmail().equals(user.getContactEmail())) {
       // See RW-1488.

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -58,10 +58,10 @@ public class ProfileService {
               }
               result.setEducation(demographicSurvey.getEducationEnum());
               result.setEthnicity(demographicSurvey.getEthnicityEnum());
-              result.setGender(demographicSurvey.getGenderEnum());
+              result.setIdentifiesAsLgbtq(demographicSurvey.getIdentifiesAsLgbtq());
+              result.setLgbtqIdentity(demographicSurvey.getLgbtqIdentity());
               result.setRace(demographicSurvey.getRaceEnum());
               result.setSexAtBirth(demographicSurvey.getSexAtBirthEnum());
-              result.setSexualOrientation(demographicSurvey.getSexualOrientationEnum());
               result.setYearOfBirth(BigDecimal.valueOf(demographicSurvey.getYear_of_birth()));
 
               return result;
@@ -121,7 +121,7 @@ public class ProfileService {
     profile.setAreaOfResearch(user.getAreaOfResearch());
     profile.setDisabled(user.getDisabled());
     profile.setEraCommonsLinkedNihUsername(user.getEraCommonsLinkedNihUsername());
-
+    profile.setProfessionalUrl(user.getProfessionalUrl());
     if (user.getComplianceTrainingCompletionTime() != null) {
       profile.setComplianceTrainingCompletionTime(
           user.getComplianceTrainingCompletionTime().getTime());

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -34,6 +34,7 @@ public interface UserService {
       String currentPosition,
       String organization,
       String areaOfResearch,
+      String professionalUrl,
       List<Degree> degrees,
       DbAddress address,
       DbDemographicSurvey demographicSurvey,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -302,6 +302,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         null,
         null,
         null,
+        null,
         null);
   }
 
@@ -314,6 +315,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       String currentPosition,
       String organization,
       String areaOfResearch,
+      String professionalUrl,
       List<Degree> degrees,
       DbAddress address,
       DbDemographicSurvey demographicSurvey,
@@ -328,6 +330,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     dbUser.setAreaOfResearch(areaOfResearch);
     dbUser.setFamilyName(familyName);
     dbUser.setGivenName(givenName);
+    dbUser.setProfessionalUrl(professionalUrl);
     dbUser.setDisabled(false);
     dbUser.setAboutYou(null);
     dbUser.setEmailVerificationStatusEnum(EmailVerificationStatus.UNVERIFIED);

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
@@ -28,12 +28,12 @@ public class DbDemographicSurvey {
   private Short disability;
   private Short education;
   private Short ethnicity;
-  private List<Short> gender;
   private long id;
+  private boolean identifiesAsLgbtq;
+  private String lgbtqIdentity;
   private DbUser user;
   private List<Short> race;
   private List<Short> sexAtBirth;
-  private List<Short> sexualOrientation;
   private int year_of_birth;
 
   public DbDemographicSurvey() {}
@@ -42,10 +42,8 @@ public class DbDemographicSurvey {
     this.disability = DemographicSurveyEnum.disabilityToStorage(demographicSurvey.getDisability());
     this.education = DemographicSurveyEnum.educationToStorage(demographicSurvey.getEducation());
     this.ethnicity = DemographicSurveyEnum.ethnicityToStorage(demographicSurvey.getEthnicity());
-    this.gender =
-        demographicSurvey.getGender().stream()
-            .map(DemographicSurveyEnum::genderToStorage)
-            .collect(Collectors.toList());
+    this.identifiesAsLgbtq = demographicSurvey.getIdentifiesAsLgbtq();
+    this.lgbtqIdentity = demographicSurvey.getLgbtqIdentity();
     this.race =
         demographicSurvey.getRace().stream()
             .map(DemographicSurveyEnum::raceToStorage)
@@ -53,10 +51,6 @@ public class DbDemographicSurvey {
     this.sexAtBirth =
         demographicSurvey.getSexAtBirth().stream()
             .map(DemographicSurveyEnum::sexAtBirthToStorage)
-            .collect(Collectors.toList());
-    this.sexualOrientation =
-        demographicSurvey.getSexualOrientation().stream()
-            .map(DemographicSurveyEnum::sexualOrientationToStorage)
             .collect(Collectors.toList());
     this.year_of_birth = demographicSurvey.getYearOfBirth().intValue();
   }
@@ -117,34 +111,6 @@ public class DbDemographicSurvey {
     this.ethnicity = DemographicSurveyEnum.ethnicityToStorage(ethnicity);
   }
 
-  @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(
-      name = "demographic_survey_gender",
-      joinColumns = @JoinColumn(name = "demographic_survey_id"))
-  @Column(name = "gender")
-  public List<Short> getGender() {
-    return gender;
-  }
-
-  public void setGender(List<Short> gender) {
-    this.gender = gender;
-  }
-
-  @Transient
-  public List<Gender> getGenderEnum() {
-    if (gender == null) return null;
-    return this.gender.stream()
-        .map(DemographicSurveyEnum::genderFromStorage)
-        .collect(Collectors.toList());
-  }
-
-  public void setGenderEnum(List<Gender> genderList) {
-    this.gender =
-        genderList.stream()
-            .map(DemographicSurveyEnum::genderToStorage)
-            .collect(Collectors.toList());
-  }
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "demographic_survey_id")
@@ -154,6 +120,24 @@ public class DbDemographicSurvey {
 
   public void setId(long demographic_survey_id) {
     this.id = demographic_survey_id;
+  }
+
+  @Column(name = "identifies_as_lgbtq")
+  public Boolean getIdentifiesAsLgbtq() {
+    return identifiesAsLgbtq;
+  }
+
+  public void setIdentifiesAsLgbtq(boolean identifiesAsLgbtq) {
+    this.identifiesAsLgbtq = identifiesAsLgbtq;
+  }
+
+  @Column(name = "lgbtq_identity")
+  public String getLgbtqIdentity() {
+    return lgbtqIdentity;
+  }
+
+  public void setLgbtqIdentity(String lgbtqIdentity) {
+    this.lgbtqIdentity = lgbtqIdentity;
   }
 
   @ManyToOne
@@ -220,33 +204,7 @@ public class DbDemographicSurvey {
             .collect(Collectors.toList());
   }
 
-  @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(
-      name = "demographic_survey_sexual_orientation",
-      joinColumns = @JoinColumn(name = "demographic_survey_id"))
-  @Column(name = "sexual_orientation")
-  public List<Short> getSexualOrientation() {
-    return sexualOrientation;
-  }
 
-  public void setSexualOrientation(List<Short> sexualOrientation) {
-    this.sexualOrientation = sexualOrientation;
-  }
-
-  @Transient
-  public List<SexualOrientation> getSexualOrientationEnum() {
-    if (sexualOrientation == null) return null;
-    return this.sexualOrientation.stream()
-        .map(DemographicSurveyEnum::sexualOrientationFromStorage)
-        .collect(Collectors.toList());
-  }
-
-  public void setSexualOrientationEnum(List<SexualOrientation> sexualOrientationList) {
-    this.sexualOrientation =
-        sexualOrientationList.stream()
-            .map(DemographicSurveyEnum::sexualOrientationToStorage)
-            .collect(Collectors.toList());
-  }
 
   @Column(name = "year_of_birth")
   public int getYear_of_birth() {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
@@ -29,7 +29,7 @@ public class DbDemographicSurvey {
   private Short education;
   private Short ethnicity;
   private long id;
-  private boolean identifiesAsLgbtq;
+  private Boolean identifiesAsLgbtq;
   private String lgbtqIdentity;
   private DbUser user;
   private List<Short> race;
@@ -127,7 +127,7 @@ public class DbDemographicSurvey {
     return identifiesAsLgbtq;
   }
 
-  public void setIdentifiesAsLgbtq(boolean identifiesAsLgbtq) {
+  public void setIdentifiesAsLgbtq(Boolean identifiesAsLgbtq) {
     this.identifiesAsLgbtq = identifiesAsLgbtq;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurvey.java
@@ -17,10 +17,8 @@ import javax.persistence.Transient;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.Education;
 import org.pmiops.workbench.model.Ethnicity;
-import org.pmiops.workbench.model.Gender;
 import org.pmiops.workbench.model.Race;
 import org.pmiops.workbench.model.SexAtBirth;
-import org.pmiops.workbench.model.SexualOrientation;
 
 @Entity
 @Table(name = "demographic_survey")
@@ -203,8 +201,6 @@ public class DbDemographicSurvey {
             .map(DemographicSurveyEnum::sexAtBirthToStorage)
             .collect(Collectors.toList());
   }
-
-
 
   @Column(name = "year_of_birth")
   public int getYear_of_birth() {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -61,6 +61,7 @@ public class DbUser {
   private String givenName;
   private String familyName;
   private String phoneNumber;
+  private String professionalUrl;
   private String currentPosition;
   private String organization;
   private Double freeTierCreditsLimitDollarsOverride = null;
@@ -686,6 +687,15 @@ public class DbUser {
 
   public void setCreationTime(Timestamp creationTime) {
     this.creationTime = creationTime;
+  }
+
+  @Column(name = "professional_url")
+  public String getProfessionalUrl() {
+    return professionalUrl;
+  }
+
+  public void setProfessionalUrl(String professionalUrl) {
+    this.professionalUrl = professionalUrl;
   }
 
   @OneToOne(

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -165,6 +165,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
               null,
               null,
               null,
+              null,
               null);
     } else {
       if (user.getDisabled()) {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -193,11 +193,6 @@ public class RdrExportServiceImpl implements RdrExportService {
             RdrExportEnums.sexAtBirthToRdrSexAtBirth(
                 dbDemographicSurvey.getSexAtBirthEnum().get(0)));
       }
-      if (dbDemographicSurvey.getSexualOrientationEnum() != null) {
-        researcher.setSexualOrientation(
-            RdrExportEnums.sexualOrientationToRdrSexualOrientation(
-                dbDemographicSurvey.getSexualOrientationEnum().get(0)));
-      }
       researcher.setDisability(
           RdrExportEnums.disabilityToRdrDisability(dbDemographicSurvey.getDisabilityEnum()));
     }
@@ -209,14 +204,6 @@ public class RdrExportServiceImpl implements RdrExportService {
               .collect(Collectors.toList()));
     } else {
       researcher.setRace(new ArrayList<>());
-    }
-    if (null != dbDemographicSurvey && dbDemographicSurvey.getGenderEnum() != null) {
-      researcher.setGender(
-          dbDemographicSurvey.getGenderEnum().stream()
-              .map(dbUserGender -> RdrExportEnums.genderToRdrGender(dbUserGender))
-              .collect(Collectors.toList()));
-    } else {
-      researcher.setGender(new ArrayList<>());
     }
     researcher.setAffiliations(
         dbUser.getInstitutionalAffiliations().stream()

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -3519,6 +3519,9 @@ definitions:
       phoneNumber:
         description: the user's phone number
         type: string
+      professionalUrl:
+        description: the link to the user's professional url
+        type: string
       currentPosition:
         description: the user's curent position (job title)
         type: string
@@ -3653,18 +3656,14 @@ definitions:
           $ref: '#/definitions/Race'
       ethnicity:
         $ref: '#/definitions/Ethnicity'
-      gender:
-        type: array
-        items:
-          $ref: '#/definitions/Gender'
+      identifiesAsLgbtq:
+        type: boolean
+      lgbtqIdentity:
+        type: string
       sexAtBirth:
         type: array
         items:
           $ref: '#/definitions/SexAtBirth'
-      sexualOrientation:
-        type: array
-        items:
-          $ref: '#/definitions/SexualOrientation'
       yearOfBirth:
         type: number
       education:

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
@@ -85,10 +85,11 @@ class ProfileAuditorTest {
         val demographicSurvey1 = DemographicSurvey()
             .apply { disability = false }
             .apply { ethnicity = Ethnicity.NOT_HISPANIC }
-            .apply { gender = listOf(Gender.PREFER_NO_ANSWER) }
             .apply { yearOfBirth = BigDecimal.valueOf(1999) }
             .apply { race = listOf(Race.PREFER_NO_ANSWER) }
             .apply { education = Education.MASTER }
+            .apply { identifiesAsLgbtq = true }
+            .apply { lgbtqIdentity = "gay" }
 
         return Profile()
             .apply { userId = 444 }
@@ -103,6 +104,7 @@ class ProfileAuditorTest {
             .apply { disabled = false }
             .apply { aboutYou = "Nobody in particular" }
             .apply { areaOfResearch = "Aliens" }
+            .apply { professionalUrl = "linkedin.com" }
             .apply { institutionalAffiliations = listOf(caltechAffiliation, mitAffiliation) }
             .apply { demographicSurvey = demographicSurvey1 }
     }

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
@@ -22,7 +22,6 @@ import org.pmiops.workbench.model.DataAccessLevel
 import org.pmiops.workbench.model.DemographicSurvey
 import org.pmiops.workbench.model.Education
 import org.pmiops.workbench.model.Ethnicity
-import org.pmiops.workbench.model.Gender
 import org.pmiops.workbench.model.InstitutionalAffiliation
 import org.pmiops.workbench.model.NonAcademicAffiliation
 import org.pmiops.workbench.model.Profile

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -190,7 +190,7 @@ public class AuthInterceptorTest {
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(null);
     when(userService.createUser(
-            "Bob", "Jones", "bob@fake-domain.org", null, null, null, null, null, null, null, null))
+            "Bob", "Jones", "bob@fake-domain.org", null, null, null, null, null, null, null, null, null))
         .thenReturn(user);
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -190,7 +190,18 @@ public class AuthInterceptorTest {
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(null);
     when(userService.createUser(
-            "Bob", "Jones", "bob@fake-domain.org", null, null, null, null, null, null, null, null, null))
+            "Bob",
+            "Jones",
+            "bob@fake-domain.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null))
         .thenReturn(user);
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }

--- a/ui/src/app/pages/login/account-creation/account-creation-options.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-options.tsx
@@ -4,12 +4,10 @@ import {
   Education,
   EducationalRole,
   Ethnicity,
-  Gender,
   IndustryRole,
   NonAcademicAffiliation,
   Race,
-  SexAtBirth,
-  SexualOrientation
+  SexAtBirth
 } from 'generated/fetch';
 
 export const AccountCreationOptions = {

--- a/ui/src/app/pages/login/account-creation/account-creation-options.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-options.tsx
@@ -77,29 +77,12 @@ export const AccountCreationOptions = {
     {label: `Not Hispanic or Latino`, value: Ethnicity.NOTHISPANIC},
     {label: ` Prefer not to answer`, value: Ethnicity.PREFERNOANSWER}
   ],
-  gender: [
-    {label: 'Male', value: Gender.MALE},
-    {label: 'Female', value: Gender.FEMALE},
-    {label: 'Non-binary', value: Gender.NONBINARY},
-    {label: 'Transgender', value: Gender.TRANSGENDER},
-    {label: 'Intersex', value: Gender.INTERSEX},
-    {label: `Prefer not to answer`, value: Gender.PREFERNOANSWER},
-    {label: `None of these describe me`, value: Gender.NONE}
-  ],
   sexAtBirth: [
     {label: 'Female', value: SexAtBirth.FEMALE},
     {label: 'Intersex', value: SexAtBirth.INTERSEX},
     {label: 'Male', value: SexAtBirth.MALE},
     {label: 'None of these describe me', value: SexAtBirth.NONEOFTHESEDESCRIBEME},
     {label: 'Prefer not to answer', value: SexAtBirth.PREFERNOANSWER}
-  ],
-  sexualOrientation: [
-    {label: 'Lesbian', value: SexualOrientation.LESBIAN},
-    {label: 'Gay', value: SexualOrientation.GAY},
-    {label: 'Straight', value: SexualOrientation.STRAIGHT},
-    {label: 'Bisexual', value: SexualOrientation.BISEXUAL},
-    {label: 'None of these describe me', value: SexualOrientation.NONEOFTHESEDESCRIBEME},
-    {label: 'Prefer not to answer', value: SexualOrientation.PREFERNOANSWER}
   ],
   levelOfEducation: [
     {label: 'Never attended school/no formal education', value: Education.NOEDUCATION},

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -13,7 +13,7 @@ import {
   Race,
   SexAtBirth,
 } from 'generated/fetch';
-import {Section} from './account-creation';
+import {Section, TextInputWithLabel} from './account-creation';
 
 import {signedOutImages} from 'app/pages/login/signed-out-images';
 import {
@@ -109,16 +109,20 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
   }
 
   toggleDisability(value) {
-    this.setState(fp.set(['profile', 'demographicSurvey', 'disability'], value));
+    this.updateDemographicAttribute('disability', value);
+  }
+
+  toggleIdentifiesAsLgbtq(value) {
+    this.updateDemographicAttribute('identifiesAsLgbtq', value);
   }
 
   updateDemographicAttribute(attribute, value) {
     this.setState(fp.set(['profile', 'demographicSurvey', attribute], value));
   }
 
-  createOptionCheckbox(checkboxLabel: string, optionKey: string, optionValue: any) {
+  createOptionCheckbox(checkboxLabel: string, optionKey: string, optionValue: any, key: string) {
     return <CheckBox label={checkboxLabel}
-                     style={styles.checkbox}
+                     style={styles.checkbox} key={key}
                      wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
                      onChange={(value) => this.updateList(optionKey, optionValue)}
     />;
@@ -136,52 +140,75 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       </ListPageHeader>
 
       {/*Race section*/}
-      <Section header='1. Race'>
+      <Section header='Race'>
         <div style={{display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap'}}>
           {AccountCreationOptions.race.map((race) => {
-            return this.createOptionCheckbox(race.label, 'race', race.value);
+            return this.createOptionCheckbox(race.label, 'race', race.value, race.value.toString());
           })}
         </div>
       </Section>
 
       {/*Ethnicity section*/}
-      <DropDownSection header='2. Ethnicity' options={AccountCreationOptions.ethnicity}
+      <DropDownSection header='Ethnicity' options={AccountCreationOptions.ethnicity}
                        value={demographicSurvey.ethnicity}
                        onChange={(e) => this.updateDemographicAttribute('ethnicity', e)}/>
+      <Section header='Do you identify as lesbian, gay, bisexual, transgender, queer (LGBTQ),
+or another sexual and/or gender minority?'>
+        <div style={{paddingTop: '0.5rem'}}>
+          <RadioButton onChange={
+            (e) => this.toggleIdentifiesAsLgbtq(true)}
+                       checked={demographicSurvey.identifiesAsLgbtq}
+                       style={{marginRight: '0.5rem'}}/>
+          <label style={{paddingRight: '3rem', color: colors.primary}}>
+            Yes
+          </label>
+          <RadioButton onChange={(e) => this.toggleIdentifiesAsLgbtq(false)}
+                       checked={!demographicSurvey.identifiesAsLgbtq}
+                       style={{marginRight: '0.5rem'}}/>
+          <label style={{color: colors.primary}}>No</label>
+        </div>
+        <label></label>
+        <TextInputWithLabel labelText='If yes, please tell us about your LGBTQ+ identity'
+                            value={demographicSurvey.lgbtqIdentity} inputName='lgbtqIdentity'
+                            containerStyle={{width: '26rem'}} inputStyle={{width: '26rem'}}
+                            onChange={(value) => this.updateDemographicAttribute('lgbtqIdentity', value)}
+                            disabled={!demographicSurvey.identifiesAsLgbtq}/>
+      </Section>
       {/*Sex at birth section*/}
-      <Section header='4. Sex at birth'>
+      <Section header='Sex at birth'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexAtBirth.map((sexAtBirth) => {
-            return this.createOptionCheckbox(sexAtBirth.label, 'sexAtBirth', sexAtBirth.value);
+            return this.createOptionCheckbox(sexAtBirth.label, 'sexAtBirth',
+              sexAtBirth.value, sexAtBirth.value.toString());
           })}
         </FlexRow>
       </Section>
 
       {/*Year of birth section*/}
-      <DropDownSection header='6. Year of Birth' options={AccountCreationOptions.Years}
+      <DropDownSection header='Year of Birth' options={AccountCreationOptions.Years}
                        value={demographicSurvey.yearOfBirth}
                        onChange={(e) => this.updateDemographicAttribute('yearOfBirth', e)}
       />
 
       {/*Education section*/}
-      <DropDownSection header='7. Highest Level of Education Completed'
+      <DropDownSection header='Highest Level of Education Completed'
                        options={AccountCreationOptions.levelOfEducation}
                        value={demographicSurvey.education}
                        onChange={
                          (e) => this.updateDemographicAttribute('education', e)}/>
 
       {/*Disability section*/}
-      <Section header='8. Do you have a Physical or Cognitive disability?'>
+      <Section header='Do you have a Physical or Cognitive disability?'>
         <div style={{paddingTop: '0.5rem'}}>
           <RadioButton onChange={
             (e) => this.toggleDisability(true)}
-                       checked={this.state.profile.demographicSurvey.disability}
+                       checked={demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{paddingRight: '3rem', color: colors.primary}}>
             Yes
           </label>
           <RadioButton onChange={(e) => this.toggleDisability(false)}
-                       checked={!this.state.profile.demographicSurvey.disability}
+                       checked={!demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{color: colors.primary}}>No</label>
         </div>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -208,9 +208,7 @@ or another sexual and/or gender minority?'>
             (e) => this.updateDemographicAttribute('disability', true)}
                        checked={demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>
-          <label style={{paddingRight: '3rem', color: colors.primary}}>
-            Yes
-          </label>
+          <label style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           <RadioButton onChange={(e) => this.updateDemographicAttribute('disability', false)}
                        checked={!demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -15,11 +15,13 @@ import {
 } from 'generated/fetch';
 import {Section, TextInputWithLabel} from './account-creation';
 
+import {TooltipTrigger} from 'app/components/popups';
 import {signedOutImages} from 'app/pages/login/signed-out-images';
 import {
   profileApi
 } from 'app/services/swagger-fetch-clients';
 import {toggleIncludes} from 'app/utils';
+import * as validate from 'validate.js';
 import {AccountCreationOptions} from './account-creation-options';
 
 
@@ -130,6 +132,16 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
 
   render() {
     const {profile: {demographicSurvey}} = this.state;
+    const validationCheck = {
+      lgbtqIdentity: {
+        length: {
+          maximum: 255,
+          tooLong: 'is too long for our system. Please reduce to 255 or fewer characters.'
+        }
+      },
+    };
+    const errors = validate(demographicSurvey, validationCheck);
+    console.log(errors);
     return <div style={{marginTop: '1rem', paddingLeft: '3rem', width: '26rem'}}>
       <label style={{color: colors.primary, fontSize: 16}}>
         Please complete Step 2 of 2
@@ -219,10 +231,17 @@ or another sexual and/or gender minority?'>
                 onClick={() => this.props.setProfile(this.profileObj, {stepName: 'accountCreation'})}>
           Previous
         </Button>
-        <Button type='primary' disabled={this.state.creatingAccount || this.state.creatingAccount}
-                onClick={() => this.createAccount()}>
-          Submit
-        </Button>
+        <TooltipTrigger content={errors && <React.Fragment>
+            <div>Please review the following: </div>
+            <ul>
+              {Object.keys(errors).map((key) => <li key={errors[key][0]}>{errors[key][0]}</li>)}
+            </ul>
+        </React.Fragment>}>
+          <Button type='primary' disabled={this.state.creatingAccount || this.state.creatingAccount || errors}
+                  onClick={() => this.createAccount()}>
+            Submit
+          </Button>
+        </TooltipTrigger>
       </div>
     </div>;
   }

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -107,15 +107,7 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
   updateList(attribute, value) {
     // Toggle Includes removes the element if it already exist and adds if not
     const attributeList = toggleIncludes(value, this.state.profile.demographicSurvey[attribute]);
-    this.setState(fp.set(['profile', 'demographicSurvey', attribute], attributeList));
-  }
-
-  toggleDisability(value) {
-    this.updateDemographicAttribute('disability', value);
-  }
-
-  toggleIdentifiesAsLgbtq(value) {
-    this.updateDemographicAttribute('identifiesAsLgbtq', value);
+    this.updateDemographicAttribute(attribute, attributeList);
   }
 
   updateDemographicAttribute(attribute, value) {
@@ -168,13 +160,13 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
 or another sexual and/or gender minority?'>
         <div style={{paddingTop: '0.5rem'}}>
           <RadioButton onChange={
-            (e) => this.toggleIdentifiesAsLgbtq(true)}
+            (e) => this.updateDemographicAttribute('identifiesAsLgbtq', true)}
                        checked={demographicSurvey.identifiesAsLgbtq}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{paddingRight: '3rem', color: colors.primary}}>
             Yes
           </label>
-          <RadioButton onChange={(e) => this.toggleIdentifiesAsLgbtq(false)}
+          <RadioButton onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
                        checked={!demographicSurvey.identifiesAsLgbtq}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{color: colors.primary}}>No</label>
@@ -213,13 +205,13 @@ or another sexual and/or gender minority?'>
       <Section header='Do you have a Physical or Cognitive disability?'>
         <div style={{paddingTop: '0.5rem'}}>
           <RadioButton onChange={
-            (e) => this.toggleDisability(true)}
+            (e) => this.updateDemographicAttribute('disability', true)}
                        checked={demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{paddingRight: '3rem', color: colors.primary}}>
             Yes
           </label>
-          <RadioButton onChange={(e) => this.toggleDisability(false)}
+          <RadioButton onChange={(e) => this.updateDemographicAttribute('disability', false)}
                        checked={!demographicSurvey.disability}
                        style={{marginRight: '0.5rem'}}/>
           <label style={{color: colors.primary}}>No</label>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -9,11 +9,9 @@ import {CheckBox, RadioButton} from 'app/components/inputs';
 import colors from 'app/styles/colors';
 import {
   DataAccessLevel,
-  Gender,
   Profile,
   Race,
   SexAtBirth,
-  SexualOrientation
 } from 'generated/fetch';
 import {Section} from './account-creation';
 
@@ -69,10 +67,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
           disability: false,
           education: undefined,
           ethnicity: undefined,
-          gender: [] as Gender[],
+          identifiesAsLgbtq: false,
+          lgbtqIdentity: '',
           race: [] as Race[],
           sexAtBirth: [] as SexAtBirth[],
-          sexualOrientation: [] as SexualOrientation[],
           yearOfBirth: 0
         }
       }
@@ -150,30 +148,12 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <DropDownSection header='2. Ethnicity' options={AccountCreationOptions.ethnicity}
                        value={demographicSurvey.ethnicity}
                        onChange={(e) => this.updateDemographicAttribute('ethnicity', e)}/>
-
-      {/*Gender section*/}
-      <Section header='3. Gender'>
-        <FlexRow style={{flexWrap: 'wrap'}}>
-          {AccountCreationOptions.gender.map((gender) => {
-            return this.createOptionCheckbox(gender.label, 'gender', gender.value);
-          })}
-        </FlexRow>
-      </Section>
       {/*Sex at birth section*/}
       <Section header='4. Sex at birth'>
         <FlexRow style={{flexWrap: 'wrap'}}>
           {AccountCreationOptions.sexAtBirth.map((sexAtBirth) => {
             return this.createOptionCheckbox(sexAtBirth.label, 'sexAtBirth', sexAtBirth.value);
           })}
-        </FlexRow>
-      </Section>
-      {/*Sexual orientation section*/}
-      <Section header='5. Sexual Orientation'>
-        <FlexRow style={{flexWrap: 'wrap'}}>
-          {AccountCreationOptions.sexualOrientation.map((sexualOrientation) => {
-            return this.createOptionCheckbox(sexualOrientation.label, 'sexualOrientation', sexualOrientation.value);
-          })
-          }
         </FlexRow>
       </Section>
 

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -125,7 +125,7 @@ const nameLength = 80;
 export const Section = (props) => {
   return <FormSection
       style={{...flexStyle.column, ...props.style}}>
-    <label style={styles.sectionHeader}>
+    <label style={{...styles.sectionHeader, ...props.sectionHeaderStyles}}>
       {props.header}
     </label>
     {props.children}
@@ -463,7 +463,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     const {
       profile: {
         givenName, familyName, currentPosition, organization,
-        contactEmail, username, areaOfResearch,
+        contactEmail, username, areaOfResearch, professionalUrl,
         address: {
           streetAddress1, streetAddress2, city, state, zipCode, country
         },
@@ -585,7 +585,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
               </FlexRow>
             </FlexColumn>
           </Section>
-          <Section header={<React.Fragment>
+          <Section sectionHeaderStyles={{borderBottom: null}} header={<React.Fragment>
             <div>Please describe your research background, experience and research interests</div>
             <div style={styles.asideText}>This information will be posted publicly on the AoU Research Hub Website
               to inform the AoU Research Participants. <span  style={{marginLeft: 2,
@@ -659,11 +659,25 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                        onChange={value => this.updateInstitutionAffiliation('other', value)}
                        style={{marginTop: '1rem', width: '18rem'}}/>}
           </FlexColumn>}
+          <Section header={<React.Fragment>
+            <div>Please your professional profile or bio page below, if available</div>
+            <div style={styles.asideText}>You could provide link to your faculty bio page from your institution's
+              website, your LinkedIn profile page, or another webpage featuring your work. This will
+              allow <i>All of Us</i> Researchers and Participants to learn more about your work and publications.</div>
+          </React.Fragment>}>
+              <TextInputWithLabel dataTestId='professionalUrl' inputName='professionalUrl'
+                                  placeholder='Professional Url' value={professionalUrl}
+                                  labelText={<div>
+                                    Paste Professional URL here <i style={{...styles.publiclyDisplayedText,
+                                      marginLeft: 2}}>Optional and publicly displayed</i>
+                                  </div>} containerStyle={{width: '26rem'}}
+                                  onChange={value => this.updateProfileObject('professionalUrl', value)}/>
+          </Section>
           <FormSection style={{paddingBottom: '1rem'}}>
             <TooltipTrigger content={errors && <React.Fragment>
               <div>Please review the following: </div>
               <ul>
-                {Object.keys(errors).map((key) => <li>{errors[key][0]}</li>)}
+                {Object.keys(errors).map((key) => <li key={errors[key][0]}>{errors[key][0]}</li>)}
               </ul>
             </React.Fragment>} disabled={!errors}>
               <Button disabled={this.state.usernameCheckInProgress || this.isUsernameValidationError || errors}

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -138,9 +138,10 @@ export const TextInputWithLabel = (props) => {
     <FlexRow style={{alignItems: 'center', marginTop: '0.1rem'}}>
       <TextInput id={props.inputId} name={props.inputName} placeholder={props.placeholder}
                  value={props.value}
+                 disabled={props.disabled}
                  onChange={props.onChange}
                  invalid={props.invalid ? props.invalid.toString() : undefined}
-                 style={{...styles.sectionInput}}/>
+                 style={{...styles.sectionInput, ...props.inputStyle}}/>
       {props.children}
     </FlexRow>
   </FlexColumn>;
@@ -455,7 +456,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
   getInstitutionalAffiliationPropertyOrEmptyString(property: string) {
     const {institutionalAffiliations} = this.state.profile;
     return institutionalAffiliations &&
-      institutionalAffiliations.length > 0 ? institutionalAffiliations[property] : '';
+      institutionalAffiliations.length > 0 ? institutionalAffiliations[0][property] : '';
   }
 
 
@@ -603,7 +604,8 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                       onChange={v => this.updateProfileObject('areaOfResearch', v)}/>
             <FlexRow style={{justifyContent: 'flex-end', width: '26rem',
               backgroundColor: colorWithWhiteness(colors.primary, 0.85), fontSize: 12,
-              color: colors.primary, padding: '0.25rem', borderRadius: '0 0 3px 3px', border: `1px solid ${colorWithWhiteness(colors.dark, 0.5)}`}}>
+              color: colors.primary, padding: '0.25rem', borderRadius: '0 0 3px 3px',
+              border: `1px solid ${colorWithWhiteness(colors.dark, 0.5)}`}}>
               {2000 - areaOfResearch.length} characters remaining
             </FlexRow>
           </Section>
@@ -691,7 +693,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         <FlexColumn>
           <FlexColumn style={styles.asideContainer}>
             <div style={styles.asideHeader}>About your new username</div>
-            <div style={styles.asideText}>We create a 'username'{serverConfigStore.getValue().gsuiteDomain} Google
+            <div style={styles.asideText}>We create a 'username'@{serverConfigStore.getValue().gsuiteDomain} Google
                 account which you will use to login to the Workbench.</div>
             <div style={{...styles.asideHeader, marginTop: '1rem'}}>Why will some information be public?</div>
             <div style={styles.asideText}>The <AoUTitle/> is committed to transparency with the Research


### PR DESCRIPTION
Description:
This adds `professionalUrl` to our DB, and changes gender identity and sexual orientation options to free text with a boolean identifier, per new caps requirements. This does not address the styling on the account creation survey page, which will be done in a follow up task. 


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
