### PR TITLE
[RW-4091][RISK=MODERATE]Interceptor for Cloud task

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
@@ -34,7 +34,7 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
   private RdrExportService rdrExportService;
   private WorkbenchLocationConfigService locationConfigService;
 
-  private final String BASE_PATH = "/v1/queueTask";
+  private final String BASE_PATH = "/v1/cloudTask";
   private final String EXPORT_RESEARCHER_PATH = BASE_PATH + "/exportResearcherData";
   private final String EXPORT_USER_PATH = BASE_PATH + "/exportWorkspaceData";
   private final String IDS_STRING_SPLIT = ", ";

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -6,6 +6,7 @@ import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.interceptors.AuthInterceptor;
 import org.pmiops.workbench.interceptors.ClearCdrVersionContextInterceptor;
+import org.pmiops.workbench.interceptors.CloudTaskInterceptor;
 import org.pmiops.workbench.interceptors.CorsInterceptor;
 import org.pmiops.workbench.interceptors.CronInterceptor;
 import org.pmiops.workbench.interceptors.SecurityHeadersInterceptor;
@@ -35,6 +36,8 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   @Autowired private CorsInterceptor corsInterceptor;
 
   @Autowired private ClearCdrVersionContextInterceptor clearCdrVersionInterceptor;
+
+  @Autowired private CloudTaskInterceptor cloudTaskInterceptor;
 
   @Autowired private CronInterceptor cronInterceptor;
 
@@ -66,6 +69,7 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
     registry.addInterceptor(authInterceptor);
     registry.addInterceptor(tracingInterceptor);
     registry.addInterceptor(cronInterceptor);
+    registry.addInterceptor(cloudTaskInterceptor);
     registry.addInterceptor(clearCdrVersionInterceptor);
     registry.addInterceptor(securityHeadersInterceptor);
   }

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -9,15 +9,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Interceptor for endpoints with tag cloudTask. All such endpoints should have valid value for
  * request hander X-AppEngine-QueueName
  */
 @Service
 public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
-  public static final String QUEUE_NAME_HEADER = "X-AppEngine-QueueName";
+  public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
-  public static final String RDR_QUEUE_NAME_HEADER = "rdrQueueTest";
+  public static final Set<String> VALID_QUEUE_NAME_SET = new HashSet<>(Arrays.asList("rdrQueueTest"));
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -40,14 +44,14 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
       }
     }
 
-    boolean hasQueueNameHeader = RDR_QUEUE_NAME_HEADER.equals(request.getHeader(QUEUE_NAME_HEADER));
+    boolean hasQueueNameHeader = VALID_QUEUE_NAME_SET.contains(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
     if (requireCloudTaskHeader && !hasQueueNameHeader) {
       response.sendError(
           HttpServletResponse.SC_FORBIDDEN,
           String.format(
               "cloud task endpoints are only invocable via app engine cloudTask, and "
                   + "require the '%s' header",
-              QUEUE_NAME_HEADER));
+              QUEUE_NAME_REQUEST_HEADER));
       return false;
     }
     return true;

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
+/**
+ * Interceptor for endpoints with tag cloudTask. All such endpoints should have valid value for
+ * request hander X-AppEngine-QueueName
+ */
 @Service
 public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
   public static final String QUEUE_NAME_HEADER = "X-AppEngine-QueueName";

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -2,6 +2,9 @@ package org.pmiops.workbench.interceptors;
 
 import com.google.api.client.http.HttpMethods;
 import io.swagger.annotations.ApiOperation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -9,19 +12,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
- * Interceptor for endpoints with tag cloudTask. All such endpoints should have valid value for
- * request hander X-AppEngine-QueueName
+ * Interceptor for endpoints with tag cloudTask. All such endpoints should have tagged as
+ * "cloudTask" and a valid value for request hander X-AppEngine-QueueName which app engine itself
+ * only sets (and overrides internally) when invoking cloud task. See
+ * https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_app_engine_task_request_headers
  */
 @Service
 public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
   public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
-  public static final Set<String> VALID_QUEUE_NAME_SET = new HashSet<>(Arrays.asList("rdrQueueTest"));
+  public static final Set<String> VALID_QUEUE_NAME_SET =
+      new HashSet<>(Arrays.asList("rdrQueueTest"));
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -44,7 +46,8 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
       }
     }
 
-    boolean hasQueueNameHeader = VALID_QUEUE_NAME_SET.contains(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
+    boolean hasQueueNameHeader =
+        VALID_QUEUE_NAME_SET.contains(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
     if (requireCloudTaskHeader && !hasQueueNameHeader) {
       response.sendError(
           HttpServletResponse.SC_FORBIDDEN,

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -1,0 +1,51 @@
+package org.pmiops.workbench.interceptors;
+
+import com.google.api.client.http.HttpMethods;
+import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+@Service
+public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
+  public static final String QUEUE_NAME_HEADER = "X-AppEngine-QueueName";
+  private static final String CLOUD_TASK_TAG = "cloudTask";
+  public static final String RDR_QUEUE_NAME_HEADER = "rdrQueueTest";
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    if (request.getMethod().equals(HttpMethods.OPTIONS)) {
+      return true;
+    }
+
+    HandlerMethod method = (HandlerMethod) handler;
+    ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);
+    if (apiOp == null) {
+      return true;
+    }
+
+    boolean requireCloudTaskHeader = false;
+    for (String tag : apiOp.tags()) {
+      if (CLOUD_TASK_TAG.equals(tag)) {
+        requireCloudTaskHeader = true;
+        break;
+      }
+    }
+    request.getHeaderNames();
+    boolean hasQueueNameHeader = RDR_QUEUE_NAME_HEADER.equals(request.getHeader(QUEUE_NAME_HEADER));
+    if (requireCloudTaskHeader && !hasQueueNameHeader) {
+      response.sendError(
+          HttpServletResponse.SC_FORBIDDEN,
+          String.format(
+              "cloud task endpoints are only invocable via app engine cloudTask, and "
+                  + "require the '%s' header",
+              QUEUE_NAME_HEADER));
+      return false;
+    }
+    return true;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -35,7 +35,7 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
         break;
       }
     }
-    request.getHeaderNames();
+
     boolean hasQueueNameHeader = RDR_QUEUE_NAME_HEADER.equals(request.getHeader(QUEUE_NAME_HEADER));
     if (requireCloudTaskHeader && !hasQueueNameHeader) {
       response.sendError(

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2254,12 +2254,17 @@ paths:
 
 
 ##########################################################################################
-## Endpoints for task in cloud task queue
+# Endpoints for task in cloud task queue
+# Note: all requests tagged as "cloudTask" must have the header X-AppEngine-QueueName:
+# to the queue name, which app engine itself only sets when invoking cloud task.
+# See o.p.w.interceptors.CloudTaskInterceptor which implements the header check.
 #########################################################################################
-  /v1/queueTask/exportResearcherData:
+  /v1/cloudTask/exportResearcherData:
     post:
       tags:
         - cloudTaskRdrExport
+        - cloudTask
+      security: []
       description: >
         Send Researcher data
       operationId: "exportResearcherData"
@@ -2275,10 +2280,12 @@ paths:
           description: >
             A SQL query for each domain in the Data Set
 
-  /v1/queueTask/exportWorkspaceData:
+  /v1/cloudTask/exportWorkspaceData:
     post:
       tags:
         - cloudTaskRdrExport
+        - cloudTask
+      security: []
       description: >
         Send Researcher data
       operationId: "exportWorkspaceData"

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2256,8 +2256,10 @@ paths:
 ##########################################################################################
 # Endpoints for task in cloud task queue
 # Note: all requests tagged as "cloudTask" must have the header X-AppEngine-QueueName:
-# to the queue name, which app engine itself only sets when invoking cloud task.
-# See o.p.w.interceptors.CloudTaskInterceptor which implements the header check.
+# to the queue name, which app engine itself only sets (and overrides internally) when invoking
+# cloud task. See
+# https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_app_engine_task_request_headers
+# and o.p.w.interceptors.CloudTaskInterceptor which implements the header check.
 #########################################################################################
   /v1/cloudTask/exportResearcherData:
     post:
@@ -2266,7 +2268,7 @@ paths:
         - cloudTask
       security: []
       description: >
-        Send Researcher data
+        Task handler which handle request from cloud task queue rdrQueueTest to send Researcher data
       operationId: "exportResearcherData"
       parameters:
         - in: body
@@ -2287,7 +2289,7 @@ paths:
         - cloudTask
       security: []
       description: >
-        Send Researcher data
+         Task handler which handle request from cloud task queue rdrQueueTest to send Workspace data
       operationId: "exportWorkspaceData"
       parameters:
         - in: body

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest
@@ -1,0 +1,68 @@
+package org.pmiops.workbench.interceptors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpMethods;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.pmiops.workbench.api.CloudTaskRdrExportController;
+import org.pmiops.workbench.api.WorkspacesApi;
+import org.springframework.web.method.HandlerMethod;
+
+public class CloudTaskInterceptorTest {
+	@Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+	@Mock private HandlerMethod handler;
+	@Mock private HttpServletRequest request;
+	@Mock private HttpServletResponse response;
+
+	private CloudTaskInterceptor interceptor;
+
+	@Before
+	public void setUp() {
+		interceptor = new CloudTaskInterceptor();
+	}
+
+	@Test
+	public void preHandleOptions_OPTIONS() throws Exception {
+		when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
+		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+	}
+
+	@Test
+	public void prehandleForCloudTaskNoHeader() throws Exception {
+		when(request.getMethod()).thenReturn(HttpMethods.POST);
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod("exportResearcherData", Object.class));
+		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+	}
+
+	@Test
+	public void prehandleForCloudTaskWithBadHeader() throws Exception {
+		when(request.getMethod()).thenReturn(HttpMethods.POST);
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod("exportResearcherData", Object.class));
+		when(request.getHeader(CloudTaskInterceptor.RDR_QUEUE_NAME_HEADER)).thenReturn("asdf");
+		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+	}
+
+	@Test
+	public void prehandleForCloudTaskWithHeader() throws Exception {
+		when(request.getMethod()).thenReturn(HttpMethods.POST);
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportController.class.getMethod("exportResearcherData", Object.class));
+		when(request.getHeader(CloudTaskInterceptor.RDR_QUEUE_NAME_HEADER)).thenReturn("rdrQueueTest");
+		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+	}
+
+	@Test
+	public void prehandleForNonCloudTask() throws Exception {
+		when(request.getMethod()).thenReturn(HttpMethods.GET);
+		when(handler.getMethod()).thenReturn(WorkspacesApi.class.getMethod("getWorkspaces"));
+		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+	}
+}

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -12,7 +12,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.pmiops.workbench.api.CloudTaskRdrExportController;
+import org.pmiops.workbench.api.CloudTaskRdrExportApi;
+
 import org.pmiops.workbench.api.WorkspacesApi;
 import org.springframework.web.method.HandlerMethod;
 
@@ -24,6 +25,8 @@ public class CloudTaskInterceptorTest {
 	@Mock private HttpServletResponse response;
 
 	private CloudTaskInterceptor interceptor;
+
+	private final String CLOUD_TASK_METHOD_NAME = "exportResearcherData";
 
 	@Before
 	public void setUp() {
@@ -39,23 +42,23 @@ public class CloudTaskInterceptorTest {
 	@Test
 	public void prehandleForCloudTaskNoHeader() throws Exception {
 		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod("exportResearcherData", Object.class));
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
 		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
 	}
 
 	@Test
 	public void prehandleForCloudTaskWithBadHeader() throws Exception {
 		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod("exportResearcherData", Object.class));
-		when(request.getHeader(CloudTaskInterceptor.RDR_QUEUE_NAME_HEADER)).thenReturn("asdf");
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+		when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("asdf");
 		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
 	}
 
 	@Test
 	public void prehandleForCloudTaskWithHeader() throws Exception {
 		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportController.class.getMethod("exportResearcherData", Object.class));
-		when(request.getHeader(CloudTaskInterceptor.RDR_QUEUE_NAME_HEADER)).thenReturn("rdrQueueTest");
+		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+		when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("rdrQueueTest");
 		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
 	}
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -13,59 +13,62 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.pmiops.workbench.api.CloudTaskRdrExportApi;
-
 import org.pmiops.workbench.api.WorkspacesApi;
 import org.springframework.web.method.HandlerMethod;
 
 public class CloudTaskInterceptorTest {
-	@Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-	@Mock private HandlerMethod handler;
-	@Mock private HttpServletRequest request;
-	@Mock private HttpServletResponse response;
+  @Mock private HandlerMethod handler;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
 
-	private CloudTaskInterceptor interceptor;
+  private CloudTaskInterceptor interceptor;
 
-	private final String CLOUD_TASK_METHOD_NAME = "exportResearcherData";
+  private final String CLOUD_TASK_METHOD_NAME = "exportResearcherData";
 
-	@Before
-	public void setUp() {
-		interceptor = new CloudTaskInterceptor();
-	}
+  @Before
+  public void setUp() {
+    interceptor = new CloudTaskInterceptor();
+  }
 
-	@Test
-	public void preHandleOptions_OPTIONS() throws Exception {
-		when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
-		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
-	}
+  @Test
+  public void preHandleOptions_OPTIONS() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
 
-	@Test
-	public void prehandleForCloudTaskNoHeader() throws Exception {
-		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
-		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-	}
+  @Test
+  public void prehandleForCloudTaskNoHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.POST);
+    when(handler.getMethod())
+        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+  }
 
-	@Test
-	public void prehandleForCloudTaskWithBadHeader() throws Exception {
-		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
-		when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("asdf");
-		assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-	}
+  @Test
+  public void prehandleForCloudTaskWithBadHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.POST);
+    when(handler.getMethod())
+        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+    when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("asdf");
+    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+  }
 
-	@Test
-	public void prehandleForCloudTaskWithHeader() throws Exception {
-		when(request.getMethod()).thenReturn(HttpMethods.POST);
-		when(handler.getMethod()).thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
-		when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("rdrQueueTest");
-		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
-	}
+  @Test
+  public void prehandleForCloudTaskWithHeader() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.POST);
+    when(handler.getMethod())
+        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+    when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER))
+        .thenReturn("rdrQueueTest");
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
 
-	@Test
-	public void prehandleForNonCloudTask() throws Exception {
-		when(request.getMethod()).thenReturn(HttpMethods.GET);
-		when(handler.getMethod()).thenReturn(WorkspacesApi.class.getMethod("getWorkspaces"));
-		assertThat(interceptor.preHandle(request, response, handler)).isTrue();
-	}
+  @Test
+  public void prehandleForNonCloudTask() throws Exception {
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
+    when(handler.getMethod()).thenReturn(WorkspacesApi.class.getMethod("getWorkspaces"));
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
 }


### PR DESCRIPTION
This PR will introduce a new interceptor for Cloud task. The target for cloud task (task handlers ) should have the following :
1) The swagger definition should have the 
     a) tag 'cloudTask'
    b) security set to [] (to avoid checking for OAuth)
2) If the queue Name is different from rdrQueue add to the interceptor header list. This header is automatically added by the google cloud.


**PR checklist**

- [X ] This PR meets the Acceptance Criteria in the JIRA story
- [ X] The JIRA story has been moved to Dev Review
- [ X] This PR includes appropriate unit tests
- [ X] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
