### PR TITLE
[RW-4315][risk=no] Distribution Metrics and Timing Recorder

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/StatusController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/StatusController.java
@@ -1,16 +1,8 @@
 package org.pmiops.workbench.api;
 
-import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.StatusResponse;
-import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.MonitoringService;
-import org.pmiops.workbench.monitoring.views.DistributionMetric;
-import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -38,21 +30,6 @@ public class StatusController implements StatusApiDelegate {
     StatusResponse statusResponse = new StatusResponse();
     statusResponse.setFirecloudStatus(fireCloudService.getFirecloudStatus());
     statusResponse.setNotebooksStatus(leonardoNotebooksClient.getNotebooksStatus());
-    sendDistribution();
-    sendEvents();
     return ResponseEntity.ok(statusResponse);
-  }
-
-  private void sendEvents() {
-    IntStream.rangeClosed(0, 99)
-        .forEach(i ->  monitoringService.recordEvent(EventMetric.NOTEBOOK_CLONE));
-  }
-
-  private void sendDistribution() {
-    final Random random = new Random();
-    Stream.generate(random::nextDouble)
-        .limit(100)
-        .collect(Collectors.toList())
-        .forEach(v -> monitoringService.recordValue(DistributionMetric.RANDOM_SAMPLE, v));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/StatusController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/StatusController.java
@@ -1,7 +1,16 @@
 package org.pmiops.workbench.api;
 
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.StatusResponse;
+import org.pmiops.workbench.monitoring.MeasurementBundle;
+import org.pmiops.workbench.monitoring.MonitoringService;
+import org.pmiops.workbench.monitoring.views.DistributionMetric;
+import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -12,12 +21,16 @@ public class StatusController implements StatusApiDelegate {
 
   private final FireCloudService fireCloudService;
   private final LeonardoNotebooksClient leonardoNotebooksClient;
+  private MonitoringService monitoringService;
 
   @Autowired
   StatusController(
-      FireCloudService fireCloudService, LeonardoNotebooksClient leonardoNotebooksClient) {
+      FireCloudService fireCloudService,
+      LeonardoNotebooksClient leonardoNotebooksClient,
+      MonitoringService monitoringService) {
     this.fireCloudService = fireCloudService;
     this.leonardoNotebooksClient = leonardoNotebooksClient;
+    this.monitoringService = monitoringService;
   }
 
   @Override
@@ -25,6 +38,21 @@ public class StatusController implements StatusApiDelegate {
     StatusResponse statusResponse = new StatusResponse();
     statusResponse.setFirecloudStatus(fireCloudService.getFirecloudStatus());
     statusResponse.setNotebooksStatus(leonardoNotebooksClient.getNotebooksStatus());
+    sendDistribution();
+    sendEvents();
     return ResponseEntity.ok(statusResponse);
+  }
+
+  private void sendEvents() {
+    IntStream.rangeClosed(0, 99)
+        .forEach(i ->  monitoringService.recordEvent(EventMetric.NOTEBOOK_CLONE));
+  }
+
+  private void sendDistribution() {
+    final Random random = new Random();
+    Stream.generate(random::nextDouble)
+        .limit(100)
+        .collect(Collectors.toList())
+        .forEach(v -> monitoringService.recordValue(DistributionMetric.RANDOM_SAMPLE, v));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/GaugeRecorderService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/GaugeRecorderService.java
@@ -3,9 +3,14 @@ package org.pmiops.workbench.monitoring;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.pmiops.workbench.monitoring.views.DistributionMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,6 +19,7 @@ public class GaugeRecorderService {
 
   private final List<GaugeDataCollector> gaugeDataCollectors;
   private final MonitoringService monitoringService;
+  private final Random random = new Random();
 
   // For local debugging, change this to Level.INFO or higher
   private final Level logLevel = Level.FINE;
@@ -32,6 +38,26 @@ public class GaugeRecorderService {
       bundlesToLogBuilder.addAll(bundles);
     }
     logValues(bundlesToLogBuilder.build());
+
+    debugRecordCumulativeAndDistribution();
+  }
+
+  private void debugRecordCumulativeAndDistribution() {
+    sendDistribution(100);
+    sendEvents(100);
+  }
+
+  private void sendEvents(int eventCount) {
+    int numEvents = (int) Math.round(random.nextDouble() * eventCount);
+    IntStream.rangeClosed(0, numEvents - 1)
+        .forEach(i ->  monitoringService.recordEvent(CumulativeMetric.DEBUG_COUNT));
+  }
+
+  private void sendDistribution(int sampleCount) {
+    Stream.generate(random::nextDouble)
+        .limit(sampleCount)
+        .collect(Collectors.toList())
+        .forEach(v -> monitoringService.recordValue(DistributionMetric.UNIFORM_RANDOM_SAMPLE, v));
   }
 
   private void logValues(Collection<MeasurementBundle> bundles) {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
@@ -15,7 +15,6 @@ import org.pmiops.workbench.monitoring.views.Metric;
 public interface MonitoringService {
 
   int DELTA_VALUE = 1;
-  Map<TagKey, TagValue> DEFAULT_TAGS = Collections.emptyMap();
 
   /**
    * Record an occurrence of a counted (a.k.a. delta or cumulative) time series. These are events
@@ -36,7 +35,7 @@ public interface MonitoringService {
   }
 
   default void recordValues(Map<Metric, Number> metricToValue) {
-    recordValues(metricToValue, DEFAULT_TAGS);
+    recordValues(metricToValue, Collections.emptyMap());
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.pmiops.workbench.monitoring.MeasurementBundle.Builder;
 import org.pmiops.workbench.monitoring.views.DistributionMetric;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.monitoring.views.Metric;
 
 public interface MonitoringService {
@@ -22,11 +22,11 @@ public interface MonitoringService {
    *
    * @param eventMetric
    */
-  default void recordEvent(EventMetric eventMetric) {
+  default void recordEvent(CumulativeMetric eventMetric) {
     recordValue(eventMetric, DELTA_VALUE);
   }
 
-  default void recordEvent(EventMetric eventMetric, Map<TagKey, TagValue> tags) {
+  default void recordEvent(CumulativeMetric eventMetric, Map<TagKey, TagValue> tags) {
     recordValues(ImmutableMap.of(eventMetric, DELTA_VALUE), tags);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
@@ -6,6 +6,8 @@ import io.opencensus.tags.TagValue;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import org.pmiops.workbench.monitoring.MeasurementBundle.Builder;
+import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.monitoring.views.Metric;
 
@@ -56,4 +58,7 @@ public interface MonitoringService {
   default void recordBundles(Collection<MeasurementBundle> viewBundles) {
     viewBundles.forEach(this::recordBundle);
   }
+
+  void timeAndRecordOperation(Builder measurementBundleBuilder,
+      DistributionMetric distributionMetric, Runnable operation);
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
@@ -6,6 +6,7 @@ import io.opencensus.tags.TagValue;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.pmiops.workbench.monitoring.MeasurementBundle.Builder;
 import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.pmiops.workbench.monitoring.views.EventMetric;
@@ -59,6 +60,30 @@ public interface MonitoringService {
     viewBundles.forEach(this::recordBundle);
   }
 
-  void timeAndRecordOperation(Builder measurementBundleBuilder,
-      DistributionMetric distributionMetric, Runnable operation);
+  /**
+   * Use a Stopwatch to time the supplied operation, then add a measurement to the supplied
+   * measurementBundleBuilder and record the associated DistributionMetric.
+   *
+   * @param measurementBundleBuilder - Builder for a MeasurementBundle to be recorded. Typically
+   *     only has tags.
+   * @param distributionMetric - Metric to be recorded. Always a distribution, as gauge and count
+   *     don't make sense for timings
+   * @param operation - Code to be run, e.g. () -> myService.computeThings()
+   */
+  void timeAndRecordOperation(
+      Builder measurementBundleBuilder, DistributionMetric distributionMetric, Runnable operation);
+
+  /**
+   * Same as above, but returns the result of the operation
+   *
+   * @param measurementBundleBuilder - Builder for a MeasurementBundle to be recorded. Typically
+   *     only has tags.
+   * @param distributionMetric - Metric to be recorded. Always a distribution, as gauge and count
+   *     don't make sense for timings
+   * @param operation - Code to be run, e.g. myService::getFooList
+   */
+  <T> T timeAndRecordOperation(
+      Builder measurementBundleBuilder,
+      DistributionMetric distributionMetric,
+      Supplier<T> operation);
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -82,6 +82,7 @@ public class MonitoringServiceImpl implements MonitoringService {
 
     // Finally, send the data to the backend (Stackdriver/Cloud Monitoring for now).
     measureMap.record(tagContextBuilder.build());
+    logger.info(String.format("Record measurements: %s, tags: %s", metricToValue, tags));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.monitoring;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 import org.jetbrains.annotations.NotNull;
+import org.pmiops.workbench.monitoring.MeasurementBundle.Builder;
 import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
@@ -79,6 +81,17 @@ public class MonitoringServiceImpl implements MonitoringService {
 
     // Finally, send the data to the backend (Stackdriver/Cloud Monitoring for now).
     measureMap.record(tagContextBuilder.build());
+  }
+
+  @Override
+  public void timeAndRecordOperation(Builder measurementBundleBuilder,
+      DistributionMetric distributionMetric, Runnable operation) {
+      final Stopwatch stopwatch = Stopwatch.createStarted();
+      operation.run();
+      stopwatch.stop();
+      recordBundle(measurementBundleBuilder
+              .addMeasurement(distributionMetric, stopwatch.elapsed().toMillis())
+              .build());
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 import org.jetbrains.annotations.NotNull;
+import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
 import org.pmiops.workbench.monitoring.views.Metric;
@@ -55,6 +56,7 @@ public class MonitoringServiceImpl implements MonitoringService {
     StreamSupport.stream(
             Iterables.concat(
                     Arrays.<Metric>asList(GaugeMetric.values()),
+                    Arrays.<Metric>asList(DistributionMetric.values()),
                     Arrays.<Metric>asList(EventMetric.values()))
                 .spliterator(),
             false)

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -20,7 +20,7 @@ import java.util.stream.StreamSupport;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.monitoring.MeasurementBundle.Builder;
 import org.pmiops.workbench.monitoring.views.DistributionMetric;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
 import org.pmiops.workbench.monitoring.views.Metric;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +60,7 @@ public class MonitoringServiceImpl implements MonitoringService {
             Iterables.concat(
                     Arrays.<Metric>asList(GaugeMetric.values()),
                     Arrays.<Metric>asList(DistributionMetric.values()),
-                    Arrays.<Metric>asList(EventMetric.values()))
+                    Arrays.<Metric>asList(CumulativeMetric.values()))
                 .spliterator(),
             false)
         .map(Metric::toView)

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -13,6 +13,7 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
@@ -84,14 +85,30 @@ public class MonitoringServiceImpl implements MonitoringService {
   }
 
   @Override
-  public void timeAndRecordOperation(Builder measurementBundleBuilder,
-      DistributionMetric distributionMetric, Runnable operation) {
-      final Stopwatch stopwatch = Stopwatch.createStarted();
-      operation.run();
-      stopwatch.stop();
-      recordBundle(measurementBundleBuilder
-              .addMeasurement(distributionMetric, stopwatch.elapsed().toMillis())
-              .build());
+  public void timeAndRecordOperation(
+      Builder measurementBundleBuilder, DistributionMetric distributionMetric, Runnable operation) {
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    operation.run();
+    stopwatch.stop();
+    recordBundle(
+        measurementBundleBuilder
+            .addMeasurement(distributionMetric, stopwatch.elapsed().toMillis())
+            .build());
+  }
+
+  @Override
+  public <T> T timeAndRecordOperation(
+      Builder measurementBundleBuilder,
+      DistributionMetric distributionMetric,
+      Supplier<T> operation) {
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    final T result = operation.get();
+    stopwatch.stop();
+    recordBundle(
+        measurementBundleBuilder
+            .addMeasurement(distributionMetric, stopwatch.elapsed().toMillis())
+            .build());
+    return result;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
@@ -9,10 +9,11 @@ import org.pmiops.workbench.utils.Enums;
 
 public enum MetricLabel implements MetricLabelBase {
   BUFFER_ENTRY_STATUS("BufferEntryStatus", Enums.getValueStrings(BufferEntryStatus.class)),
+  DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
   DATASET_INVALID("Invalid", Booleans.VALUE_STRINGS),
+  OPERATION_NAME("OperationNmae"),
   USER_BYPASSED_BETA("BypassedBeta", Booleans.VALUE_STRINGS),
   USER_DISABLED("Disabled", Booleans.VALUE_STRINGS),
-  DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
   WORKSPACE_ACTIVE_STATUS("ActiveStatus");
 
   private String keyName;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/attachments/MetricLabel.java
@@ -11,7 +11,7 @@ public enum MetricLabel implements MetricLabelBase {
   BUFFER_ENTRY_STATUS("BufferEntryStatus", Enums.getValueStrings(BufferEntryStatus.class)),
   DATA_ACCESS_LEVEL("DataAccessLevel", Enums.getValueStrings(DataAccessLevel.class)),
   DATASET_INVALID("Invalid", Booleans.VALUE_STRINGS),
-  OPERATION_NAME("OperationNmae"),
+  OPERATION_NAME("OperationName"),
   USER_BYPASSED_BETA("BypassedBeta", Booleans.VALUE_STRINGS),
   USER_DISABLED("Disabled", Booleans.VALUE_STRINGS),
   WORKSPACE_ACTIVE_STATUS("ActiveStatus");

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/CumulativeMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/CumulativeMetric.java
@@ -7,7 +7,8 @@ import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
 /** Metric enum values for events to be counted. */
-public enum EventMetric implements Metric {
+public enum CumulativeMetric implements Metric {
+  DEBUG_COUNT("debug_count", "Debug Cumulative"),
   NOTEBOOK_CLONE("notebook_clone_2", "Clone (duplicate) a notebook"),
   NOTEBOOK_DELETE("notebook_delete_2", "Delete a notebook"),
   NOTEBOOK_SAVE("notebook_save_2", "Save (or create) a notebook");
@@ -16,11 +17,11 @@ public enum EventMetric implements Metric {
   private final String description;
   private final List<MetricLabel> labels;
 
-  EventMetric(String name, String description) {
+  CumulativeMetric(String name, String description) {
     this(name, description, Collections.emptyList());
   }
 
-  EventMetric(String name, String description, List<MetricLabel> labels) {
+  CumulativeMetric(String name, String description, List<MetricLabel> labels) {
     this.name = name;
     this.description = description;
     this.labels = labels;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
@@ -1,0 +1,30 @@
+package org.pmiops.workbench.monitoring.views;
+
+import com.google.common.collect.ImmutableList;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.BucketBoundaries;
+
+public enum DistributionAggregation {
+  TIME(UnitOfMeasure.MILLISECOND, Aggregation.Distribution.create(BucketBoundaries.create(
+      ImmutableList
+          .of(0.0, 25.0, 50.0, 75.0, 100.0, 200.0, 400.0, 600.0, 800.0, 1000.0, 2000.0, 4000.0,
+              6000.0))));
+
+  private final UnitOfMeasure unitOfMeasure;
+  private final Aggregation.Distribution distribution;
+
+  DistributionAggregation(UnitOfMeasure unitOfMeasure, Distribution distribution) {
+
+    this.unitOfMeasure = unitOfMeasure;
+    this.distribution = distribution;
+  }
+
+  public UnitOfMeasure getUnitOfMeasure() {
+    return unitOfMeasure;
+  }
+
+  public Distribution getDistribution() {
+    return distribution;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
@@ -6,10 +6,13 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.BucketBoundaries;
 
 public enum DistributionAggregation {
-  TIME(UnitOfMeasure.MILLISECOND, Aggregation.Distribution.create(BucketBoundaries.create(
-      ImmutableList
-          .of(0.0, 25.0, 50.0, 75.0, 100.0, 200.0, 400.0, 600.0, 800.0, 1000.0, 2000.0, 4000.0,
-              6000.0))));
+  TIME(
+      UnitOfMeasure.MILLISECOND,
+      Aggregation.Distribution.create(
+          BucketBoundaries.create(
+              ImmutableList.of(
+                  0.0, 25.0, 50.0, 75.0, 100.0, 200.0, 400.0, 600.0, 800.0, 1000.0, 2000.0, 4000.0,
+                  6000.0))));
 
   private final UnitOfMeasure unitOfMeasure;
   private final Aggregation.Distribution distribution;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionAggregation.java
@@ -6,7 +6,12 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.BucketBoundaries;
 
 public enum DistributionAggregation {
-  TIME(
+  RANDOM_DOUBLE(
+      UnitOfMeasure.COUNT,
+      Aggregation.Distribution.create(
+          BucketBoundaries.create(
+              ImmutableList.of(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)))),
+  OPERATION_TIME(
       UnitOfMeasure.MILLISECOND,
       Aggregation.Distribution.create(
           BucketBoundaries.create(

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -1,0 +1,59 @@
+package org.pmiops.workbench.monitoring.views;
+
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Measure.MeasureLong;
+import java.util.Collections;
+import java.util.List;
+import org.pmiops.workbench.monitoring.attachments.MetricLabel;
+
+public enum DistributionMetric implements Metric {
+  LIST_WORKSPACES_TIME("operation_time_tmp", "Time to list complete some operation.",
+      Collections.singletonList(MetricLabel.OPERATION_NAME), DistributionAggregation.TIME, MeasureLong.class);
+
+  private final String name;
+  private final String description;
+  private final List<MetricLabel> metricLabels;
+  private final DistributionAggregation distributionAggregation;
+  private final Class measureClass;
+
+
+  DistributionMetric(String name, String description, List<MetricLabel> metricLabels,
+      DistributionAggregation distributionAggregation, Class measureClass) {
+    this.name = name;
+    this.description = description;
+    this.metricLabels = metricLabels;
+    this.distributionAggregation = distributionAggregation;
+    this.measureClass = measureClass;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getUnit() {
+    return distributionAggregation.getUnitOfMeasure().getUcmSymbol();
+  }
+
+  @Override
+  public Class getMeasureClass() {
+    return measureClass;
+  }
+
+  @Override
+  public Aggregation getAggregation() {
+    return distributionAggregation.getDistribution();
+  }
+
+  @Override
+  public List<MetricLabel> getLabels() {
+    return metricLabels;
+  }
+
+}

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -7,9 +7,15 @@ import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
 public enum DistributionMetric implements Metric {
-  OPERATION_TIME(
-      "operation_time_tmp_2",
-      "Time to list complete some operation.",
+  COHORT_OPERATION_TIME(
+      "cohort_operation_time",
+      "Time to complete Cohort-related operation.",
+      Collections.singletonList(MetricLabel.OPERATION_NAME),
+      DistributionAggregation.TIME,
+      MeasureLong.class),
+  WORKSPACE_OPERATION_TIME(
+      "workspace_operation_time",
+      "Time to complete Workspace-related operation.",
       Collections.singletonList(MetricLabel.OPERATION_NAME),
       DistributionAggregation.TIME,
       MeasureLong.class);

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -7,8 +7,8 @@ import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
 public enum DistributionMetric implements Metric {
-  LIST_WORKSPACES_TIME(
-      "operation_time_tmp",
+  OPERATION_TIME(
+      "operation_time_tmp_2",
       "Time to list complete some operation.",
       Collections.singletonList(MetricLabel.OPERATION_NAME),
       DistributionAggregation.TIME,

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -14,7 +14,7 @@ public enum DistributionMetric implements Metric {
       Collections.singletonList(MetricLabel.OPERATION_NAME),
       DistributionAggregation.OPERATION_TIME,
       MeasureLong.class),
-  RANDOM_SAMPLE(
+  UNIFORM_RANDOM_SAMPLE(
       "random_sample_2",
       "Random values",
       Collections.emptyList(),

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -7,8 +7,12 @@ import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
 public enum DistributionMetric implements Metric {
-  LIST_WORKSPACES_TIME("operation_time_tmp", "Time to list complete some operation.",
-      Collections.singletonList(MetricLabel.OPERATION_NAME), DistributionAggregation.TIME, MeasureLong.class);
+  LIST_WORKSPACES_TIME(
+      "operation_time_tmp",
+      "Time to list complete some operation.",
+      Collections.singletonList(MetricLabel.OPERATION_NAME),
+      DistributionAggregation.TIME,
+      MeasureLong.class);
 
   private final String name;
   private final String description;
@@ -16,9 +20,12 @@ public enum DistributionMetric implements Metric {
   private final DistributionAggregation distributionAggregation;
   private final Class measureClass;
 
-
-  DistributionMetric(String name, String description, List<MetricLabel> metricLabels,
-      DistributionAggregation distributionAggregation, Class measureClass) {
+  DistributionMetric(
+      String name,
+      String description,
+      List<MetricLabel> metricLabels,
+      DistributionAggregation distributionAggregation,
+      Class measureClass) {
     this.name = name;
     this.description = description;
     this.metricLabels = metricLabels;
@@ -55,5 +62,4 @@ public enum DistributionMetric implements Metric {
   public List<MetricLabel> getLabels() {
     return metricLabels;
   }
-
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/DistributionMetric.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.monitoring.views;
 
 import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import java.util.Collections;
 import java.util.List;
@@ -11,13 +12,19 @@ public enum DistributionMetric implements Metric {
       "cohort_operation_time",
       "Time to complete Cohort-related operation.",
       Collections.singletonList(MetricLabel.OPERATION_NAME),
-      DistributionAggregation.TIME,
+      DistributionAggregation.OPERATION_TIME,
       MeasureLong.class),
+  RANDOM_SAMPLE(
+      "random_sample_2",
+      "Random values",
+      Collections.emptyList(),
+      DistributionAggregation.RANDOM_DOUBLE,
+      MeasureDouble.class),
   WORKSPACE_OPERATION_TIME(
       "workspace_operation_time",
       "Time to complete Workspace-related operation.",
       Collections.singletonList(MetricLabel.OPERATION_NAME),
-      DistributionAggregation.TIME,
+      DistributionAggregation.OPERATION_TIME,
       MeasureLong.class);
 
   private final String name;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
@@ -38,7 +38,7 @@ public enum EventMetric implements Metric {
 
   @Override
   public String getUnit() {
-    return Metric.UNITLESS_UNIT;
+    return UnitOfMeasure.COUNT.getUcmSymbol();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
@@ -30,26 +30,26 @@ public enum GaugeMetric implements Metric {
       "workspace_count_3",
       "Count of all workspaces",
       ImmutableList.of(MetricLabel.WORKSPACE_ACTIVE_STATUS, MetricLabel.DATA_ACCESS_LEVEL),
-      Metric.UNITLESS_UNIT,
+      UnitOfMeasure.COUNT,
       MeasureLong.class);
 
   public static final LastValue AGGREGATION = LastValue.create();
   private final String name;
   private final String description;
-  private final String unit;
+  private final UnitOfMeasure unit;
   private final Class measureClass;
   private final List<MetricLabel> allowedAttachments;
 
   GaugeMetric(String name, String description) {
-    this(name, description, Collections.emptyList(), Metric.UNITLESS_UNIT, MeasureLong.class);
+    this(name, description, Collections.emptyList(), UnitOfMeasure.COUNT, MeasureLong.class);
   }
 
   GaugeMetric(String name, String description, List<MetricLabel> labels) {
-    this(name, description, labels, Metric.UNITLESS_UNIT, MeasureLong.class);
+    this(name, description, labels, UnitOfMeasure.COUNT, MeasureLong.class);
   }
 
   GaugeMetric(
-      String name, String description, List<MetricLabel> labels, String unit, Class measureClass) {
+      String name, String description, List<MetricLabel> labels, UnitOfMeasure unit, Class measureClass) {
     this.name = name;
     this.description = description;
     this.allowedAttachments = labels;
@@ -69,7 +69,7 @@ public enum GaugeMetric implements Metric {
 
   @Override
   public String getUnit() {
-    return unit;
+    return unit.getUcmSymbol();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
@@ -49,7 +49,11 @@ public enum GaugeMetric implements Metric {
   }
 
   GaugeMetric(
-      String name, String description, List<MetricLabel> labels, UnitOfMeasure unit, Class measureClass) {
+      String name,
+      String description,
+      List<MetricLabel> labels,
+      UnitOfMeasure unit,
+      Class measureClass) {
     this.name = name;
     this.description = description;
     this.allowedAttachments = labels;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/Metric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/Metric.java
@@ -32,8 +32,6 @@ public interface Metric {
           MeasureLong.class, Metric::getMeasureLong,
           MeasureDouble.class, Metric::getMeasureDouble);
 
-  String UNITLESS_UNIT = "1";
-
   String getName();
 
   default Name getStatsName() {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/UnitOfMeasure.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/UnitOfMeasure.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.monitoring.views;
 
 /**
  * Unit strings must conform to the
+ *
  * @see <a href=https://unitsofmeasure.org/ucum.html>Unified Code for Units of Measure</a>
  * @return canonical string for unit
  */

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/UnitOfMeasure.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/UnitOfMeasure.java
@@ -1,0 +1,21 @@
+package org.pmiops.workbench.monitoring.views;
+
+/**
+ * Unit strings must conform to the
+ * @see <a href=https://unitsofmeasure.org/ucum.html>Unified Code for Units of Measure</a>
+ * @return canonical string for unit
+ */
+public enum UnitOfMeasure {
+  COUNT("1"),
+  MILLISECOND("ms");
+
+  private String ucmValue;
+
+  UnitOfMeasure(String ucmValue) {
+    this.ucmValue = ucmValue;
+  }
+
+  public String getUcmSymbol() {
+    return ucmValue;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -23,7 +23,7 @@ import org.pmiops.workbench.google.GoogleCloudLocators;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.monitoring.MonitoringService;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -168,7 +168,7 @@ public class NotebooksServiceImpl implements NotebooksService {
             workspaceNamespace,
             workspaceName,
             newName);
-    monitoringService.recordEvent(EventMetric.NOTEBOOK_CLONE);
+    monitoringService.recordEvent(CumulativeMetric.NOTEBOOK_CLONE);
     return copiedNotebookFileDetail;
   }
 
@@ -181,7 +181,7 @@ public class NotebooksServiceImpl implements NotebooksService {
         workspaceService.getRequired(workspaceNamespace, workspaceName).getWorkspaceId(),
         userProvider.get().getUserId(),
         notebookLocators.fullPath);
-    monitoringService.recordEvent(EventMetric.NOTEBOOK_DELETE);
+    monitoringService.recordEvent(CumulativeMetric.NOTEBOOK_DELETE);
   }
 
   @Override
@@ -224,7 +224,7 @@ public class NotebooksServiceImpl implements NotebooksService {
         bucketName,
         "notebooks/" + NotebooksService.withNotebookExtension(notebookName),
         notebookContents.toString().getBytes(StandardCharsets.UTF_8));
-    monitoringService.recordEvent(EventMetric.NOTEBOOK_SAVE);
+    monitoringService.recordEvent(CumulativeMetric.NOTEBOOK_SAVE);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -9,7 +9,6 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
@@ -544,18 +543,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       log.warning("Service Account does not have access to bucket " + bucketName);
       throw e;
     }
-  }
-
-  private void timeAndRecordOperation(
-      Runnable operation, DistributionMetric metric, String operationName) {
-    final Stopwatch stopwatch = Stopwatch.createStarted();
-    operation.run();
-    stopwatch.stop();
-    monitoringService.recordBundle(
-        MeasurementBundle.builder()
-            .addMeasurement(metric, stopwatch.elapsed().toMillis())
-            .addTag(MetricLabel.OPERATION_NAME, operationName)
-            .build());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -5,7 +5,6 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
-import com.google.api.Monitoring;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
@@ -318,10 +317,11 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     response.setItems(workspaceService.getWorkspaces());
     stopwatch.stop();
 
-    monitoringService.recordBundle(MeasurementBundle.builder()
-        .addMeasurement(DistributionMetric.LIST_WORKSPACES_TIME, stopwatch.elapsed().toMillis())
-        .addTag(MetricLabel.OPERATION_NAME, "getWorkspaces")
-        .build());
+    monitoringService.recordBundle(
+        MeasurementBundle.builder()
+            .addMeasurement(DistributionMetric.LIST_WORKSPACES_TIME, stopwatch.elapsed().toMillis())
+            .addTag(MetricLabel.OPERATION_NAME, "getWorkspaces")
+            .build());
     return ResponseEntity.ok(response);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MetricTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MetricTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
 
 public class MetricTest {
@@ -13,7 +13,7 @@ public class MetricTest {
   public void testMatchingAttachmentIsSupported() {
     assertThat(GaugeMetric.USER_COUNT.getLabels()).contains(MetricLabel.USER_BYPASSED_BETA);
     assertThat(GaugeMetric.USER_COUNT.supportsLabel(MetricLabel.USER_BYPASSED_BETA)).isTrue();
-    assertThat(EventMetric.NOTEBOOK_CLONE.supportsLabel(MetricLabel.USER_BYPASSED_BETA)).isFalse();
+    assertThat(CumulativeMetric.NOTEBOOK_CLONE.supportsLabel(MetricLabel.USER_BYPASSED_BETA)).isFalse();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -76,14 +76,14 @@ public class MonitoringServiceTest {
 
   @Test
   public void testRecordIncrement() {
-    monitoringService.recordEvent(EventMetric.NOTEBOOK_SAVE);
+    monitoringService.recordEvent(CumulativeMetric.NOTEBOOK_SAVE);
     verify(mockInitService).createAndRegister();
 
-    final int metricCount = GaugeMetric.values().length + EventMetric.values().length;
+    final int metricCount = GaugeMetric.values().length + CumulativeMetric.values().length;
     verify(mockViewManager, times(metricCount)).registerView(any(View.class));
 
     verify(mockStatsRecorder).newMeasureMap();
-    verify(mockMeasureMap).put(EventMetric.NOTEBOOK_SAVE.getMeasureLong(), 1L);
+    verify(mockMeasureMap).put(CumulativeMetric.NOTEBOOK_SAVE.getMeasureLong(), 1L);
     verify(mockMeasureMap).record(any(TagContext.class));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -28,7 +28,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.MonitoringService;
-import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.CumulativeMetric;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -172,7 +172,7 @@ public class NotebooksServiceTest {
   @Test
   public void testSaveNotebook_firesMetric() {
     notebooksService.saveNotebook(BUCKET_NAME, NOTEBOOK_NAME, NOTEBOOK_CONTENTS);
-    verify(mockMonitoringService).recordEvent(EventMetric.NOTEBOOK_SAVE);
+    verify(mockMonitoringService).recordEvent(CumulativeMetric.NOTEBOOK_SAVE);
   }
 
   @Test
@@ -181,7 +181,7 @@ public class NotebooksServiceTest {
     doReturn(WORKSPACE).when(mockWorkspaceService).getRequired(anyString(), anyString());
 
     notebooksService.deleteNotebook(NAMESPACE_NAME, WORKSPACE_NAME, NOTEBOOK_NAME);
-    verify(mockMonitoringService).recordEvent(EventMetric.NOTEBOOK_DELETE);
+    verify(mockMonitoringService).recordEvent(CumulativeMetric.NOTEBOOK_DELETE);
   }
 
   @Test
@@ -190,7 +190,7 @@ public class NotebooksServiceTest {
     doReturn(WORKSPACE).when(mockWorkspaceService).getRequired(anyString(), anyString());
 
     notebooksService.cloneNotebook(NAMESPACE_NAME, WORKSPACE_NAME, PREVIOUS_NOTEBOOK);
-    verify(mockMonitoringService).recordEvent(EventMetric.NOTEBOOK_CLONE);
+    verify(mockMonitoringService).recordEvent(CumulativeMetric.NOTEBOOK_CLONE);
   }
 
   private void stubNotebookToJson() {


### PR DESCRIPTION
In order to understand all the metric types better, I started recording Distribution Metrics, including timings for various operations of interest to perf. 

Distribution metrics have an Aggregation type of Distribution, and use a boundary set (BucketBoundaries). These are exported to [Stackdriver](https://cloud.google.com/monitoring/custom-metrics/creating-metrics) as metrics with the `ValueType` of `DISTRIBUTION`.

I'm having difficulty getting metrics to show up in the local environment, possibly due to a lack of sufficient points. 

In order to generate timings for various method calls and chunks of code, I created two flavors of a method on the MonitoringService called `timeAndRecordOperation`

All of the metrics for the WorkspacesController are written to the new `DistributionMetric.WORKSPACE_OPERATION_TIME`, which created the following Custom `CUMULATIVE, DISTRIBUTION` Metric in the all-of-us-workbench-test project:

```
{
  "name": "projects/all-of-us-workbench-test/metricDescriptors/custom.googleapis.com/workspace_operation_time",
  "labels": [
    {
      "key": "opencensus_task",
      "description": "Opencensus task identifier"
    },
    {
      "key": "OperationName"
    }
  ],
  "metricKind": "CUMULATIVE",
  "valueType": "DISTRIBUTION",
  "unit": "ms",
  "description": "Time to complete Workspace-related operation.",
  "displayName": "custom.googleapis.com/workspace_operation_time",
  "type": "custom.googleapis.com/workspace_operation_time",
  "monitoredResourceTypes": [
    "aws_ec2_instance",
    "cloud_composer_environment",
    "cloud_composer_workflow",
    "dataflow_job",
    "gce_instance",
    "generic_node",
    "generic_task",
    "gke_container",
    "global",
    "k8s_cluster",
    "k8s_container",
    "k8s_node",
    "k8s_pod",
    "knative_broker",
    "knative_revision",
    "knative_trigger",
    "produced_api"
  ]
}
```

Similarly, the metric enum value for the Cohort Controller generated this Stackdriver metric upon OpenCensus view registration:
```
{
  "name": "projects/all-of-us-workbench-test/metricDescriptors/custom.googleapis.com/cohort_operation_time",
  "labels": [
    {
      "key": "opencensus_task",
      "description": "Opencensus task identifier"
    },
    {
      "key": "OperationName"
    }
  ],
  "metricKind": "CUMULATIVE",
  "valueType": "DISTRIBUTION",
  "unit": "ms",
  "description": "Time to complete Cohort-related operation.",
  "displayName": "custom.googleapis.com/cohort_operation_time",
  "type": "custom.googleapis.com/cohort_operation_time",
  "monitoredResourceTypes": [
    "aws_ec2_instance",
    "cloud_composer_environment",
    "cloud_composer_workflow",
    "dataflow_job",
    "gce_instance",
    "generic_node",
    "generic_task",
    "gke_container",
    "global",
    "k8s_cluster",
    "k8s_container",
    "k8s_node",
    "k8s_pod",
    "knative_broker",
    "knative_revision",
    "knative_trigger",
    "produced_api"
  ]
}
```

**TIL**
- Void methods can't be passed in as `Supplier<Void>`. Thus, two methods were necessary.
- The Stopwatch class from Guava is handy for timing these kinds of things
- 
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
