### PR TITLE
[RW-4314][risk=no] Gauge metric for GSuite Domain Account Count

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -259,13 +259,14 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
       final Directory directoryService = getGoogleDirectoryService();
       Optional<String> nextPageToken = Optional.empty();
       do {
-        final Directory.Users.List listQuery = directoryService
-            .users()
-            .list()
-            .setDomain(gSuiteDomain())
-            .setViewType(USER_VIEW_TYPE)
-            .setMaxResults(MAX_USERS_LIST_PAGE_SIZE)
-            .setOrderBy(EMAIL_USER_FIELD);
+        final Directory.Users.List listQuery =
+            directoryService
+                .users()
+                .list()
+                .setDomain(gSuiteDomain())
+                .setViewType(USER_VIEW_TYPE)
+                .setMaxResults(MAX_USERS_LIST_PAGE_SIZE)
+                .setOrderBy(EMAIL_USER_FIELD);
         nextPageToken.ifPresent(listQuery::setPageToken);
 
         final Users usersQueryResult = listQuery.execute();
@@ -278,10 +279,11 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
       return Collections.emptyList();
     }
 
-    return Collections.singleton(MeasurementBundle.builder()
-        .addMeasurement(GaugeMetric.GSUITE_USER_COUNT, userCount)
-        .addTag(MetricLabel.GSUITE_DOMAIN, gSuiteDomain())
-        .build());
+    return Collections.singleton(
+        MeasurementBundle.builder()
+            .addMeasurement(GaugeMetric.GSUITE_USER_COUNT, userCount)
+            .addTag(MetricLabel.GSUITE_DOMAIN, gSuiteDomain())
+            .build());
   }
 
   private String randomString() {

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -280,24 +280,25 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     ImmutableSet.Builder<MeasurementBundle> resultBuilder = ImmutableSet.builder();
 
     final String localDomain = gSuiteDomain();
-    final long localDomainUserCount = countUsersInDomain(localDomain);
-    resultBuilder.add(
-        MeasurementBundle.builder()
-            .addMeasurement(GaugeMetric.GSUITE_USER_COUNT, localDomainUserCount)
-            .addTag(MetricLabel.GSUITE_DOMAIN, localDomain)
-            .build());
+    addDomainCountMeasurement(resultBuilder, localDomain, countUsersInDomain(localDomain));
 
     final String topLevelDomain = getTopLevelGSuiteDomain();
     // Avoid creating duplicate data point if the local domain is the top domain
     if (!localDomain.equals(topLevelDomain)) {
-      final long topLevelDomainUserCount = countUsersInDomain(topLevelDomain);
-      resultBuilder.add(
-          MeasurementBundle.builder()
-              .addMeasurement(GaugeMetric.GSUITE_USER_COUNT, topLevelDomainUserCount)
-              .addTag(MetricLabel.GSUITE_DOMAIN, topLevelDomain)
-              .build());
+      addDomainCountMeasurement(resultBuilder, topLevelDomain, countUsersInDomain(topLevelDomain));
     }
     return resultBuilder.build();
+  }
+
+  private void addDomainCountMeasurement(
+      ImmutableSet.Builder<MeasurementBundle> resultBuilder,
+      String gSuiteDomain,
+      long domainUserCount) {
+    resultBuilder.add(
+        MeasurementBundle.builder()
+            .addMeasurement(GaugeMetric.GSUITE_USER_COUNT, domainUserCount)
+            .addTag(MetricLabel.GSUITE_DOMAIN, gSuiteDomain)
+            .build());
   }
 
   private long countUsersInDomain(String gSuiteDomain) {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
@@ -11,7 +11,9 @@ public enum MetricLabel implements MetricLabelBase {
   BUFFER_ENTRY_STATUS("BufferEntryStatus", Enums.getValueStrings(BufferEntryStatus.class)),
   DATASET_INVALID("Invalid", Booleans.VALUE_STRINGS),
   DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
-  GSUITE_DOMAIN("gsuite_domain"),  // provide this (slightly redundant) in case we ever merge time series across projects or have multiple domains per project
+  GSUITE_DOMAIN(
+      "gsuite_domain"), // provide this (slightly redundant) in case we ever merge time series
+  // across projects or have multiple domains per project
   USER_BYPASSED_BETA("BypassedBeta", Booleans.VALUE_STRINGS),
   USER_DISABLED("Disabled", Booleans.VALUE_STRINGS),
   WORKSPACE_ACTIVE_STATUS("ActiveStatus");

--- a/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
@@ -10,9 +10,10 @@ import org.pmiops.workbench.utils.Enums;
 public enum MetricLabel implements MetricLabelBase {
   BUFFER_ENTRY_STATUS("BufferEntryStatus", Enums.getValueStrings(BufferEntryStatus.class)),
   DATASET_INVALID("Invalid", Booleans.VALUE_STRINGS),
+  DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
+  GSUITE_DOMAIN("gsuite_domain"),  // provide this (slightly redundant) in case we ever merge time series across projects or have multiple domains per project
   USER_BYPASSED_BETA("BypassedBeta", Booleans.VALUE_STRINGS),
   USER_DISABLED("Disabled", Booleans.VALUE_STRINGS),
-  DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
   WORKSPACE_ACTIVE_STATUS("ActiveStatus");
 
   private String keyName;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
@@ -11,9 +11,7 @@ public enum MetricLabel implements MetricLabelBase {
   BUFFER_ENTRY_STATUS("BufferEntryStatus", Enums.getValueStrings(BufferEntryStatus.class)),
   DATASET_INVALID("Invalid", Booleans.VALUE_STRINGS),
   DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
-  GSUITE_DOMAIN(
-      "gsuite_domain"), // provide this (slightly redundant) in case we ever merge time series
-  // across projects or have multiple domains per project
+  GSUITE_DOMAIN("gsuite_domain"),
   USER_BYPASSED_BETA("BypassedBeta", Booleans.VALUE_STRINGS),
   USER_DISABLED("Disabled", Booleans.VALUE_STRINGS),
   WORKSPACE_ACTIVE_STATUS("ActiveStatus");

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
@@ -19,6 +19,10 @@ public enum GaugeMetric implements Metric {
       "dataset_count_2",
       "Count of all datasets in existence",
       ImmutableList.of(MetricLabel.DATASET_INVALID)),
+  GSUITE_USER_COUNT(
+      "gsuite_user_count",
+      "Number of users in GSuite Directory.",
+      ImmutableList.of(MetricLabel.GSUITE_DOMAIN)),
   USER_COUNT(
       "user_count_2",
       "total number of users",


### PR DESCRIPTION
The closest API I could find for this information was the [Users List API](https://developers.google.com/admin-sdk/directory/v1/reference/users/list). There's no count or summary I could find, so I'm hitting it with the max page size of 500 and then fetching more. I might be able to reduce the size of each user returned using the fields attribute.

I put a label on the gauge for the domain name. This is both a reminder and for future-proofness, in case we wanted to have multiple domains per environment or somehow look at multiple environments in the same chart someday. We don't expect either of those to happen yet.

Here's a screen shot with it in action.
![Screen Shot 2020-01-22 at 11 56 14 AM](https://user-images.githubusercontent.com/53479492/72916186-9281b800-3d0f-11ea-958d-c4ce93a22e1d.png)

[Stackdriver dashboard link](https://console.cloud.google.com/monitoring/dashboards/custom/18329516758933998444?project=all-of-us-workbench-test&timeDomain=1d).
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
