### PR TITLE
[RW-3910][risk=no] Set word breaks in dataset preview table columns

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -775,7 +775,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
       const dataTestId = 'data-test-id-' + text;
       return <TooltipTrigger data-test-id={dataTestId} side='top' content={text}
                              disabled={this.isEllipsisActive(text)}>
-        <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+        <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}} title={text}>
           {text}
         </div>
       </TooltipTrigger>;
@@ -797,7 +797,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
         {filteredPreviewData.values.map(value =>
           <Column key={value.value} header={this.getHeaderValue(value)}
                   headerStyle={{textAlign: 'left', width: '5rem'}} style={{width: '5rem'}}
-                  field={value.value}/>
+                  bodyStyle={{hyphens: 'auto'}} field={value.value}/>
         )}
       </DataTable>;
     }


### PR DESCRIPTION
Description:
- Use hyphens to break words that overlap the table cells
Before:
<img width="1022" alt="Screen Shot 2020-01-27 at 2 23 40 PM" src="https://user-images.githubusercontent.com/40036095/73377785-3b3a9500-4285-11ea-843b-f4ba23061312.png">

After:
<img width="989" alt="Screen Shot 2020-01-27 at 2 20 29 PM" src="https://user-images.githubusercontent.com/40036095/73377814-48578400-4285-11ea-855f-ea6807102875.png">

- Also added title attributes to column headers so the full text will show on hover
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
