### PR TITLE
[RW-4230][risk=low] Switch cluster resources from GCS -> https static

### DIFF
--- a/api/cluster-resources/README.md
+++ b/api/cluster-resources/README.md
@@ -6,19 +6,19 @@ https://github.com/DataBiosphere/leonardo/blob/cfdbff2448b9cff73ad658ba028d1feaf
 
 ## Local testing
 
-To manually test updates to this script locally:
+To manually test updates to this script:
 
-- Push the script to GCS (username-suffixed):
+- Push a personal API server to test:
 
   ```
-  api$ gsutil cp cluster-resources/initialize_notebook_cluster.sh "gs://all-of-us-workbench-test-cluster-resources/initialize_notebook_cluster-${USER}.sh"
+  api$ ./project.rb deploy-api --no-promote --version "${USER}" --project all-of-us-workbench-test"
   ```
 
 - (**Disclaimer**: local code change, do not submit) Temporarily update your
-  local server config to use your custom script:
+  local server config to use your API server for static asset serving:
 
   ```
-  api$ sed -i "s,initialize_notebook_cluster\.sh,initialize_notebook_cluster-${USER}.sh," src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+  api$ sed -i "s/api-dot-all-of-us-workbench-test.appspot.com/${USER}-dot-\0/" config/config_local.json
   ```
 
 - Ensure the change is picked up by your API server and point a local UI to it
@@ -112,5 +112,5 @@ To test the menu contents JSON alone:
 
 # Releasing
 
-Resources are pushed to the appropriate GCS environment as part of our normal
-release process.
+Resources are pushed as static assets on the API GAE server as part of our
+normal release process.

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -76,20 +76,20 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     }
 
     WorkbenchConfig config = workbenchConfigProvider.get();
-    String gcsPrefix = "gs://" + config.googleCloudStorageService.clusterResourcesBucketName;
+    String assetsBaseUrl = config.server.apiBaseUrl + "/static";
 
     Map<String, String> nbExtensions = new HashMap<>();
-    nbExtensions.put("aou-snippets-menu", gcsPrefix + "/aou-snippets-menu.js");
-    nbExtensions.put("aou-download-extension", gcsPrefix + "/aou-download-policy-extension.js");
+    nbExtensions.put("aou-snippets-menu", assetsBaseUrl + "/aou-snippets-menu.js");
+    nbExtensions.put("aou-download-extension", assetsBaseUrl + "/aou-download-policy-extension.js");
     nbExtensions.put(
-        "aou-activity-checker-extension", gcsPrefix + "/activity-checker-extension.js");
+        "aou-activity-checker-extension", assetsBaseUrl + "/activity-checker-extension.js");
 
     return new ClusterRequest()
         .labels(ImmutableMap.of(CLUSTER_LABEL_AOU, "true", CLUSTER_LABEL_CREATED_BY, userEmail))
         .defaultClientId(config.server.oauthClientId)
         // Note: Filenames must be kept in sync with files in cluster-resources directory.
-        .jupyterUserScriptUri(gcsPrefix + "/initialize_notebook_cluster.sh")
-        .jupyterStartUserScriptUri(gcsPrefix + "/start_notebook_cluster.sh")
+        .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_cluster.sh")
+        .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_cluster.sh")
         .userJupyterExtensionConfig(
             new UserJupyterExtensionConfig()
                 .nbExtensions(nbExtensions)


### PR DESCRIPTION
- Read from our static API https assets
- Add instructions for testing local cluster resources
- Teardown/refactoring of GCS pushing steps is tracked by https://precisionmedicineinitiative.atlassian.net/browse/RW-4313
- Verified manually that all extensions and scripts successfully loaded/executed via a local API server (which by default, references static assets in the test environment).