### PR TITLE
[no ticket][risk=no] Singleton-scoped version of WorkbenchConfig Bean

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -48,7 +48,6 @@ public class MonitoringServiceImpl implements MonitoringService {
       registerMetricViews();
       viewsAreRegistered = true;
     }
-    stackdriverStatsExporterService.createAndRegister();
   }
 
   private void registerMetricViews() {

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringServiceImpl.java
@@ -41,13 +41,9 @@ public class MonitoringServiceImpl implements MonitoringService {
     this.statsRecorder = statsRecorder;
     this.stackdriverStatsExporterService = stackdriverStatsExporterService;
     this.tagger = tagger;
-  }
 
-  private void initStatsConfigurationIdempotent() {
-    if (!viewsAreRegistered) {
-      registerMetricViews();
-      viewsAreRegistered = true;
-    }
+    stackdriverStatsExporterService.createAndRegister();
+    registerMetricViews();
   }
 
   private void registerMetricViews() {
@@ -63,7 +59,6 @@ public class MonitoringServiceImpl implements MonitoringService {
 
   @Override
   public void recordValues(Map<Metric, Number> metricToValue, Map<TagKey, TagValue> tags) {
-    initStatsConfigurationIdempotent();
     if (metricToValue.isEmpty()) {
       logger.warning("recordValue() called with empty map.");
       return;
@@ -97,9 +92,5 @@ public class MonitoringServiceImpl implements MonitoringService {
           Level.WARNING,
           String.format("Unrecognized measure class %s", metric.getMeasureClass().getName()));
     }
-  }
-
-  private void logAndSwallow(RuntimeException e) {
-    logger.log(Level.WARNING, "Exception encountered during monitoring.", e);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringSpringConfiguration.java
@@ -9,7 +9,6 @@ import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
 import java.util.UUID;
-import java.util.logging.Level;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -53,9 +52,10 @@ public class MonitoringSpringConfiguration {
     }
   }
 
-  @Bean()
+  @Bean
   public MonitoredResource getMonitoredResource(
-      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON) Provider<WorkbenchConfig> workbenchConfigProvider,
+      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON)
+          Provider<WorkbenchConfig> workbenchConfigProvider,
       @Qualifier(APP_ENGINE_NODE_ID) Provider<String> appEngineNodeIdProvider) {
     return MonitoredResource.newBuilder()
         .setType(MONITORED_RESOURCE_TYPE)
@@ -76,5 +76,4 @@ public class MonitoringSpringConfiguration {
   private String makeRandomNodeId() {
     return UNKNOWN_INSTANCE_PREFIX + UUID.randomUUID().toString();
   }
-
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringSpringConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/MonitoringSpringConfiguration.java
@@ -1,15 +1,33 @@
 package org.pmiops.workbench.monitoring;
 
+import com.google.api.MonitoredResource;
+import com.google.appengine.api.modules.ModulesException;
+import com.google.appengine.api.modules.ModulesService;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
+import java.util.UUID;
+import java.util.logging.Level;
+import javax.inject.Provider;
+import org.pmiops.workbench.config.CacheSpringConfiguration;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MonitoringSpringConfiguration {
+
+  private static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
+  private static final String MONITORED_RESOURCE_TYPE = "generic_node";
+  private static final String PROJECT_ID_LABEL = "project_id";
+  private static final String LOCATION_LABEL = "location";
+  private static final String NAMESPACE_LABEL = "namespace";
+  private static final String NODE_ID_LABEL = "node_id";
+
+  public static final String APP_ENGINE_NODE_ID = "appEngineNodeId";
 
   @Bean
   public ViewManager getViewManager() {
@@ -25,4 +43,38 @@ public class MonitoringSpringConfiguration {
   public Tagger getTagger() {
     return Tags.getTagger();
   }
+
+  @Bean(name = APP_ENGINE_NODE_ID)
+  public String getAppEngineNodeId(ModulesService modulesService) {
+    try {
+      return modulesService.getCurrentInstanceId();
+    } catch (ModulesException e) {
+      return makeRandomNodeId();
+    }
+  }
+
+  @Bean()
+  public MonitoredResource getMonitoredResource(
+      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON) Provider<WorkbenchConfig> workbenchConfigProvider,
+      @Qualifier(APP_ENGINE_NODE_ID) Provider<String> appEngineNodeIdProvider) {
+    return MonitoredResource.newBuilder()
+        .setType(MONITORED_RESOURCE_TYPE)
+        .putLabels(PROJECT_ID_LABEL, workbenchConfigProvider.get().server.projectId)
+        .putLabels(LOCATION_LABEL, workbenchConfigProvider.get().server.appEngineLocationId)
+        .putLabels(NAMESPACE_LABEL, workbenchConfigProvider.get().server.shortName.toLowerCase())
+        .putLabels(NODE_ID_LABEL, appEngineNodeIdProvider.get())
+        .build();
+  }
+
+  /**
+   * Stackdriver instances have very long, random ID strings. When running locally, however, the
+   * ModulesService throws an exception, so we need to assign non-conflicting and non-repeating ID
+   * strings.
+   *
+   * @return
+   */
+  private String makeRandomNodeId() {
+    return UNKNOWN_INSTANCE_PREFIX + UUID.randomUUID().toString();
+  }
+
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Provider;
-import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 /**
@@ -24,15 +22,12 @@ public class StackdriverStatsExporterService {
       Logger.getLogger(StackdriverStatsExporterService.class.getName());
   private static final String STACKDRIVER_CUSTOM_METRICS_PREFIX = "custom.googleapis.com/";
 
+  private MonitoredResource monitoredResource;
   private Provider<WorkbenchConfig> workbenchConfigProvider;
-  private Provider<MonitoredResource> monitoredResourceProvider;
 
   public StackdriverStatsExporterService(
-      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON)
-          Provider<WorkbenchConfig> workbenchConfigProvider,
-      Provider<MonitoredResource> monitoredResourceProvider) {
-    this.monitoredResourceProvider = monitoredResourceProvider;
-    logger.warning("Making StackdriverStatsExporterService");
+      MonitoredResource monitoredResource, Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.monitoredResource = monitoredResource;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
@@ -57,7 +52,7 @@ public class StackdriverStatsExporterService {
     return StackdriverStatsConfiguration.builder()
         .setMetricNamePrefix(STACKDRIVER_CUSTOM_METRICS_PREFIX)
         .setProjectId(workbenchConfigProvider.get().server.projectId)
-        .setMonitoredResource(monitoredResourceProvider.get())
+        .setMonitoredResource(monitoredResource)
         .build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -30,9 +30,8 @@ public class StackdriverStatsExporterService {
   private static final String LOCATION_LABEL = "location";
   private static final String NAMESPACE_LABEL = "namespace";
   private static final String NODE_ID_LABEL = "node_id";
-  public static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
+  private static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
 
-  private boolean initialized;
   private Provider<WorkbenchConfig> workbenchConfigProvider;
   private ModulesService modulesService;
 
@@ -40,7 +39,7 @@ public class StackdriverStatsExporterService {
       Provider<WorkbenchConfig> workbenchConfigProvider, ModulesService modulesService) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.modulesService = modulesService;
-    this.initialized = false;
+    createAndRegister();
   }
 
   /**
@@ -48,18 +47,16 @@ public class StackdriverStatsExporterService {
    * happen once, so we have an isInitialized guard for that.
    */
   public void createAndRegister() {
-    if (!initialized) {
-      try {
-        final StackdriverStatsConfiguration configuration = makeStackdriverStatsConfiguration();
-        StackdriverStatsExporter.createAndRegister(configuration);
-        logger.info(
-            String.format(
-                "Configured StackDriver exports with configuration:\n%s",
-                configuration.toString()));
-        initialized = true;
-      } catch (IOException e) {
-        logger.log(Level.WARNING, "Failed to initialize global StackdriverStatsExporter.", e);
-      }
+    try {
+      final StackdriverStatsConfiguration configuration = makeStackdriverStatsConfiguration();
+      StackdriverStatsExporter.createAndRegister(configuration);
+      logger.info(
+          String.format(
+              "Configured StackDriver exports with configuration:\n%s",
+              configuration.toString()));
+      initialized = true;
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Failed to initialize global StackdriverStatsExporter.", e);
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -1,17 +1,13 @@
 package org.pmiops.workbench.monitoring;
 
 import com.google.api.MonitoredResource;
-import com.google.appengine.api.modules.ModulesException;
-import com.google.appengine.api.modules.ModulesService;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
 import java.io.IOException;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Provider;
-import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,37 +23,30 @@ public class StackdriverStatsExporterService {
   private static final Logger logger =
       Logger.getLogger(StackdriverStatsExporterService.class.getName());
   private static final String STACKDRIVER_CUSTOM_METRICS_PREFIX = "custom.googleapis.com/";
-  private static final String MONITORED_RESOURCE_TYPE = "generic_node";
-  private static final String PROJECT_ID_LABEL = "project_id";
-  private static final String LOCATION_LABEL = "location";
-  private static final String NAMESPACE_LABEL = "namespace";
-  private static final String NODE_ID_LABEL = "node_id";
-  private static final String UNKNOWN_INSTANCE_PREFIX = "unknown-";
 
   private Provider<WorkbenchConfig> workbenchConfigProvider;
   private Provider<MonitoredResource> monitoredResourceProvider;
 
   public StackdriverStatsExporterService(
-      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON) Provider<WorkbenchConfig> workbenchConfigProvider,
+      @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON)
+          Provider<WorkbenchConfig> workbenchConfigProvider,
       Provider<MonitoredResource> monitoredResourceProvider) {
     this.monitoredResourceProvider = monitoredResourceProvider;
     logger.warning("Making StackdriverStatsExporterService");
     this.workbenchConfigProvider = workbenchConfigProvider;
-    createAndRegister();
   }
 
   /**
    * Create and register the stats configuration on the stats exporter. This operation should only
    * happen once, so we have an isInitialized guard for that.
    */
-  private void createAndRegister() {
+  public void createAndRegister() {
     try {
       final StackdriverStatsConfiguration configuration = makeStackdriverStatsConfiguration();
       StackdriverStatsExporter.createAndRegister(configuration);
       logger.info(
           String.format(
-              "Configured StackDriver exports with configuration:\n%s",
-              configuration.toString()));
+              "Configured StackDriver exports with configuration:\n%s", configuration.toString()));
     } catch (IOException e) {
       logger.log(Level.WARNING, "Failed to initialize global StackdriverStatsExporter.", e);
     }

--- a/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/MonitoringServiceTest.java
@@ -77,7 +77,6 @@ public class MonitoringServiceTest {
   @Test
   public void testRecordIncrement() {
     monitoringService.recordEvent(EventMetric.NOTEBOOK_SAVE);
-    verify(mockInitService).createAndRegister();
 
     final int metricCount = GaugeMetric.values().length + EventMetric.values().length;
     verify(mockViewManager, times(metricCount)).registerView(any(View.class));
@@ -92,7 +91,6 @@ public class MonitoringServiceTest {
     long value = 16L;
     monitoringService.recordValue(GaugeMetric.BILLING_BUFFER_PROJECT_COUNT, value);
 
-    verify(mockInitService).createAndRegister();
     verify(mockStatsRecorder).newMeasureMap();
     verify(mockMeasureMap).put(GaugeMetric.BILLING_BUFFER_PROJECT_COUNT.getMeasureLong(), value);
     verify(mockMeasureMap).record(any(TagContext.class));
@@ -112,7 +110,6 @@ public class MonitoringServiceTest {
   @Test
   public void testRecordValue_noOpOnEmptyMap() {
     monitoringService.recordValues(Collections.emptyMap());
-    verify(mockInitService).createAndRegister();
     verifyZeroInteractions(mockStatsRecorder);
     verifyZeroInteractions(mockMeasureMap);
   }

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -2,18 +2,19 @@ package org.pmiops.workbench.monitoring;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import com.google.api.MonitoredResource;
-import com.google.appengine.api.modules.ModulesException;
 import com.google.appengine.api.modules.ModulesService;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
-import java.util.Map;
+import javax.inject.Provider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.config.CacheSpringConfiguration;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.ServerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
@@ -24,15 +25,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class StackdriverStatsExporterServiceTest {
 
   private static final String PROJECT_ID = "fake-project";
-  private static final String FOUND_NODE_ID = "node-11001001";
-  @Autowired private ModulesService mockModulesService;
   @Autowired private StackdriverStatsExporterService exporterService;
 
   @TestConfiguration
   @Import(StackdriverStatsExporterService.class)
-  @MockBean(ModulesService.class)
+  @MockBean({ModulesService.class})
   static class Configuration {
-    @Bean
+    @Bean(name = CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON)
     public WorkbenchConfig workbenchConfig() {
       final WorkbenchConfig workbenchConfig = new WorkbenchConfig();
       // Nothing should show up in any Metrics backend for these tests.
@@ -42,12 +41,24 @@ public class StackdriverStatsExporterServiceTest {
       workbenchConfig.server.appEngineLocationId = "moon-luna-1";
       return workbenchConfig;
     }
+
+    // In order to mock a value class that's injected via a Provider, I believe
+    // this is still the best way to do it (assuming I'm OK with Singleton scope, which
+    // is what I want here).
+    @Bean
+    public MonitoredResource getMonitoredResource(
+        @Qualifier(CacheSpringConfiguration.WORKBENCH_CONFIG_SINGLETON)
+            Provider<WorkbenchConfig> workbenchConfigProvider,
+        @Qualifier(MonitoringSpringConfiguration.APP_ENGINE_NODE_ID)
+            Provider<String> appEngineNodeIdProvider) {
+      final MonitoredResource mockMonitoredResource = mock(MonitoredResource.class);
+      doReturn("generic_node").when(mockMonitoredResource).getType();
+      return mockMonitoredResource;
+    }
   }
 
   @Test
   public void testMakeConfiguration() {
-    doReturn(FOUND_NODE_ID).when(mockModulesService).getCurrentInstanceId();
-
     StackdriverStatsConfiguration statsConfiguration =
         exporterService.makeStackdriverStatsConfiguration();
     assertThat(statsConfiguration.getProjectId()).isEqualTo(PROJECT_ID);
@@ -55,17 +66,5 @@ public class StackdriverStatsExporterServiceTest {
 
     final MonitoredResource monitoredResource = statsConfiguration.getMonitoredResource();
     assertThat(monitoredResource.getType()).isEqualTo("generic_node");
-
-    final Map<String, String> labelToValue = monitoredResource.getLabelsMap();
-    assertThat(statsConfiguration.getMonitoredResource().getLabelsMap()).isNotEmpty();
-    assertThat(labelToValue.get("node_id")).isEqualTo(FOUND_NODE_ID);
-  }
-
-  @Test
-  public void testMakeMonitoredResource_noInstanceIdAvailable() {
-    doThrow(ModulesException.class).when(mockModulesService).getCurrentInstanceId();
-    final MonitoredResource monitoredResource =
-        exporterService.makeStackdriverStatsConfiguration().getMonitoredResource();
-    assertThat(monitoredResource.getLabelsMap().get("node_id")).isNotEmpty();
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
@@ -12,11 +12,9 @@ import java.util.logging.Logger;
 import org.pmiops.workbench.db.dao.ConfigDao;
 import org.pmiops.workbench.db.model.DbConfig;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.context.annotation.RequestScope;
 
@@ -73,9 +71,8 @@ public class CacheSpringConfiguration {
   }
 
   /**
-   * Request-scoped WorkbenchConfig bean. This version should be used in all
-   * cases where updates during execution are desired. It may not be used in
-   * an Autowired Constructor or Bean function
+   * Request-scoped WorkbenchConfig bean. This version should be used in all cases where updates
+   * during execution are desired. It may not be used in an Autowired Constructor or Bean function
    */
   @Bean(name = WORKBENCH_CONFIG_REQUEST_SCOPED)
   @Primary
@@ -87,8 +84,8 @@ public class CacheSpringConfiguration {
   }
 
   /**
-   * Singleton version for use in Service constructors and Bean function
-   * arguments. Not updated dynamically
+   * Singleton version for use in Service constructors and Bean function arguments. Not updated
+   * dynamically
    */
   @Bean(name = WORKBENCH_CONFIG_SINGLETON)
   WorkbenchConfig getWorkbenchConfigSingleton(

--- a/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/CacheSpringConfiguration.java
@@ -8,9 +8,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import org.pmiops.workbench.db.dao.ConfigDao;
 import org.pmiops.workbench.db.model.DbConfig;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -20,9 +22,9 @@ import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
 public class CacheSpringConfiguration {
-
+  private static final Logger logger = Logger.getLogger(CacheSpringConfiguration.class.getName());
   private static final Map<String, Class<?>> CONFIG_CLASS_MAP = new HashMap<>();
-  public static final String WORKBENCH_CONFIG_REQUEST_SCOPED = "WORKBENCH_CONFIG_SINGLETON";
+  public static final String WORKBENCH_CONFIG_REQUEST_SCOPED = "WORKBENCH_CONFIG_REQUEST_SCOPED";
   public static final String WORKBENCH_CONFIG_SINGLETON = "WORKBENCH_CONFIG_SINGLETON";
 
   static {
@@ -75,7 +77,7 @@ public class CacheSpringConfiguration {
    * cases where updates during execution are desired. It may not be used in
    * an Autowired Constructor or Bean function
    */
-  @Bean(name = "WORKBENCH_CONFIG_REQUEST_SCOPED")
+  @Bean(name = WORKBENCH_CONFIG_REQUEST_SCOPED)
   @Primary
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   WorkbenchConfig getWorkbenchConfig(
@@ -89,7 +91,6 @@ public class CacheSpringConfiguration {
    * arguments. Not updated dynamically
    */
   @Bean(name = WORKBENCH_CONFIG_SINGLETON)
-  @Scope("SINGLETON")
   WorkbenchConfig getWorkbenchConfigSingleton(
       @Qualifier("configCache") LoadingCache<String, Object> configCache)
       throws ExecutionException {


### PR DESCRIPTION
Currently, our WorkbenchConfig is provided by a Request-scoped bean. This is the best option in most cases as it's responsive to changes in the config cache, and also ensures the config retrieved is are the same throughout a request's execution.

The disadvantage of this arrangement is that this configuration information is unavailable in Autowired constructors or Bean function parameters that depend on such constructors, as in most cases these are run outside of any request scope. This means we can't, for example, have one implementation of a bean provided in the local environment and a different one in the deployed environments, since the information about which environment we're running in is only available via the config. Currently I have some code that waits until the first request to call an ugly "init" function in at least one place.

Another nice thing about having this available in constructors is that we can inject objects created at a higher level of abstraction (and depend on the config) instead of the config itself. This provides better encapsulation, as you can argue that very few methods need the whole config object.

The `MonitoredResource` provider is an example of a "thing" that's a singleton but configuration-dependent. If I have more than one service that needs one of these, now I can just inject this provider. 


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
