### PR TITLE
[RW-4284][risk=no] Inactive Billing status banner

### DIFF
--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -164,7 +164,8 @@ export const Breadcrumb = fp.flow(
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
-      if (!prevProps.workspace && this.props.workspace && this.props.workspace.billingStatus === BillingStatus.INACTIVE) {
+      if (!prevProps.workspace && this.props.workspace &&
+        this.props.workspace.billingStatus === BillingStatus.INACTIVE) {
         this.setState({showInvalidBillingBanner: true});
       }
     }

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {dropNotebookFileSuffix} from 'app/pages/analysis/util';
+import {InvalidBillingBanner} from 'app/pages/workspace/invalid-billing-banner';
 import colors from 'app/styles/colors';
 import {
   withCurrentCohort,
@@ -13,7 +14,6 @@ import {
 import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {BillingStatus, Cohort, ConceptSet} from 'generated/fetch';
-import {InvalidBillingBanner} from "app/pages/workspace/invalid-billing-banner";
 
 const styles = {
   firstLink: {
@@ -160,7 +160,7 @@ export const Breadcrumb = fp.flow(
       super(props);
       this.state = {
         showInvalidBillingBanner: false
-      }
+      };
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -12,7 +12,8 @@ import {
 } from 'app/utils';
 import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Cohort, ConceptSet} from 'generated/fetch';
+import {BillingStatus, Cohort, ConceptSet} from 'generated/fetch';
+import {InvalidBillingBanner} from "app/pages/workspace/invalid-billing-banner";
 
 const styles = {
   firstLink: {
@@ -143,6 +144,10 @@ interface Props {
   routeConfigData: any;
 }
 
+interface State {
+  showInvalidBillingBanner: boolean;
+}
+
 export const Breadcrumb = fp.flow(
   withCurrentWorkspace(),
   withCurrentCohort(),
@@ -150,9 +155,18 @@ export const Breadcrumb = fp.flow(
   withUrlParams(),
   withRouteConfigData()
 )(
-  class extends React.Component<Props> {
+  class extends React.Component<Props, State> {
     constructor(props) {
       super(props);
+      this.state = {
+        showInvalidBillingBanner: false
+      }
+    }
+
+    componentDidUpdate(prevProps: Readonly<Props>): void {
+      if (!prevProps.workspace && this.props.workspace && this.props.workspace.billingStatus === BillingStatus.INACTIVE) {
+        this.setState({showInvalidBillingBanner: true});
+      }
     }
 
     trail(): Array<BreadcrumbData> {
@@ -174,26 +188,31 @@ export const Breadcrumb = fp.flow(
     }
 
     render() {
-      return <div style={{
-        marginLeft: '3.25rem',
-        display: 'inline-block',
-      }}>
-        {this.first().map(({label, url}, i) => {
-          return <React.Fragment key={i}>
-            <BreadcrumbLink href={url} style={styles.firstLink}>
-              {label}
+      return <React.Fragment>
+        {this.state.showInvalidBillingBanner &&
+        <InvalidBillingBanner onClose={() => this.setState({showInvalidBillingBanner: false})}/>}
+
+        <div style={{
+          marginLeft: '3.25rem',
+          display: 'inline-block',
+        }}>
+          {this.first().map(({label, url}, i) => {
+            return <React.Fragment key={i}>
+              <BreadcrumbLink href={url} style={styles.firstLink}>
+                {label}
+              </BreadcrumbLink>
+              <span style={{
+                color: colors.primary
+              }}> &gt; </span>
+            </React.Fragment>;
+          })}
+          {this.last() && <div>
+            <BreadcrumbLink href={this.last().url} style={styles.lastLink}>
+              {this.last().label}
             </BreadcrumbLink>
-            <span style={{
-              color: colors.primary
-            }}> &gt; </span>
-          </React.Fragment>;
-        })}
-        {this.last() && <div>
-          <BreadcrumbLink href={this.last().url} style={styles.lastLink}>
-            {this.last().label}
-          </BreadcrumbLink>
-        </div>}
-      </div>;
+          </div>}
+        </div>
+      </React.Fragment>;
     }
   }
 );

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -84,6 +84,6 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
 
   render() {
     return ReactDOM.createPortal(this.renderBanner(),
-      document.getElementById('body'))
+      document.getElementById('body'));
   }
 }

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -84,6 +84,6 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
 
   render() {
     return ReactDOM.createPortal(this.renderBanner(),
-      document.getElementById('body'));
+      document.getElementsByTagName('body')[0]);
   }
 }

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
@@ -25,7 +26,6 @@ const styles = reactStyles({
 
 
 export interface Props {
-  statusAlertId: number;
   title: string;
   message: string;
   link: string;
@@ -41,18 +41,18 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
     window.open(link, '_blank');
   }
 
-  render() {
+  renderBanner() {
     const {title, message, link} = this.props;
     return <FlexColumn style={styles.alertBanner}>
       <FlexRow style={{width: '100%'}}>
         <ClrIcon
-            shape={'warning-standard'}
-            class={'is-solid'}
-            size={20}
-            style={{
-              color: colors.warning,
-              flex: '0 0 auto'
-            }}
+          shape={'warning-standard'}
+          class={'is-solid'}
+          size={20}
+          style={{
+            color: colors.warning,
+            flex: '0 0 auto'
+          }}
         />
         <div style={{
           fontWeight: 'bold',
@@ -63,22 +63,27 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
           top: '-0.2rem'
         }}>{title}</div>
         <ClrIcon
-            shape={'times'}
-            size={20}
-            style={{marginLeft: 'auto', flex: '0 0 auto'}}
-            onClick={() => this.props.onClose()}
+          shape={'times'}
+          size={20}
+          style={{marginLeft: 'auto', flex: '0 0 auto'}}
+          onClick={() => this.props.onClose()}
         />
       </FlexRow>
       <div>{message}</div>
       {
         link && <Button
-            style={{marginTop: 'auto', width: '125px'}}
-            onClick={() => this.navigateToLink(link)}
-            data-test-id='status-banner-read-more-button'
+          style={{marginTop: 'auto', width: '125px'}}
+          onClick={() => this.navigateToLink(link)}
+          data-test-id='status-banner-read-more-button'
         >
           READ MORE
         </Button>
       }
     </FlexColumn>;
+  }
+
+  render() {
+    return ReactDOM.createPortal(this.renderBanner(),
+      document.getElementById('body'))
   }
 }

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -50,6 +50,7 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
         />
         <div style={{
           fontWeight: 600,
+          width: '80%',
           marginLeft: '.4rem',
           lineHeight: '18px'
           // These next two styles fake the appearance of only having spacing below the line

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
@@ -11,6 +10,7 @@ const styles = reactStyles({
   alertBanner: {
     backgroundColor: colorWithWhiteness(colors.highlight, .5),
     color: colors.primary,
+    fontSize: '12px',
     marginRight: '1rem',
     marginTop: '1rem',
     padding: '0.5rem',
@@ -19,16 +19,14 @@ const styles = reactStyles({
     position: 'absolute',
     top: '0',
     right: '0',
-    zIndex: 1,
+    zIndex: 101,
   }
 });
-
-
 
 export interface Props {
   title: string;
   message: string;
-  link: string;
+  footer: JSX.Element;
   onClose: Function;
 }
 
@@ -37,48 +35,49 @@ export class StatusAlertBanner extends React.Component<Props, {}> {
     super(props);
   }
 
-  navigateToLink(link) {
-    window.open(link, '_blank');
-  }
-
   renderBanner() {
-    const {title, message, link} = this.props;
+    const {title, message} = this.props;
     return <FlexColumn style={styles.alertBanner}>
-      <FlexRow style={{width: '100%'}}>
+      <FlexRow style={{alignItems: 'center', marginTop: '.1rem'}}>
         <ClrIcon
           shape={'warning-standard'}
           class={'is-solid'}
-          size={20}
+          size={26}
           style={{
             color: colors.warning,
             flex: '0 0 auto'
           }}
         />
         <div style={{
-          fontWeight: 'bold',
-          marginLeft: '.2rem',
+          fontWeight: 600,
+          marginLeft: '.4rem',
+          lineHeight: '18px'
           // These next two styles fake the appearance of only having spacing below the line
           // whereas line-height is automatically distributed both above and below
-          position: 'relative',
-          top: '-0.2rem'
         }}>{title}</div>
-        <ClrIcon
-          shape={'times'}
-          size={20}
-          style={{marginLeft: 'auto', flex: '0 0 auto'}}
-          onClick={() => this.props.onClose()}
-        />
       </FlexRow>
-      <div>{message}</div>
-      {
-        link && <Button
-          style={{marginTop: 'auto', width: '125px'}}
-          onClick={() => this.navigateToLink(link)}
-          data-test-id='status-banner-read-more-button'
-        >
-          READ MORE
-        </Button>
-      }
+      <div style={{
+        lineHeight: '20px',
+        marginTop: '.3rem',
+        paddingLeft: '.2rem',
+        paddingRight: '.2rem'}
+      }>
+        {message}
+      </div>
+      <div style={{marginTop: '.5rem'}}>
+        {this.props.footer}
+      </div>
+      <ClrIcon
+        shape={'times'}
+        size={20}
+        style={{
+          position: 'absolute',
+          top: '.3rem',
+          right: '.3rem',
+          colors: colors.accent
+        }}
+        onClick={() => this.props.onClose()}
+      />
     </FlexColumn>;
   }
 

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {Breadcrumb} from 'app/components/breadcrumb';
+import {Button} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import {SideNav} from 'app/components/side-nav';
 import {StatusAlertBanner} from 'app/components/status-alert-banner';
@@ -8,8 +9,6 @@ import colors from 'app/styles/colors';
 import {cookiesEnabled, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
-import {Button} from "app/components/buttons";
-import {FlexColumn} from "app/components/flex";
 
 const styles = reactStyles({
   headerContainer: {

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -212,7 +212,6 @@ export const NavBar = withUserProfile()(
         <Breadcrumb/>
         {
           this.state.statusAlertVisible && <StatusAlertBanner
-              statusAlertId={this.state.statusAlertDetails.statusAlertId}
               title={this.state.statusAlertDetails.title}
               message={this.state.statusAlertDetails.message}
               link={this.state.statusAlertDetails.link}

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -8,6 +8,8 @@ import colors from 'app/styles/colors';
 import {cookiesEnabled, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
+import {Button} from "app/components/buttons";
+import {FlexColumn} from "app/components/flex";
 
 const styles = reactStyles({
   headerContainer: {
@@ -166,6 +168,10 @@ export const NavBar = withUserProfile()(
       }
     }
 
+    navigateToLink(link) {
+      window.open(link, '_blank');
+    }
+
     handleStatusAlertBannerUnmount() {
       if (cookiesEnabled()) {
         localStorage.setItem(cookieKey, `${this.state.statusAlertDetails.statusAlertId}`);
@@ -214,7 +220,13 @@ export const NavBar = withUserProfile()(
           this.state.statusAlertVisible && <StatusAlertBanner
               title={this.state.statusAlertDetails.title}
               message={this.state.statusAlertDetails.message}
-              link={this.state.statusAlertDetails.link}
+              footer={
+                  this.state.statusAlertDetails.link &&
+                  <Button data-test-id='status-banner-read-more-button'
+                          onClick={() => this.navigateToLink(this.state.statusAlertDetails.link)}>
+                    READ MORE
+                  </Button>
+              }
               onClose={this.handleStatusAlertBannerUnmount}
           />
         }

--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -1,12 +1,12 @@
-import {WorkspaceData} from "app/utils/workspace-data";
-import {BillingStatus, Profile} from "generated/fetch";
-import * as fp from "lodash";
-import {withCurrentWorkspace, withUrlParams, withUserProfile} from "app/utils";
-import * as React from "react";
-import {StatusAlertBanner} from "app/components/status-alert-banner";
-import {Button, Clickable} from "app/components/buttons";
-import {openZendeskWidget} from "app/utils/zendesk";
-import {navigate, NavStore} from "app/utils/navigation";
+import {Button} from 'app/components/buttons';
+import {StatusAlertBanner} from 'app/components/status-alert-banner';
+import {withCurrentWorkspace, withUserProfile} from 'app/utils';
+import {navigate} from 'app/utils/navigation';
+import {WorkspaceData} from 'app/utils/workspace-data';
+import {openZendeskWidget} from 'app/utils/zendesk';
+import {Profile} from 'generated/fetch';
+import * as fp from 'lodash';
+import * as React from 'react';
 
 interface Props {
   workspace: WorkspaceData;
@@ -48,5 +48,5 @@ export const InvalidBillingBanner = fp.flow(
         </a>
       </div>
     }
-  />
+  />;
 });

--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -1,0 +1,52 @@
+import {WorkspaceData} from "app/utils/workspace-data";
+import {BillingStatus, Profile} from "generated/fetch";
+import * as fp from "lodash";
+import {withCurrentWorkspace, withUrlParams, withUserProfile} from "app/utils";
+import * as React from "react";
+import {StatusAlertBanner} from "app/components/status-alert-banner";
+import {Button, Clickable} from "app/components/buttons";
+import {openZendeskWidget} from "app/utils/zendesk";
+import {navigate, NavStore} from "app/utils/navigation";
+
+interface Props {
+  workspace: WorkspaceData;
+  profileState: {
+    profile: Profile
+  };
+  onClose: Function;
+}
+
+export const InvalidBillingBanner = fp.flow(
+  withCurrentWorkspace(),
+  withUserProfile(),
+)((props: Props) => {
+  return <StatusAlertBanner
+    onClose={() => props.onClose()}
+    title={'This workspace has run out of free credits'}
+    message={'The free credits for the creator of this workspace have run out or expired. ' +
+    'Please provide a valid billing account or contact support to extend free credits.'}
+    footer={
+      <div style={{display: 'flex', flexDirection: 'column'}}>
+        <Button style={{height: '38px', width: '70%', fontWeight: 400}}
+                onClick={() => {
+                  openZendeskWidget(
+                    props.profileState.profile.givenName,
+                    props.profileState.profile.familyName,
+                    props.profileState.profile.username,
+                    props.profileState.profile.contactEmail,
+                  );
+                }}
+        >
+          Request Extension
+        </Button>
+        <a style={{marginTop: '.5rem', marginLeft: '.2rem'}}
+           onClick={() => {
+             navigate(['workspaces', props.workspace.namespace, props.workspace.id, 'edit']);
+           }}
+        >
+          Provide billing account
+        </a>
+      </div>
+    }
+  />
+});

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -2,12 +2,12 @@ import {Component, Input} from '@angular/core';
 
 import {Clickable} from 'app/components/buttons';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams, withUserProfile} from 'app/utils';
+import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams} from 'app/utils';
 import {NavStore} from 'app/utils/navigation';
 
 import {InvalidBillingBanner} from 'app/pages/workspace/invalid-billing-banner';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {BillingStatus, Profile} from 'generated/fetch';
+import {BillingStatus} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -7,6 +7,7 @@ import {NavStore} from 'app/utils/navigation';
 
 import * as fp from 'lodash/fp';
 import * as React from 'react';
+import {StatusAlertBanner} from "app/components/status-alert-banner";
 
 
 const styles = reactStyles({
@@ -55,6 +56,14 @@ export const WorkspaceNavBarReact = fp.flow(
     const hideSeparator = selected || (activeTabIndex === tabs.indexOf(currentTab) + 1);
 
     return <React.Fragment key={name}>
+      {false &&
+        <StatusAlertBanner
+          title={'title'}
+          message={'messge'}
+          link={'issa link'}
+          onClose={() => {}}
+        />
+      }
       <Clickable
         data-test-id={name}
         aria-selected={selected}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -5,12 +5,13 @@ import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams, withUserProfile} from 'app/utils';
 import {navigate, NavStore} from 'app/utils/navigation';
 
+import {StatusAlertBanner} from 'app/components/status-alert-banner';
+import {WorkspaceData} from 'app/utils/workspace-data';
+import {openZendeskWidget} from 'app/utils/zendesk';
+import {BillingStatus, Profile} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {StatusAlertBanner} from "app/components/status-alert-banner";
-import {WorkspaceData} from "app/utils/workspace-data";
-import {openZendeskWidget} from "app/utils/zendesk";
-import {BillingStatus, Profile} from "generated/fetch";
+import {InvalidBillingBanner} from "app/pages/workspace/invalid-billing-banner";
 
 
 const styles = reactStyles({
@@ -51,11 +52,11 @@ interface Props {
   tabPath: string;
   profileState: {
     profile: Profile
-  }
+  };
 }
 
 interface State {
-  showInvalidBillingBanner: boolean
+  showInvalidBillingBanner: boolean;
 }
 
 export const WorkspaceNavBarReact = fp.flow(
@@ -69,7 +70,7 @@ export const WorkspaceNavBarReact = fp.flow(
       super(props);
       this.state = {
         showInvalidBillingBanner: false
-      }
+      };
     }
 
     componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
@@ -89,34 +90,7 @@ export const WorkspaceNavBarReact = fp.flow(
 
         return <React.Fragment key={name}>
           {this.state.showInvalidBillingBanner &&
-          <StatusAlertBanner
-            title={'This workspace has run out of free credits'}
-            message={'The free credits for the creator of this workspace have run out or expired. Please provide a valid billing account or contact support to extend free credits.'}
-            footer={
-              <div style={{display: 'flex', flexDirection: 'column'}}>
-                <Button style={{height: '38px', width: '70%', fontWeight: 400}}
-                        onClick={() => {
-                          openZendeskWidget(
-                            this.props.profileState.profile.givenName,
-                            this.props.profileState.profile.familyName,
-                            this.props.profileState.profile.username,
-                            this.props.profileState.profile.contactEmail,
-                          );
-                        }}
-                >
-                  Request Extension
-                </Button>
-                <a style={{marginTop: '.5rem', marginLeft: '.2rem'}}
-                   onClick={() => {
-                     navigate(['workspaces', this.props.workspace.namespace, this.props.workspace.id, 'edit']);
-                   }}
-                >
-                  Provide billing account
-                </a>
-              </div>
-            }
-            onClose={() => {this.setState({showInvalidBillingBanner: false})}}
-          />
+          <InvalidBillingBanner onClose={() => {this.setState({showInvalidBillingBanner: false}); }}/>
           }
           <Clickable
             data-test-id={name}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -48,9 +48,6 @@ interface Props {
   workspace: WorkspaceData;
   urlParams: any;
   tabPath: string;
-  profileState: {
-    profile: Profile
-  };
 }
 
 interface State {
@@ -60,7 +57,6 @@ interface State {
 export const WorkspaceNavBarReact = fp.flow(
   withCurrentWorkspace(),
   withUrlParams(),
-  withUserProfile()
 )(
   class extends React.Component<Props, State> {
 
@@ -71,7 +67,7 @@ export const WorkspaceNavBarReact = fp.flow(
       };
     }
 
-    componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
+    componentDidUpdate(prevProps: Readonly<Props>): void {
       if (!prevProps.workspace && this.props.workspace && this.props.workspace.billingStatus === BillingStatus.INACTIVE) {
         this.setState({showInvalidBillingBanner: true});
       }
@@ -88,8 +84,7 @@ export const WorkspaceNavBarReact = fp.flow(
 
         return <React.Fragment key={name}>
           {this.state.showInvalidBillingBanner &&
-          <InvalidBillingBanner onClose={() => {this.setState({showInvalidBillingBanner: false}); }}/>
-          }
+          <InvalidBillingBanner onClose={() => {this.setState({showInvalidBillingBanner: false}); }}/>}
           <Clickable
             data-test-id={name}
             aria-selected={selected}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -1,17 +1,15 @@
 import {Component, Input} from '@angular/core';
 
-import {Button, Clickable} from 'app/components/buttons';
+import {Clickable} from 'app/components/buttons';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams, withUserProfile} from 'app/utils';
-import {navigate, NavStore} from 'app/utils/navigation';
+import {NavStore} from 'app/utils/navigation';
 
-import {StatusAlertBanner} from 'app/components/status-alert-banner';
+import {InvalidBillingBanner} from 'app/pages/workspace/invalid-billing-banner';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {openZendeskWidget} from 'app/utils/zendesk';
 import {BillingStatus, Profile} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {InvalidBillingBanner} from "app/pages/workspace/invalid-billing-banner";
 
 
 const styles = reactStyles({


### PR DESCRIPTION
This adds a banner for users viewing a workspace with inactive billing.

The banner
![Screen Shot 2020-01-30 at 4 55 46 PM](https://user-images.githubusercontent.com/2770197/73494322-4aebd380-4382-11ea-83ac-3b66bdf67c46.png)

I had to refactor the existing status banner a bit to reuse it. Some styling changes were made along the way.

#### Original
![Screen Shot 2020-01-30 at 1 27 34 PM](https://user-images.githubusercontent.com/2770197/73494314-48897980-4382-11ea-840d-e94084ad0959.png)

#### New
![Screen Shot 2020-01-30 at 5 00 40 PM](https://user-images.githubusercontent.com/2770197/73494308-46271f80-4382-11ea-8b29-3f3569558d6d.png)

Another big change was using `ReactDOM.createPortal` to allow the banner to be rendered from any component. Previously it would render to the top right corner of its parent component so it wouldn't go to the correct position unless the parent fit the entire page.

TIL
- ReactDOM.createPortal allow you to render components anywhere in the DOM. https://reactjs.org/docs/portals.html
- Our method of passing in props through `withCurrentWorkspace` `withUserProfile` etc, pass in the props AFTER the component has already been constructed and rendered. Thus, any state that relies on it must be checked in `componentDidUpdate` and not in the initial constructor.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
