### PR TITLE
use other Monitoring API

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -435,6 +435,8 @@ dependencies {
   compile "io.opencensus:opencensus-exporter-trace-stackdriver:${OPENCENSUS_VERSION}"
   compile "io.opencensus:opencensus-impl:${OPENCENSUS_VERSION}"
 
+  compile 'com.google.cloud:google-cloud-monitoring:1.99.1'
+
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.6'

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MeasurementBundle.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MeasurementBundle.java
@@ -8,7 +8,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
-import org.pmiops.workbench.monitoring.views.Metric;
+import org.pmiops.workbench.monitoring.views.MetricBase;
 
 /**
  * Simple bundle class to avoid dealing with lists of pairs of maps. This situation can occur in
@@ -16,15 +16,15 @@ import org.pmiops.workbench.monitoring.views.Metric;
  * to avoid excessive proliferation of (confusing) argument list types, we try to consolidate here.
  */
 public class MeasurementBundle {
-  private final Map<Metric, Number> measurements;
+  private final Map<MetricBase, Number> measurements;
   private final Map<MetricLabel, TagValue> tags;
 
-  private MeasurementBundle(Map<Metric, Number> measurements, Map<MetricLabel, TagValue> tags) {
+  private MeasurementBundle(Map<MetricBase, Number> measurements, Map<MetricLabel, TagValue> tags) {
     this.measurements = measurements;
     this.tags = tags;
   }
 
-  public Map<Metric, Number> getMeasurements() {
+  public Map<MetricBase, Number> getMeasurements() {
     return measurements;
   }
 
@@ -68,7 +68,7 @@ public class MeasurementBundle {
   }
 
   public static class Builder {
-    private ImmutableMap.Builder<Metric, Number> measurementsBuilder;
+    private ImmutableMap.Builder<MetricBase, Number> measurementsBuilder;
     private ImmutableMap.Builder<MetricLabel, TagValue> tagsBuilder;
 
     private Builder() {
@@ -76,17 +76,17 @@ public class MeasurementBundle {
       tagsBuilder = ImmutableMap.builder();
     }
 
-    public Builder addEvent(Metric metric) {
+    public Builder addEvent(MetricBase metric) {
       measurementsBuilder.put(metric, MonitoringService.DELTA_VALUE);
       return this;
     }
 
-    public Builder addMeasurement(Metric metric, Number value) {
+    public Builder addMeasurement(MetricBase metric, Number value) {
       measurementsBuilder.put(metric, value);
       return this;
     }
 
-    public Builder addAllMeasurements(Map<Metric, Number> map) {
+    public Builder addAllMeasurements(Map<MetricBase, Number> map) {
       measurementsBuilder.putAll(ImmutableMap.copyOf(map));
       return this;
     }
@@ -117,7 +117,7 @@ public class MeasurementBundle {
      * attachments, according to Attachment#supportsDiscreteValue()
      */
     private void validate() {
-      ImmutableMap<Metric, Number> measurements = measurementsBuilder.build();
+      ImmutableMap<MetricBase, Number> measurements = measurementsBuilder.build();
       ImmutableMap<MetricLabel, TagValue> tags = tagsBuilder.build();
       if (measurements.isEmpty()) {
         throw new IllegalStateException("MeasurementBundle must have at least one measurement.");
@@ -127,7 +127,7 @@ public class MeasurementBundle {
         final MetricLabel attachment = entry.getKey();
         final TagValue attachmentValue = entry.getValue();
 
-        for (Metric metric : measurements.keySet()) {
+        for (MetricBase metric : measurements.keySet()) {
           if (!metric.supportsLabel(attachment)) {
             throw new IllegalStateException(
                 (String.format(

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringService.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.pmiops.workbench.monitoring.views.EventMetric;
-import org.pmiops.workbench.monitoring.views.Metric;
+import org.pmiops.workbench.monitoring.views.MetricBase;
 
 public interface MonitoringService {
 
@@ -28,11 +28,11 @@ public interface MonitoringService {
     recordValues(ImmutableMap.of(eventMetric, DELTA_VALUE), tags);
   }
 
-  default void recordValue(Metric metric, Number value) {
+  default void recordValue(MetricBase metric, Number value) {
     recordValues(ImmutableMap.of(metric, value));
   }
 
-  default void recordValues(Map<Metric, Number> metricToValue) {
+  default void recordValues(Map<MetricBase, Number> metricToValue) {
     recordValues(metricToValue, DEFAULT_TAGS);
   }
 
@@ -45,7 +45,7 @@ public interface MonitoringService {
    *     attachments should apply to all entries in this map.
    * @param tags Map of String/AttachmentValue pairs to be associated with these data.
    */
-  void recordValues(Map<Metric, Number> metricToValue, Map<TagKey, TagValue> tags);
+  void recordValues(Map<MetricBase, Number> metricToValue, Map<TagKey, TagValue> tags);
 
   default void recordBundle(MeasurementBundle measurementBundle) {
     recordValues(measurementBundle.getMeasurements(), measurementBundle.getTags());

--- a/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringServiceImpl.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Service;
 
 @Service("OPEN_CENSUS_MONITORING_SERVICE")
 public class OpenCensusMonitoringServiceImpl implements MonitoringService {
-  private static final Logger logger = Logger.getLogger(OpenCensusMonitoringServiceImpl.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(OpenCensusMonitoringServiceImpl.class.getName());
   private boolean viewsAreRegistered = false;
   private ViewManager viewManager;
   private StatsRecorder statsRecorder;

--- a/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringServiceImpl.java
@@ -18,13 +18,13 @@ import java.util.stream.StreamSupport;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
-import org.pmiops.workbench.monitoring.views.Metric;
+import org.pmiops.workbench.monitoring.views.MetricBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-@Service
-public class MonitoringServiceImpl implements MonitoringService {
-  private static final Logger logger = Logger.getLogger(MonitoringServiceImpl.class.getName());
+@Service("OPEN_CENSUS_MONITORING_SERVICE")
+public class OpenCensusMonitoringServiceImpl implements MonitoringService {
+  private static final Logger logger = Logger.getLogger(OpenCensusMonitoringServiceImpl.class.getName());
   private boolean viewsAreRegistered = false;
   private ViewManager viewManager;
   private StatsRecorder statsRecorder;
@@ -32,7 +32,7 @@ public class MonitoringServiceImpl implements MonitoringService {
   private Tagger tagger;
 
   @Autowired
-  MonitoringServiceImpl(
+  OpenCensusMonitoringServiceImpl(
       ViewManager viewManager,
       StatsRecorder statsRecorder,
       StackdriverStatsExporterService stackdriverStatsExporterService,
@@ -54,16 +54,16 @@ public class MonitoringServiceImpl implements MonitoringService {
   private void registerMetricViews() {
     StreamSupport.stream(
             Iterables.concat(
-                    Arrays.<Metric>asList(GaugeMetric.values()),
-                    Arrays.<Metric>asList(EventMetric.values()))
+                    Arrays.<MetricBase>asList(GaugeMetric.values()),
+                    Arrays.<MetricBase>asList(EventMetric.values()))
                 .spliterator(),
             false)
-        .map(Metric::toView)
+        .map(MetricBase::toView)
         .forEach(viewManager::registerView);
   }
 
   @Override
-  public void recordValues(Map<Metric, Number> metricToValue, Map<TagKey, TagValue> tags) {
+  public void recordValues(Map<MetricBase, Number> metricToValue, Map<TagKey, TagValue> tags) {
     initStatsConfigurationIdempotent();
     if (metricToValue.isEmpty()) {
       logger.warning("recordValue() called with empty map.");
@@ -88,7 +88,7 @@ public class MonitoringServiceImpl implements MonitoringService {
    * @param value
    */
   private void addToMeasureMap(
-      @NotNull MeasureMap measureMap, @NotNull Metric metric, @NotNull Number value) {
+      @NotNull MeasureMap measureMap, @NotNull MetricBase metric, @NotNull Number value) {
     if (metric.getMeasureClass().equals(MeasureLong.class)) {
       measureMap.put(metric.getMeasureLong(), value.longValue());
     } else if (metric.getMeasureClass().equals(MeasureDouble.class)) {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/OpenCensusMonitoringSpringConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class MonitoringSpringConfiguration {
+public class OpenCensusMonitoringSpringConfiguration {
 
   @Bean
   public ViewManager getViewManager() {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverCloudMonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverCloudMonitoringServiceImpl.java
@@ -1,11 +1,9 @@
 package org.pmiops.workbench.monitoring;
 
 import com.google.api.Metric;
+import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.MonitoredResource;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.ProjectName;
@@ -18,30 +16,31 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.inject.Provider;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.monitoring.views.EventMetric;
-import org.pmiops.workbench.monitoring.views.GaugeMetric;
 import org.pmiops.workbench.monitoring.views.MetricBase;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 /**
- * As an alternative to the OpenCensus library, we provide a way to write using the Google
- * APIs directly
+ * As an alternative to the OpenCensus library, we provide a way to write using the Google APIs
+ * directly
  */
 @Service
 @Primary
 public class StackdriverCloudMonitoringServiceImpl implements MonitoringService {
-  private static final Logger logger = Logger.getLogger(StackdriverCloudMonitoringServiceImpl.class.getName());
+
+  private static final Logger logger =
+      Logger.getLogger(StackdriverCloudMonitoringServiceImpl.class.getName());
+  public static final Duration INTERVAL_SIZE = Duration.ofSeconds(1);
 
   private Clock clock;
   private MetricServiceClient metricServiceClient;
@@ -61,46 +60,51 @@ public class StackdriverCloudMonitoringServiceImpl implements MonitoringService 
 
   @Override
   public void recordValues(Map<MetricBase, Number> metricToValue, Map<TagKey, TagValue> tags) {
-    final TimeInterval interval = makeCurrentInterval();
-    final CreateTimeSeriesRequest.Builder requestBuilder = CreateTimeSeriesRequest.newBuilder()
-        .setName(ProjectName.of(workbenchConfigProvider.get().server.projectId).toString());
+    final CreateTimeSeriesRequest.Builder requestBuilder =
+        CreateTimeSeriesRequest.newBuilder()
+            .setName(ProjectName.of(workbenchConfigProvider.get().server.projectId).toString());
 
-    metricToValue.forEach((metricBase, value) -> {
-      final TypedValue.Builder typedValueBuilder = TypedValue.newBuilder();
-      if (metricBase.getMeasureClass().equals(MeasureLong.class)) {
-        typedValueBuilder.setInt64Value(value.longValue());
-      } else if (metricBase.getMeasureClass().equals(MeasureDouble.class)) {
-        typedValueBuilder.setDoubleValue(value.doubleValue());
-      } else {
-        logger.log(
-            Level.WARNING,
-            String.format("Unrecognized measure class %s", metricBase.getMeasureClass().getName()));
-      }
-      final Point point = Point.newBuilder()
-          .setValue(typedValueBuilder.build())
-          .setInterval(interval)
-          .build();
-      final Metric metric = toStackdriverMetric(metricBase, tags);
-      final TimeSeries timeSeries = TimeSeries.newBuilder()
-          .addPoints(point)
-          .setMetric(metric)
-          .setResource(monitoredResourceProvider.get())
-          .build();
-      requestBuilder.addTimeSeries(timeSeries);
-    });
+    metricToValue.forEach(
+        (metricBase, value) -> {
+          final TypedValue.Builder typedValueBuilder = TypedValue.newBuilder();
+          if (metricBase.getMeasureClass().equals(MeasureLong.class)) {
+            typedValueBuilder.setInt64Value(value.longValue());
+          } else if (metricBase.getMeasureClass().equals(MeasureDouble.class)) {
+            typedValueBuilder.setDoubleValue(value.doubleValue());
+          } else {
+            logger.log(
+                Level.WARNING,
+                String.format(
+                    "Unrecognized measure class %s", metricBase.getMeasureClass().getName()));
+          }
+          final TimeInterval interval = makeCurrentInterval(metricBase.getMetricKind());
+          final Point point =
+              Point.newBuilder().setValue(typedValueBuilder.build()).setInterval(interval).build();
+          final Metric metric = toStackdriverMetric(metricBase, tags);
+          final TimeSeries timeSeries =
+              TimeSeries.newBuilder()
+                  .addPoints(point)
+                  .setMetric(metric)
+                  .setResource(monitoredResourceProvider.get())
+                  .build();
+          requestBuilder.addTimeSeries(timeSeries);
+        });
 
     CreateTimeSeriesRequest createTimeSeriesRequest = requestBuilder.build();
     metricServiceClient.createTimeSeries(createTimeSeriesRequest);
-    logger.info(String.format("Created TimeSeries with request: %s", createTimeSeriesRequest.toString()));
+    logger.info(
+        String.format("Created TimeSeries with request: %s", createTimeSeriesRequest.toString()));
   }
 
-  // Convert a MetricBase object, along with a map of label-value pairs (as OC TagKey/TagValue for now)
+  // Convert a MetricBase object, along with a map of label-value pairs (as OC TagKey/TagValue for
+  // now)
   // into the Metric object we need to build a timeseries.
   private Metric toStackdriverMetric(MetricBase metricBase, Map<TagKey, TagValue> tagKeyToValue) {
-    final Map<String, String> stringKeyToValue = tagKeyToValue.entrySet()
-        .stream()
-        .map(e -> new SimpleImmutableEntry<>(e.getKey().getName(), e.getValue().asString()))
-        .collect(Collectors.toMap(SimpleImmutableEntry::getKey, SimpleImmutableEntry::getValue));
+    final Map<String, String> stringKeyToValue =
+        tagKeyToValue.entrySet().stream()
+            .map(e -> new SimpleImmutableEntry<>(e.getKey().getName(), e.getValue().asString()))
+            .collect(
+                Collectors.toMap(SimpleImmutableEntry::getKey, SimpleImmutableEntry::getValue));
     return Metric.newBuilder()
         .setType(metricBase.getMetricPathName())
         .putAllLabels(stringKeyToValue)
@@ -108,9 +112,14 @@ public class StackdriverCloudMonitoringServiceImpl implements MonitoringService 
   }
 
   @NotNull
-  private TimeInterval makeCurrentInterval() {
-    return TimeInterval.newBuilder()
-        .setEndTime(Timestamps.fromMillis(clock.millis()))
-        .build();
+  private TimeInterval makeCurrentInterval(MetricKind metricKind) {
+    final Instant now = clock.instant();
+    final Instant earlier = now.minus(INTERVAL_SIZE);
+    final TimeInterval.Builder resultBuilder =
+        TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(now.toEpochMilli()));
+    if (metricKind != MetricKind.GAUGE) {
+      resultBuilder.setStartTime(Timestamps.fromMillis(earlier.toEpochMilli()));
+    }
+    return resultBuilder.build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverCloudMonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverCloudMonitoringServiceImpl.java
@@ -1,0 +1,116 @@
+package org.pmiops.workbench.monitoring;
+
+import com.google.api.Metric;
+import com.google.api.MonitoredResource;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.monitoring.v3.CreateTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.util.Timestamps;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import java.time.Clock;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.inject.Provider;
+import org.jetbrains.annotations.NotNull;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.monitoring.views.EventMetric;
+import org.pmiops.workbench.monitoring.views.GaugeMetric;
+import org.pmiops.workbench.monitoring.views.MetricBase;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+/**
+ * As an alternative to the OpenCensus library, we provide a way to write using the Google
+ * APIs directly
+ */
+@Service
+@Primary
+public class StackdriverCloudMonitoringServiceImpl implements MonitoringService {
+  private static final Logger logger = Logger.getLogger(StackdriverCloudMonitoringServiceImpl.class.getName());
+
+  private Clock clock;
+  private MetricServiceClient metricServiceClient;
+  private Provider<MonitoredResource> monitoredResourceProvider;
+  private Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  public StackdriverCloudMonitoringServiceImpl(
+      Clock clock,
+      MetricServiceClient metricServiceClient,
+      Provider<MonitoredResource> monitoredResourceProvider,
+      Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.clock = clock;
+    this.metricServiceClient = metricServiceClient;
+    this.monitoredResourceProvider = monitoredResourceProvider;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  @Override
+  public void recordValues(Map<MetricBase, Number> metricToValue, Map<TagKey, TagValue> tags) {
+    final TimeInterval interval = makeCurrentInterval();
+    final CreateTimeSeriesRequest.Builder requestBuilder = CreateTimeSeriesRequest.newBuilder()
+        .setName(ProjectName.of(workbenchConfigProvider.get().server.projectId).toString());
+
+    metricToValue.forEach((metricBase, value) -> {
+      final TypedValue.Builder typedValueBuilder = TypedValue.newBuilder();
+      if (metricBase.getMeasureClass().equals(MeasureLong.class)) {
+        typedValueBuilder.setInt64Value(value.longValue());
+      } else if (metricBase.getMeasureClass().equals(MeasureDouble.class)) {
+        typedValueBuilder.setDoubleValue(value.doubleValue());
+      } else {
+        logger.log(
+            Level.WARNING,
+            String.format("Unrecognized measure class %s", metricBase.getMeasureClass().getName()));
+      }
+      final Point point = Point.newBuilder()
+          .setValue(typedValueBuilder.build())
+          .setInterval(interval)
+          .build();
+      final Metric metric = toStackdriverMetric(metricBase, tags);
+      final TimeSeries timeSeries = TimeSeries.newBuilder()
+          .addPoints(point)
+          .setMetric(metric)
+          .setResource(monitoredResourceProvider.get())
+          .build();
+      requestBuilder.addTimeSeries(timeSeries);
+    });
+
+    CreateTimeSeriesRequest createTimeSeriesRequest = requestBuilder.build();
+    metricServiceClient.createTimeSeries(createTimeSeriesRequest);
+    logger.info(String.format("Created TimeSeries with request: %s", createTimeSeriesRequest.toString()));
+  }
+
+  // Convert a MetricBase object, along with a map of label-value pairs (as OC TagKey/TagValue for now)
+  // into the Metric object we need to build a timeseries.
+  private Metric toStackdriverMetric(MetricBase metricBase, Map<TagKey, TagValue> tagKeyToValue) {
+    final Map<String, String> stringKeyToValue = tagKeyToValue.entrySet()
+        .stream()
+        .map(e -> new SimpleImmutableEntry<>(e.getKey().getName(), e.getValue().asString()))
+        .collect(Collectors.toMap(SimpleImmutableEntry::getKey, SimpleImmutableEntry::getValue));
+    return Metric.newBuilder()
+        .setType(metricBase.getMetricPathName())
+        .putAllLabels(stringKeyToValue)
+        .build();
+  }
+
+  @NotNull
+  private TimeInterval makeCurrentInterval() {
+    return TimeInterval.newBuilder()
+        .setEndTime(Timestamps.fromMillis(clock.millis()))
+        .build();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverMonitoringSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverMonitoringSpringConfiguration.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.util.UUID;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.springframework.aop.scope.ScopedProxyFactoryBean;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,11 +31,11 @@ public class StackdriverMonitoringSpringConfiguration {
   }
 
   /**
-   * Provide a  MonitoredResource object for Stackdriver Monitoring. (Additionally, this could
-   * be used for tracing and logging as well, though we should tread carefully there.
+   * Provide a MonitoredResource object for Stackdriver Monitoring. (Additionally, this could be
+   * used for tracing and logging as well, though we should tread carefully there.
    *
-   * This method was moved of an OpenCensus-specific service for use by both the Cloud Monitoring API-
-   * based monitoring service implementation and the OC-based one.
+   * <p>This method was moved of an OpenCensus-specific service for use by both the Cloud Monitoring
+   * API- based monitoring service implementation and the OC-based one.
    */
   @Bean
   @Scope("prototype")

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverMonitoringSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverMonitoringSpringConfiguration.java
@@ -1,0 +1,70 @@
+package org.pmiops.workbench.monitoring;
+
+import com.google.api.MonitoredResource;
+import com.google.appengine.api.modules.ModulesException;
+import com.google.appengine.api.modules.ModulesService;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import java.io.IOException;
+import java.util.UUID;
+import javax.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.springframework.aop.scope.ScopedProxyFactoryBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class StackdriverMonitoringSpringConfiguration {
+
+  private static final String MONITORED_RESOURCE_TYPE = "generic_node";
+  private static final String PROJECT_ID_LABEL = "project_id";
+  private static final String LOCATION_LABEL = "location";
+  private static final String NAMESPACE_LABEL = "namespace";
+  private static final String NODE_ID_LABEL = "node_id";
+  private static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
+
+  public static final String APP_ENGINE_NODE_ID = "APP_ENGINE_NODE_ID";
+
+  @Bean
+  public MetricServiceClient getMetricServiceClient() throws IOException {
+    return MetricServiceClient.create();
+  }
+
+  /**
+   * Provide a  MonitoredResource object for Stackdriver Monitoring. (Additionally, this could
+   * be used for tracing and logging as well, though we should tread carefully there.
+   *
+   * This method was moved of an OpenCensus-specific service for use by both the Cloud Monitoring API-
+   * based monitoring service implementation and the OC-based one.
+   */
+  @Bean
+  @Scope("prototype")
+  public MonitoredResource getMonitoredResource(
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      @Qualifier(APP_ENGINE_NODE_ID) Provider<String> nodeIdProvider) {
+    return MonitoredResource.newBuilder()
+        .setType(MONITORED_RESOURCE_TYPE)
+        .putLabels(PROJECT_ID_LABEL, workbenchConfigProvider.get().server.projectId)
+        .putLabels(LOCATION_LABEL, workbenchConfigProvider.get().server.appEngineLocationId)
+        .putLabels(NAMESPACE_LABEL, workbenchConfigProvider.get().server.shortName.toLowerCase())
+        .putLabels(NODE_ID_LABEL, nodeIdProvider.get())
+        .build();
+  }
+
+  /**
+   * Stackdriver instances have very long, random ID strings. When running locally, however, the
+   * ModulesService throws an exception, so we need to assign non-conflicting and non-repeating ID
+   * strings.
+   *
+   * @return - node ID string.
+   */
+  @Bean(name = APP_ENGINE_NODE_ID)
+  public String getAppEngineNodeId(ModulesService modulesService) {
+    try {
+      return modulesService.getCurrentInstanceId();
+    } catch (ModulesException e) {
+      return UNKNOWN_INSTANCE_PREFIX + UUID.randomUUID().toString();
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -72,6 +72,7 @@ public class StackdriverStatsExporterService {
         .setMonitoredResource(monitoredResourceProvider.get())
         .build();
   }
+
   private String getProjectId() {
     return workbenchConfigProvider.get().server.projectId;
   }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.monitoring.views;
 
+import com.google.api.MetricDescriptor.MetricKind;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure.MeasureLong;
 import java.util.Collections;
@@ -7,7 +8,7 @@ import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
 /** Metric enum values for events to be counted. */
-public enum EventMetric implements Metric {
+public enum EventMetric implements MetricBase {
   NOTEBOOK_CLONE("notebook_clone_2", "Clone (duplicate) a notebook"),
   NOTEBOOK_DELETE("notebook_delete_2", "Delete a notebook"),
   NOTEBOOK_SAVE("notebook_save_2", "Save (or create) a notebook");
@@ -38,7 +39,7 @@ public enum EventMetric implements Metric {
 
   @Override
   public String getUnit() {
-    return Metric.UNITLESS_UNIT;
+    return MetricBase.UNITLESS_UNIT;
   }
 
   @Override
@@ -55,4 +56,10 @@ public enum EventMetric implements Metric {
   public List<MetricLabel> getLabels() {
     return labels;
   }
+
+  @Override
+  public MetricKind getMetricKind() {
+    return MetricKind.CUMULATIVE;
+  }
+
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/EventMetric.java
@@ -61,5 +61,4 @@ public enum EventMetric implements MetricBase {
   public MetricKind getMetricKind() {
     return MetricKind.CUMULATIVE;
   }
-
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/GaugeMetric.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.monitoring.views;
 
+import com.google.api.MetricDescriptor.MetricKind;
 import com.google.common.collect.ImmutableList;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Aggregation.LastValue;
@@ -8,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 
-public enum GaugeMetric implements Metric {
+public enum GaugeMetric implements MetricBase {
   BILLING_BUFFER_PROJECT_COUNT(
       "billing_buffer_project_count",
       "Number of projects in the billing buffer for each status",
@@ -30,7 +31,7 @@ public enum GaugeMetric implements Metric {
       "workspace_count_3",
       "Count of all workspaces",
       ImmutableList.of(MetricLabel.WORKSPACE_ACTIVE_STATUS, MetricLabel.DATA_ACCESS_LEVEL),
-      Metric.UNITLESS_UNIT,
+      MetricBase.UNITLESS_UNIT,
       MeasureLong.class);
 
   public static final LastValue AGGREGATION = LastValue.create();
@@ -41,11 +42,11 @@ public enum GaugeMetric implements Metric {
   private final List<MetricLabel> allowedAttachments;
 
   GaugeMetric(String name, String description) {
-    this(name, description, Collections.emptyList(), Metric.UNITLESS_UNIT, MeasureLong.class);
+    this(name, description, Collections.emptyList(), MetricBase.UNITLESS_UNIT, MeasureLong.class);
   }
 
   GaugeMetric(String name, String description, List<MetricLabel> labels) {
-    this(name, description, labels, Metric.UNITLESS_UNIT, MeasureLong.class);
+    this(name, description, labels, MetricBase.UNITLESS_UNIT, MeasureLong.class);
   }
 
   GaugeMetric(
@@ -90,6 +91,11 @@ public enum GaugeMetric implements Metric {
   @Override
   public List<MetricLabel> getLabels() {
     return allowedAttachments;
+  }
+
+  @Override
+  public MetricKind getMetricKind() {
+    return MetricKind.GAUGE;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/MetricBase.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/MetricBase.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.monitoring.views;
 
+import com.google.api.MetricDescriptor.MetricKind;
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
@@ -24,20 +25,32 @@ import org.pmiops.workbench.monitoring.attachments.MetricLabelBase;
  * there's no such thing as a Metric in the latter. We use OpenCensus terminology in this system as
  * we may wish to support other metrics backends, and don't want to depend on Stackdriver concepts
  * or implementation details.
+ *
+ * Currenlty, there is a  mix of both Stackdriver and OpenCensus types referenced in this interface.
+ * The plan is to avoid that by moving these backend-specific functions into translator classes/services.
  */
-public interface Metric {
+public interface MetricBase {
 
-  Map<Class, Function<Metric, Measure>> MEASURE_CLASS_TO_MEASURE_FUNCTION =
+  Map<Class, Function<MetricBase, Measure>> MEASURE_CLASS_TO_MEASURE_FUNCTION =
       ImmutableMap.of(
-          MeasureLong.class, Metric::getMeasureLong,
-          MeasureDouble.class, Metric::getMeasureDouble);
+          MeasureLong.class, MetricBase::getMeasureLong,
+          MeasureDouble.class, MetricBase::getMeasureDouble);
 
   String UNITLESS_UNIT = "1";
+  String STACKDRIVER_CUSTOM_METRICS_PREFIX = "custom.googleapis.com/";
 
   String getName();
 
   default Name getStatsName() {
     return Name.create(getName());
+  }
+
+  /**
+   * Return
+   * @return
+   */
+  default String getMetricPathName() {
+    return String.format("%s%s", STACKDRIVER_CUSTOM_METRICS_PREFIX, getName());
   }
 
   String getDescription();
@@ -85,4 +98,6 @@ public interface Metric {
   default boolean supportsLabel(MetricLabel label) {
     return getLabels().contains(label);
   }
+
+  MetricKind getMetricKind();
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/views/MetricBase.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/views/MetricBase.java
@@ -26,8 +26,9 @@ import org.pmiops.workbench.monitoring.attachments.MetricLabelBase;
  * we may wish to support other metrics backends, and don't want to depend on Stackdriver concepts
  * or implementation details.
  *
- * Currenlty, there is a  mix of both Stackdriver and OpenCensus types referenced in this interface.
- * The plan is to avoid that by moving these backend-specific functions into translator classes/services.
+ * <p>Currenlty, there is a mix of both Stackdriver and OpenCensus types referenced in this
+ * interface. The plan is to avoid that by moving these backend-specific functions into translator
+ * classes/services.
  */
 public interface MetricBase {
 
@@ -47,6 +48,7 @@ public interface MetricBase {
 
   /**
    * Return
+   *
    * @return
    */
   default String getMetricPathName() {

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MeasurementBundleTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MeasurementBundleTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.pmiops.workbench.db.model.DbBillingProjectBufferEntry.BufferEntryStatus;
 import org.pmiops.workbench.monitoring.attachments.MetricLabel;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
-import org.pmiops.workbench.monitoring.views.Metric;
+import org.pmiops.workbench.monitoring.views.MetricBase;
 
 public class MeasurementBundleTest {
 
@@ -25,7 +25,7 @@ public class MeasurementBundleTest {
 
   @Test
   public void testBuild_multipleMeasurementsNoAttachments() {
-    final ImmutableMap<Metric, Number> measurementMap =
+    final ImmutableMap<MetricBase, Number> measurementMap =
         ImmutableMap.of(
             GaugeMetric.BILLING_BUFFER_PROJECT_COUNT, 202L,
             GaugeMetric.COHORT_COUNT, 300L,

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
@@ -48,7 +48,7 @@ public class MonitoringServiceTest {
   @Autowired private MonitoringService monitoringService;
 
   @TestConfiguration
-  @Import({MonitoringServiceImpl.class})
+  @Import({OpenCensusMonitoringServiceImpl.class})
   @MockBean({
     ViewManager.class,
     StatsRecorder.class,

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -39,8 +39,8 @@ import org.pmiops.workbench.firecloud.FireCloudConfig;
 import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.model.FileDetail;
-import org.pmiops.workbench.monitoring.MonitoringServiceImpl;
-import org.pmiops.workbench.monitoring.MonitoringSpringConfiguration;
+import org.pmiops.workbench.monitoring.OpenCensusMonitoringServiceImpl;
+import org.pmiops.workbench.monitoring.OpenCensusMonitoringSpringConfiguration;
 import org.pmiops.workbench.monitoring.StackdriverStatsExporterService;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
@@ -57,8 +57,8 @@ import org.springframework.context.annotation.Primary;
 /** A tool that will generate a CSV export of our workspace data */
 @Configuration
 @Import({
-  MonitoringServiceImpl.class,
-  MonitoringSpringConfiguration.class,
+  OpenCensusMonitoringServiceImpl.class,
+  OpenCensusMonitoringSpringConfiguration.class,
   NotebooksServiceImpl.class,
   StackdriverStatsExporterService.class,
   UserRecentResourceServiceImpl.class

--- a/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
@@ -67,7 +67,7 @@ public class CacheSpringConfiguration {
   }
 
   @Bean
-//  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  //  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   WorkbenchConfig getWorkbenchConfig(
       @Qualifier("configCache") LoadingCache<String, Object> configCache)
       throws ExecutionException {

--- a/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
@@ -67,7 +67,7 @@ public class CacheSpringConfiguration {
   }
 
   @Bean
-  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+//  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   WorkbenchConfig getWorkbenchConfig(
       @Qualifier("configCache") LoadingCache<String, Object> configCache)
       throws ExecutionException {


### PR DESCRIPTION
Hedge our bets, as it sounds like OpenCensus isn't doing the right stuff in AppEngine Standard.

builds a new service implementation that's a drop-in replacement for the old one. Application code needn't change.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
