### PR TITLE
[RW-4132][risk=low] Disallow editing of workspace "request review"

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -371,12 +371,9 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
     ResearchPurpose researchPurpose = request.getWorkspace().getResearchPurpose();
     if (researchPurpose != null) {
+      // Note: this utility does not set the "review requested" bit or time. This is currently
+      // immutable on a workspace, see RW-4132.
       WorkspaceConversionUtils.setResearchPurposeDetails(dbWorkspace, researchPurpose);
-      if (researchPurpose.getReviewRequested()) {
-        Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-        dbWorkspace.setTimeRequested(now);
-      }
-      dbWorkspace.setReviewRequested(researchPurpose.getReviewRequested());
     }
 
     if (workspace.getBillingAccountName() != null) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -828,6 +828,7 @@ public class WorkspacesControllerTest {
   @Test
   public void testUpdateWorkspaceResearchPurpose() throws Exception {
     Workspace ws = createWorkspace();
+    ws.getResearchPurpose().reviewRequested(true);
     ws = workspacesController.createWorkspace(ws).getBody();
 
     ResearchPurpose rp =
@@ -841,8 +842,7 @@ public class WorkspacesControllerTest {
             .populationHealth(false)
             .socialBehavioral(false)
             .drugDevelopment(false)
-            .additionalNotes(null)
-            .reviewRequested(false);
+            .additionalNotes(null);
     ws.setResearchPurpose(rp);
     UpdateWorkspaceRequest request = new UpdateWorkspaceRequest();
     request.setWorkspace(ws);
@@ -863,7 +863,25 @@ public class WorkspacesControllerTest {
     assertThat(updatedRp.getDrugDevelopment()).isFalse();
     assertThat(updatedRp.getPopulation()).isFalse();
     assertThat(updatedRp.getAdditionalNotes()).isNull();
+    assertThat(updatedRp.getReviewRequested()).isTrue();
+  }
+
+  @Test
+  public void testUpdateWorkspaceResearchPurpose_cannotUpdateReviewRequest() throws Exception {
+    Workspace ws = createWorkspace();
+    ws.getResearchPurpose().setReviewRequested(false);
+    ws = workspacesController.createWorkspace(ws).getBody();
+
+    ws.getResearchPurpose().setReviewRequested(true);
+    UpdateWorkspaceRequest request = new UpdateWorkspaceRequest().workspace(ws);
+    ResearchPurpose updatedRp =
+        workspacesController
+            .updateWorkspace(ws.getNamespace(), ws.getId(), request)
+            .getBody()
+            .getResearchPurpose();
+
     assertThat(updatedRp.getReviewRequested()).isFalse();
+    assertThat(updatedRp.getTimeRequested()).isNull();
   }
 
   @Test(expected = ForbiddenException.class)

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1037,12 +1037,14 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           </FlexRow>
           <div>
             <RadioButton name='reviewRequested'
+                         disabled={this.isMode(WorkspaceEditMode.Edit)}
                          onChange={() => {
                            this.updateResearchPurpose('reviewRequested', true);
                          }}
                          checked={this.state.workspace.researchPurpose.reviewRequested}/>
             <label style={{...styles.text, marginLeft: '0.5rem', marginRight: '3rem'}}>Yes</label>
             <RadioButton name='reviewRequested'
+                         disabled={this.isMode(WorkspaceEditMode.Edit)}
                          onChange={() => {
                            this.updateResearchPurpose('reviewRequested', false);
                          }}


### PR DESCRIPTION
This simplifies the flow for the new Zendesk ticket integration. In the future, we might add this capability back in.