### PR TITLE
[RW-4322][risk=low] Implement describe-cluster debug tool

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1329,7 +1329,7 @@ def describe_cluster(cmd_name, *args)
     end
   end
   common.warning "unable to determine project by cluster ID" unless project_from_cluster
-  if not op.opts.project
+  unless op.opts.project
     op.opts.project = project_from_cluster
   end
 
@@ -1377,7 +1377,6 @@ Common.register_command({
   :description => "List all clusters in this environment",
   :fn => ->(*args) { list_clusters("list-clusters", *args) }
 })
-
 
 def load_es_index(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1317,16 +1317,22 @@ def describe_cluster(cmd_name, *args)
 
   # Infer the project from the cluster ID project ID. If for some reason, the
   # target cluster ID does not conform to the current billing prefix (e.g. if we
-  # changed the prefix), --project will override this.
+  # changed the prefix), --project can be used to override this.
   common = Common.new
+  matching_prefix = ""
   project_from_cluster = nil
   ENVIRONMENTS.each_key do |env|
-    if op.opts.cluster_id.start_with?(get_billing_project_prefix(env))
+    env_prefix = get_billing_project_prefix(env)
+    if op.opts.cluster_id.start_with?(env_prefix)
       # Take the most specific prefix match, since prod is a substring of the others.
-      if not project_from_cluster or project_from_cluster.length < env.length
+      if matching_prefix.length < env_prefix.length
         project_from_cluster = env
+        matching_prefix = env_prefix
       end
     end
+  end
+  if project_from_cluster == "local"
+    project_from_cluster = TEST_PROJECT
   end
   common.warning "unable to determine project by cluster ID" unless project_from_cluster
   unless op.opts.project

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1340,12 +1340,11 @@ def describe_cluster(cmd_name, *args)
   gcc.validate
 
   api_url = get_leo_api_url(gcc.project)
-  sa_ctx = ServiceAccountContext.new(gcc.project)
-  sa_ctx.run do
+  ServiceAccountContext.new(gcc.project).run do |ctx|
     common = Common.new
     common.run_inline %W{
        gradle manageClusters
-      -PappArgs=['describe','#{api_url}','#{gcc.project}','#{sa_ctx.service_account}','#{op.opts.cluster_id}']}
+      -PappArgs=['describe','#{api_url}','#{gcc.project}','#{ctx.service_account}','#{op.opts.cluster_id}']}
   end
 end
 

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1257,6 +1257,10 @@ definitions:
         items:
           type: string
         description: The scopes for the cluster.
+      stagingBucket:
+        type: string
+        description: Bucket name containing logs and staging resources for the cluster.
+
 
   ListClusterResponse:
     description: ''

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -91,7 +91,7 @@ public class ManageClusters {
 
   private static void listClusters(String apiUrl) throws IOException, ApiException {
     AtomicInteger count = new AtomicInteger();
-    newApiClient(apiUrl).listClusters(null, true).stream()
+    newApiClient(apiUrl).listClusters(null, false).stream()
         .sorted(Comparator.comparing(c -> Instant.parse(c.getCreatedDate())))
         .forEachOrdered(
             (c) -> {
@@ -111,11 +111,18 @@ public class ManageClusters {
               "given cluster ID '%s' is invalid, wanted format 'project/clusterName'", clusterId));
       return;
     }
+    String clusterProject = parts[0];
+    String clusterName = parts[1];
 
     // Leo's getCluster API swagger tends to be outdated; issue a raw getCluster request to ensure
     // we get all available information for debugging.
     ClusterApi client = newApiClient(apiUrl);
-    com.squareup.okhttp.Call call = client.getClusterCall(parts[0], parts[1], null, null);
+    com.squareup.okhttp.Call call =
+        client.getClusterCall(
+            clusterProject,
+            clusterName,
+            /* progressListener */ null,
+            /* progressRequestListener */ null);
     ApiResponse<Object> resp = client.getApiClient().execute(call, Object.class);
 
     // Parse the response as well so we can log specific structured fields.

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -137,7 +137,8 @@ public class ManageClusters {
         "    gcloud iam service-accounts keys create %s --iam-account %s\n",
         keyPath, workbenchServiceAccount);
     System.out.printf("    gcloud auth activate-service-account --key-file %s\n\n", keyPath);
-    System.out.printf("    gsutil ls gs://%s\n\n", cluster.getStagingBucket());
+    System.out.printf("    gsutil ls gs://%s/**\n", cluster.getStagingBucket());
+    System.out.printf("    gsutil cat ... # inspect or copy logs\n\n");
     System.out.printf("    # Delete the key when done\n");
     System.out.printf(
         "    gcloud iam service-accounts keys delete $(jq -r .private_key_id %s) --iam-account %s\n\n",

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -2,7 +2,9 @@ package org.pmiops.workbench.tools;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.time.Clock;
@@ -11,6 +13,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -19,7 +22,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.pmiops.workbench.notebooks.ApiClient;
 import org.pmiops.workbench.notebooks.ApiException;
+import org.pmiops.workbench.notebooks.ApiResponse;
 import org.pmiops.workbench.notebooks.api.ClusterApi;
+import org.pmiops.workbench.notebooks.model.Cluster;
 import org.pmiops.workbench.notebooks.model.ClusterStatus;
 import org.pmiops.workbench.notebooks.model.ListClusterResponse;
 import org.springframework.boot.CommandLineRunner;
@@ -41,6 +46,11 @@ public class ManageClusters {
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/userinfo.email"
       };
+  private static final List<String> DESCRIBE_ARG_NAMES =
+      ImmutableList.of("api_url", "project", "service_account", "cluster_id");
+  private static final List<String> DELETE_ARG_NAMES =
+      ImmutableList.of("api_url", "min_age", "ids", "dry_run");
+  private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
 
   private static Set<String> commaDelimitedStringToSet(String str) {
     return Arrays.asList(str.split(",")).stream()
@@ -81,7 +91,7 @@ public class ManageClusters {
 
   private static void listClusters(String apiUrl) throws IOException, ApiException {
     AtomicInteger count = new AtomicInteger();
-    newApiClient(apiUrl).listClusters(null, false).stream()
+    newApiClient(apiUrl).listClusters(null, true).stream()
         .sorted(Comparator.comparing(c -> Instant.parse(c.getCreatedDate())))
         .forEachOrdered(
             (c) -> {
@@ -89,6 +99,42 @@ public class ManageClusters {
               count.getAndIncrement();
             });
     System.out.println(String.format("listed %d clusters", count.get()));
+  }
+
+  private static void describeCluster(
+      String apiUrl, String workbenchProjectId, String workbenchServiceAccount, String clusterId)
+      throws IOException, ApiException {
+    String[] parts = clusterId.split("/");
+    if (parts.length != 2) {
+      System.err.println(
+          String.format(
+              "given cluster ID '%s' is invalid, wanted format 'project/clusterName'", clusterId));
+      return;
+    }
+
+    // Leo's getCluster API swagger tends to be outdated; issue a raw getCluster request to ensure
+    // we get all available information for debugging.
+    ClusterApi client = newApiClient(apiUrl);
+    com.squareup.okhttp.Call call = client.getClusterCall(parts[0], parts[1], null, null);
+    ApiResponse<Object> resp = client.getApiClient().execute(call, Object.class);
+
+    // Parse the response as well so we can log specific structured fields.
+    Cluster cluster = PRETTY_GSON.fromJson(PRETTY_GSON.toJson(resp.getData()), Cluster.class);
+
+    System.out.println(PRETTY_GSON.toJson(resp.getData()));
+    System.out.printf("\n\nTo inspect logs in cloud storage, run the following:\n\n");
+
+    // TODO(PD-4740): Use impersonation here instead.
+    String keyPath = String.format("/tmp/%s-key.json", workbenchProjectId);
+    System.out.printf(
+        "    gcloud iam service-accounts keys create %s --iam-account %s\n",
+        keyPath, workbenchServiceAccount);
+    System.out.printf("    gcloud auth activate-service-account --key-file %s\n\n", keyPath);
+    System.out.printf("    gsutil ls gs://%s\n\n", cluster.getStagingBucket());
+    System.out.printf("    # Delete the key when done\n");
+    System.out.printf(
+        "    gcloud iam service-accounts keys delete $(jq -r .private_key_id %s) --iam-account %s\n\n",
+        keyPath, workbenchServiceAccount);
   }
 
   private static void deleteClusters(
@@ -140,13 +186,23 @@ public class ManageClusters {
   public CommandLineRunner run() {
     return (args) -> {
       if (args.length < 1) {
-        throw new IllegalArgumentException("must specify a command 'list' or 'delete'");
+        throw new IllegalArgumentException("must specify a command 'list', 'describe' or 'delete'");
       }
       String cmd = args[0];
       args = Arrays.copyOfRange(args, 1, args.length);
       switch (cmd) {
+        case "describe":
+          if (args.length != DESCRIBE_ARG_NAMES.size()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Expected %d args %s. Got: %s",
+                    DESCRIBE_ARG_NAMES.size(), DESCRIBE_ARG_NAMES, Arrays.asList(args)));
+          }
+          describeCluster(args[0], args[1], args[2], args[3]);
+          return;
+
         case "list":
-          if (args.length > 1) {
+          if (args.length != 1) {
             throw new IllegalArgumentException("Expected 1 arg. Got " + Arrays.asList(args));
           }
           listClusters(args[0]);
@@ -155,9 +211,11 @@ public class ManageClusters {
         case "delete":
           // User-friendly command-line parsing is done in devstart.rb, so we do only simple
           // positional argument parsing here.
-          if (args.length != 4) {
+          if (args.length != DELETE_ARG_NAMES.size()) {
             throw new IllegalArgumentException(
-                "Expected 4 args (api_url, min_age, ids, dry_run). Got " + Arrays.asList(args));
+                String.format(
+                    "Expected %d args %s. Got: %s",
+                    DELETE_ARG_NAMES.size(), DELETE_ARG_NAMES, Arrays.asList(args)));
           }
           String apiUrl = args[0];
           Instant oldest = null;


### PR DESCRIPTION
Usage:

```
./project.rb list-clusters --project all-of-us-rw-prod
... # find cluster of interest

./project.rb describe-cluster --id aou-rw-xxxxxx/all-of-us-xx
```

Prints command line instructions for inspecting the logs directory for the cluster.

Sample output: https://pmi-engteam.slack.com/files/U5KGPEEPK/FSS4UKYF5/describe-cluster_output