### PR TITLE
[RW-4091][RISK=NO]Change the return object for cloud task to array of long

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -1,9 +1,8 @@
 package org.pmiops.workbench.api;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+import org.pmiops.workbench.model.ArrayOfLong;
 import org.pmiops.workbench.rdr.RdrExportService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +13,6 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
   private RdrExportService rdrExportService;
 
   private static final Logger log = Logger.getLogger(CloudTaskRdrExportController.class.getName());
-  private final String IDS_STRING_SPLIT = ", ";
 
   CloudTaskRdrExportController(RdrExportService rdrExportService) {
     this.rdrExportService = rdrExportService;
@@ -29,16 +27,12 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
    * @return
    */
   @Override
-  public ResponseEntity<Void> exportResearcherData(Object researcherIds) {
-    if (researcherIds == null || ((ArrayList) researcherIds).isEmpty()) {
+  public ResponseEntity<Void> exportResearcherData(ArrayOfLong researcherIds) {
+    if (researcherIds == null || researcherIds.isEmpty()) {
       log.severe(" call to export Researcher Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    List<Long> requestUserIdList =
-        (ArrayList<Long>)
-            ((ArrayList) researcherIds)
-                .stream().map(id -> ((Integer) id).longValue()).collect(Collectors.toList());
-    rdrExportService.exportUsers(requestUserIdList);
+    rdrExportService.exportUsers(researcherIds);
 
     return ResponseEntity.noContent().build();
   }
@@ -50,13 +44,12 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
    * @return
    */
   @Override
-  public ResponseEntity<Void> exportWorkspaceData(Object workspaceIds) {
+  public ResponseEntity<Void> exportWorkspaceData(ArrayOfLong workspaceIds) {
     if (workspaceIds == null || ((ArrayList) workspaceIds).isEmpty()) {
       log.severe(" call to export Workspace Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    List<Long> requestUserIdList = (ArrayList<Long>) workspaceIds;
-    rdrExportService.exportWorkspaces(requestUserIdList);
+    rdrExportService.exportWorkspaces(workspaceIds);
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2270,14 +2270,15 @@ paths:
       description: >
         Task handler which handle request from cloud task queue rdrQueueTest to send Researcher data
       operationId: "exportResearcherData"
+      consumes:
+        - application/json
       parameters:
         - in: body
           name: researcherIds
           required: true
-          description: The IDs of concepts to be added to the concept set.
+          description: The IDs of Users to be exported to Rdr.
           schema:
-            type: object
-
+            $ref: "#/definitions/ArrayOfLong"
       responses:
         200:
           description: >
@@ -2296,9 +2297,9 @@ paths:
         - in: body
           name: researchIds
           required: true
-          description: The IDs of concepts to be added to the concept set.
+          description: The IDs of workspace to be exported to Rdr.
           schema:
-             type: object
+            $ref: "#/definitions/ArrayOfLong"
       responses:
         200:
           description: >
@@ -4094,9 +4095,8 @@ definitions:
         description: The name of the Jupyter VM which generated egress, e.g. all-of-us-260-m.
         type: string
 
-  RdrExportId:
-    type: object
-    properties:
-      exportId:
+  ArrayOfLong:
+      type: array
+      items:
         type: integer
         format: int64

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2261,6 +2261,9 @@ paths:
 # https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_app_engine_task_request_headers
 # and o.p.w.interceptors.CloudTaskInterceptor which implements the header check.
 #########################################################################################
+
+# Using body parameter ref ArrayOfLong instead of defining array of type long here because of
+# bug in swagger version 2.3.0 https://github.com/swagger-api/swagger-codegen/issues/6745.2.2.3
   /v1/cloudTask/exportResearcherData:
     post:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.pmiops.workbench.api.CloudTaskRdrExportApi;
 import org.pmiops.workbench.api.WorkspacesApi;
+import org.pmiops.workbench.model.ArrayOfLong;
 import org.springframework.web.method.HandlerMethod;
 
 public class CloudTaskInterceptorTest {
@@ -42,7 +43,8 @@ public class CloudTaskInterceptorTest {
   public void prehandleForCloudTaskNoHeader() throws Exception {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())
-        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+        .thenReturn(
+            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
   }
 
@@ -50,7 +52,8 @@ public class CloudTaskInterceptorTest {
   public void prehandleForCloudTaskWithBadHeader() throws Exception {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())
-        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+        .thenReturn(
+            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
     when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("asdf");
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
   }
@@ -59,7 +62,8 @@ public class CloudTaskInterceptorTest {
   public void prehandleForCloudTaskWithHeader() throws Exception {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())
-        .thenReturn(CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, Object.class));
+        .thenReturn(
+            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
     when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER))
         .thenReturn("rdrQueueTest");
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();


### PR DESCRIPTION
The request body for cloud task was set to Object just so RDR is unblocked and we can start export data. This PR is replacing generic Object to Array of Long

---
**PR checklist**

- [ X] This PR meets the Acceptance Criteria in the JIRA story
- [ X] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ X] I have run and tested this change locally
- [ X] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
