### PR TITLE
[RW-4159][risk=no] UI environment flags & feature flag cleanup

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -31,6 +31,7 @@ public class ConfigController implements ConfigApiDelegate {
             .defaultFreeCreditsDollarLimit(config.billing.defaultFreeCreditsDollarLimit)
             .enableBillingLockout(config.featureFlags.enableBillingLockout)
             .firecloudURL(config.firecloud.baseUrl)
-            .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass));
+            .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
+            .enableNewAccountCreation(config.featureFlags.enableNewAccountCreation));
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2329,6 +2329,9 @@ definitions:
       projectId:
         type: string
         description: The cloud project in which this app is running.
+      firecloudURL:
+        type: string
+        description: The Firecloud URL to use for REST requests.
       publicApiKeyForErrorReports:
         type: string
         description: |
@@ -2337,19 +2340,19 @@ definitions:
       enableComplianceTraining:
         type: boolean
         default: false
-        description: Feature flag for enabling compliance training in registration steps
+        description: Whether the compliance training access module is enabled.
       enableDataUseAgreement:
         type: boolean
         default: false
-        description: Feature flag for enabling data use agreement
-      unsafeAllowSelfBypass:
-        type: boolean
-        default: false
-        description: Enable a user to bypass themself
+        description: Whether the data use agreement access module is enabled.
       enableEraCommons:
         type: boolean
         default: false
-        description: Feature flag for enabling eRA commons
+        description: Whether the eRA Commons access module is enabled.
+      unsafeAllowSelfBypass:
+        type: boolean
+        default: false
+        description: Whether a user is allowed to self-bypass. Only enabled in test environments.
       defaultFreeCreditsDollarLimit:
         type: number
         format: double
@@ -2358,9 +2361,10 @@ definitions:
         type: boolean
         default: false
         description: Feature flag for billing lockout and upgrade
-      firecloudURL:
-        type: string
-        description: The Firecloud URL to use for REST requests.
+      enableNewAccountCreation:
+        type: boolean
+        default: false
+        description: Feature flag for collecting new demographics & TOS acknowledgement on user creation.
 
   FeaturedWorkspacesConfigResponse:
     type: object

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -5,7 +5,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {
-  CardButton,
   Clickable,
 } from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
@@ -23,7 +22,6 @@ import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
-import {environment} from 'environments/environment';
 import {
   Profile,
 } from 'generated/fetch';
@@ -64,40 +62,6 @@ export const styles = reactStyles({
   },
   welcomeMessageIcon: {
     height: '2.25rem', width: '2.75rem'
-  },
-  // once enableHomepageRestyle is enabled, delete all styles ending in 'ToDelete'
-  // '/assets/images/AoU-HP-background.jpg' can also be deleted when the feature flag is removed
-  mainHeaderToDelete: {
-    color: colors.white, fontSize: 28, fontWeight: 400,
-    display: 'flex', letterSpacing: 'normal'
-  },
-  backgroundImageToDelete: {
-    backgroundImage: 'url("/assets/images/AoU-HP-background.jpg")',
-    backgroundRepeat: 'no-repeat', backgroundSize: 'cover', height: '100%',
-    marginLeft: '-1rem', marginRight: '-0.6rem', display: 'flex',
-    flexDirection: 'column', justifyContent: 'space-between'
-  },
-  quickRowToDelete: {
-    display: 'flex', justifyContent: 'flex-start', maxHeight: '26rem',
-    flexDirection: 'row', marginLeft: '4rem', padding: '1rem'
-  },
-  quickTourLabelToDelete: {
-    fontSize: 28, lineHeight: '34px', color: colors.white, paddingRight: '2.3rem',
-    marginTop: '2rem', width: '33%'
-  },
-  bottomBannerToDelete: {
-    width: '100%', display: 'flex', backgroundColor: colors.primary, height: '5rem',
-    paddingLeft: '3.5rem', alignItems: 'center', marginTop: '1rem'
-  },
-  bottomLinksToDelete: {
-    color: colors.white, fontSize: '0.7rem', height: '1rem',
-    marginLeft: '2.5rem', fontWeight: 400
-  },
-  singleCardToDelete: {
-    width: '87.34%', minHeight: '18rem', maxHeight: '26rem',
-    borderRadius: '5px', backgroundColor: 'rgba(255, 255, 255, 0.15)',
-    boxShadow: '0 0 2px 0 rgba(0, 0, 0, 0.12), 0 3px 2px 0 rgba(0, 0, 0, 0.12)',
-    border: 'none', marginTop: '1rem', padding: '1rem'
   },
 });
 
@@ -277,156 +241,32 @@ export const Homepage = withUserProfile()(class extends React.Component<
       }
     ];
 
-    if (environment.enableHomepageRestyle) {
-      return <React.Fragment>
-        <FlexColumn style={styles.pageWrapper}>
-          <FlexRow style={{marginLeft: '3%'}}>
-            <FlexColumn style={{width: '50%'}}>
-              <FlexRow>
-                <FlexColumn>
-                  <Header style={{fontWeight: 500, color: colors.secondary, fontSize: '0.92rem'}}>
-                    Welcome to</Header>
-                  <Header style={{textTransform: 'uppercase', marginTop: '0.2rem'}}>
-                    Researcher Workbench</Header>
-                </FlexColumn>
-                <FlexRow style={{alignItems: 'flex-end', marginLeft: '1rem'}}>
-                  <img style={styles.welcomeMessageIcon} src='/assets/images/workspace-icon.svg'/>
-                  <img style={styles.welcomeMessageIcon} src='/assets/images/cohort-icon.svg'/>
-                  <img style={styles.welcomeMessageIcon} src='/assets/images/analysis-icon.svg'/>
-                </FlexRow>
+    return <React.Fragment>
+      <FlexColumn style={styles.pageWrapper}>
+        <FlexRow style={{marginLeft: '3%'}}>
+          <FlexColumn style={{width: '50%'}}>
+            <FlexRow>
+              <FlexColumn>
+                <Header style={{fontWeight: 500, color: colors.secondary, fontSize: '0.92rem'}}>
+                  Welcome to</Header>
+                <Header style={{textTransform: 'uppercase', marginTop: '0.2rem'}}>
+                  Researcher Workbench</Header>
+              </FlexColumn>
+              <FlexRow style={{alignItems: 'flex-end', marginLeft: '1rem'}}>
+                <img style={styles.welcomeMessageIcon} src='/assets/images/workspace-icon.svg'/>
+                <img style={styles.welcomeMessageIcon} src='/assets/images/cohort-icon.svg'/>
+                <img style={styles.welcomeMessageIcon} src='/assets/images/analysis-icon.svg'/>
               </FlexRow>
-              <SmallHeader style={{color: colors.primary, marginTop: '0.25rem'}}>
-                The secure analysis platform to analyze <i>All of Us</i> data</SmallHeader>
-            </FlexColumn>
-            <div></div>
-          </FlexRow>
-          <FadeBox style={styles.fadeBox}>
-            {/* The elements inside this fadeBox will be changed as part of ongoing
-            homepage redesign work*/}
-            <FlexColumn style={{justifyContent: 'flex-start'}}>
-                {accessTasksLoaded ?
-                  (accessTasksRemaining ?
-                      (<RegistrationDashboard eraCommonsLinked={eraCommonsLinked}
-                                              eraCommonsError={eraCommonsError}
-                                              trainingCompleted={trainingCompleted}
-                                              firstVisitTraining={firstVisitTraining}
-                                              betaAccessGranted={betaAccessGranted}
-                                              twoFactorAuthCompleted={twoFactorAuthCompleted}
-                                            dataUseAgreementCompleted={dataUseAgreementCompleted}/>
-                      ) : (
-                          <React.Fragment>
-                            <FlexColumn>
-                              <FlexRow style={{justifyContent: 'space-between', alignItems: 'center'}}>
-                                <FlexRow style={{alignItems: 'center'}}>
-                                  <SemiBoldHeader style={{marginTop: '0px'}}>Workspaces</SemiBoldHeader>
-                                  <ClrIcon
-                                    shape='plus-circle'
-                                    size={30}
-                                    className={'is-solid'}
-                                    style={{color: colors.accent, marginLeft: '1rem', cursor: 'pointer'}}
-                                    onClick={() => {
-                                      AnalyticsTracker.Workspaces.OpenCreatePage();
-                                      navigate(['workspaces/build']);
-                                    }}
-                                  />
-                                </FlexRow>
-                                <span
-                                  style={{alignSelf: 'flex-end', color: colors.accent, cursor: 'pointer'}}
-                                  onClick={() => navigate(['workspaces'])}
-                                >
-                                  See all Workspaces
-                                </span>
-                              </FlexRow>
-                              <RecentWorkspaces />
-                            </FlexColumn>
-                            <FlexColumn>
-                              {this.state.userHasWorkspaces !== null &&
-
-                                <React.Fragment>
-                                  {this.state.userHasWorkspaces ?
-                                  <RecentResources/> :
-
-                                  <div style={{
-                                    backgroundColor: addOpacity(colors.primary, .1).toString(),
-                                    color: colors.primary,
-                                    borderRadius: 10,
-                                    margin: '2em 0em'}}>
-                                    <div style={{margin: '1em 2em'}}>
-                                      <h2 style={{fontWeight: 600, marginTop: 0}}>Here are some tips to get you started:</h2>
-                                      <CustomBulletList>
-                                        <CustomBulletListItem bullet='→'>
-                                          Create a <a href='https://support.google.com/chrome/answer/2364824'>Chrome Profile </a>
-                                          with your <i>All of Us</i> Researcher Workbench Google account. This will keep your Workbench
-                                          browser sessions isolated from your other Google accounts.
-                                        </CustomBulletListItem>
-                                        <CustomBulletListItem bullet='→'>
-                                          Check out <a onClick={() => navigate(['library'])}> Featured Workspaces </a>
-                                          from the left hand panel to browse through example workspaces.
-                                        </CustomBulletListItem>
-                                        <CustomBulletListItem bullet='→'>
-                                          Browse through our <a href='https://aousupporthelp.zendesk.com/hc/en-us'> support materials </a>
-                                          and forum topics.
-                                        </CustomBulletListItem>
-                                      </CustomBulletList>
-                                    </div>
-                                  </div>}
-                                </React.Fragment>
-                              }
-                            </FlexColumn>
-                          </React.Fragment>
-                        )
-                  ) :
-                  <Spinner dark={true} style={{width: '100%', marginTop: '5rem'}}/>}
-            </FlexColumn>
-          </FadeBox>
-          <div style={{backgroundColor: addOpacity(colors.light, .4).toString()}}>
-            <FlexColumn style={{marginLeft: '3%'}}>
-              <div style={styles.quickTourLabel}>Quick Tour and Videos</div>
-              <FlexRow style={styles.quickTourCardsRow}>
-                {quickTourResources.map((thumbnail, i) => {
-                  return <React.Fragment key={i}>
-                    <Clickable onClick={thumbnail.onClick}
-                               data-test-id={'quick-tour-resource-' + i}>
-                      <img style={{width: '11rem', marginRight: '0.5rem'}}
-                           src={thumbnail.src}/>
-                    </Clickable>
-                  </React.Fragment>;
-                })}
-              </FlexRow>
-            </FlexColumn>
-            <div style={styles.bottomBanner}>
-              <div style={styles.logo}>
-                <img src='/assets/images/all-of-us-logo-footer.svg'/>
-              </div>
-              <div style={styles.bottomLinks}>Copyright ©2018</div>
-              <div style={styles.bottomLinks}>Privacy Policy</div>
-              <div style={styles.bottomLinks}>Terms of Service</div>
-            </div>
-          </div>
-        </FlexColumn>
-        {quickTour &&
-        <QuickTourReact closeFunction={() => this.setState({quickTour: false})} />}
-        {videoOpen && <Modal width={900}>
-          <div style={{display: 'flex'}}>
-            <div style={{flexGrow: 1}}></div>
-            <Clickable onClick={() => this.setState({videoOpen: false})}>
-              <ClrIcon
-                shape='times'
-                size='24'
-                style={{color: colors.accent, marginBottom: 17}}
-              />
-            </Clickable>
-          </div>
-          <video width='100%' controls autoPlay>
-            <source src={videoLink} type='video/mp4'/>
-          </video>
-        </Modal>}
-      </React.Fragment>;
-    } else { // delete this block below once enableHomepageRestyle is removed
-      return <React.Fragment>
-        <div style={styles.backgroundImageToDelete}>
-          <div style={{display: 'flex', justifyContent: 'center'}}>
-            <div style={styles.singleCardToDelete}>
+            </FlexRow>
+            <SmallHeader style={{color: colors.primary, marginTop: '0.25rem'}}>
+              The secure analysis platform to analyze <i>All of Us</i> data</SmallHeader>
+          </FlexColumn>
+          <div></div>
+        </FlexRow>
+        <FadeBox style={styles.fadeBox}>
+          {/* The elements inside this fadeBox will be changed as part of ongoing
+          homepage redesign work*/}
+          <FlexColumn style={{justifyContent: 'flex-start'}}>
               {accessTasksLoaded ?
                 (accessTasksRemaining ?
                     (<RegistrationDashboard eraCommonsLinked={eraCommonsLinked}
@@ -435,78 +275,116 @@ export const Homepage = withUserProfile()(class extends React.Component<
                                             firstVisitTraining={firstVisitTraining}
                                             betaAccessGranted={betaAccessGranted}
                                             twoFactorAuthCompleted={twoFactorAuthCompleted}
-                                            dataUseAgreementCompleted={dataUseAgreementCompleted}/>
+                                          dataUseAgreementCompleted={dataUseAgreementCompleted}/>
                     ) : (
-                      <FlexRow style={{paddingTop: '2rem'}}>
-                        <div style={styles.contentWrapperLeft}>
-                          <div style={styles.mainHeaderToDelete}>Researcher Workbench</div>
-                          <CardButton onClick={() => {
-                            AnalyticsTracker.Workspaces.OpenCreatePage();
-                            navigate(['workspaces/build']);
-                          }}
-                                      style={{margin: '1.9rem 106px 0 3%'}}>
-                            Create a <br/> New Workspace
-                            <ClrIcon shape='plus-circle' style={{height: '32px', width: '32px'}}/>
-                          </CardButton>
-                        </div>
-                        <div style={styles.contentWrapperRight}>
-                          <a onClick={() => navigate(['workspaces'])}
-                             style={{fontSize: '14px', color: colors.white}}>
-                            See All Workspaces</a>
-                          <FlexColumn style={{marginRight: '3%'}}>
-                            <div style={{color: colors.white, height: '1.9rem'}}>
-                              <div style={{marginTop: '.5rem'}}>Your Last Accessed Items</div>
-                            </div>
-                            <RecentResources dark={true}/>
+                        <React.Fragment>
+                          <FlexColumn>
+                            <FlexRow style={{justifyContent: 'space-between', alignItems: 'center'}}>
+                              <FlexRow style={{alignItems: 'center'}}>
+                                <SemiBoldHeader style={{marginTop: '0px'}}>Workspaces</SemiBoldHeader>
+                                <ClrIcon
+                                  shape='plus-circle'
+                                  size={30}
+                                  className={'is-solid'}
+                                  style={{color: colors.accent, marginLeft: '1rem', cursor: 'pointer'}}
+                                  onClick={() => {
+                                    AnalyticsTracker.Workspaces.OpenCreatePage();
+                                    navigate(['workspaces/build']);
+                                  }}
+                                />
+                              </FlexRow>
+                              <span
+                                style={{alignSelf: 'flex-end', color: colors.accent, cursor: 'pointer'}}
+                                onClick={() => navigate(['workspaces'])}
+                              >
+                                See all Workspaces
+                              </span>
+                            </FlexRow>
+                            <RecentWorkspaces />
                           </FlexColumn>
-                        </div>
-                      </FlexRow>)
+                          <FlexColumn>
+                            {this.state.userHasWorkspaces !== null &&
+
+                              <React.Fragment>
+                                {this.state.userHasWorkspaces ?
+                                <RecentResources/> :
+
+                                <div style={{
+                                  backgroundColor: addOpacity(colors.primary, .1).toString(),
+                                  color: colors.primary,
+                                  borderRadius: 10,
+                                  margin: '2em 0em'}}>
+                                  <div style={{margin: '1em 2em'}}>
+                                    <h2 style={{fontWeight: 600, marginTop: 0}}>Here are some tips to get you started:</h2>
+                                    <CustomBulletList>
+                                      <CustomBulletListItem bullet='→'>
+                                        Create a <a href='https://support.google.com/chrome/answer/2364824'>Chrome Profile </a>
+                                        with your <i>All of Us</i> Researcher Workbench Google account. This will keep your Workbench
+                                        browser sessions isolated from your other Google accounts.
+                                      </CustomBulletListItem>
+                                      <CustomBulletListItem bullet='→'>
+                                        Check out <a onClick={() => navigate(['library'])}> Featured Workspaces </a>
+                                        from the left hand panel to browse through example workspaces.
+                                      </CustomBulletListItem>
+                                      <CustomBulletListItem bullet='→'>
+                                        Browse through our <a href='https://aousupporthelp.zendesk.com/hc/en-us'> support materials </a>
+                                        and forum topics.
+                                      </CustomBulletListItem>
+                                    </CustomBulletList>
+                                  </div>
+                                </div>}
+                              </React.Fragment>
+                            }
+                          </FlexColumn>
+                        </React.Fragment>
+                      )
                 ) :
                 <Spinner dark={true} style={{width: '100%', marginTop: '5rem'}}/>}
-            </div>
-          </div>
-          <div>
-            <div style={styles.quickRowToDelete}>
-              <div style={styles.quickTourLabelToDelete}>Quick Tour & Videos</div>
+          </FlexColumn>
+        </FadeBox>
+        <div style={{backgroundColor: addOpacity(colors.light, .4).toString()}}>
+          <FlexColumn style={{marginLeft: '3%'}}>
+            <div style={styles.quickTourLabel}>Quick Tour and Videos</div>
+            <FlexRow style={styles.quickTourCardsRow}>
               {quickTourResources.map((thumbnail, i) => {
                 return <React.Fragment key={i}>
                   <Clickable onClick={thumbnail.onClick}
                              data-test-id={'quick-tour-resource-' + i}>
-                    <img style={{maxHeight: '121px', width: '8rem', marginRight: '1rem'}}
+                    <img style={{width: '11rem', marginRight: '0.5rem'}}
                          src={thumbnail.src}/>
                   </Clickable>
                 </React.Fragment>;
               })}
+            </FlexRow>
+          </FlexColumn>
+          <div style={styles.bottomBanner}>
+            <div style={styles.logo}>
+              <img src='/assets/images/all-of-us-logo-footer.svg'/>
             </div>
-            <div style={styles.bottomBannerToDelete}>
-              <div style={styles.logo}>
-                <img src='/assets/images/all-of-us-logo-footer.svg'/>
-              </div>
-              <div style={styles.bottomLinksToDelete}>Privacy Policy</div>
-              <div style={styles.bottomLinksToDelete}>Terms of Service</div>
-            </div>
+            <div style={styles.bottomLinks}>Copyright ©2018</div>
+            <div style={styles.bottomLinks}>Privacy Policy</div>
+            <div style={styles.bottomLinks}>Terms of Service</div>
           </div>
         </div>
-
-        {quickTour &&
-        <QuickTourReact closeFunction={() => this.setState({quickTour: false})} />}
-        {videoOpen && <Modal width={900}>
-          <div style={{display: 'flex'}}>
-            <div style={{flexGrow: 1}}></div>
-            <Clickable onClick={() => this.setState({videoOpen: false})}>
-              <ClrIcon
-                shape='times'
-                size='24'
-                style={{color: colors.accent, marginBottom: 17}}
-              />
-            </Clickable>
-          </div>
-          <video width='100%' controls autoPlay>
-            <source src={videoLink} type='video/mp4'/>
-          </video>
-        </Modal>}
-      </React.Fragment>;
-    }
+      </FlexColumn>
+      {quickTour &&
+      <QuickTourReact closeFunction={() => this.setState({quickTour: false})} />}
+      {videoOpen && <Modal width={900}>
+        <div style={{display: 'flex'}}>
+          <div style={{flexGrow: 1}}></div>
+          <Clickable onClick={() => this.setState({videoOpen: false})}>
+            <ClrIcon
+              shape='times'
+              size='24'
+              style={{color: colors.accent, marginBottom: 17}}
+            />
+          </Clickable>
+        </div>
+        <video width='100%' controls autoPlay>
+          <source src={videoLink} type='video/mp4'/>
+        </video>
+      </Modal>}
+    </React.Fragment>;
   }
 
 });

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -253,9 +253,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
     // it within the registration box.
     return <FlexColumn style={{position: 'relative'}} data-test-id='registration-dashboard'>
       {bypassInProgress && <SpinnerOverlay />}
-      {environment.enableHomepageRestyle && <div style={styles.mainHeader}>Getting Started</div>}
-      {!environment.enableHomepageRestyle &&
-        <div style={{...styles.mainHeader, color: colors.white}}>Getting Started</div>}
+      <div style={styles.mainHeader}>Getting Started</div>
       {canUnsafeSelfBypass &&
         <div data-test-id='self-bypass'
              style={{...baseStyles.card, ...styles.warningModal, margin: '0.85rem 0 0'}}>

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -20,8 +20,10 @@ const component = () => {
     AccountCreationState>(<AccountCreation {...props}/>);
 };
 
+const defaultConfig = {gsuiteDomain: 'researchallofus.org', enableNewAccountCreation: false};
+
 beforeEach(() => {
-  serverConfigStore.next({gsuiteDomain: 'researchallofus.org'});
+  serverConfigStore.next(defaultConfig);
   props = {
     profile: {username: '',
       dataAccessLevel: DataAccessLevel.Unregistered,
@@ -71,25 +73,23 @@ it('should handle family name validity', () => {
   expect(wrapper.exists('#familyNameError')).toBeTruthy();
 });
 
-if (!environment.enableAccountPages) {
-  it('should handle organization validity', () => {
-    const wrapper = component();
-    const testInput = fp.repeat(300, 'a');
-    expect(wrapper.exists('#organization')).toBeTruthy();
-    expect(wrapper.exists('#organizationError')).toBeFalsy();
-    wrapper.find('input#organization').simulate('change', {target: {value: testInput}});
-    expect(wrapper.exists('#organizationError')).toBeTruthy();
-  });
+it('should handle organization validity', () => {
+  const wrapper = component();
+  const testInput = fp.repeat(300, 'a');
+  expect(wrapper.exists('#organization')).toBeTruthy();
+  expect(wrapper.exists('#organizationError')).toBeFalsy();
+  wrapper.find('input#organization').simulate('change', {target: {value: testInput}});
+  expect(wrapper.exists('#organizationError')).toBeTruthy();
+});
 
-  it('should handle current position validity', () => {
-    const wrapper = component();
-    const testInput = fp.repeat(300, 'a');
-    expect(wrapper.exists('#currentPosition')).toBeTruthy();
-    expect(wrapper.exists('#currentPositionError')).toBeFalsy();
-    wrapper.find('input#currentPosition').simulate('change', {target: {value: testInput}});
-    expect(wrapper.exists('#currentPositionError')).toBeTruthy();
-  });
-}
+it('should handle current position validity', () => {
+  const wrapper = component();
+  const testInput = fp.repeat(300, 'a');
+  expect(wrapper.exists('#currentPosition')).toBeTruthy();
+  expect(wrapper.exists('#currentPositionError')).toBeFalsy();
+  wrapper.find('input#currentPosition').simulate('change', {target: {value: testInput}});
+  expect(wrapper.exists('#currentPositionError')).toBeTruthy();
+});
 
 it('should handle username validity starts with .', () => {
   const wrapper = component();
@@ -152,64 +152,65 @@ it('should handle invalid Email', () => {
   expect(wrapper.exists('#invalidEmailError')).toBeFalsy();
 });
 
-if (environment.enableAccountPages) {
-  it('should display Institution name and role option by default', () => {
-    const wrapper = component();
-    const institutionName = wrapper.find('[data-test-id="institutionname"]');
-    expect(institutionName).toBeTruthy();
-    const institutionRole = wrapper.find('[data-test-id="institutionRole"]');
-    expect(institutionRole).toBeTruthy();
-    expect(institutionRole.find('li').length).toBe(AccountCreationOptions.roles.length);
-    expect(institutionRole.find('li').get(0).props.children).toBe(AccountCreationOptions.roles[0].label);
-  });
+it('should display Institution name and role option by default', () => {
+  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true});
+  const wrapper = component();
+  const institutionName = wrapper.find('[data-test-id="institutionname"]');
+  expect(institutionName).toBeTruthy();
+  const institutionRole = wrapper.find('[data-test-id="institutionRole"]');
+  expect(institutionRole).toBeTruthy();
+  expect(institutionRole.find('li').length).toBe(AccountCreationOptions.roles.length);
+  expect(institutionRole.find('li').get(0).props.children).toBe(AccountCreationOptions.roles[0].label);
+});
 
-  it('should display Affiliation information if No is selected', () => {
-    const wrapper = component();
-    const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
-      .find('input');
-    expect(institutionAffilationOption).toBeTruthy();
-    institutionAffilationOption.simulate('click');
-    const affiliationDropDown = wrapper.find('Dropdown');
-    const affiliationOptions = affiliationDropDown.find('DropdownItem');
-    expect(affiliationOptions.length).toBe(AccountCreationOptions.nonAcademicAffiliations.length);
-    expect(affiliationOptions.find('li').get(0).props.children)
-      .toBe(AccountCreationOptions.nonAcademicAffiliations[0].label);
-  });
+it('should display Affiliation information if No is selected', () => {
+  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true});
+  const wrapper = component();
+  const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
+    .find('input');
+  expect(institutionAffilationOption).toBeTruthy();
+  institutionAffilationOption.simulate('click');
+  const affiliationDropDown = wrapper.find('Dropdown');
+  const affiliationOptions = affiliationDropDown.find('DropdownItem');
+  expect(affiliationOptions.length).toBe(AccountCreationOptions.nonAcademicAffiliations.length);
+  expect(affiliationOptions.find('li').get(0).props.children)
+    .toBe(AccountCreationOptions.nonAcademicAffiliations[0].label);
+});
 
-  it('should display Affiliation Roles should change as per affiliation', () => {
-    const wrapper = component();
-    const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
-      .find('input');
-    expect(institutionAffilationOption).toBeTruthy();
-    institutionAffilationOption.simulate('click');
-    const affiliationDropDown = wrapper.find('Dropdown');
-    affiliationDropDown.simulate('click');
-    const affiliationOptions = affiliationDropDown.find('DropdownItem');
+it('should display Affiliation Roles should change as per affiliation', () => {
+  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true});
+  const wrapper = component();
+  const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
+    .find('input');
+  expect(institutionAffilationOption).toBeTruthy();
+  institutionAffilationOption.simulate('click');
+  const affiliationDropDown = wrapper.find('Dropdown');
+  affiliationDropDown.simulate('click');
+  const affiliationOptions = affiliationDropDown.find('DropdownItem');
 
-    // Industry affiliation
-    affiliationOptions.find('DropdownItem').find('li').first().simulate('click');
-    // affiliationOptions.childAt(0).simulate('click');
-    let affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
-    expect(affilationRoleDropDowns).toBeTruthy();
-    expect(affilationRoleDropDowns.find('li').length).toBe(AccountCreationOptions.industryRole.length);
+  // Industry affiliation
+  affiliationOptions.find('DropdownItem').find('li').first().simulate('click');
+  // affiliationOptions.childAt(0).simulate('click');
+  let affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
+  expect(affilationRoleDropDowns).toBeTruthy();
+  expect(affilationRoleDropDowns.find('li').length).toBe(AccountCreationOptions.industryRole.length);
 
-    expect(affilationRoleDropDowns.find('li').get(0).props.children)
-      .toBe(AccountCreationOptions.industryRole[0].label);
+  expect(affilationRoleDropDowns.find('li').get(0).props.children)
+    .toBe(AccountCreationOptions.industryRole[0].label);
 
-    // Education affiliation
-    affiliationOptions.find('DropdownItem').find('li').at(1).simulate('click');
-    // affiliationOptions.childAt(0).simulate('click');
-    affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
-    expect(affilationRoleDropDowns).toBeTruthy();
-    expect(affilationRoleDropDowns.find('li').length).toBe(AccountCreationOptions.educationRole.length);
+  // Education affiliation
+  affiliationOptions.find('DropdownItem').find('li').at(1).simulate('click');
+  // affiliationOptions.childAt(0).simulate('click');
+  affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
+  expect(affilationRoleDropDowns).toBeTruthy();
+  expect(affilationRoleDropDowns.find('li').length).toBe(AccountCreationOptions.educationRole.length);
 
-    expect(affilationRoleDropDowns.find('li').get(0).props.children)
-      .toBe(AccountCreationOptions.educationRole[0].label);
+  expect(affilationRoleDropDowns.find('li').get(0).props.children)
+    .toBe(AccountCreationOptions.educationRole[0].label);
 
-    // Community Scientist
-    affiliationOptions.find('DropdownItem').find('li').at(2).simulate('click');
-    // affiliationOptions.childAt(0).simulate('click');
-    affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
-    expect(affilationRoleDropDowns.length).toBe(0);
-  });
-}
+  // Community Scientist
+  affiliationOptions.find('DropdownItem').find('li').at(2).simulate('click');
+  // affiliationOptions.childAt(0).simulate('click');
+  affilationRoleDropDowns = wrapper.find('[data-test-id="affiliationrole"]');
+  expect(affilationRoleDropDowns.length).toBe(0);
+});

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -27,7 +27,6 @@ import {FlexColumn, FlexRow, flexStyle} from 'app/components/flex';
 import {signedOutImages} from 'app/pages/login/signed-out-images';
 import {AoUTitle} from 'app/pages/profile/data-use-agreement-styles';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {environment} from 'environments/environment';
 import {
   DataAccessLevel,
   Degree,
@@ -490,6 +489,8 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         },
       },
     } = this.state;
+    const enableNewAccountCreation = serverConfigStore.getValue().enableNewAccountCreation;
+
     const usernameLabelText =
       <div>New Username
         <TooltipTrigger side='top' content={<div>Usernames can contain only letters
@@ -504,10 +505,10 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
 
     const errors = this.validateAccountCreation();
     return <div id='account-creation'
-                style={{paddingTop: environment.enableAccountPages ? '1.5rem' :
+                style={{paddingTop: enableNewAccountCreation ? '1.5rem' :
                       '3rem', paddingRight: '3rem', paddingLeft: '3rem'}}>
       <div style={{fontSize: 28, fontWeight: 400, color: colors.primary}}>Create your account</div>
-      {environment.enableAccountPages && <FlexRow>
+      {enableNewAccountCreation && <FlexRow>
         <FlexColumn style={{marginTop: '0.5rem'}}>
           <div style={{...styles.text, fontSize: 16, marginTop: '1rem'}}>
             Please complete Step 1 of 2
@@ -732,7 +733,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         </FlexColumn>
       </FlexRow>}
       {/*The following will be deleted once enableAccountPages is set to true in prod*/}
-      {!environment.enableAccountPages && <div>
+      {!enableNewAccountCreation && <div>
         <FormSection>
           <TextInput id='givenName' name='givenName' autoFocus
                      placeholder='First Name'
@@ -843,7 +844,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           </Button>
         </FormSection>
       </div>}
-      {!environment.enableAccountPages && this.state.showAllFieldsRequiredError &&
+      {!enableNewAccountCreation && this.state.showAllFieldsRequiredError &&
       <Error>
         All fields are required.
       </Error>}

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -46,18 +46,17 @@ export interface Environment {
 
   inactivityTimeoutSeconds: number;
   inactivityWarningBeforeSeconds: number;
-  // Add transient client-side flags below here
-  // homepage restyling changes ; excludes DUA
-  // See RW-3275
-  // Exit criteria: once the epic is completed and fully reviewed
-  enableHomepageRestyle: boolean;
   // Whether users should be able to see the Published Workspaces
   // tab in the Workspace Library.
   enablePublishedWorkspaces: boolean;
-  // Enable create account pages as per CAPS requirement
-  enableAccountPages: boolean;
   // Profile changes for CAPS requirements in RW-3441.
   enableProfileCapsFeatures: boolean;
   // Enable Surveys and Physical Measurements tabs in concept search
   enableNewConceptTabs: boolean;
+  // WARNING: Please think *very* carefully before adding a new environment flag here! Instead
+  // of this file, prefer storing feature flags in the server-side WorkbenchConfig and passing them
+  // to the UI via ConfigController and serverConfigStore.
+  //
+  // The UI environment config should be restricted to truly UI-specific environment variables, such
+  // as server API endpoints and client IDs.
 }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -18,9 +18,7 @@ export const environment: Environment = {
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true,
   enablePublishedWorkspaces: true,
-  enableAccountPages: true,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: true
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -18,7 +18,7 @@ export const environment: Environment = {
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enablePublishedWorkspaces: true,
+  enablePublishedWorkspaces: false,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: true
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -17,9 +17,7 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-perf.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true,
   enablePublishedWorkspaces: false,
-  enableAccountPages: false,
   enableProfileCapsFeatures: false,
   enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -16,13 +16,7 @@ export const environment: Environment = {
   trainingUrl: 'https://aou.nnlm.gov',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  // Use care when changing these flags in prod!
-  //
-  // See environment-type.ts for more details on transient flags, including
-  // exit criteria and Jira ticket links.
-  enableHomepageRestyle: true,
   enablePublishedWorkspaces: false,
-  enableAccountPages: false,
   enableProfileCapsFeatures: false,
   enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -16,9 +16,7 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true,
   enablePublishedWorkspaces: false,
-  enableAccountPages: false,
   enableProfileCapsFeatures: false,
   enableNewConceptTabs: false
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -16,9 +16,7 @@ export const environment: Environment = {
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true,
   enablePublishedWorkspaces: false,
-  enableAccountPages: false,
   enableProfileCapsFeatures: false,
   enableNewConceptTabs: false
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -15,7 +15,7 @@ export const testEnvironmentBase = {
   shouldShowDisplayTag: true,
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enablePublishedWorkspaces: true,
+  enablePublishedWorkspaces: false,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: false
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -13,11 +13,9 @@ export const testEnvironmentBase = {
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   shouldShowDisplayTag: true,
-  enablePublishedWorkspaces: true,
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
-  enableHomepageRestyle: true,
+  enablePublishedWorkspaces: true,
   enableProfileCapsFeatures: true,
-  enableAccountPages: true,
   enableNewConceptTabs: false
 };


### PR DESCRIPTION
This PR contains a bit of prep work and cleanup that's loosely related to the Terms of Service signature UI:

1) Remove our redundant environment.enableAccountPages flag, and instead propagate the WorkbenchConfig.enableNewAccountCreation flag and use that. This will help reduce bugs as we roll out the new-account functionality in the backend & UI.

2) Remove the unused enableHomepageRestyle flag. It's set to true in all environments, so is overdue for removal.
