### PR TITLE
[RW-4247][risk=no] Reworking Concept Set Builder to include PM and Surveys

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -117,7 +117,7 @@ VALUES
 (1586134,'The Basics','Survey includes participant demographic information.',0,0,1),
 (43529712,'Personal Medical History','This survey includes information about past medical history, including medical conditions and approximate age of diagnosis.',0,0,4),
 (43528895,'Healthcare Access & Utilization','Survey includes information about a participants access to and use of health care.',0,0,5),
-(43528698,'Family Medical History','Survey includes information about the medical history of a participants immediate biological family members.',0,0,6)"
+(43528698,'Family History','Survey includes information about the medical history of a participants immediate biological family members.',0,0,6)"
 
 # Populate some tables from cdr data
 ###############

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
 import org.pmiops.workbench.testconfig.TestJpaConfig;
 import org.pmiops.workbench.testconfig.TestWorkbenchConfig;
@@ -70,7 +71,7 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
   public void testGetConceptCountNoConceptsSaved() {
     assertThat(
             conceptBigQueryService.getParticipantCountForConcepts(
-                "condition_occurrence", ImmutableSet.of(1L, 6L, 13L, 192819L)))
+                Domain.CONDITION, "condition_occurrence", ImmutableSet.of(1L, 6L, 13L, 192819L)))
         .isEqualTo(0);
   }
 
@@ -83,7 +84,7 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
     assertThat(
             conceptBigQueryService.getParticipantCountForConcepts(
-                "condition_occurrence", ImmutableSet.of(1L, 6L, 13L, 192819L)))
+                Domain.CONDITION, "condition_occurrence", ImmutableSet.of(1L, 6L, 13L, 192819L)))
         .isEqualTo(2);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -279,7 +279,10 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
             .filter(concept -> !concept.getConceptClassId().equals(CONCEPT_CLASS_ID_QUESTION))
             .filter(
                 concept -> {
-                  Domain domain = CommonStorageEnums.domainIdToDomain(concept.getDomainId());
+                  Domain domain =
+                      Domain.PHYSICALMEASUREMENT.equals(domainEnum)
+                          ? Domain.PHYSICALMEASUREMENT
+                          : CommonStorageEnums.domainIdToDomain(concept.getDomainId());
                   return !domainEnum.equals(domain);
                 })
             .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -153,7 +153,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
       String omopTable = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(dbConceptSet.getDomainEnum());
       dbConceptSet.setParticipantCount(
           conceptBigQueryService.getParticipantCountForConcepts(
-              omopTable, dbConceptSet.getConceptIds()));
+              dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
     }
 
     try {
@@ -342,7 +342,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
       String omopTable = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(dbConceptSet.getDomainEnum());
       dbConceptSet.setParticipantCount(
           conceptBigQueryService.getParticipantCountForConcepts(
-              omopTable, dbConceptSet.getConceptIds()));
+              dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
     }
 
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -99,11 +99,10 @@ public class ConceptsController implements ConceptsApiDelegate {
       String workspaceNamespace, String workspaceId, DomainCountsRequest request) {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    DomainCountsListResponse response = new DomainCountsListResponse();
     List<DomainCount> counts =
         conceptService.countDomains(
             request.getQuery(), request.getSurveyName(), request.getStandardConceptFilter());
-    return ResponseEntity.ok(response.domainCounts(counts));
+    return ResponseEntity.ok(new DomainCountsListResponse().domainCounts(counts));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.concept.ConceptService.STANDARD_CONCEPT_CODES;
 import static org.pmiops.workbench.model.StandardConceptFilter.STANDARD_CONCEPTS;
 
 import java.util.ArrayList;
@@ -136,18 +137,18 @@ public class ConceptsController implements ConceptsApiDelegate {
     return maxResults;
   }
 
-  public static Concept toClientConcept(DbConcept concept) {
+  public static Concept toClientConcept(DbConcept dbConcept) {
     return new Concept()
-        .conceptClassId(concept.getConceptClassId())
-        .conceptCode(concept.getConceptCode())
-        .conceptName(concept.getConceptName())
-        .conceptId(concept.getConceptId())
-        .countValue(concept.getCountValue())
-        .domainId(concept.getDomainId())
-        .prevalence(concept.getPrevalence())
-        .standardConcept(ConceptService.STANDARD_CONCEPT_CODE.equals(concept.getStandardConcept()))
-        .vocabularyId(concept.getVocabularyId())
-        .conceptSynonyms(concept.getSynonyms());
+        .conceptClassId(dbConcept.getConceptClassId())
+        .conceptCode(dbConcept.getConceptCode())
+        .conceptName(dbConcept.getConceptName())
+        .conceptId(dbConcept.getConceptId())
+        .countValue(dbConcept.getCountValue())
+        .domainId(dbConcept.getDomainId())
+        .prevalence(dbConcept.getPrevalence())
+        .standardConcept(STANDARD_CONCEPT_CODES.contains(dbConcept.getStandardConcept()))
+        .vocabularyId(dbConcept.getVocabularyId())
+        .conceptSynonyms(dbConcept.getSynonyms());
   }
 
   private SurveyQuestions toClientSurveyQuestions(DbCriteria dbCriteria) {

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -1,30 +1,27 @@
 package org.pmiops.workbench.api;
 
-import static org.pmiops.workbench.model.StandardConceptFilter.ALL_CONCEPTS;
+import static org.pmiops.workbench.model.StandardConceptFilter.STANDARD_CONCEPTS;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.concept.ConceptService;
-import org.pmiops.workbench.db.model.CommonStorageEnums;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptListResponse;
-import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainCount;
+import org.pmiops.workbench.model.DomainCountsListResponse;
+import org.pmiops.workbench.model.DomainCountsRequest;
+import org.pmiops.workbench.model.DomainInfo;
 import org.pmiops.workbench.model.DomainInfoResponse;
 import org.pmiops.workbench.model.SearchConceptsRequest;
-import org.pmiops.workbench.model.StandardConceptFilter;
-import org.pmiops.workbench.model.SurveyAnswerResponse;
+import org.pmiops.workbench.model.SearchSurveysRequest;
+import org.pmiops.workbench.model.SurveyModule;
 import org.pmiops.workbench.model.SurveyQuestions;
 import org.pmiops.workbench.model.SurveysResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -41,16 +38,11 @@ public class ConceptsController implements ConceptsApiDelegate {
   private static final int MAX_MAX_RESULTS = 1000;
 
   private final ConceptService conceptService;
-  private final ConceptBigQueryService conceptBigQueryService;
   private final WorkspaceService workspaceService;
 
   @Autowired
-  public ConceptsController(
-      ConceptService conceptService,
-      ConceptBigQueryService conceptBigQueryService,
-      WorkspaceService workspaceService) {
+  public ConceptsController(ConceptService conceptService, WorkspaceService workspaceService) {
     this.conceptService = conceptService;
-    this.conceptBigQueryService = conceptBigQueryService;
     this.workspaceService = workspaceService;
   }
 
@@ -59,31 +51,33 @@ public class ConceptsController implements ConceptsApiDelegate {
       String workspaceNamespace, String workspaceId) {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    DomainInfoResponse response =
+    return ResponseEntity.ok(
         new DomainInfoResponse()
             .items(
                 conceptService.getDomainInfo().stream()
-                    .map(DbDomainInfo.TO_CLIENT_DOMAIN_INFO)
-                    .collect(Collectors.toList()));
-    return ResponseEntity.ok(response);
+                    .map(this::toClientDomainInfo)
+                    .collect(Collectors.toList())));
   }
 
   @Override
-  public ResponseEntity<List<SurveyAnswerResponse>> getSurveyAnswers(
-      String workspaceNamespace, String workspaceId, Long questionConceptId) {
+  public ResponseEntity<List<SurveyQuestions>> searchSurveys(
+      String workspaceNamespace, String workspaceId, SearchSurveysRequest request) {
+    if (STANDARD_CONCEPTS.equals(request.getStandardConceptFilter())) {
+      return ResponseEntity.ok(new ArrayList<>());
+    }
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    List<SurveyAnswerResponse> answer = conceptBigQueryService.getSurveyAnswer(questionConceptId);
-    return ResponseEntity.ok(answer);
-  }
 
-  public ResponseEntity<List<SurveyQuestions>> getSurveyQuestions(
-      String workspaceNamespace, String workspaceId, String surveyName) {
-    workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    List<SurveyQuestions> surveyQuestionAnswerList =
-        conceptBigQueryService.getSurveyQuestions(surveyName);
-    return ResponseEntity.ok(surveyQuestionAnswerList);
+    Slice<DbCriteria> questionList =
+        conceptService.searchSurveys(
+            request.getQuery(),
+            request.getSurveyName(),
+            calculateResultLimit(request.getMaxResults()),
+            Optional.ofNullable(request.getPageNumber()).orElse(0));
+    return ResponseEntity.ok(
+        questionList.getContent().stream()
+            .map(this::toClientSurveyQuestions)
+            .collect(Collectors.toList()));
   }
 
   @Override
@@ -91,70 +85,24 @@ public class ConceptsController implements ConceptsApiDelegate {
       String workspaceNamespace, String workspaceId) {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-
-    SurveysResponse response =
+    return ResponseEntity.ok(
         new SurveysResponse()
             .items(
                 conceptService.getSurveyInfo().stream()
-                    .map(DbSurveyModule.TO_CLIENT_SURVEY_MODULE)
-                    .collect(Collectors.toList()));
-    return ResponseEntity.ok(response);
+                    .map(this::toClientSurveyModule)
+                    .collect(Collectors.toList())));
   }
 
-  private void addDomainCounts(SearchConceptsRequest request, ConceptListResponse response) {
-    if (request.getIncludeDomainCounts()) {
-      StandardConceptFilter standardConceptFilter = request.getStandardConceptFilter();
-      boolean allConcepts = standardConceptFilter == ALL_CONCEPTS;
-      DbDomainInfo pmDomainInfo = null;
-      String matchExp = ConceptService.modifyMultipleMatchKeyword(request.getQuery());
-      List<DbDomainInfo> allDbDomainInfos = conceptService.getAllDomainsOrderByDomainId();
-      List<DbDomainInfo> matchingDbDomainInfos =
-          matchExp == null ? allDbDomainInfos : new ArrayList<>();
-      if (matchingDbDomainInfos.isEmpty()) {
-        matchingDbDomainInfos =
-            conceptService.getConceptCounts(matchExp, request.getStandardConceptFilter().name());
-        if (allConcepts) {
-          pmDomainInfo =
-              conceptService.findPhysicalMeasurementConceptCounts(
-                  matchExp, request.getStandardConceptFilter().name());
-        }
-      }
-      Map<Domain, DbDomainInfo> domainCountMap =
-          Maps.uniqueIndex(matchingDbDomainInfos, DbDomainInfo::getDomainEnum);
-      // Loop through all domains to populate the results (so we get zeros for domains with no
-      // matches.)
-      for (DbDomainInfo allDbDomainInfo : allDbDomainInfos) {
-        Domain domain = allDbDomainInfo.getDomainEnum();
-        DbDomainInfo matchingDbDomainInfo = domainCountMap.get(domain);
-        if (domain.equals(Domain.PHYSICALMEASUREMENT) && pmDomainInfo != null) {
-          matchingDbDomainInfo = pmDomainInfo;
-        }
-        response.addDomainCountsItem(
-            new DomainCount()
-                .domain(domain)
-                .conceptCount(
-                    matchingDbDomainInfo == null
-                        ? 0L
-                        : (allConcepts
-                            ? matchingDbDomainInfo.getAllConceptCount()
-                            : matchingDbDomainInfo.getStandardConceptCount()))
-                .name(allDbDomainInfo.getName()));
-      }
-      long conceptCount = 0;
-      if (allConcepts) {
-        conceptCount =
-            matchExp == null
-                ? request.getSurveyName() == null
-                    ? conceptService.countSurveys()
-                    : conceptService.countSurveyByName(request.getSurveyName())
-                : conceptService.countSurveyBySearchTerm(matchExp);
-      }
-      response.addDomainCountsItem(
-          new DomainCount()
-              .domain(Domain.SURVEY)
-              .conceptCount(conceptCount)
-              .name(CommonStorageEnums.domainToDomainId(Domain.SURVEY).concat("s")));
-    }
+  @Override
+  public ResponseEntity<DomainCountsListResponse> domainCounts(
+      String workspaceNamespace, String workspaceId, DomainCountsRequest request) {
+    workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+    DomainCountsListResponse response = new DomainCountsListResponse();
+    List<DomainCount> counts =
+        conceptService.countDomains(
+            request.getQuery(), request.getSurveyName(), request.getStandardConceptFilter());
+    return ResponseEntity.ok(response.domainCounts(counts));
   }
 
   @Override
@@ -162,45 +110,30 @@ public class ConceptsController implements ConceptsApiDelegate {
       String workspaceNamespace, String workspaceId, SearchConceptsRequest request) {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    int maxResults = Optional.ofNullable(request.getMaxResults()).orElse(DEFAULT_MAX_RESULTS);
-    maxResults = Math.min(maxResults, MAX_MAX_RESULTS);
+
+    Slice<DbConcept> concepts =
+        conceptService.searchConcepts(
+            request.getQuery(),
+            request.getStandardConceptFilter(),
+            request.getDomain(),
+            calculateResultLimit(request.getMaxResults()),
+            Optional.ofNullable(request.getPageNumber()).orElse(0));
+
+    return ResponseEntity.ok(
+        new ConceptListResponse()
+            .items(
+                concepts.getContent().stream()
+                    .map(ConceptsController::toClientConcept)
+                    .collect(Collectors.toList())));
+  }
+
+  private int calculateResultLimit(Integer limit) {
+    int maxResults =
+        Math.min(Optional.ofNullable(limit).orElse(DEFAULT_MAX_RESULTS), MAX_MAX_RESULTS);
     if (maxResults < 1) {
       throw new BadRequestException("Invalid value for maxResults: " + maxResults);
     }
-
-    ConceptListResponse response = new ConceptListResponse();
-    if (request.getDomain().equals(Domain.SURVEY)) {
-      if (ALL_CONCEPTS.equals(request.getStandardConceptFilter())) {
-        Slice<DbCriteria> questionList =
-            conceptService.searchSurveys(
-                request.getQuery(),
-                request.getSurveyName(),
-                maxResults,
-                (request.getPageNumber() == null) ? 0 : request.getPageNumber());
-        response.setQuestions(
-            questionList.getContent().stream()
-                .map(this::toClientSurveyQuestions)
-                .collect(Collectors.toList()));
-      }
-    } else {
-      Slice<DbConcept> concepts =
-          conceptService.searchConcepts(
-              request.getQuery(),
-              request.getStandardConceptFilter().name(),
-              ImmutableList.of(CommonStorageEnums.domainToDomainId(request.getDomain())),
-              maxResults,
-              (request.getPageNumber() == null) ? 0 : request.getPageNumber());
-      if (concepts != null) {
-        response.setItems(
-            concepts.getContent().stream()
-                .map(ConceptsController::toClientConcept)
-                .collect(Collectors.toList()));
-      }
-    }
-
-    // TODO: consider doing these queries in parallel
-    addDomainCounts(request, response);
-    return ResponseEntity.ok(response);
+    return maxResults;
   }
 
   public static Concept toClientConcept(DbConcept concept) {
@@ -221,5 +154,25 @@ public class ConceptsController implements ConceptsApiDelegate {
     return new SurveyQuestions()
         .conceptId(dbCriteria.getLongConceptId())
         .question(dbCriteria.getName());
+  }
+
+  private DomainInfo toClientDomainInfo(DbDomainInfo dbDomainInfo) {
+    return new DomainInfo()
+        .domain(dbDomainInfo.getDomainEnum())
+        .name(dbDomainInfo.getName())
+        .description(dbDomainInfo.getDescription())
+        .allConceptCount(dbDomainInfo.getAllConceptCount())
+        .standardConceptCount(dbDomainInfo.getStandardConceptCount())
+        .participantCount(dbDomainInfo.getParticipantCount());
+  }
+
+  private SurveyModule toClientSurveyModule(DbSurveyModule dbSurveyModule) {
+    return new SurveyModule()
+        .conceptId(dbSurveyModule.getConceptId())
+        .name(dbSurveyModule.getName())
+        .description(dbSurveyModule.getDescription())
+        .questionCount(dbSurveyModule.getQuestionCount())
+        .participantCount(dbSurveyModule.getParticipantCount())
+        .orderNumber(dbSurveyModule.getOrderNumber());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.concept.ConceptService.ConceptIds;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService.ConceptColumns;
+import org.pmiops.workbench.model.Domain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +37,7 @@ public class ConceptBigQueryService {
     this.conceptService = conceptService;
   }
 
-  public int getParticipantCountForConcepts(String omopTable, Set<Long> conceptIds) {
+  public int getParticipantCountForConcepts(Domain domain, String omopTable, Set<Long> conceptIds) {
     ConceptColumns conceptColumns = cdrBigQuerySchemaConfigService.getConceptColumns(omopTable);
     ConceptIds classifiedConceptIds = conceptService.classifyConceptIds(conceptIds);
     if (classifiedConceptIds.getSourceConceptIds().isEmpty()
@@ -60,7 +61,11 @@ public class ConceptBigQueryService {
       }
     }
     if (!classifiedConceptIds.getSourceConceptIds().isEmpty()) {
-      innerSql.append(conceptColumns.getSourceConceptColumn().name);
+      if (Domain.SURVEY.equals(domain)) {
+        innerSql.append("observation_source_concept_id");
+      } else {
+        innerSql.append(conceptColumns.getSourceConceptColumn().name);
+      }
       innerSql.append(" in unnest(@sourceConceptIds)");
       paramMap.put(
           "sourceConceptIds",

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -5,17 +5,13 @@ import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.concept.ConceptService.ConceptIds;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService.ConceptColumns;
-import org.pmiops.workbench.model.SurveyAnswerResponse;
-import org.pmiops.workbench.model.SurveyQuestions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -26,29 +22,9 @@ public class ConceptBigQueryService {
   private final CdrBigQuerySchemaConfigService cdrBigQuerySchemaConfigService;
   private final ConceptService conceptService;
 
-  private static final String SURVEY_PARAM = "survey";
-  private static final String QUESTION_PARAM = "question_concept_id";
-
-  private static final String SURVEY_QUESTION_SQL_TEMPLATE =
-      "select DISTINCT(question) as question,\n"
-          + "question_concept_id as concept_id \n"
-          + "from `${projectId}.${dataSetId}.ds_survey`\n"
-          + "where UPPER(survey) = @"
-          + SURVEY_PARAM;
-
   private static final String SURVEY_QUESTION_CONCEPT_ID_SQL_TEMPLATE =
       "select DISTINCT(question_concept_id) as concept_id \n"
           + "from `${projectId}.${dataSetId}.ds_survey`\n";
-
-  private static final String SURVEY_ANSWER_SQL_TEMPLATE =
-      "select a.answer, answer_concept_id, ans_part_count, "
-          + "round((ans_part_count/ques_part_cnt)*100,2) from "
-          + "(SELECT answer, answer_concept_id, question_concept_id, count(distinct person_id) ans_part_count "
-          + "FROM `${projectId}.${dataSetId}.ds_survey` GROUP BY 1,2,3) a join "
-          + "(SELECT question, question_concept_id, count(distinct person_id) ques_part_cnt "
-          + "FROM `${projectId}.${dataSetId}.ds_survey` GROUP BY 1,2) b on "
-          + "a.question_concept_id = b.question_concept_id WHERE a.question_concept_id = @"
-          + QUESTION_PARAM;
 
   @Autowired
   public ConceptBigQueryService(
@@ -101,82 +77,13 @@ public class ConceptBigQueryService {
     return (int) result.iterateAll().iterator().next().get(0).getLongValue();
   }
 
-  private QueryJobConfiguration buildSurveyQuestionQuery(String surveyName) {
-    String finalSql = SURVEY_QUESTION_SQL_TEMPLATE;
-    Map<String, QueryParameterValue> params = new HashMap<>();
-    params.put(SURVEY_PARAM, QueryParameterValue.string(surveyName.toUpperCase()));
-    return QueryJobConfiguration.newBuilder(finalSql)
-        .setNamedParameters(params)
-        .setUseLegacySql(false)
-        .build();
-  }
-
-  private QueryJobConfiguration buildSurveyAnswerQuery(Long questionConceptId) {
-    String finalSql = SURVEY_ANSWER_SQL_TEMPLATE;
-    Map<String, QueryParameterValue> params = new HashMap<>();
-    params.put(QUESTION_PARAM, QueryParameterValue.int64(questionConceptId));
-    return QueryJobConfiguration.newBuilder(finalSql)
-        .setNamedParameters(params)
-        .setUseLegacySql(false)
-        .build();
-  }
-
-  private QueryJobConfiguration buildSurveyQuestionConceptIdQuery() {
-    String finalSql = SURVEY_QUESTION_CONCEPT_ID_SQL_TEMPLATE;
-    return QueryJobConfiguration.newBuilder(finalSql).setUseLegacySql(false).build();
-  }
-
-  public List<SurveyQuestions> getSurveyQuestions(String surveyName) {
-    List<SurveyQuestions> responseList = new ArrayList<>();
-
-    TableResult result =
-        bigQueryService.executeQuery(
-            bigQueryService.filterBigQueryConfig(buildSurveyQuestionQuery(surveyName)), 360000L);
-    result
-        .getValues()
-        .forEach(
-            surveyValue -> {
-              String question = surveyValue.get(0).getValue().toString();
-              Long concept_id = Long.parseLong(surveyValue.get(1).getValue().toString());
-              responseList.add(new SurveyQuestions().question(question).conceptId(concept_id));
-            });
-    return responseList;
-  }
-
-  public List<SurveyAnswerResponse> getSurveyAnswer(Long questionConceptId) {
-    List<SurveyAnswerResponse> answerList = new ArrayList<>();
-    TableResult result =
-        bigQueryService.executeQuery(
-            bigQueryService.filterBigQueryConfig(buildSurveyAnswerQuery(questionConceptId)),
-            360000L);
-    result
-        .getValues()
-        .forEach(
-            surveyValue -> {
-              SurveyAnswerResponse answer = new SurveyAnswerResponse();
-              if (surveyValue.get(2).getValue() != null) {
-                answer.setParticipationCount(
-                    Long.parseLong(surveyValue.get(2).getValue().toString()));
-              } else {
-                answer.setParticipationCount(0l);
-              }
-              answer.setAnswer(surveyValue.get(0).getValue().toString());
-              answer.setConceptId(Long.parseLong(surveyValue.get(1).getValue().toString()));
-              if (surveyValue.get(3).getValue() != null) {
-                answer.setPercentAnswered(
-                    Double.parseDouble(surveyValue.get(3).getValue().toString()));
-              } else {
-                answer.setPercentAnswered(0.0);
-              }
-              answerList.add(answer);
-            });
-    return answerList;
-  }
-
   public List<Long> getSurveyQuestionConceptIds() {
+    QueryJobConfiguration qjc =
+        QueryJobConfiguration.newBuilder(SURVEY_QUESTION_CONCEPT_ID_SQL_TEMPLATE)
+            .setUseLegacySql(false)
+            .build();
     TableResult result =
-        bigQueryService.executeQuery(
-            bigQueryService.filterBigQueryConfig(buildSurveyQuestionConceptIdQuery()), 360000L);
+        bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(qjc), 360000L);
     List<Long> conceptIdList = new ArrayList<>();
     result
         .getValues()

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -1,10 +1,15 @@
 package org.pmiops.workbench.concept;
 
+import static org.pmiops.workbench.model.StandardConceptFilter.ALL_CONCEPTS;
+import static org.pmiops.workbench.model.StandardConceptFilter.STANDARD_CONCEPTS;
+
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
+import java.util.stream.StreamSupport;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
@@ -15,6 +20,8 @@ import org.pmiops.workbench.cdr.model.DbDomainInfo;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.db.model.CommonStorageEnums;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.DomainCount;
+import org.pmiops.workbench.model.StandardConceptFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +32,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ConceptService {
+
+  public static final String STANDARD_CONCEPT_CODE = "S";
+  public static final String CLASSIFICATION_CONCEPT_CODE = "C";
+  public static final String EMPTY_CONCEPT_CODE = "";
+  public static final ImmutableList<String> STANDARD_CONCEPT_CODES =
+      ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE);
+  public static final ImmutableList<String> ALL_CONCEPT_CODES =
+      ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE, EMPTY_CONCEPT_CODE);
 
   public static class ConceptIds {
 
@@ -45,24 +60,14 @@ public class ConceptService {
     }
   }
 
-  @Autowired private ConceptDao conceptDao;
-  @Autowired private DomainInfoDao domainInfoDao;
-  @Autowired private SurveyModuleDao surveyModuleDao;
-  @Autowired private CBCriteriaDao cbCriteriaDao;
-  public static final String VOCAB_ID = "PPI";
-  public static final String CONCEPT_CLASS_ID = "Clinical Observation";
-  public static final String STANDARD_CONCEPTS = "STANDARD_CONCEPTS";
-  public static final String STANDARD_CONCEPT_CODE = "S";
-  public static final String CLASSIFICATION_CONCEPT_CODE = "C";
-  public static final String EMPTY_CONCEPT_CODE = "";
-  public static final ImmutableList<String> STANDARD_CONCEPT_CODES =
-      ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE);
-  public static final ImmutableList<String> ALL_CONCEPT_CODES =
-      ImmutableList.of(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE, EMPTY_CONCEPT_CODE);
+  private ConceptDao conceptDao;
+  private DomainInfoDao domainInfoDao;
+  private SurveyModuleDao surveyModuleDao;
+  private CBCriteriaDao cbCriteriaDao;
 
   public ConceptService() {}
 
-  // Used for tests
+  @Autowired
   public ConceptService(
       ConceptDao conceptDao,
       DomainInfoDao domainInfoDao,
@@ -74,7 +79,7 @@ public class ConceptService {
     this.cbCriteriaDao = cbCriteriaDao;
   }
 
-  public static String modifyMultipleMatchKeyword(String query) {
+  private static String modifyMultipleMatchKeyword(String query) {
     // This function modifies the keyword to match all the words if multiple words are present(by
     // adding + before each word to indicate match that matching each word is essential)
     if (query == null || query.trim().isEmpty()) {
@@ -92,7 +97,7 @@ public class ConceptService {
         tempKey = key;
       }
       if (!tempKey.isEmpty()) {
-        String toAdd = new String("+" + tempKey);
+        String toAdd = "+" + tempKey;
         if (tempKey.contains("-") && !temp.contains(tempKey)) {
           temp.add(tempKey);
         } else if (tempKey.contains("*") && tempKey.length() > 1) {
@@ -119,90 +124,97 @@ public class ConceptService {
     return domainInfoDao.findByOrderByDomainId();
   }
 
-  public List<DbDomainInfo> getAllDomainsOrderByDomainId() {
-    return domainInfoDao.findByOrderByDomainId();
-  }
-
-  public List<DbDomainInfo> getConceptCounts(String matchExp, String standardConceptFilter) {
-    return domainInfoDao.findConceptCounts(matchExp, getConceptTypes(standardConceptFilter));
-  }
-
-  public DbDomainInfo findPhysicalMeasurementConceptCounts(
-      String matchExp, String standardConceptFilter) {
-    return domainInfoDao.findPhysicalMeasurementConceptCounts(
-        matchExp, getConceptTypes(standardConceptFilter));
-  }
-
-  private ImmutableList<String> getConceptTypes(String standardConceptFilter) {
-    return STANDARD_CONCEPTS.equals(standardConceptFilter)
-        ? STANDARD_CONCEPT_CODES
-        : ALL_CONCEPT_CODES;
-  }
-
   public List<DbSurveyModule> getSurveyInfo() {
     return surveyModuleDao.findByParticipantCountNotOrderByOrderNumberAsc(0L);
   }
 
-  public long countSurveyBySearchTerm(String matchExp) {
-    return cbCriteriaDao.countSurveyBySearchTerm(matchExp);
-  }
-
-  public long countSurveyByName(String surveyName) {
-    return cbCriteriaDao.countSurveyByName(surveyName);
-  }
-
-  public long countSurveys() {
-    return cbCriteriaDao.countSurveys();
-  }
-
   public Slice<DbConcept> searchConcepts(
       String query,
-      String standardConceptFilter,
-      ImmutableList<String> domainIds,
+      StandardConceptFilter standardConceptFilter,
+      Domain domain,
       int limit,
       int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.DESC, "countValue"));
     ImmutableList<String> conceptTypes = getConceptTypes(standardConceptFilter);
-    if (domainIds.contains(CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT))) {
-      ImmutableList<String> domains =
-          ImmutableList.of(CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT));
-      return StringUtils.isBlank(keyword)
-          ? conceptDao.findConcepts(conceptTypes, domains, VOCAB_ID, CONCEPT_CLASS_ID, pageable)
-          : conceptDao.findConcepts(
-              keyword, conceptTypes, domains, VOCAB_ID, CONCEPT_CLASS_ID, pageable);
-    } else {
-      return StringUtils.isBlank(keyword)
-          ? conceptDao.findConcepts(conceptTypes, domainIds, pageable)
-          : conceptDao.findConcepts(keyword, conceptTypes, domainIds, pageable);
-    }
+    return conceptDao.findConcepts(keyword, conceptTypes, domain, pageable);
   }
 
   public Slice<DbCriteria> searchSurveys(String query, String surveyName, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.ASC, "id"));
-    if (StringUtils.isBlank(keyword)) {
-      return StringUtils.isBlank(surveyName)
-          ? cbCriteriaDao.findSurveys(pageable)
-          : cbCriteriaDao.findSurveysByName(surveyName, pageable);
+    return cbCriteriaDao.findSurveys(keyword, surveyName, pageable);
+  }
+
+  public List<DomainCount> countDomains(
+      String query, String surveyName, StandardConceptFilter standardConceptFilter) {
+    List<DomainCount> domainCountList = new ArrayList<>();
+    boolean allConcepts = ALL_CONCEPTS.equals(standardConceptFilter);
+    DbDomainInfo pmDomainInfo = null;
+    String matchExp = modifyMultipleMatchKeyword(query);
+    List<DbDomainInfo> allDbDomainInfos = domainInfoDao.findByOrderByDomainId();
+    List<DbDomainInfo> matchingDbDomainInfos =
+        matchExp == null ? allDbDomainInfos : new ArrayList<>();
+    if (matchingDbDomainInfos.isEmpty()) {
+      matchingDbDomainInfos =
+          domainInfoDao.findConceptCounts(matchExp, getConceptTypes(standardConceptFilter));
+      if (allConcepts) {
+        pmDomainInfo =
+            domainInfoDao.findPhysicalMeasurementConceptCounts(
+                matchExp, getConceptTypes(standardConceptFilter));
+      }
     }
-    return cbCriteriaDao.findSurveys(keyword, pageable);
+    Map<Domain, DbDomainInfo> domainCountMap =
+        Maps.uniqueIndex(matchingDbDomainInfos, DbDomainInfo::getDomainEnum);
+    // Loop through all domains to populate the results (so we get zeros for domains with no
+    // matches.)
+    for (DbDomainInfo allDbDomainInfo : allDbDomainInfos) {
+      Domain domain = allDbDomainInfo.getDomainEnum();
+      DbDomainInfo matchingDbDomainInfo = domainCountMap.get(domain);
+      if (domain.equals(Domain.PHYSICALMEASUREMENT) && pmDomainInfo != null) {
+        matchingDbDomainInfo = pmDomainInfo;
+      }
+      domainCountList.add(
+          new DomainCount()
+              .domain(domain)
+              .conceptCount(
+                  matchingDbDomainInfo == null
+                      ? 0L
+                      : (allConcepts
+                          ? matchingDbDomainInfo.getAllConceptCount()
+                          : matchingDbDomainInfo.getStandardConceptCount()))
+              .name(allDbDomainInfo.getName()));
+    }
+    long conceptCount = 0;
+    if (allConcepts) {
+      conceptCount = cbCriteriaDao.countSurveys(matchExp, surveyName);
+    }
+    domainCountList.add(
+        new DomainCount()
+            .domain(Domain.SURVEY)
+            .conceptCount(conceptCount)
+            .name(CommonStorageEnums.domainToDomainId(Domain.SURVEY).concat("s")));
+    return domainCountList;
   }
 
   public ConceptIds classifyConceptIds(Set<Long> conceptIds) {
     ImmutableList.Builder<Long> standardConceptIds = ImmutableList.builder();
     ImmutableList.Builder<Long> sourceConceptIds = ImmutableList.builder();
-
-    Iterable<DbConcept> concepts = conceptDao.findAll(conceptIds);
-    for (DbConcept concept : concepts) {
-      if (ConceptService.STANDARD_CONCEPT_CODE.equals(concept.getStandardConcept())
-          || ConceptService.CLASSIFICATION_CONCEPT_CODE.equals(concept.getStandardConcept())) {
-        standardConceptIds.add(concept.getConceptId());
-      } else {
-        // We may need to handle classification / concept hierarchy here eventually...
-        sourceConceptIds.add(concept.getConceptId());
-      }
-    }
+    StreamSupport.stream(conceptDao.findAll(conceptIds).spliterator(), false)
+        .forEach(
+            c -> {
+              if (STANDARD_CONCEPT_CODES.contains(c.getStandardConcept())) {
+                standardConceptIds.add(c.getConceptId());
+              } else {
+                sourceConceptIds.add(c.getConceptId());
+              }
+            });
     return new ConceptIds(standardConceptIds.build(), sourceConceptIds.build());
+  }
+
+  private ImmutableList<String> getConceptTypes(StandardConceptFilter standardConceptFilter) {
+    return STANDARD_CONCEPTS.equals(standardConceptFilter)
+        ? STANDARD_CONCEPT_CODES
+        : ALL_CONCEPT_CODES;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -31,7 +31,7 @@ public class ConceptSetService {
       String omopTable = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(conceptSet.getDomainEnum());
       dbConceptSet.setParticipantCount(
           conceptBigQueryService.getParticipantCountForConcepts(
-              omopTable, conceptSet.getConceptIds()));
+              conceptSet.getDomainEnum(), omopTable, conceptSet.getConceptIds()));
     }
     dbConceptSet.setWorkspaceId(targetWorkspace.getWorkspaceId());
     dbConceptSet.setCreator(targetWorkspace.getCreator());

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -22,6 +22,7 @@ public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
           .put(Domain.PERSON, "person")
           .put(Domain.VISIT, "visit_occurrence")
           .put(Domain.SURVEY, "observation")
+          .put(Domain.PHYSICALMEASUREMENT, "measurement")
           .build();
 
   List<DbConceptSet> findByWorkspaceId(long workspaceId);

--- a/api/src/main/resources/client_api.yaml
+++ b/api/src/main/resources/client_api.yaml
@@ -126,6 +126,31 @@ paths:
           schema:
             $ref: "#/definitions/ConceptListResponse"
 
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/domainCounts:
+    post:
+      tags:
+        - concepts
+      consumes:
+        - application/json
+      description: >
+        Searches for concepts in concept table by name, and optionally filter on
+        domain, vocabulary IDs, or standard concept status. Uses the CDR version affiliated
+        with the workspace specified in the path.
+      operationId: "domainCounts"
+      parameters:
+        - $ref: '#/parameters/workspaceNamespace'
+        - $ref: '#/parameters/workspaceId'
+        - in: body
+          name: request
+          description: domain counts search request
+          schema:
+            $ref: "#/definitions/DomainCountsRequest"
+      responses:
+        200:
+          description: A collection of concepts
+          schema:
+            $ref: "#/definitions/DomainCountsListResponse"
+
 definitions:
 
   DataTableSpecification:
@@ -501,7 +526,6 @@ definitions:
     required:
       - standardConceptFilter
       - domain
-      - includeDomainCounts
     properties:
       query:
         type: string
@@ -528,14 +552,32 @@ definitions:
         type: integer
         format: int32
         description: The maximum number of results returned. Defaults to 20.
-      includeDomainCounts:
-        type: boolean
-        default: false
-        description: True if per-domain counts of concepts matching the criteria should be included in the response
       pageNumber:
         type: integer
         default: 0
         description: By default it returns the first page and then its next pages from that on.
+
+  DomainCountsRequest:
+    type: object
+    required:
+      - standardConceptFilter
+    properties:
+      query:
+        type: string
+        description: >
+          A query string that can be used to match a subset of the name (case-insensitively),
+          the entire code value (case-insensitively), or the concept ID. If not specified, all
+          concepts are returned.
+      standardConceptFilter:
+        description: >
+          STANDARD_CONCEPTS if only standard concepts should be returned,
+          NON_STANDARD_CONCEPTS if only non-standard
+          concepts should be returned; defaults to ALL_CONCEPTS, meaning both
+          standard and non-standard concepts will be returned.
+        $ref: "#/definitions/StandardConceptFilter"
+      surveyName:
+        description: The name of the survey clicked
+        type: string
 
   ConceptListResponse:
     type: object
@@ -550,6 +592,12 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/SurveyQuestions"
+
+  DomainCountsListResponse:
+    type: object
+    required:
+      - domainCounts
+    properties:
       domainCounts:
         type: "array"
         items:

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1955,50 +1955,28 @@ paths:
           schema:
             $ref: "#/definitions/SurveysResponse"
 
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/{surveyName}/surveyQuestions:
-    get:
+  /v1/workspaces/{workspaceNamespace}/{workspaceId}/searchSurveys:
+    post:
       tags:
         - concepts
       description: >
-        Returns survey questions and answers in the workspace's CDR version
-      operationId: "getSurveyQuestions"
+        Searches for surveys in criteria table by synonyms or survey name
+      operationId: "searchSurveys"
       parameters:
         - $ref: '#/parameters/workspaceNamespace'
         - $ref: '#/parameters/workspaceId'
-        - in: path
-          name: surveyName
-          required: true
-          type: string
+        - in: body
+          name: request
+          description: survey search request
+          schema:
+            $ref: "#/definitions/SearchSurveysRequest"
       responses:
         200:
-          description: information about the surveys
+          description: collection of survey questions
           schema:
             type: "array"
             items:
               $ref: "#/definitions/SurveyQuestions"
-
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/surveyAnswer:
-    get:
-      tags:
-        - concepts
-      description: >
-        Returns with all the answer for survey Question
-      operationId: "getSurveyAnswers"
-      parameters:
-        - $ref: '#/parameters/workspaceNamespace'
-        - $ref: '#/parameters/workspaceId'
-        - in: query
-          name: questionConceptId
-          required: true
-          type: integer
-          format: int64
-      responses:
-        200:
-          description: List of Survey Details with Answer
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/SurveyAnswerResponse"
 
   ### Data set ############################################
   /v1/workspaces/{workspaceNamespace}/{workspaceId}/data-set/generateCode/{kernelType}:
@@ -3386,6 +3364,36 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/SurveyModule"
+
+  SearchSurveysRequest:
+    type: object
+    required:
+      - standardConceptFilter
+    properties:
+      query:
+        type: string
+        description: >
+          A query string that can be used to match a subset of the name (case-insensitively),
+          the entire code value (case-insensitively), or the concept ID. If not specified, all
+          concepts are returned.
+      standardConceptFilter:
+        description: >
+          STANDARD_CONCEPTS if only standard concepts should be returned,
+          NON_STANDARD_CONCEPTS if only non-standard
+          concepts should be returned; defaults to ALL_CONCEPTS, meaning both
+          standard and non-standard concepts will be returned.
+        $ref: "#/definitions/StandardConceptFilter"
+      surveyName:
+        description: The name of the survey clicked
+        type: string
+      maxResults:
+        type: integer
+        format: int32
+        description: The maximum number of results returned. Defaults to 20.
+      pageNumber:
+        type: integer
+        default: 0
+        description: By default it returns the first page and then its next pages from that on.
 
   SurveyQuestions:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -509,9 +509,12 @@ public class ConceptSetsControllerTest {
   public void testUpdateConceptSetConceptsAddAndRemove() {
     saveConcepts();
     when(conceptBigQueryService.getParticipantCountForConcepts(
-            "condition_occurrence", ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId())))
+            Domain.CONDITION,
+            "condition_occurrence",
+            ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId())))
         .thenReturn(123);
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId(), CLIENT_CONCEPT_3.getConceptId())))
         .thenReturn(246);
@@ -546,6 +549,7 @@ public class ConceptSetsControllerTest {
   public void testUpdateConceptSetConceptsAddMany() {
     saveConcepts();
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(
                 CLIENT_CONCEPT_1.getConceptId(),
@@ -571,7 +575,9 @@ public class ConceptSetsControllerTest {
     assertThat(updated.getParticipantCount()).isEqualTo(456);
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
-            "condition_occurrence", ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId())))
+            Domain.CONDITION,
+            "condition_occurrence",
+            ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId())))
         .thenReturn(123);
     ConceptSet removed =
         conceptSetsController
@@ -594,6 +600,7 @@ public class ConceptSetsControllerTest {
   public void testUpdateConceptSetConceptsAddManyOnCreate() {
     saveConcepts();
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(
                 CLIENT_CONCEPT_1.getConceptId(),

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -21,7 +21,9 @@ import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cdr.model.DbConcept;
+import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
+import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
@@ -40,10 +42,13 @@ import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptListResponse;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainCount;
+import org.pmiops.workbench.model.DomainCountsListResponse;
+import org.pmiops.workbench.model.DomainCountsRequest;
 import org.pmiops.workbench.model.DomainInfo;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.SearchConceptsRequest;
 import org.pmiops.workbench.model.StandardConceptFilter;
+import org.pmiops.workbench.model.SurveyModule;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
@@ -197,6 +202,17 @@ public class ConceptsControllerTest {
           .standardConceptCount(3)
           .allConceptCount(4);
 
+  private static final DbDomainInfo OBSERVATION_DOMAIN =
+      new DbDomainInfo()
+          .domainEnum(Domain.OBSERVATION)
+          .domainId("Observation")
+          .name("Observation")
+          .description("Observation")
+          .conceptId(CONCEPT_4.getConceptId())
+          .participantCount(33)
+          .standardConceptCount(56)
+          .allConceptCount(90);
+
   private static final DbDomainInfo SURVEY_DOMAIN =
       new DbDomainInfo()
           .domainEnum(Domain.SURVEY)
@@ -204,9 +220,36 @@ public class ConceptsControllerTest {
           .name("Surveys")
           .description("SURVEY")
           .conceptId(CONCEPT_4.getConceptId())
-          .participantCount(0)
+          .participantCount(45)
           .standardConceptCount(0)
-          .allConceptCount(0);
+          .allConceptCount(2);
+
+  private static final DbSurveyModule BASICS_SURVEY_MODULE =
+      new DbSurveyModule()
+          .conceptId(1L)
+          .description("The Basics")
+          .name("The Basics")
+          .orderNumber(1)
+          .participantCount(200)
+          .questionCount(16);
+
+  private static final DbSurveyModule LIFESTYLE_SURVEY_MODULE =
+      new DbSurveyModule()
+          .conceptId(2L)
+          .description("Lifestyle")
+          .name("Lifestyle")
+          .orderNumber(3)
+          .participantCount(2000)
+          .questionCount(24);
+
+  private static final DbSurveyModule OVERALL_HEALTH_SURVEY_MODULE =
+      new DbSurveyModule()
+          .conceptId(3L)
+          .description("Overall Health")
+          .name("Overall Health")
+          .orderNumber(2)
+          .participantCount(2000)
+          .questionCount(24);
 
   private static final String WORKSPACE_NAMESPACE = "ns";
   private static final String WORKSPACE_NAME = "name";
@@ -236,13 +279,12 @@ public class ConceptsControllerTest {
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private CdrVersionDao cdrVersionDao;
-  @Autowired private ConceptBigQueryService conceptBigQueryService;
   @Autowired private DomainInfoDao domainInfoDao;
+  @Autowired private SurveyModuleDao surveyModuleDao;
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired FireCloudService fireCloudService;
   @Autowired UserDao userDao;
   @Mock Provider<DbUser> userProvider;
-  @Autowired SurveyModuleDao surveyModuleDao;
 
   private ConceptsController conceptsController;
 
@@ -253,8 +295,7 @@ public class ConceptsControllerTest {
     // controller directly.
     ConceptService conceptService =
         new ConceptService(conceptDao, domainInfoDao, surveyModuleDao, cbCriteriaDao);
-    conceptsController =
-        new ConceptsController(conceptService, conceptBigQueryService, workspaceService);
+    conceptsController = new ConceptsController(conceptService, workspaceService);
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);
@@ -290,6 +331,42 @@ public class ConceptsControllerTest {
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
     when(fireCloudService.getWorkspaceAcl(WORKSPACE_NAMESPACE, WORKSPACE_NAME))
         .thenReturn(workspaceAccessLevelResponse);
+
+    DbCriteria parentSurvey =
+        cbCriteriaDao.save(
+            new DbCriteria()
+                .ancestorData(false)
+                .attribute(false)
+                .code("c")
+                .conceptId("1")
+                .count("20")
+                .domainId("SURVEY")
+                .group(true)
+                .hierarchy(true)
+                .name("The Basics")
+                .parentId(0L)
+                .selectable(true)
+                .standard(true)
+                .subtype("QUESTION")
+                .type("PPI"));
+
+    cbCriteriaDao.save(
+        new DbCriteria()
+            .ancestorData(false)
+            .attribute(false)
+            .code("c")
+            .conceptId("1")
+            .count("20")
+            .domainId("SURVEY")
+            .group(true)
+            .hierarchy(true)
+            .name("question")
+            .parentId(parentSurvey.getId())
+            .selectable(true)
+            .standard(true)
+            .subtype("QUESTION")
+            .type("PPI")
+            .synonyms("test"));
   }
 
   @Test
@@ -301,14 +378,12 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query(" ")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)));
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)));
   }
 
   @Test
   public void testSearchConceptsBlankQueryWithResults() {
     saveConcepts();
-    saveDomains();
     assertResults(
         conceptsController.searchConcepts(
             "ns",
@@ -316,8 +391,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query(" ")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)),
         CLIENT_CONCEPT_6,
         CLIENT_CONCEPT_5,
         CLIENT_CONCEPT_3,
@@ -325,111 +399,132 @@ public class ConceptsControllerTest {
   }
 
   @Test
-  public void testSearchConceptsBlankQueryWithDomainAllCounts() {
+  public void testDomainCountSourceAndStandardTotalCount() {
     saveConcepts();
     saveDomains();
-    // When no query is provided, domain concept counts come from domain info directly.
-    ResponseEntity<ConceptListResponse> response =
-        conceptsController.searchConcepts(
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
             "ns",
             "name",
-            new SearchConceptsRequest()
-                .includeDomainCounts(true)
-                .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
-    assertResultsWithCounts(
+            new DomainCountsRequest().standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
+    assertCounts(
         response,
         ImmutableList.of(
             toDomainCount(CONDITION_DOMAIN, false),
             toDomainCount(DRUG_DOMAIN, false),
             toDomainCount(MEASUREMENT_DOMAIN, false),
+            toDomainCount(OBSERVATION_DOMAIN, false),
             toDomainCount(PROCEDURE_DOMAIN, false),
-            toDomainCount(SURVEY_DOMAIN, false)),
-        ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5, CLIENT_CONCEPT_3, CLIENT_CONCEPT_1));
+            toDomainCount(SURVEY_DOMAIN, false)));
   }
 
   @Test
-  public void testSearchConceptsBlankQueryWithDomainStandardCounts() {
+  public void testDomainCountSourceAndStandardWithSearchTerm() {
     saveConcepts();
     saveDomains();
-    // When no query is provided, domain concept counts come from domain info directly.
-    ResponseEntity<ConceptListResponse> response =
-        conceptsController.searchConcepts(
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
             "ns",
             "name",
-            new SearchConceptsRequest()
-                .domain(Domain.CONDITION)
-                .includeDomainCounts(true)
+            new DomainCountsRequest()
+                .query("conceptA")
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
+    assertCounts(
+        response,
+        ImmutableList.of(
+            toDomainCount(CONDITION_DOMAIN, 1),
+            toDomainCount(DRUG_DOMAIN, 0),
+            toDomainCount(MEASUREMENT_DOMAIN, 0),
+            toDomainCount(OBSERVATION_DOMAIN, 0),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)));
+  }
+
+  @Test
+  public void testDomainCountStandardTotalCount() {
+    saveConcepts();
+    saveDomains();
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
+            "ns",
+            "name",
+            new DomainCountsRequest()
                 .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS));
-    assertResultsWithCounts(
+    assertCounts(
         response,
         ImmutableList.of(
             toDomainCount(CONDITION_DOMAIN, true),
             toDomainCount(DRUG_DOMAIN, true),
             toDomainCount(MEASUREMENT_DOMAIN, true),
+            toDomainCount(OBSERVATION_DOMAIN, true),
             toDomainCount(PROCEDURE_DOMAIN, true),
-            toDomainCount(SURVEY_DOMAIN, true)),
-        ImmutableList.of(CLIENT_CONCEPT_5, CLIENT_CONCEPT_1));
+            toDomainCount(SURVEY_DOMAIN, true)));
   }
 
   @Test
-  public void testSearchConceptsBlankQueryWithDomainAndVocabStandardCounts() {
+  public void testDomainCountStandardWithSearchTerm() {
     saveConcepts();
     saveDomains();
-    // When no query is provided, domain concept counts come from domain info directly.
-    ResponseEntity<ConceptListResponse> response =
-        conceptsController.searchConcepts(
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
             "ns",
             "name",
-            new SearchConceptsRequest()
-                .includeDomainCounts(true)
-                .domain(Domain.CONDITION)
+            new DomainCountsRequest()
+                .query("conceptD")
                 .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS));
-    assertResultsWithCounts(
+    assertCounts(
         response,
         ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, true),
-            toDomainCount(DRUG_DOMAIN, true),
-            toDomainCount(MEASUREMENT_DOMAIN, true),
-            toDomainCount(PROCEDURE_DOMAIN, true),
-            toDomainCount(SURVEY_DOMAIN, true)),
-        ImmutableList.of(CLIENT_CONCEPT_5, CLIENT_CONCEPT_1));
+            toDomainCount(CONDITION_DOMAIN, 1),
+            toDomainCount(DRUG_DOMAIN, 0),
+            toDomainCount(MEASUREMENT_DOMAIN, 0),
+            toDomainCount(OBSERVATION_DOMAIN, 1),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 0)));
   }
 
   @Test
-  public void testSearchConceptsBlankQueryInDomain() {
+  public void testSurveyCountSourceAndStandardWithSearchTerm() {
     saveConcepts();
-    assertResults(
-        conceptsController.searchConcepts(
+    saveDomains();
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
             "ns",
             "name",
-            new SearchConceptsRequest()
-                .domain(Domain.CONDITION)
-                .query(" ")
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)),
-        CLIENT_CONCEPT_6,
-        CLIENT_CONCEPT_5,
-        CLIENT_CONCEPT_3,
-        CLIENT_CONCEPT_1);
+            new DomainCountsRequest()
+                .query("test")
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
+    assertCounts(
+        response,
+        ImmutableList.of(
+            toDomainCount(CONDITION_DOMAIN, 2),
+            toDomainCount(DRUG_DOMAIN, 0),
+            toDomainCount(MEASUREMENT_DOMAIN, 0),
+            toDomainCount(OBSERVATION_DOMAIN, 1),
+            toDomainCount(PROCEDURE_DOMAIN, 0),
+            toDomainCount(SURVEY_DOMAIN, 1)));
   }
 
   @Test
-  public void testSearchConceptsBlankQueryInDomainWithVocabularyIds() {
+  public void testSurveyCountSourceAndStandardWithSurveyName() {
     saveConcepts();
-    assertResults(
-        conceptsController.searchConcepts(
+    saveDomains();
+    ResponseEntity<DomainCountsListResponse> response =
+        conceptsController.domainCounts(
             "ns",
             "name",
-            new SearchConceptsRequest()
-                .domain(Domain.CONDITION)
-                .query(" ")
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)),
-        CLIENT_CONCEPT_6,
-        CLIENT_CONCEPT_5,
-        CLIENT_CONCEPT_3,
-        CLIENT_CONCEPT_1);
+            new DomainCountsRequest()
+                .surveyName("The Basics")
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
+    assertCounts(
+        response,
+        ImmutableList.of(
+            toDomainCount(CONDITION_DOMAIN, false),
+            toDomainCount(DRUG_DOMAIN, false),
+            toDomainCount(MEASUREMENT_DOMAIN, false),
+            toDomainCount(OBSERVATION_DOMAIN, false),
+            toDomainCount(PROCEDURE_DOMAIN, false),
+            toDomainCount(SURVEY_DOMAIN, 1)));
   }
 
   @Test
@@ -441,8 +536,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("a")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)));
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)));
   }
 
   @Test
@@ -455,8 +549,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("x")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)));
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)));
   }
 
   @Test
@@ -469,8 +562,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("conceptA")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
         CLIENT_CONCEPT_1);
   }
 
@@ -485,8 +577,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("123")
                 .domain(Domain.OBSERVATION)
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
         CLIENT_CONCEPT_4);
   }
 
@@ -500,8 +591,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("V456")
                 .domain(Domain.OBSERVATION)
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
         CLIENT_CONCEPT_4);
   }
 
@@ -515,156 +605,23 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("conceptD")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)),
         CLIENT_CONCEPT_6,
         CLIENT_CONCEPT_5);
   }
 
   @Test
-  public void testSearchConceptsWithDomainAllCounts() {
+  public void testSearchConceptsWithVocabularyStandard() {
     saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
+    assertResults(
         conceptsController.searchConcepts(
             "ns",
             "name",
             new SearchConceptsRequest()
                 .query("conceptD")
                 .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(true)),
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 2),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 0)),
-        ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5));
-  }
-
-  @Test
-  public void testSearchConceptsWithDomainStandardCounts() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .domain(Domain.OBSERVATION)
-                .query("conceptD")
-                .includeDomainCounts(true)
                 .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 1),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 0)),
-        ImmutableList.of(CLIENT_CONCEPT_4));
-  }
-
-  @Test
-  public void testSearchConceptsWithoutDomainCounts() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .query("conceptD")
-                .domain(Domain.CONDITION)
-                .includeDomainCounts(false)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)),
-        null,
-        ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5));
-  }
-
-  @Test
-  public void testSearchConceptsWithVocabularyStandardCounts() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .query("conceptD")
-                .domain(Domain.CONDITION)
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)),
-        null,
-        ImmutableList.of(CLIENT_CONCEPT_5));
-  }
-
-  @Test
-  public void testSearchConceptsWithDomainAndVocabularyStandardCounts() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .query("conceptD")
-                .domain(Domain.CONDITION)
-                .includeDomainCounts(true)
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 1),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 0)),
-        ImmutableList.of(CLIENT_CONCEPT_5));
-  }
-
-  @Test
-  public void testSearchConceptsWithDomainAndVocabularyAllCounts() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .query("conceptD")
-                .domain(Domain.CONDITION)
-                .includeDomainCounts(true)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)),
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 2),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 0)),
-        ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5));
-  }
-
-  @Test
-  public void testSearchConceptsWithDomainAndVocabularyAllCountsMatchAllConditions() {
-    saveConcepts();
-    saveDomains();
-    assertResultsWithCounts(
-        conceptsController.searchConcepts(
-            "ns",
-            "name",
-            new SearchConceptsRequest()
-                .query("con")
-                .domain(Domain.CONDITION)
-                .includeDomainCounts(true)
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)),
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 4),
-            toDomainCount(DRUG_DOMAIN, 0),
-            // Although it doesn't match the domain filter, we still include the measurement concept
-            // in domain counts
-            toDomainCount(MEASUREMENT_DOMAIN, 1),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 0)),
-        ImmutableList.of(CLIENT_CONCEPT_6, CLIENT_CONCEPT_5, CLIENT_CONCEPT_3, CLIENT_CONCEPT_1));
+        CLIENT_CONCEPT_5);
   }
 
   @Test
@@ -677,7 +634,6 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .domain(Domain.MEASUREMENT)
                 .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)
                 .query("conceptB")),
         CLIENT_CONCEPT_2);
   }
@@ -692,8 +648,7 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .domain(Domain.CONDITION)
                 .query("conceptA")
-                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)),
+                .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
         CLIENT_CONCEPT_1);
   }
 
@@ -707,7 +662,6 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("zzz")
                 .domain(Domain.OBSERVATION)
-                .includeDomainCounts(false)
                 .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)));
   }
 
@@ -721,7 +675,6 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("conceptA")
                 .domain(Domain.CONDITION)
-                .includeDomainCounts(false)
                 .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)),
         CLIENT_CONCEPT_1);
   }
@@ -736,7 +689,6 @@ public class ConceptsControllerTest {
             new SearchConceptsRequest()
                 .query("con")
                 .standardConceptFilter(StandardConceptFilter.STANDARD_CONCEPTS)
-                .includeDomainCounts(false)
                 .domain(Domain.CONDITION)),
         CLIENT_CONCEPT_5,
         CLIENT_CONCEPT_1);
@@ -753,7 +705,6 @@ public class ConceptsControllerTest {
                 .query("conceptC")
                 .domain(Domain.CONDITION)
                 .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)
                 .maxResults(1)),
         CLIENT_CONCEPT_3);
   }
@@ -769,7 +720,6 @@ public class ConceptsControllerTest {
                 .query("est")
                 .domain(Domain.CONDITION)
                 .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS)
-                .includeDomainCounts(false)
                 .maxResults(1000)),
         CLIENT_CONCEPT_6,
         CLIENT_CONCEPT_5);
@@ -805,12 +755,50 @@ public class ConceptsControllerTest {
                 .allConceptCount(MEASUREMENT_DOMAIN.getAllConceptCount())
                 .standardConceptCount(MEASUREMENT_DOMAIN.getStandardConceptCount()),
             new DomainInfo()
+                .domain(OBSERVATION_DOMAIN.getDomainEnum())
+                .name(OBSERVATION_DOMAIN.getName())
+                .description(OBSERVATION_DOMAIN.getDescription())
+                .participantCount(OBSERVATION_DOMAIN.getParticipantCount())
+                .allConceptCount(OBSERVATION_DOMAIN.getAllConceptCount())
+                .standardConceptCount(OBSERVATION_DOMAIN.getStandardConceptCount()),
+            new DomainInfo()
                 .domain(PROCEDURE_DOMAIN.getDomainEnum())
                 .name(PROCEDURE_DOMAIN.getName())
                 .description(PROCEDURE_DOMAIN.getDescription())
                 .participantCount(PROCEDURE_DOMAIN.getParticipantCount())
                 .allConceptCount(PROCEDURE_DOMAIN.getAllConceptCount())
                 .standardConceptCount(PROCEDURE_DOMAIN.getStandardConceptCount()))
+        .inOrder();
+  }
+
+  @Test
+  public void testGetSurveyInfo() {
+    saveSurveyInfo();
+    List<SurveyModule> surveyModules =
+        conceptsController.getSurveyInfo("ns", "name").getBody().getItems();
+    assertThat(surveyModules)
+        .containsExactly(
+            new SurveyModule()
+                .conceptId(BASICS_SURVEY_MODULE.getConceptId())
+                .description(BASICS_SURVEY_MODULE.getDescription())
+                .name(BASICS_SURVEY_MODULE.getName())
+                .orderNumber(BASICS_SURVEY_MODULE.getOrderNumber())
+                .participantCount(BASICS_SURVEY_MODULE.getParticipantCount())
+                .questionCount(BASICS_SURVEY_MODULE.getQuestionCount()),
+            new SurveyModule()
+                .conceptId(OVERALL_HEALTH_SURVEY_MODULE.getConceptId())
+                .description(OVERALL_HEALTH_SURVEY_MODULE.getDescription())
+                .name(OVERALL_HEALTH_SURVEY_MODULE.getName())
+                .orderNumber(OVERALL_HEALTH_SURVEY_MODULE.getOrderNumber())
+                .participantCount(OVERALL_HEALTH_SURVEY_MODULE.getParticipantCount())
+                .questionCount(OVERALL_HEALTH_SURVEY_MODULE.getQuestionCount()),
+            new SurveyModule()
+                .conceptId(LIFESTYLE_SURVEY_MODULE.getConceptId())
+                .description(LIFESTYLE_SURVEY_MODULE.getDescription())
+                .name(LIFESTYLE_SURVEY_MODULE.getName())
+                .orderNumber(LIFESTYLE_SURVEY_MODULE.getOrderNumber())
+                .participantCount(LIFESTYLE_SURVEY_MODULE.getParticipantCount())
+                .questionCount(LIFESTYLE_SURVEY_MODULE.getQuestionCount()))
         .inOrder();
   }
 
@@ -847,6 +835,13 @@ public class ConceptsControllerTest {
     domainInfoDao.save(PROCEDURE_DOMAIN);
     domainInfoDao.save(CONDITION_DOMAIN);
     domainInfoDao.save(DRUG_DOMAIN);
+    domainInfoDao.save(OBSERVATION_DOMAIN);
+  }
+
+  private void saveSurveyInfo() {
+    surveyModuleDao.save(BASICS_SURVEY_MODULE);
+    surveyModuleDao.save(LIFESTYLE_SURVEY_MODULE);
+    surveyModuleDao.save(OVERALL_HEALTH_SURVEY_MODULE);
   }
 
   private DomainCount toDomainCount(DbDomainInfo domainInfo, boolean standardCount) {
@@ -862,17 +857,13 @@ public class ConceptsControllerTest {
         .domain(domainInfo.getDomainEnum());
   }
 
-  private void assertResultsWithCounts(
-      ResponseEntity<ConceptListResponse> response,
-      ImmutableList<DomainCount> domainCounts,
-      ImmutableList<Concept> concepts) {
-    assertThat(response.getBody().getDomainCounts()).isEqualTo(domainCounts);
-    assertThat(response.getBody().getItems()).isEqualTo(concepts);
-  }
-
   private void assertResults(
       ResponseEntity<ConceptListResponse> response, Concept... expectedConcepts) {
     assertThat(response.getBody().getItems()).isEqualTo(ImmutableList.copyOf(expectedConcepts));
-    assertThat(response.getBody().getDomainCounts()).isNull();
+  }
+
+  private void assertCounts(
+      ResponseEntity<DomainCountsListResponse> response, ImmutableList<DomainCount> domainCounts) {
+    assertThat(response.getBody().getDomainCounts()).isEqualTo(domainCounts);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -348,7 +348,8 @@ public class ConceptsControllerTest {
                 .selectable(true)
                 .standard(true)
                 .subtype("QUESTION")
-                .type("PPI"));
+                .type("PPI")
+                .path("0"));
 
     cbCriteriaDao.save(
         new DbCriteria()
@@ -366,7 +367,8 @@ public class ConceptsControllerTest {
             .standard(true)
             .subtype("QUESTION")
             .type("PPI")
-            .synonyms("test"));
+            .synonyms("test")
+            .path(parentSurvey.getId() + ".1"));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -63,7 +63,8 @@ public class CBCriteriaDaoTest {
                 .standard(false)
                 .selectable(true)
                 .parentId(surveyCriteria.getId())
-                .synonyms("test"));
+                .synonyms("test")
+                .path(surveyCriteria.getId() + ".1"));
     sourceCriteria =
         cbCriteriaDao.save(
             new DbCriteria()

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -320,7 +320,7 @@ public class CBCriteriaDaoTest {
 
   @Test
   public void countSurveyBySearchTerm() {
-    assertThat(cbCriteriaDao.countSurveyBySearchTerm("test")).isEqualTo(1);
+    assertThat(cbCriteriaDao.countSurveyByKeyword("test")).isEqualTo(1);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -1,8 +1,6 @@
 package org.pmiops.workbench.cdr.dao;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.HashSet;
@@ -148,8 +146,7 @@ public class CBCriteriaDaoTest {
             DomainType.SURVEY.toString(),
             CriteriaType.PPI.toString(),
             CriteriaSubType.SURVEY.toString());
-    assertEquals(1, criteriaList.size());
-    assertEquals(surveyCriteria, criteriaList.get(0));
+    assertThat(criteriaList).containsExactly(surveyCriteria);
   }
 
   @Test
@@ -157,9 +154,7 @@ public class CBCriteriaDaoTest {
     // test that we match both source and standard codes
     List<DbCriteria> exactMatchByCode =
         cbCriteriaDao.findExactMatchByCode(DomainType.CONDITION.toString(), "120");
-    assertEquals(2, exactMatchByCode.size());
-    assertEquals(standardCriteria, exactMatchByCode.get(0));
-    assertEquals(sourceCriteria, exactMatchByCode.get(1));
+    assertThat(exactMatchByCode).containsExactly(standardCriteria, sourceCriteria);
   }
 
   @Test
@@ -172,8 +167,7 @@ public class CBCriteriaDaoTest {
             Boolean.FALSE,
             "00",
             page);
-    assertEquals(1, criteriaList.size());
-    assertEquals(icd9Criteria, criteriaList.get(0));
+    assertThat(criteriaList).containsExactly(icd9Criteria);
   }
 
   @Test
@@ -182,8 +176,7 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findCriteriaByDomainAndCode(
             DomainType.CONDITION.toString(), Boolean.FALSE, "001", page);
-    assertEquals(1, criteriaList.size());
-    assertEquals(icd9Criteria, criteriaList.get(0));
+    assertThat(criteriaList).containsExactly(icd9Criteria);
   }
 
   @Test
@@ -192,25 +185,19 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> measurements =
         cbCriteriaDao.findCriteriaByDomainAndSynonyms(
             DomainType.MEASUREMENT.toString(), Boolean.TRUE, "001", page);
-    assertEquals(1, measurements.size());
-    assertEquals(measurementCriteria, measurements.get(0));
+    assertThat(measurements).containsExactly(measurementCriteria);
   }
 
   @Test
   public void findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc() {
-    DbCriteria actualIcd9 =
-        cbCriteriaDao
-            .findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
-                DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L)
-            .get(0);
-    assertEquals(sourceCriteria, actualIcd9);
-
-    DbCriteria actualIcd10 =
-        cbCriteriaDao
-            .findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
-                DomainType.CONDITION.toString(), CriteriaType.ICD10CM.toString(), false, 0L)
-            .get(0);
-    assertEquals(icd10Criteria, actualIcd10);
+    List<DbCriteria> actualIcd9s =
+        cbCriteriaDao.findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
+            DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L);
+    assertThat(actualIcd9s).containsExactly(sourceCriteria, icd9Criteria);
+    List<DbCriteria> actualIcd10s =
+        cbCriteriaDao.findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
+            DomainType.CONDITION.toString(), CriteriaType.ICD10CM.toString(), false, 0L);
+    assertThat(actualIcd10s).containsExactly(icd10Criteria);
   }
 
   @Test
@@ -218,10 +205,7 @@ public class CBCriteriaDaoTest {
     final List<DbCriteria> demoList =
         cbCriteriaDao.findCriteriaByDomainAndTypeOrderByIdAsc(
             DomainType.PERSON.toString(), CriteriaType.RACE.toString());
-    assertEquals(3, demoList.size());
-    assertEquals(raceParent, demoList.get(0));
-    assertEquals(raceAsian, demoList.get(1));
-    assertEquals(raceWhite, demoList.get(2));
+    assertThat(demoList).containsExactly(raceParent, raceAsian, raceWhite);
   }
 
   @Test
@@ -230,8 +214,7 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> labs =
         cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndCode(
             DomainType.MEASUREMENT.toString(), CriteriaType.LOINC.toString(), true, "LP123", page);
-    assertEquals(1, labs.size());
-    assertEquals(measurementCriteria, labs.get(0));
+    assertThat(labs).containsExactly(measurementCriteria);
   }
 
   @Test
@@ -240,8 +223,7 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> conditions =
         cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndSynonyms(
             DomainType.CONDITION.toString(), CriteriaType.SNOMED.toString(), true, "myMatch", page);
-    assertEquals(1, conditions.size());
-    assertEquals(standardCriteria, conditions.get(0));
+    assertThat(conditions).containsExactly(standardCriteria);
   }
 
   @Test
@@ -250,18 +232,16 @@ public class CBCriteriaDaoTest {
         "create table cb_criteria_relationship(concept_id_1 integer, concept_id_2 integer)");
     jdbcTemplate.execute(
         "insert into cb_criteria_relationship(concept_id_1, concept_id_2) values (12345, 1)");
-    assertEquals(1, cbCriteriaDao.findConceptId2ByConceptId1(12345L).get(0).intValue());
+    assertThat(cbCriteriaDao.findConceptId2ByConceptId1(12345L)).containsExactly(1);
     jdbcTemplate.execute("drop table cb_criteria_relationship");
   }
 
   @Test
   public void findStandardCriteriaByDomainAndConceptId() {
-    assertEquals(
-        icd10Criteria,
-        cbCriteriaDao
-            .findStandardCriteriaByDomainAndConceptId(
-                DomainType.CONDITION.toString(), false, ImmutableList.of("1"))
-            .get(0));
+    assertThat(
+            cbCriteriaDao.findStandardCriteriaByDomainAndConceptId(
+                DomainType.CONDITION.toString(), false, ImmutableList.of("1")))
+        .containsExactly(icd10Criteria);
   }
 
   @Test
@@ -274,20 +254,18 @@ public class CBCriteriaDaoTest {
             CriteriaType.SNOMED.toString(),
             true,
             parentConceptIds);
-    assertEquals(standardCriteria, results.get(0));
+    assertThat(results).containsExactly(standardCriteria);
   }
 
   @Test
   public void findCriteriaLeavesAndParentsByPath() {
-    assertEquals(icd9Criteria, cbCriteriaDao.findCriteriaLeavesAndParentsByPath("5").get(0));
+    assertThat(cbCriteriaDao.findCriteriaLeavesAndParentsByPath("5")).containsExactly(icd9Criteria);
   }
 
   @Test
   public void findGenderRaceEthnicity() {
     List<DbCriteria> criteriaList = cbCriteriaDao.findGenderRaceEthnicity();
-    assertEquals(2, criteriaList.size());
-    assertTrue(criteriaList.contains(raceAsian));
-    assertTrue(criteriaList.contains(raceWhite));
+    assertThat(criteriaList).containsExactly(raceAsian, raceWhite);
   }
 
   @Test
@@ -296,87 +274,81 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findByDomainIdAndTypeAndParentIdNotIn(
             DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
-    assertEquals(2, criteriaList.size());
-    assertEquals(raceAsian, criteriaList.get(0));
-    assertEquals(raceWhite, criteriaList.get(1));
+    assertThat(criteriaList).containsExactly(raceAsian, raceWhite).inOrder();
 
     // reverse
     sort = new Sort(Direction.DESC, "name");
     criteriaList =
         cbCriteriaDao.findByDomainIdAndTypeAndParentIdNotIn(
             DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
-    assertEquals(2, criteriaList.size());
-    assertEquals(raceWhite, criteriaList.get(0));
-    assertEquals(raceAsian, criteriaList.get(1));
+    assertThat(criteriaList).containsExactly(raceWhite, raceAsian).inOrder();
   }
 
   @Test
   public void findMenuOptions() {
     List<DbMenuOption> options = cbCriteriaDao.findMenuOptions();
-    assertEquals(6, options.size());
+    DbMenuOption option1 = options.get(0);
+    assertThat(option1.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option1.getType()).isEqualTo("ICD10CM");
+    assertThat(option1.getStandard()).isFalse();
 
-    DbMenuOption option = options.get(0);
-    assertEquals(DomainType.CONDITION.toString(), option.getDomain());
-    assertEquals("ICD10CM", option.getType());
-    assertFalse(option.getStandard());
+    DbMenuOption option2 = options.get(1);
+    assertThat(option2.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option2.getType()).isEqualTo("ICD9CM");
+    assertThat(option2.getStandard()).isFalse();
 
-    option = options.get(1);
-    assertEquals(DomainType.CONDITION.toString(), option.getDomain());
-    assertEquals("ICD9CM", option.getType());
-    assertFalse(option.getStandard());
+    DbMenuOption option3 = options.get(2);
+    assertThat(option3.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option3.getType()).isEqualTo("SNOMED");
+    assertThat(option3.getStandard()).isTrue();
 
-    option = options.get(2);
-    assertEquals(DomainType.CONDITION.toString(), option.getDomain());
-    assertEquals("SNOMED", option.getType());
-    assertTrue(option.getStandard());
+    DbMenuOption option4 = options.get(3);
+    assertThat(option4.getDomain()).isEqualTo(DomainType.MEASUREMENT.toString());
+    assertThat(option4.getType()).isEqualTo("LOINC");
+    assertThat(option4.getStandard()).isTrue();
 
-    option = options.get(3);
-    assertEquals(DomainType.MEASUREMENT.toString(), option.getDomain());
-    assertEquals("LOINC", option.getType());
-    assertTrue(option.getStandard());
+    DbMenuOption option5 = options.get(4);
+    assertThat(option5.getDomain()).isEqualTo(DomainType.PERSON.toString());
+    assertThat(option5.getType()).isEqualTo("RACE");
+    assertThat(option5.getStandard()).isTrue();
 
-    option = options.get(4);
-    assertEquals(DomainType.PERSON.toString(), option.getDomain());
-    assertEquals("RACE", option.getType());
-    assertTrue(option.getStandard());
-
-    option = options.get(5);
-    assertEquals(DomainType.SURVEY.toString(), option.getDomain());
-    assertEquals("PPI", option.getType());
-    assertFalse(option.getStandard());
+    DbMenuOption option6 = options.get(5);
+    assertThat(option6.getDomain()).isEqualTo(DomainType.SURVEY.toString());
+    assertThat(option6.getType()).isEqualTo("PPI");
+    assertThat(option6.getStandard()).isFalse();
   }
 
   @Test
   public void countSurveyBySearchTerm() {
-    assertEquals(1, cbCriteriaDao.countSurveyBySearchTerm("test"));
+    assertThat(cbCriteriaDao.countSurveyBySearchTerm("test")).isEqualTo(1);
   }
 
   @Test
-  public void findSurveys() {
+  public void findSurveysKeyword() {
     PageRequest page = new PageRequest(0, 10);
-    assertEquals(questionCriteria, cbCriteriaDao.findSurveys("test", page).getContent().get(0));
+    assertThat(cbCriteriaDao.findSurveys("test", null, page)).containsExactly(questionCriteria);
   }
 
   @Test
   public void countSurveyByName() {
-    assertEquals(1, cbCriteriaDao.countSurveyByName("The Basics"));
+    assertThat(cbCriteriaDao.countSurveyByName("The Basics")).isEqualTo(1);
   }
 
   @Test
   public void findSurveysByName() {
     PageRequest page = new PageRequest(0, 10);
-    assertEquals(
-        questionCriteria, cbCriteriaDao.findSurveysByName("The Basics", page).getContent().get(0));
+    assertThat(cbCriteriaDao.findSurveys(null, "The Basics", page))
+        .containsExactly(questionCriteria);
   }
 
   @Test
   public void findSurveysNoSurveyName() {
     PageRequest page = new PageRequest(0, 10);
-    assertEquals(questionCriteria, cbCriteriaDao.findSurveys(page).getContent().get(0));
+    assertThat(cbCriteriaDao.findSurveys(null, null, page)).containsExactly(questionCriteria);
   }
 
   @Test
   public void countSurveys() {
-    assertEquals(1, cbCriteriaDao.countSurveys());
+    assertThat(cbCriteriaDao.countSurveys()).isEqualTo(1);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
@@ -145,7 +145,10 @@ public class ConceptDaoTest {
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
             "Height", ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
-    assertThat(concepts).containsExactly(physicalMeasurement);
+    assertThat(concepts)
+        .containsExactly(
+            physicalMeasurement.domainId(
+                CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT)));
   }
 
   @Test
@@ -154,6 +157,9 @@ public class ConceptDaoTest {
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
             null, ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
-    assertThat(concepts).containsExactly(physicalMeasurement);
+    assertThat(concepts)
+        .containsExactly(
+            physicalMeasurement.domainId(
+                CommonStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT)));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.cdr.dao;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -9,8 +8,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.cdr.model.DbConcept;
+import org.pmiops.workbench.db.model.CommonStorageEnums;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +29,7 @@ public class ConceptDaoTest {
   @Autowired ConceptDao conceptDao;
   private DbConcept concept1;
   private DbConcept concept2;
+  private DbConcept physicalMeasurement;
 
   @Before
   public void setUp() {
@@ -37,7 +38,7 @@ public class ConceptDaoTest {
         conceptDao.save(
             new DbConcept()
                 .conceptId(1L)
-                .domainId(DomainType.CONDITION.toString())
+                .domainId(CommonStorageEnums.domainToDomainId(Domain.CONDITION))
                 .conceptName("Personal history of malignant neoplasm of breast")
                 .vocabularyId(CriteriaType.ICD9CM.toString())
                 .conceptClassId("4-char billing code")
@@ -54,7 +55,7 @@ public class ConceptDaoTest {
         conceptDao.save(
             new DbConcept()
                 .conceptId(2L)
-                .domainId(DomainType.CONDITION.toString())
+                .domainId(CommonStorageEnums.domainToDomainId(Domain.CONDITION))
                 .conceptName("Personal history of malignant neoplasm")
                 .vocabularyId(CriteriaType.SNOMED.toString())
                 .conceptClassId("4-char billing code")
@@ -67,40 +68,92 @@ public class ConceptDaoTest {
                     ImmutableList.of(
                         "35225339",
                         "Personal history of malignant neoplasm of breast|Personal history of malignant neoplasm of breast")));
+    physicalMeasurement =
+        conceptDao.save(
+            new DbConcept()
+                .conceptId(3L)
+                .domainId(CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT))
+                .conceptName("Height")
+                .vocabularyId(CriteriaType.PPI.toString())
+                .conceptClassId("Clinical Observation")
+                .conceptCode("020202")
+                .standardConcept("")
+                .count(2400L)
+                .prevalence(0.0F)
+                .sourceCountValue(2400L)
+                .synonyms(ImmutableList.of("020202", "Height")));
   }
 
   @Test
   public void findAll() {
     List<DbConcept> concepts = (List<DbConcept>) conceptDao.findAll();
-    assertEquals(2, concepts.size());
-    assertTrue(concepts.contains(concept1));
-    assertTrue(concepts.contains(concept2));
+    assertThat(concepts).containsExactly(concept1, concept2, physicalMeasurement);
   }
 
   @Test
-  public void findStandardConcepts() {
+  public void findStandardConceptsWithKeyword() {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
-        conceptDao.findConcepts(
-            "history",
-            ImmutableList.of("S", "C"),
-            ImmutableList.of(DomainType.CONDITION.toString()),
-            page);
-    assertEquals(1, concepts.getContent().size());
-    assertTrue(concepts.getContent().contains(concept2));
+        conceptDao.findConcepts("history", ImmutableList.of("S", "C"), Domain.CONDITION, page);
+    assertThat(concepts).containsExactly(concept2);
   }
 
   @Test
-  public void findAllConcepts() {
+  public void findStandardConceptsWithoutKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts(null, ImmutableList.of("S", "C"), Domain.CONDITION, page);
+    assertThat(concepts).containsExactly(concept2);
+  }
+
+  @Test
+  public void findAllConceptsWithKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts("history", ImmutableList.of("S", "C", ""), Domain.CONDITION, page);
+    assertThat(concepts).containsExactly(concept1, concept2);
+  }
+
+  @Test
+  public void findAllConceptsWithoutKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts(null, ImmutableList.of("S", "C", ""), Domain.CONDITION, page);
+    assertThat(concepts).containsExactly(concept1, concept2);
+  }
+
+  @Test
+  public void findStandardConceptsPhysicalMeasurementsWithKeyword() {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
-            "history",
-            ImmutableList.of("S", "C", ""),
-            ImmutableList.of(DomainType.CONDITION.toString()),
-            page);
-    assertEquals(2, concepts.getContent().size());
-    assertTrue(concepts.getContent().contains(concept1));
-    assertTrue(concepts.getContent().contains(concept2));
+            "height", ImmutableList.of("S", "C"), Domain.PHYSICALMEASUREMENT, page);
+    assertThat(concepts).hasSize(0);
+  }
+
+  @Test
+  public void findStandardConceptsPhysicalMeasurementsWithoutKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts(null, ImmutableList.of("S", "C"), Domain.PHYSICALMEASUREMENT, page);
+    assertThat(concepts).hasSize(0);
+  }
+
+  @Test
+  public void findAllConceptsPhysicalMeasurementsWithKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts(
+            "Height", ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
+    assertThat(concepts).containsExactly(physicalMeasurement);
+  }
+
+  @Test
+  public void findAllConceptsPhysicalMeasurementsWithoutKeyword() {
+    Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
+    Slice<DbConcept> concepts =
+        conceptDao.findConcepts(
+            null, ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
+    assertThat(concepts).containsExactly(physicalMeasurement);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -1073,6 +1073,7 @@ public class WorkspacesControllerTest {
             .getBody();
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId(), CLIENT_CONCEPT_2.getConceptId())))
         .thenReturn(123);
@@ -1244,6 +1245,7 @@ public class WorkspacesControllerTest {
     cdrVersion2 = cdrVersionDao.save(cdrVersion2);
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId(), CLIENT_CONCEPT_2.getConceptId())))
         .thenReturn(123);
@@ -1276,6 +1278,7 @@ public class WorkspacesControllerTest {
             modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
+            Domain.CONDITION,
             "condition_occurrence",
             ImmutableSet.of(CLIENT_CONCEPT_1.getConceptId(), CLIENT_CONCEPT_2.getConceptId())))
         .thenReturn(456);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.cdr.dao;
 
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
 import org.springframework.data.domain.Page;
@@ -283,4 +284,19 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "from DbCriteria c "
               + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
   long countSurveys();
+
+  default Page<DbCriteria> findSurveys(String keyword, String surveyName, Pageable pageable) {
+    if (StringUtils.isBlank(keyword)) {
+      return StringUtils.isBlank(surveyName)
+          ? findSurveys(pageable)
+          : findSurveysByName(surveyName, pageable);
+    }
+    return findSurveys(keyword, pageable);
+  }
+
+  default long countSurveys(String keyword, String surveyName) {
+    return keyword == null
+        ? surveyName == null ? countSurveys() : countSurveyByName(surveyName)
+        : countSurveyBySearchTerm(keyword);
+  }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -285,6 +285,15 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
   long countSurveys();
 
+  /**
+   * Find surveys by specified keyword or surveyName. If both keyword and surveyName are blank
+   * return all surveys.
+   *
+   * @param keyword
+   * @param surveyName
+   * @param pageable
+   * @return
+   */
   default Page<DbCriteria> findSurveys(String keyword, String surveyName, Pageable pageable) {
     if (StringUtils.isBlank(keyword)) {
       return StringUtils.isBlank(surveyName)
@@ -294,9 +303,18 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
     return findSurveys(keyword, pageable);
   }
 
+  /**
+   * Count surveys by specified keyword or surveyName. If both keyword and surveyName are blank
+   * count all surveys.
+   *
+   * @param keyword
+   * @param surveyName
+   * @return
+   */
   default long countSurveys(String keyword, String surveyName) {
-    return keyword == null
-        ? surveyName == null ? countSurveys() : countSurveyByName(surveyName)
-        : countSurveyBySearchTerm(keyword);
+    if (StringUtils.isBlank(keyword)) {
+      return StringUtils.isBlank(surveyName) ? countSurveys() : countSurveyByName(surveyName);
+    }
+    return countSurveyBySearchTerm(keyword);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -245,7 +245,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "from DbCriteria c "
               + "where domainId = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
               + "and match(synonyms, :term) > 0")
-  long countSurveyBySearchTerm(@Param("term") String term);
+  long countSurveyByKeyword(@Param("term") String term);
 
   @Query(
       value =
@@ -315,6 +315,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
     if (StringUtils.isBlank(keyword)) {
       return StringUtils.isBlank(surveyName) ? countSurveys() : countSurveyByName(surveyName);
     }
-    return countSurveyBySearchTerm(keyword);
+    return countSurveyByKeyword(keyword);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -260,7 +260,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select count(c) "
               + "from DbCriteria c "
               + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
-              + "and c.parentId in (select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName)")
+              + "and c.path like CONCAT((select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName), '.%')")
   long countSurveyByName(@Param("surveyName") String surveyName);
 
   @Query(
@@ -268,7 +268,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select c "
               + "from DbCriteria c "
               + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
-              + "and c.parentId in (select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName)")
+              + "and c.path like CONCAT((select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName), '.%')")
   Page<DbCriteria> findSurveysByName(@Param("surveyName") String surveyName, Pageable page);
 
   @Query(

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -28,7 +28,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
               + "and c.standardConcept IN (?2) "
               + "and c.domainId = ?3")
-  Page<DbConcept> findConceptsWithKeyword(
+  Page<DbConcept> findConcepts(
       String keyword, ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
   /**
@@ -45,8 +45,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
               + "and c.domainId = ?2")
-  Page<DbConcept> findConceptsWithoutKeyword(
-      ImmutableList<String> conceptTypes, String domainId, Pageable page);
+  Page<DbConcept> findConcepts(ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
   /**
    * Return PM concepts in each vocabulary for the specified domain matching the specified
@@ -54,7 +53,6 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
    *
    * @param keyword SQL MATCH expression to match concept name or synonym
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -63,18 +61,17 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
               + "and c.standardConcept IN (?2) "
-              + "and c.domainId = ?3 "
+              + "and c.domainId = 'Measurement' "
               + "and c.vocabularyId = 'PPI' "
               + "and c.conceptClassId = 'Clinical Observation'")
-  Page<DbConcept> findPhysicalMeasurementConceptsWithKeyword(
-      String keyword, ImmutableList<String> conceptTypes, String domainId, Pageable page);
+  Page<DbConcept> findPhysicalMeasurementConcepts(
+      String keyword, ImmutableList<String> conceptTypes, Pageable page);
 
   /**
    * Return PM concepts in each vocabulary for the specified domain matching the specified
    * expression, matching concept name, synonym, ID, or code.
    *
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -82,11 +79,11 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
           "select distinct c from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
-              + "and c.domainId = ?2 "
+              + "and c.domainId = 'Measurement' "
               + "and c.vocabularyId = 'PPI' "
               + "and c.conceptClassId = 'Clinical Observation'")
-  Page<DbConcept> findPhysicalMeasurementConceptWithoutKeyword(
-      ImmutableList<String> conceptTypes, String domainId, Pageable page);
+  Page<DbConcept> findPhysicalMeasurementConcepts(
+      ImmutableList<String> conceptTypes, Pageable page);
 
   /**
    * Return any concepts in each vocabulary for the specified domain matching the specified
@@ -95,15 +92,13 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
   default Page<DbConcept> findConcepts(
       String keyword, ImmutableList<String> conceptTypes, Domain domainId, Pageable pageable) {
     if (Domain.PHYSICALMEASUREMENT.equals(domainId)) {
-      String measurement = CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT);
       return StringUtils.isBlank(keyword)
-          ? findPhysicalMeasurementConceptWithoutKeyword(conceptTypes, measurement, pageable)
-          : findPhysicalMeasurementConceptsWithKeyword(
-              keyword, conceptTypes, measurement, pageable);
+          ? findPhysicalMeasurementConcepts(conceptTypes, pageable)
+          : findPhysicalMeasurementConcepts(keyword, conceptTypes, pageable);
     }
     String toDomainId = CommonStorageEnums.domainToDomainId(domainId);
     return StringUtils.isBlank(keyword)
-        ? findConceptsWithoutKeyword(conceptTypes, toDomainId, pageable)
-        : findConceptsWithKeyword(keyword, conceptTypes, toDomainId, pageable);
+        ? findConcepts(conceptTypes, toDomainId, pageable)
+        : findConcepts(keyword, conceptTypes, toDomainId, pageable);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -57,7 +57,9 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
    */
   @Query(
       value =
-          "select distinct c from DbConcept c "
+          "select new DbConcept(c.conceptId, c.conceptName, c.standardConcept, c.conceptCode, c.conceptClassId, c.vocabularyId, "
+              + "'Physical Measurement' as domainId, c.countValue, c.sourceCountValue, c.prevalence, c.synonymsStr) "
+              + "from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
               + "and c.standardConcept IN (?2) "
@@ -76,7 +78,9 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
    */
   @Query(
       value =
-          "select distinct c from DbConcept c "
+          "select new DbConcept(c.conceptId, c.conceptName, c.standardConcept, c.conceptCode, c.conceptClassId, c.vocabularyId, "
+              + "'Physical Measurement' as domainId, c.countValue, c.sourceCountValue, c.prevalence, c.synonymsStr) "
+              + "from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
               + "and c.domainId = 'Measurement' "

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -1,7 +1,10 @@
 package org.pmiops.workbench.cdr.dao;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.model.DbConcept;
+import org.pmiops.workbench.db.model.CommonStorageEnums;
+import org.pmiops.workbench.model.Domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
@@ -13,9 +16,9 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
    * Return standard or all concepts in each vocabulary for the specified domain matching the
    * specified expression, matching concept name, synonym, ID, or code.
    *
-   * @param matchExp SQL MATCH expression to match concept name or synonym
+   * @param keyword SQL MATCH expression to match concept name or synonym
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainIds domain IDs to use when filtering concepts
+   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -24,19 +27,16 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
               + "and c.standardConcept IN (?2) "
-              + "and c.domainId in (?3)")
-  Page<DbConcept> findConcepts(
-      String matchExp,
-      ImmutableList<String> conceptTypes,
-      ImmutableList<String> domainIds,
-      Pageable page);
+              + "and c.domainId = ?3")
+  Page<DbConcept> findConceptsWithKeyword(
+      String keyword, ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
    * specified expression, matching concept name, synonym, ID, or code.
    *
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainIds domain IDs to use when filtering concepts
+   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -44,19 +44,17 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
           "select distinct c from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
-              + "and c.domainId in (?2)")
-  Page<DbConcept> findConcepts(
-      ImmutableList<String> conceptTypes, ImmutableList<String> domainIds, Pageable page);
+              + "and c.domainId = ?2")
+  Page<DbConcept> findConceptsWithoutKeyword(
+      ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
   /**
-   * Return standard or all concepts in each vocabulary for the specified domain matching the
-   * specified expression, matching concept name, synonym, ID, or code.
+   * Return PM concepts in each vocabulary for the specified domain matching the specified
+   * expression, matching concept name, synonym, ID, or code.
    *
-   * @param matchExp SQL MATCH expression to match concept name or synonym
+   * @param keyword SQL MATCH expression to match concept name or synonym
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainIds domain IDs to use when filtering concepts
-   * @param vocabularyId vocabulary id type to search
-   * @param conceptClassId concept class id type to search
+   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -65,25 +63,18 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
               + "and c.standardConcept IN (?2) "
-              + "and c.domainId in (?3) "
-              + "and c.vocabularyId = ?4 "
-              + "and c.conceptClassId = ?5")
-  Page<DbConcept> findConcepts(
-      String matchExp,
-      ImmutableList<String> conceptTypes,
-      ImmutableList<String> domainIds,
-      String vocabularyId,
-      String conceptClassId,
-      Pageable page);
+              + "and c.domainId = ?3 "
+              + "and c.vocabularyId = 'PPI' "
+              + "and c.conceptClassId = 'Clinical Observation'")
+  Page<DbConcept> findPhysicalMeasurementConceptsWithKeyword(
+      String keyword, ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
   /**
-   * Return standard or all concepts in each vocabulary for the specified domain matching the
-   * specified expression, matching concept name, synonym, ID, or code.
+   * Return PM concepts in each vocabulary for the specified domain matching the specified
+   * expression, matching concept name, synonym, ID, or code.
    *
    * @param conceptTypes can be 'S', 'C' or ''
-   * @param domainIds domain IDs to use when filtering concepts
-   * @param vocabularyId vocabulary id type to search
-   * @param conceptClassId concept class id type to search
+   * @param domainId domain ID to use when filtering concepts
    * @return per-vocabulary concept counts
    */
   @Query(
@@ -91,13 +82,28 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
           "select distinct c from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and c.standardConcept IN (?1) "
-              + "and c.domainId in (?2) "
-              + "and c.vocabularyId = ?3 "
-              + "and c.conceptClassId = ?4")
-  Page<DbConcept> findConcepts(
-      ImmutableList<String> conceptTypes,
-      ImmutableList<String> domainIds,
-      String vocabularyId,
-      String conceptClassId,
-      Pageable page);
+              + "and c.domainId = ?2 "
+              + "and c.vocabularyId = 'PPI' "
+              + "and c.conceptClassId = 'Clinical Observation'")
+  Page<DbConcept> findPhysicalMeasurementConceptWithoutKeyword(
+      ImmutableList<String> conceptTypes, String domainId, Pageable page);
+
+  /**
+   * Return any concepts in each vocabulary for the specified domain matching the specified
+   * expression, matching concept name, synonym, ID, or code.
+   */
+  default Page<DbConcept> findConcepts(
+      String keyword, ImmutableList<String> conceptTypes, Domain domainId, Pageable pageable) {
+    if (Domain.PHYSICALMEASUREMENT.equals(domainId)) {
+      String measurement = CommonStorageEnums.domainToDomainId(Domain.MEASUREMENT);
+      return StringUtils.isBlank(keyword)
+          ? findPhysicalMeasurementConceptWithoutKeyword(conceptTypes, measurement, pageable)
+          : findPhysicalMeasurementConceptsWithKeyword(
+              keyword, conceptTypes, measurement, pageable);
+    }
+    String toDomainId = CommonStorageEnums.domainToDomainId(domainId);
+    return StringUtils.isBlank(keyword)
+        ? findConceptsWithoutKeyword(conceptTypes, toDomainId, pageable)
+        : findConceptsWithKeyword(keyword, conceptTypes, toDomainId, pageable);
+  }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
@@ -2,43 +2,10 @@ package org.pmiops.workbench.cdr.dao;
 
 import java.util.List;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface SurveyModuleDao extends CrudRepository<DbSurveyModule, Long> {
-
-  /**
-   * Returns metadata and question counts for survey modules, matching questions by name, code, or
-   * concept ID, and answers to questions by string value.
-   *
-   * @param matchExpression a boolean full text match expression based on the user's query; see
-   *     https://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
-   */
-  @Query(
-      nativeQuery = true,
-      value =
-          "select m.name, m.description,\n"
-              + "m.concept_id, COUNT(DISTINCT c.concept_id) as question_count,\n"
-              +
-              // We don't show participant counts when filtering by keyword, and don't have a way of
-              // computing them easily; return 0.
-              "0 participant_count, m.order_number \n"
-              + "from survey_module m\n"
-              + "join achilles_results r on m.concept_id = r.stratum_1\n"
-              + "join concept c on r.stratum_2 = c.concept_id\n"
-              + "where r.analysis_id = 3110\n"
-              +
-              // Because we're using a native query we use MySQL match() here directly instead of
-              // matchConcept()
-              // TODO: add AchillesResults entity, replace this with JQL
-              "and (match(c.concept_name) against (?1 in boolean mode) > 0 or\n"
-              + "match(r.stratum_4) against(?1 in boolean mode) > 0) \n"
-              + "group by m.name, m.description, m.concept_id\n"
-              + "order by m.order_number")
-  List<DbSurveyModule> findSurveyModuleQuestionCounts(String matchExpression);
-
-  DbSurveyModule findByConceptId(long conceptId);
 
   List<DbSurveyModule> findByParticipantCountNotOrderByOrderNumberAsc(
       @Param("participantCount") Long participantCount);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConcept.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConcept.java
@@ -49,6 +49,33 @@ public class DbConcept {
         .synonymsStr(a.getSynonymsStr());
   }
 
+  // Used from JQL queries in DomainInfoDao
+  public DbConcept(
+      long conceptId,
+      String conceptName,
+      String standardConcept,
+      String conceptCode,
+      String conceptClassId,
+      String vocabularyId,
+      String domainId,
+      long countValue,
+      long sourceCountValue,
+      float prevalence,
+      String synonymsStr) {
+    this.conceptId = conceptId;
+    this.conceptName = conceptName;
+    this.standardConcept = standardConcept;
+    this.conceptCode = conceptCode;
+    this.conceptClassId = conceptClassId;
+    this.vocabularyId = vocabularyId;
+    this.domainId = domainId;
+    this.countValue = countValue;
+    this.sourceCountValue = sourceCountValue;
+    this.prevalence = prevalence;
+    this.synonymsStr = synonymsStr;
+    this.synonyms = new ArrayList<>();
+  }
+
   @Id
   @Column(name = "concept_id")
   public long getConceptId() {

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConcept.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConcept.java
@@ -14,8 +14,6 @@ import javax.persistence.Transient;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 @Entity
-// TODO need to add a way to dynamically switch between database versions
-// this dynamic connection will eliminate the need for the catalog attribute
 @Table(name = "concept")
 public class DbConcept {
 
@@ -49,7 +47,7 @@ public class DbConcept {
         .synonymsStr(a.getSynonymsStr());
   }
 
-  // Used from JQL queries in DomainInfoDao
+  // Used from JQL queries in DbConcept
   public DbConcept(
       long conceptId,
       String conceptName,

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConceptRelationship.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConceptRelationship.java
@@ -9,8 +9,6 @@ import javax.persistence.Table;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 @Entity
-// TODO need to add a way to dynamically switch between database versions
-// this dynamic connection will eliminate the need for the catalog attribute
 @Table(name = "concept_relationship")
 public class DbConceptRelationship {
 

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConceptSynonym.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/DbConceptSynonym.java
@@ -11,8 +11,6 @@ import javax.persistence.Table;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 @Entity
-// TODO need to add a way to dynamically switch between database versions
-// this dynamic connection will eliminate the need for the catalog attribute
 // NOTE: This class and ConceptSynonymDao exist only to make CriteriaDao work in tests;
 // if we stop using concept_synonym there at some point we can get rid of them.
 @Table(name = "concept_synonym")

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -12,7 +12,7 @@ import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, summarizeErrors, withCurrentWorkspace} from 'app/utils';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Concept, ConceptSet, CreateConceptSetRequest, CriteriaType, Domain, DomainCount, UpdateConceptSetRequest} from 'generated/fetch';
+import {Concept, ConceptSet, CreateConceptSetRequest, Domain, DomainCount, UpdateConceptSetRequest} from 'generated/fetch';
 import {validate} from 'validate.js';
 
 const styles = reactStyles({

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -26,13 +26,10 @@ const styles = reactStyles({
 });
 
 const filterConcepts = (concepts: any[], domain: Domain) => {
-  if (domain === Domain.PHYSICALMEASUREMENT) {
-    return concepts.filter(concept => concept.domainId === fp.capitalize(Domain[Domain.MEASUREMENT])
-      && concept.vocabularyId === CriteriaType[CriteriaType.PPI]);
-  } else if (domain === Domain.SURVEY) {
+  if (domain === Domain.SURVEY) {
     return concepts.filter(concept => !!concept.question);
   } else {
-    return concepts.filter(concept => concept.domainId === fp.capitalize(Domain[domain]));
+    return concepts.filter(concept => concept.domainId.replace(' ', '').toLowerCase() === Domain[domain].toLowerCase());
   }
 };
 
@@ -132,7 +129,7 @@ export const ConceptAddModal = withCurrentWorkspace()
       const conceptSet: ConceptSet = {
         name: name,
         description: newSetDescription,
-        domain: selectedDomain.domain === Domain.PHYSICALMEASUREMENT ? Domain.MEASUREMENT : selectedDomain.domain
+        domain: selectedDomain.domain
       };
       const request: CreateConceptSetRequest = {
         conceptSet: conceptSet,

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -79,32 +79,48 @@ describe('ConceptHomepage', () => {
       .toBe(SurveyStubVariables.STUB_SURVEYS.length);
   });
 
-  it('should default to standard concepts only, and performs a full search', async() => {
-    const spy = jest.spyOn(conceptsApi(), 'searchConcepts');
+  it('should default to standard concepts only, and performs a count call and full search', async() => {
+    const conceptSpy = jest.spyOn(conceptsApi(), 'searchConcepts');
+    const countSpy = jest.spyOn(conceptsApi(), 'domainCounts');
+    const surveySpy = jest.spyOn(conceptsApi(), 'searchSurveys');
     const wrapper = mount(<ConceptHomepage />);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
+    const request = {
+      query: defaultSearchTerm,
+      // Tests that it searches only standard concepts.
+      standardConceptFilter: StandardConceptFilter.STANDARDCONCEPTS,
+      maxResults: 1000
+    };
+
+    // Tests that the domain tab counts are called
+    expect(countSpy).toHaveBeenCalledWith(
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+      request
+    );
+    expect(countSpy).toHaveBeenCalledTimes(1);
 
     DomainStubVariables.STUB_DOMAINS.forEach((domain) => {
-      const includeDomainCounts = isSelectedDomain(domain, wrapper);
-      const expectedRequest = {
-        query: defaultSearchTerm,
-        // Tests that it searches only standard concepts.
-        standardConceptFilter: StandardConceptFilter.STANDARDCONCEPTS,
-        domain: domain.domain,
-        includeDomainCounts: includeDomainCounts,
-        maxResults: 1000
-      };
-      expect(spy).toHaveBeenCalledWith(
+      const expectedRequest = {...request, domain: domain.domain};
+      expect(conceptSpy).toHaveBeenCalledWith(
         WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
         WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
         expectedRequest
       );
     });
 
-    // Test that it makes a call for each domain. Adding 1 to the length since currently we manually add surveys to conceptsCache on init
-    expect(spy).toHaveBeenCalledTimes(DomainStubVariables.STUB_DOMAINS.length + 1);
+    // Test that it makes a call for each domain.
+    expect(conceptSpy).toHaveBeenCalledTimes(DomainStubVariables.STUB_DOMAINS.length);
+
+    // Test that it makes a separate call for surveys.
+    expect(surveySpy).toHaveBeenCalledWith(
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+      request
+    );
+    expect(surveySpy).toHaveBeenCalledTimes(1);
 
     // Test that it switches to the table view
     expect(wrapper.find('[data-test-id="conceptTable"]').length).toBeGreaterThan(0);
@@ -133,13 +149,11 @@ describe('ConceptHomepage', () => {
     await waitOneTickAndUpdate(wrapper);
 
     DomainStubVariables.STUB_DOMAINS.forEach((domain) => {
-      const includeDomainCounts = isSelectedDomain(domain, wrapper);
       const expectedRequest = {
         query: defaultSearchTerm,
         // Tests that it searches only standard concepts.
         standardConceptFilter: StandardConceptFilter.ALLCONCEPTS,
         domain: domain.domain,
-        includeDomainCounts: includeDomainCounts,
         maxResults: 1000
       };
       expect(spy).toHaveBeenCalledWith(

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -296,7 +296,11 @@ export const ConceptHomepage = withCurrentWorkspace()(
         this.browseSurvey(queryParams.survey);
       }
       if (queryParams.domain) {
-        this.browseDomain(this.state.conceptDomainList.find(dc => dc.domain === queryParams.domain));
+        if (queryParams.domain === Domain.SURVEY) {
+          this.browseSurvey('');
+        } else {
+          this.browseDomain(this.state.conceptDomainList.find(dc => dc.domain === queryParams.domain));
+        }
       }
     }
 
@@ -402,7 +406,8 @@ export const ConceptHomepage = withCurrentWorkspace()(
           currentInputString: '',
           currentSearchString: '',
           selectedDomain: {domain: Domain.SURVEY, name: 'Surveys', conceptCount: 0},
-          selectedSurvey: surveyName}, () => this.searchConcepts());
+          selectedSurvey: surveyName,
+          standardConceptsOnly: false}, () => this.searchConcepts());
       } else {
         this.setState({browsingSurvey: true, selectedSurvey: surveyName});
       }
@@ -520,6 +525,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                         labelStyle={{marginLeft: '0.2rem'}}
                         data-test-id='standardConceptsCheckBox'
                         style={{marginLeft: '0.5rem', height: '16px', width: '16px'}}
+                        manageOwnState={false}
                         onChange={() => this.handleCheckboxChange()}/>
             </div>
             {showSearchError &&

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -178,8 +178,6 @@ interface State { // Browse survey
   conceptDomainCounts: Array<DomainCount>;
   // Array of domains and their metadata
   conceptDomainList: Array<DomainInfo>;
-  // Array of Physical Measurements
-  conceptPhysicalMeasurementsList: Array<any>;
   conceptsSavedText: string;
   // Array of surveys
   conceptSurveysList: Array<SurveyModule>;
@@ -223,7 +221,6 @@ export const ConceptHomepage = withCurrentWorkspace()(
         surveyAddModalOpen: false,
         conceptDomainCounts: [],
         conceptDomainList: [],
-        conceptPhysicalMeasurementsList: [],
         concepts: [],
         conceptsCache: [],
         conceptsSavedText: '',
@@ -275,11 +272,10 @@ export const ConceptHomepage = withCurrentWorkspace()(
         }
         this.setState({
           conceptsCache: conceptsCache,
-          conceptDomainList: conceptDomainInfo.items.filter(item => item.domain !== Domain.PHYSICALMEASUREMENT),
+          conceptDomainList: conceptDomainInfo.items,
           conceptDomainCounts: conceptDomainCounts,
           conceptSurveysList: surveysInfo.items,
           selectedDomain: conceptDomainCounts[0],
-          conceptPhysicalMeasurementsList: conceptDomainInfo.items.filter(item => item.domain === Domain.PHYSICALMEASUREMENT),
         });
       } catch (e) {
         console.error(e);
@@ -497,7 +493,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
     }
 
     render() {
-      const {loadingDomains, browsingSurvey, conceptDomainList, conceptPhysicalMeasurementsList, conceptSurveysList,
+      const {loadingDomains, browsingSurvey, conceptDomainList, conceptSurveysList,
         standardConceptsOnly, showSearchError, searching, selectedDomain, conceptAddModalOpen, currentInputString, currentSearchString,
         conceptsSavedText, selectedSurvey, selectedConceptDomainMap, selectedSurveyQuestions, surveyAddModalOpen} = this.state;
       return <React.Fragment>
@@ -550,7 +546,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                 Domains
               </div>
               <div style={styles.cardList}>
-              {conceptDomainList.map((domain, i) => {
+              {conceptDomainList.filter(item => item.domain !== Domain.PHYSICALMEASUREMENT).map((domain, i) => {
                 return <DomainCard conceptDomainInfo={domain}
                                      standardConceptsOnly={standardConceptsOnly}
                                      browseInDomain={() => this.browseDomain(domain)}
@@ -570,7 +566,7 @@ export const ConceptHomepage = withCurrentWorkspace()(
                   Program Physical Measurements
                 </div>
                 <div style={styles.cardList}>
-                  {conceptPhysicalMeasurementsList.map((physicalMeasurement, p) => {
+                  {conceptDomainList.filter(item => item.domain === Domain.PHYSICALMEASUREMENT).map((physicalMeasurement, p) => {
                     return <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurement} key={p}
                                        browsePhysicalMeasurements={() => this.browseDomain(physicalMeasurement)}/>;
                   })}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -368,15 +368,10 @@ export const ConceptHomepage = withCurrentWorkspace()(
 
     selectConcepts(concepts: any[]) {
       const {selectedDomain: {domain}, selectedConceptDomainMap} = this.state;
-      if (domain === Domain.PHYSICALMEASUREMENT) {
-        selectedConceptDomainMap[domain] = concepts.filter(concept =>
-          concept.domainId.toLowerCase() === Domain[Domain.MEASUREMENT].toLowerCase()
-            && concept.vocabularyId === CriteriaType[CriteriaType.PPI]
-        );
-      } else if (domain === Domain.SURVEY) {
+      if (domain === Domain.SURVEY) {
         selectedConceptDomainMap[domain] = concepts.filter(concept => !!concept.question);
       } else {
-        selectedConceptDomainMap[domain] = concepts.filter(concept => concept.domainId.toLowerCase() === Domain[domain].toLowerCase());
+        selectedConceptDomainMap[domain] = concepts.filter(concept => concept.domainId.replace(' ', '').toLowerCase() === Domain[domain].toLowerCase());
       }
       this.setState({selectedConceptDomainMap: selectedConceptDomainMap});
     }

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -23,7 +23,6 @@ import {environment} from 'environments/environment';
 import {
   Concept,
   ConceptSet,
-  CriteriaType,
   Domain,
   DomainCount,
   DomainInfo,
@@ -371,7 +370,9 @@ export const ConceptHomepage = withCurrentWorkspace()(
       if (domain === Domain.SURVEY) {
         selectedConceptDomainMap[domain] = concepts.filter(concept => !!concept.question);
       } else {
-        selectedConceptDomainMap[domain] = concepts.filter(concept => concept.domainId.replace(' ', '').toLowerCase() === Domain[domain].toLowerCase());
+        selectedConceptDomainMap[domain] = concepts.filter(
+          concept => concept.domainId.replace(' ', '')
+            .toLowerCase() === Domain[domain].toLowerCase());
       }
       this.setState({selectedConceptDomainMap: selectedConceptDomainMap});
     }

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -208,11 +208,10 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
       const {urlParams: {ns, wsid, csid}} = this.props;
       try {
         await conceptSetsApi().deleteConceptSet(ns, wsid, csid);
-        navigate(['workspaces', ns, wsid, 'data', 'concepts', 'sets']);
+        navigate(['workspaces', ns, wsid, 'data', 'concepts']);
       } catch (error) {
-        console.log(error);
-        this.setState({error: true,
-          errorMessage: 'Could not delete concept set \'' + this.state.conceptSet.name + '\''});
+        console.error(error);
+        this.setState({error: true, errorMessage: 'Could not delete concept set \'' + this.state.conceptSet.name + '\''});
       } finally {
         this.setState({deleting: false});
       }

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -303,7 +303,9 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                     </div>
                   </React.Fragment>}
                   <div style={styles.conceptSetData}>
-                    <div data-test-id='participant-count'>Participant Count: {conceptSet.participantCount.toLocaleString()}</div>
+                    <div data-test-id='participant-count'>
+                      Participant Count: {!!conceptSet.participantCount ? conceptSet.participantCount.toLocaleString() : ''}
+                    </div>
                     <div style={{marginLeft: '2rem'}} data-test-id='concept-set-domain'>
                       Domain: {conceptSet.domain === Domain.PHYSICALMEASUREMENT
                         ? 'Physical Measurements' : fp.capitalize(conceptSet.domain.toString())}

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -27,7 +27,7 @@ import {
 import {currentConceptSetStore, navigate, navigateByUrl} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
-import {Concept, ConceptSet, CopyRequest, ResourceType, WorkspaceAccessLevel} from 'generated/fetch';
+import {Concept, ConceptSet, CopyRequest, Domain, ResourceType, WorkspaceAccessLevel} from 'generated/fetch';
 
 const styles = reactStyles({
   conceptSetHeader: {
@@ -223,17 +223,14 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
     }
 
     get conceptSetConceptsCount(): number {
-      return !!this.state.conceptSet && this.state.conceptSet.concepts ?
-        this.state.conceptSet.concepts.length : 0;
+      return !!this.state.conceptSet && this.state.conceptSet.concepts ? this.state.conceptSet.concepts.length : 0;
     }
 
     addToConceptSet() {
       const {workspace} = this.props;
       const {conceptSet} = this.state;
-      const queryParams = conceptSet.survey ? '?survey=' +  conceptSet.survey :
-          '?domain=' + conceptSet.domain;
-      navigateByUrl('workspaces/' + workspace.namespace + '/' +
-          workspace.id + '/data/concepts' + queryParams);
+      const queryParams = conceptSet.survey ? '?survey=' +  conceptSet.survey : '?domain=' + conceptSet.domain;
+      navigateByUrl('workspaces/' + workspace.namespace + '/' + workspace.id + '/data/concepts' + queryParams);
     }
 
     render() {
@@ -301,21 +298,21 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                                             style={{marginTop: '0.1rem'}}/>
                       </Clickable>
                     </div>
-                    <div style={{marginBottom: '1.5rem', color: colors.primary}}
-                         data-test-id='concept-set-description'>
-                      {conceptSet.description}</div>
+                    <div style={{marginBottom: '1.5rem', color: colors.primary}} data-test-id='concept-set-description'>
+                      {conceptSet.description}
+                    </div>
                   </React.Fragment>}
                   <div style={styles.conceptSetData}>
-                      <div data-test-id='participant-count'>
-                        Participant Count: {conceptSet.participantCount}</div>
-                      <div style={{marginLeft: '2rem'}} data-test-id='concept-set-domain'>
-                          Domain: {fp.capitalize(conceptSet.domain.toString())}</div>
+                    <div data-test-id='participant-count'>Participant Count: {conceptSet.participantCount.toLocaleString()}</div>
+                    <div style={{marginLeft: '2rem'}} data-test-id='concept-set-domain'>
+                      Domain: {conceptSet.domain === Domain.PHYSICALMEASUREMENT
+                        ? 'Physical Measurements' : fp.capitalize(conceptSet.domain.toString())}
+                    </div>
                   </div>
                 </div>
               </FlexRow>
               <FlexColumn>
-                <Button type='secondaryLight' style={styles.buttonBoxes}
-                        onClick={() => this.addToConceptSet()}>
+                <Button type='secondaryLight' style={styles.buttonBoxes} onClick={() => this.addToConceptSet()}>
                   <ClrIcon shape='search' style={{marginRight: '0.3rem'}}/>Add concepts to set
                 </Button>
               </FlexColumn>

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -93,17 +93,6 @@ const domainColumns = [
     testId: null
   }
 ];
-const surveyColumns = [
-  {
-    bodyStyle: styles.colStyle,
-    className: null,
-    field: 'question',
-    header: 'Question',
-    headerStyle: styles.headerStyle,
-    selectionMode: null,
-    testId: 'question'
-  }
-];
 
 interface SynonymsObjectState {
   seeMore: boolean;
@@ -293,7 +282,18 @@ export class ConceptTable extends React.Component<Props, State> {
   }
 
   renderColumns() {
-    const {domain} = this.props;
+    const {concepts, domain} = this.props;
+    const surveyColumn = [
+      {
+        bodyStyle: styles.colStyle,
+        className: null,
+        field: concepts.length && !!concepts[0].question ? 'question' : 'conceptName',
+        header: 'Question',
+        headerStyle: styles.headerStyle,
+        selectionMode: null,
+        testId: 'question'
+      }
+    ];
     const columns = [
       {
         bodyStyle: {...styles.colStyle, textAlign: 'center'},
@@ -304,7 +304,7 @@ export class ConceptTable extends React.Component<Props, State> {
         selectionMode: 'multiple',
         testId: 'conceptCheckBox'
       },
-      ...(domain === Domain.SURVEY && environment.enableNewConceptTabs ? surveyColumns : domainColumns)
+      ...(domain === Domain.SURVEY && environment.enableNewConceptTabs ? surveyColumn : domainColumns)
     ];
     return columns.map((col, c) => <Column
       bodyStyle={col.bodyStyle}

--- a/ui/src/app/pages/data/concept/concept-table.tsx
+++ b/ui/src/app/pages/data/concept/concept-table.tsx
@@ -5,7 +5,6 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
-import {environment} from 'environments/environment';
 import {Domain} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {Column} from 'primereact/column';
@@ -304,7 +303,7 @@ export class ConceptTable extends React.Component<Props, State> {
         selectionMode: 'multiple',
         testId: 'conceptCheckBox'
       },
-      ...(domain === Domain.SURVEY && environment.enableNewConceptTabs ? surveyColumn : domainColumns)
+      ...(domain === Domain.SURVEY ? surveyColumn : domainColumns)
     ];
     return columns.map((col, c) => <Column
       bodyStyle={col.bodyStyle}

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -19,5 +19,5 @@ export const testEnvironmentBase = {
   enableHomepageRestyle: true,
   enableProfileCapsFeatures: true,
   enableAccountPages: true,
-  enableNewConceptTabs: true
+  enableNewConceptTabs: false
 };

--- a/ui/src/testing/stubs/concepts-api-stub.ts
+++ b/ui/src/testing/stubs/concepts-api-stub.ts
@@ -190,17 +190,7 @@ export class ConceptsApiStub extends ConceptsApi {
         items: [],
         standardConcepts: [],
         vocabularyCounts: [],
-        domainCounts: undefined
       };
-      if (request.includeDomainCounts) {
-        response.domainCounts = DomainStubVariables.STUB_DOMAINS.map((domainInfo) => {
-          return {
-            domain: domainInfo.domain,
-            name: domainInfo.name,
-            conceptCount: domainInfo.allConceptCount
-          };
-        });
-      }
       const foundDomain =
         DomainStubVariables.STUB_DOMAINS.find(domain => domain.domain === request.domain);
       this.concepts.forEach((concept) => {

--- a/ui/src/testing/stubs/concepts-api-stub.ts
+++ b/ui/src/testing/stubs/concepts-api-stub.ts
@@ -4,11 +4,12 @@ import {
   ConceptsApi,
   Domain,
   DomainCount,
+  DomainCountsListResponse,
   DomainInfo,
   DomainInfoResponse,
   SearchConceptsRequest,
   StandardConceptFilter,
-  SurveyModule,
+  SurveyModule, SurveyQuestions,
   SurveysResponse
 } from 'generated/fetch';
 
@@ -133,14 +134,6 @@ export class DomainStubVariables {
       allConceptCount: 65,
       participantCount: 200
     },
-    {
-      domain: Domain.SURVEY,
-      name: 'Survey',
-      description: 'The Surveys Stub',
-      standardConceptCount: 4,
-      allConceptCount: 43,
-      participantCount: 150
-    }
   ];
 }
 
@@ -162,6 +155,18 @@ export class DomainCountStubVariables {
   ];
 }
 
+export class SurveyQuestionStubVariables {
+  static STUB_SURVEY_QUESTIONS: SurveyQuestions[] = [
+    {
+      question: 'Survey question 1',
+      conceptId: 1
+    }, {
+      question: 'Survey question 2',
+      conceptId: 2
+    }
+  ];
+}
+
 export class ConceptsApiStub extends ConceptsApi {
   public concepts?: Concept[];
   constructor() {
@@ -177,6 +182,10 @@ export class ConceptsApiStub extends ConceptsApi {
 
   public getSurveyInfo(workspaceNamespace: string, workspaceId: string): Promise<SurveysResponse> {
     return Promise.resolve({items: SurveyStubVariables.STUB_SURVEYS});
+  }
+
+  public domainCounts(workspaceNamespace: string, workspaceId: string): Promise<DomainCountsListResponse> {
+    return Promise.resolve({domainCounts: DomainCountStubVariables.STUB_DOMAIN_COUNTS});
   }
 
   // This just returns static values rather than doing a real search.
@@ -217,6 +226,10 @@ export class ConceptsApiStub extends ConceptsApi {
       });
       resolve(response);
     });
+  }
+
+  public searchSurveys(workspaceNamespace: string, workspaceId: string, request?: SearchConceptsRequest): Promise<Array<SurveyQuestions>> {
+    return Promise.resolve(SurveyQuestionStubVariables.STUB_SURVEY_QUESTIONS);
   }
 
 }


### PR DESCRIPTION
- Added the ability to create/edit/delete PM and Surveys inside the Concept Set Builder.
- Updated/added test coverage for each new bucket type
- Updated routing after deleting concept sets
- In test/staging/stable/prod PM will be behind feature flag because it is causing problems in Data Set Builder

![image](https://user-images.githubusercontent.com/3904919/73101608-a2d39780-3eb5-11ea-9a62-33bbe167e428.png)

![image](https://user-images.githubusercontent.com/3904919/73101632-b0891d00-3eb5-11ea-9484-2abe3f6d00bb.png)
