### PR TITLE
[risk=no][RW-2957] seconds/millis issue

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -683,13 +683,14 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       if (userBadgesByName.containsKey(complianceService.getResearchEthicsTrainingField())) {
         BadgeDetailsV2 complianceBadge =
             userBadgesByName.get(complianceService.getResearchEthicsTrainingField());
+        System.err.println(complianceBadge);
         if (complianceBadge.getValid()) {
           if (dbUser.getComplianceTrainingCompletionTime() == null) {
             // The badge was previously invalid and is now valid.
             newComplianceTrainingCompletionTime = now;
           } else if (!dbUser
               .getComplianceTrainingExpirationTime()
-              .equals(new Timestamp(complianceBadge.getDateexpire()))) {
+              .equals(Timestamp.from(Instant.ofEpochSecond(complianceBadge.getDateexpire())))) {
             // The badge was previously valid, but has a new expiration date (and so is a new
             // training)
             newComplianceTrainingCompletionTime = now;
@@ -698,7 +699,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
             newComplianceTrainingCompletionTime = dbUser.getComplianceTrainingCompletionTime();
           }
           // Always update the expiration time if the training badge is valid
-          newComplianceTrainingExpirationTime = new Timestamp(complianceBadge.getDateexpire());
+          newComplianceTrainingExpirationTime = Timestamp.from(Instant.ofEpochSecond(complianceBadge.getDateexpire()));
         } else {
           // The current badge is invalid or expired, the training must be completed or retaken.
           newComplianceTrainingCompletionTime = null;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -683,7 +683,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       if (userBadgesByName.containsKey(complianceService.getResearchEthicsTrainingField())) {
         BadgeDetailsV2 complianceBadge =
             userBadgesByName.get(complianceService.getResearchEthicsTrainingField());
-        System.err.println(complianceBadge);
         if (complianceBadge.getValid()) {
           if (dbUser.getComplianceTrainingCompletionTime() == null) {
             // The badge was previously invalid and is now valid.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -698,7 +698,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
             newComplianceTrainingCompletionTime = dbUser.getComplianceTrainingCompletionTime();
           }
           // Always update the expiration time if the training badge is valid
-          newComplianceTrainingExpirationTime = Timestamp.from(Instant.ofEpochSecond(complianceBadge.getDateexpire()));
+          newComplianceTrainingExpirationTime =
+              Timestamp.from(Instant.ofEpochSecond(complianceBadge.getDateexpire()));
         } else {
           // The current badge is invalid or expired, the training must be completed or retaken.
           newComplianceTrainingCompletionTime = null;

--- a/api/src/main/resources/moodle.yaml
+++ b/api/src/main/resources/moodle.yaml
@@ -206,18 +206,18 @@ definitions:
         lastissued:
           type: integer
           format: int64
-          description: Date of latest issued badge. As a stringy epoch.
+          description: Date of latest issued badge. As a stringy epoch in SECONDS.
         dateexpire:
           type: integer
           format: int64
-          description: Latest expiration of obtained badge. As a stringy epoch.
+          description: Latest expiration of obtained badge. As a stringy epoch in SECONDS.
         message:
           type: string
           description: General API message
         globalexpiration:
           type: integer
           format: int64
-          description: Global expiration, overrides badge expiration date. As a stringy epoch.
+          description: Global expiration, overrides badge expiration date. As a stringy epoch in SECONDS.
 
     BadgeDetailsV1:
       properties:

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -340,7 +340,7 @@ public class UserServiceTest {
   public void testClearsEraCommonsStatus() {
     DbUser testUser = userDao.findUserByUsername(USERNAME);
     // Put the test user in a state where eRA commons is completed.
-    testUser.setEraCommonsCompletionTime(new Timestamp(TIMESTAMP_MSECS));
+    testUser.setEraCommonsCompletionTime(Timestamp.from(Instant.ofEpochSecond(TIMESTAMP_SECS)));
     testUser.setEraCommonsLinkedNihUsername("nih-user");
 
     //noinspection UnusedAssignment

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -53,8 +53,7 @@ public class UserServiceTest {
 
   // An arbitrary timestamp to use as the anchor time for access module test cases.
   private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
-  @Deprecated
-  private static final long TIMESTAMP_MSECS = START_INSTANT.toEpochMilli();
+  @Deprecated private static final long TIMESTAMP_MSECS = START_INSTANT.toEpochMilli();
   private static final long TIMESTAMP_SECS = START_INSTANT.getEpochSecond();
   private static final FakeClock PROVIDED_CLOCK = new FakeClock(START_INSTANT);
   private static final int CLOCK_INCREMENT_MILLIS = 1000;

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -53,7 +53,9 @@ public class UserServiceTest {
 
   // An arbitrary timestamp to use as the anchor time for access module test cases.
   private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
+  @Deprecated
   private static final long TIMESTAMP_MSECS = START_INSTANT.toEpochMilli();
+  private static final long TIMESTAMP_SECS = START_INSTANT.getEpochSecond();
   private static final FakeClock PROVIDED_CLOCK = new FakeClock(START_INSTANT);
   private static final int CLOCK_INCREMENT_MILLIS = 1000;
   private static DbUser providedDbUser;
@@ -151,7 +153,7 @@ public class UserServiceTest {
     providedWorkbenchConfig.featureFlags.enableMoodleV2Api = true;
 
     BadgeDetailsV2 retBadge = new BadgeDetailsV2();
-    long expiry = PROVIDED_CLOCK.instant().toEpochMilli() + 100000;
+    long expiry = PROVIDED_CLOCK.instant().getEpochSecond() + 100;
     retBadge.setDateexpire(expiry);
     retBadge.setValid(true);
 
@@ -165,9 +167,9 @@ public class UserServiceTest {
     // The user should be updated in the database with a non-empty completion and expiration time.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertThat(user.getComplianceTrainingCompletionTime())
-        .isEqualTo(new Timestamp(TIMESTAMP_MSECS));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(TIMESTAMP_SECS)));
     assertThat(user.getComplianceTrainingExpirationTime())
-        .isEqualTo(Timestamp.from(Instant.ofEpochMilli(expiry)));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(expiry)));
 
     // Completion timestamp should not change when the method is called again.
     tick();
@@ -181,7 +183,7 @@ public class UserServiceTest {
     providedWorkbenchConfig.featureFlags.enableMoodleV2Api = true;
 
     BadgeDetailsV2 retBadge = new BadgeDetailsV2();
-    long expiry = PROVIDED_CLOCK.instant().toEpochMilli();
+    long expiry = PROVIDED_CLOCK.instant().getEpochSecond();
     retBadge.setDateexpire(expiry);
     retBadge.setValid(true);
 
@@ -195,12 +197,12 @@ public class UserServiceTest {
     // The user should be updated in the database with a non-empty completion and expiration time.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertThat(user.getComplianceTrainingCompletionTime())
-        .isEqualTo(Timestamp.from(Instant.ofEpochMilli(TIMESTAMP_MSECS)));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(TIMESTAMP_SECS)));
     assertThat(user.getComplianceTrainingExpirationTime())
-        .isEqualTo(Timestamp.from(Instant.ofEpochMilli(expiry)));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(expiry)));
 
     // Deprecate the old training.
-    long newExpiry = expiry - 1000;
+    long newExpiry = expiry - 1;
     retBadge.setDateexpire(newExpiry);
     retBadge.setValid(false);
 
@@ -209,16 +211,16 @@ public class UserServiceTest {
     assertThat(user.getComplianceTrainingCompletionTime()).isNull();
 
     // The user does a new training.
-    long newerExpiry = expiry + 1000;
+    long newerExpiry = expiry + 1;
     retBadge.setDateexpire(newerExpiry);
     retBadge.setValid(true);
 
     // Completion and expiry timestamp should be updated.
     userService.syncComplianceTrainingStatusV2();
     assertThat(user.getComplianceTrainingCompletionTime())
-        .isEqualTo(Timestamp.from(Instant.ofEpochMilli(TIMESTAMP_MSECS)));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(TIMESTAMP_SECS)));
     assertThat(user.getComplianceTrainingExpirationTime())
-        .isEqualTo(Timestamp.from(Instant.ofEpochMilli(newerExpiry)));
+        .isEqualTo(Timestamp.from(Instant.ofEpochSecond(newerExpiry)));
 
     // A global expiration is set.
     long globalExpiry = expiry - 1000;


### PR DESCRIPTION
Moodle sends us epochs in seconds and everything we use for time in Java thinks everything should be in milliseconds.