### PR TITLE
[RW-4132][risk=moderate] Integrate with Zendesk for workspace review requests

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -438,6 +438,7 @@ dependencies {
   // Force these dependencies to safe versions, Zendesk client depends on this.
   compile 'io.netty:netty-codec-http:4.1.44.Final'
   compile 'com.typesafe.netty:netty-reactive-streams:2.0.4'
+  compile 'com.beust:jcommander:1.78'
   compile 'com.cloudbees.thirdparty:zendesk-java-client:0.12.0'
 
   compile 'javax.inject:javax.inject:1'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -435,6 +435,8 @@ dependencies {
   compile "io.opencensus:opencensus-exporter-trace-stackdriver:${OPENCENSUS_VERSION}"
   compile "io.opencensus:opencensus-impl:${OPENCENSUS_VERSION}"
 
+  // Force this dependency to a safe version, Zendesk client depends on this.
+  compile 'io.netty:netty-codec-http:4.1.44.Final'
   compile 'com.cloudbees.thirdparty:zendesk-java-client:0.12.0'
 
   compile 'javax.inject:javax.inject:1'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -435,8 +435,9 @@ dependencies {
   compile "io.opencensus:opencensus-exporter-trace-stackdriver:${OPENCENSUS_VERSION}"
   compile "io.opencensus:opencensus-impl:${OPENCENSUS_VERSION}"
 
-  // Force this dependency to a safe version, Zendesk client depends on this.
+  // Force these dependencies to safe versions, Zendesk client depends on this.
   compile 'io.netty:netty-codec-http:4.1.44.Final'
+  compile 'com.typesafe.netty:netty-reactive-streams:2.0.4'
   compile 'com.cloudbees.thirdparty:zendesk-java-client:0.12.0'
 
   compile 'javax.inject:javax.inject:1'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -435,6 +435,8 @@ dependencies {
   compile "io.opencensus:opencensus-exporter-trace-stackdriver:${OPENCENSUS_VERSION}"
   compile "io.opencensus:opencensus-impl:${OPENCENSUS_VERSION}"
 
+  compile 'com.cloudbees.thirdparty:zendesk-java-client:0.12.0'
+
   compile 'javax.inject:javax.inject:1'
   compile 'io.swagger:swagger-annotations:1.5.16'
   compile 'org.apache.commons:commons-lang3:3.6'

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -66,6 +66,9 @@
     "fromEmail": "donotreply@fake-research-aou.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "http:\/\/elastic:9200",
     "enableBasicAuth": false,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -67,7 +67,7 @@
     "sendRetries": 3
   },
   "zendesk": {
-    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+    "host": "https:\/\/aousupporthelp1580753096.zendesk.com"
   },
   "elasticsearch": {
     "baseUrl": "http:\/\/elastic:9200",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -69,7 +69,7 @@
     "sendRetries": 3
   },
   "zendesk": {
-    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+    "host": "https:\/\/aousupporthelp1580753096.zendesk.com"
   },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -68,6 +68,9 @@
     "fromEmail": "donotreply@fake-research-aou.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",
     "enableBasicAuth": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -65,6 +65,9 @@
     "fromEmail": "donotreply@researchallofus.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "",
     "enableBasicAuth": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -65,6 +65,9 @@
     "fromEmail": "donotreply@fake-research-aou.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",
     "enableBasicAuth": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -66,7 +66,7 @@
     "sendRetries": 3
   },
   "zendesk": {
-    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+    "host": "https:\/\/aousupporthelp1580753096.zendesk.com"
   },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -65,6 +65,9 @@
     "fromEmail": "donotreply@fake-research-aou.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",
     "enableBasicAuth": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -66,7 +66,7 @@
     "sendRetries": 3
   },
   "zendesk": {
-    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+    "host": "https:\/\/aousupporthelp1580753096.zendesk.com"
   },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -67,7 +67,7 @@
     "sendRetries": 3
   },
   "zendesk": {
-    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+    "host": "https:\/\/aousupporthelp1580753096.zendesk.com"
   },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -66,6 +66,9 @@
     "fromEmail": "donotreply@fake-research-aou.org",
     "sendRetries": 3
   },
+  "zendesk": {
+    "host": "https:\/\/aousupporthelp1579899699.zendesk.com"
+  },
   "elasticsearch": {
     "baseUrl": "https:\/\/7c7c7bf81223406abe60fec3dcb34e71.us-east-1.aws.found.io:9243",
     "enableBasicAuth": true,

--- a/api/src/main/java/org/pmiops/workbench/zendesk/README.md
+++ b/api/src/main/java/org/pmiops/workbench/zendesk/README.md
@@ -1,0 +1,28 @@
+# Zendesk Integration
+
+The current Zendesk integration is very light-weight, one-step up from email.
+We use the [Zendesk REST API](https://developer.zendesk.com/rest_api/docs/support)
+via a [Java client library](https://github.com/cloudbees/zendesk-java-client).
+
+We currently only send unauthenticated calls to Zendesk, which is sufficient to
+create new Zendesk requests. If authentication is desired in the future, the
+following paths have been explored:
+
+1. Using an admin-generated API token. This can be created/revoked via the
+   Zendesk admin console. https://developer.zendesk.com/rest_api/docs/support/requests#api-token
+   We'd likely want to store that key in GCS as a secret; note that this grants
+   fairly wide unscoped permissions (admin-level).
+2. Using oauth: as of 1/31/20 this appears to be a very heavy integration which
+   requires a web flow for the end user in order to leverage. This path does not
+   seem promising for the purpose of backend Zendesk API requests.
+
+## Workspace Review Requests
+
+When a workspace review is requested, a Zendesk ticket is automatically filed.
+This ticket template must be kept up-to-date with the latest workspace research
+purpose details as the model evolves, though a raw JSON view of the workspace is
+also included as a fallback.
+
+As of 1/31/20, this is a one-way process. Any outreach back to the owner or
+follow-up to approve/reject the workspace would need to be managed within the
+Zendesk ticket.

--- a/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskConfig.java
@@ -1,0 +1,23 @@
+package org.pmiops.workbench.zendesk;
+
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.DbUser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+import org.zendesk.client.v2.Zendesk;
+
+@Configuration
+public class ZendeskConfig {
+  @Bean
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public Zendesk getZendeskClient(WorkbenchConfig config, DbUser user) {
+    // Note: this client attaches the current user's AoU username, but does not actually
+    // authenticate as them. The client can be used for anonymous endpoints such as the request
+    // create endpoint.
+    // If we decided we need an authenticated client in the future, we could use a Zendesk "API
+    // token" for this purpose, e.g. to get/update/close existing tickets.
+    return new Zendesk.Builder(config.zendesk.host).setUsername(user.getUsername()).build();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskRequests.java
+++ b/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskRequests.java
@@ -56,7 +56,7 @@ public class ZendeskRequests {
             "",
             "[Review requester]",
             String.format(
-                "%s %s (%s, %s)",
+                "Workspace creator - %s %s (%s, %s)",
                 user.getGivenName(),
                 user.getFamilyName(),
                 user.getUsername(),

--- a/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskRequests.java
+++ b/api/src/main/java/org/pmiops/workbench/zendesk/ZendeskRequests.java
@@ -1,0 +1,110 @@
+package org.pmiops.workbench.zendesk;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.Workspace;
+import org.zendesk.client.v2.model.Comment;
+import org.zendesk.client.v2.model.Request;
+import org.zendesk.client.v2.model.Ticket.Requester;
+import org.zendesk.client.v2.model.Type;
+
+public class ZendeskRequests {
+  private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
+
+  @VisibleForTesting
+  static final String RESEARCH_PURPOSE_RAW_JSON_HEADER = "[Raw research purpose JSON]";
+
+  private ZendeskRequests() {}
+
+  private static String buildZendeskTicketBody(DbUser user, Workspace workspace) {
+    ResearchPurpose rp = workspace.getResearchPurpose();
+    String primaryPurpose =
+        ImmutableMap.<String, Boolean>builder()
+            .put(
+                "Disease focused research: "
+                    + Optional.ofNullable(rp.getDiseaseOfFocus()).orElse(""),
+                rp.getDiseaseFocusedResearch())
+            .put("Methods development/validation study", rp.getMethodsDevelopment())
+            .put("Research Control", rp.getControlSet()).put("Genetic Research", rp.getAncestry())
+            .put("Social/Behavioral Research", rp.getSocialBehavioral())
+            .put("Population Health/Public Health Research", rp.getPopulationHealth())
+            .put("Drug/Therapeutics Development Research", rp.getDrugDevelopment())
+            .put("For-Profit Purpose", rp.getCommercialPurpose())
+            .put("Educational Purpose", rp.getEducational())
+            .put("Other Purpose: " + rp.getOtherPurposeDetails(), rp.getOtherPurpose()).build()
+            .entrySet().stream()
+            .filter(Entry::getValue)
+            .map(e -> " - " + e.getKey())
+            .collect(Collectors.joining("\n"));
+    return Lists.newArrayList(
+            "[Workspace name]",
+            workspace.getName(),
+            "",
+            "[Workspace ID]",
+            String.format("%s/%s", workspace.getNamespace(), workspace.getId()),
+            "",
+            "[Review requester]",
+            String.format(
+                "%s %s (%s, %s)",
+                user.getGivenName(),
+                user.getFamilyName(),
+                user.getUsername(),
+                user.getContactEmail()),
+            "",
+            "[Primary purpose of project]",
+            primaryPurpose,
+            "",
+            "[Provide the reason for choosing All of Us data for your investigation]",
+            rp.getReasonForAllOfUs(),
+            "",
+            "[What are the specific scientific question(s) you intend to study]",
+            rp.getIntendedStudy(),
+            "",
+            "[What are your anticipated findings from this study]",
+            rp.getAnticipatedFindings(),
+            "",
+            "[Population area(s) of focus]",
+            Joiner.on(", ")
+                .join(Optional.ofNullable(rp.getPopulationDetails()).orElse(ImmutableList.of())),
+            "",
+            Optional.ofNullable(rp.getOtherPopulationDetails())
+                .filter(s -> !s.isEmpty())
+                .map(s -> "[Other population]\n" + s)
+                .orElse(""),
+            "",
+            RESEARCH_PURPOSE_RAW_JSON_HEADER,
+            PRETTY_GSON.toJson(rp))
+        .stream()
+        .filter(Predicates.notNull())
+        .collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * Produces a Zendesk {@link Request} for a review of the given the given workspace, requested by
+   * the given user.
+   */
+  public static Request workspaceToReviewRequest(DbUser user, Workspace workspace) {
+    Request zdReq = new Request();
+    zdReq.setType(Type.TASK);
+    zdReq.setSubject("Workspace Review request for '" + workspace.getName() + "'");
+    Requester requester = new Requester();
+    requester.setName(user.getGivenName() + " " + user.getFamilyName());
+    requester.setEmail(user.getUsername());
+    zdReq.setRequester(requester);
+    Comment comment = new Comment();
+    comment.setBody(buildZendeskTicketBody(user, workspace));
+    zdReq.setComment(comment);
+    return zdReq;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -134,6 +134,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.zendesk.client.v2.Zendesk;
 
 // TODO(jaycarlton): many of the tests here are testing DataSetServiceImpl more than
 //   DataSetControllerImpl, so move those tests and setup stuff into DataSetServiceTest
@@ -236,6 +237,8 @@ public class DataSetControllerTest {
 
   @Autowired ManualWorkspaceMapper manualWorkspaceMapper;
 
+  @Autowired Provider<Zendesk> mockZendeskProvider;
+
   @TestConfiguration
   @Import({
     CohortFactoryImpl.class,
@@ -266,7 +269,8 @@ public class DataSetControllerTest {
     CohortQueryBuilder.class,
     UserRecentResourceService.class,
     WorkspaceAuditor.class,
-    UserServiceAuditor.class
+    UserServiceAuditor.class,
+    Zendesk.class
   })
   static class Configuration {
 
@@ -348,6 +352,7 @@ public class DataSetControllerTest {
             fireCloudService,
             cloudStorageService,
             cloudBillingProvider,
+            mockZendeskProvider,
             CLOCK,
             notebooksService,
             userService,

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -174,6 +174,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.zendesk.client.v2.Zendesk;
+import org.zendesk.client.v2.model.Request;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -382,6 +383,8 @@ public class WorkspacesControllerTest {
     fcWorkspaceAcl = createWorkspaceACL();
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);
     testMockFactory.stubCreateFcWorkspace(fireCloudService);
+
+    when(mockZendesk.createRequest(any())).thenReturn(new Request());
   }
 
   private DbUser createUser(String email) {
@@ -638,7 +641,7 @@ public class WorkspacesControllerTest {
             new ProjectBillingInfo().setBillingAccountName("billing-account"));
     assertThat(workspace2.getBillingAccountName()).isEqualTo("billing-account");
 
-    verify(mockZendesk.createRequest(any()), times(1));
+    verify(mockZendesk, times(1)).createRequest(any());
   }
 
   @Test
@@ -1079,7 +1082,7 @@ public class WorkspacesControllerTest {
     assertThat(clonedWorkspace.getResearchPurpose()).isEqualTo(modPurpose);
     assertThat(clonedWorkspace.getBillingAccountName()).isEqualTo(newBillingAccountName);
 
-    verify(mockZendesk.createRequest(any()), times(1));
+    verify(mockZendesk, times(1)).createRequest(any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -173,6 +173,7 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.zendesk.client.v2.Zendesk;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -275,7 +276,8 @@ public class WorkspacesControllerTest {
     UserRecentResourceService.class,
     ConceptService.class,
     MonitoringService.class,
-    WorkspaceAuditor.class
+    WorkspaceAuditor.class,
+    Zendesk.class
   })
   static class Configuration {
 
@@ -334,6 +336,7 @@ public class WorkspacesControllerTest {
   @Autowired UserRecentResourceService userRecentResourceService;
   @Autowired CohortReviewController cohortReviewController;
   @Autowired ConceptBigQueryService conceptBigQueryService;
+  @Autowired Zendesk mockZendesk;
 
   private DbCdrVersion cdrVersion;
   private String cdrVersionId;
@@ -519,39 +522,37 @@ public class WorkspacesControllerTest {
     return createWorkspace("namespace", "name");
   }
 
-  // TODO(calbach): Clean up this test file to make better use of chained builders.
   private Workspace createWorkspace(String workspaceNameSpace, String workspaceName) {
-    ResearchPurpose researchPurpose = new ResearchPurpose();
-    researchPurpose.setDiseaseFocusedResearch(true);
-    researchPurpose.setDiseaseOfFocus("cancer");
-    researchPurpose.setMethodsDevelopment(true);
-    researchPurpose.setControlSet(true);
-    researchPurpose.setAncestry(true);
-    researchPurpose.setCommercialPurpose(true);
-    researchPurpose.setSocialBehavioral(true);
-    researchPurpose.setPopulationHealth(true);
-    researchPurpose.setEducational(true);
-    researchPurpose.setDrugDevelopment(true);
-    researchPurpose.setPopulation(false);
-    researchPurpose.setPopulationDetails(Collections.emptyList());
-    researchPurpose.setAdditionalNotes("additional notes");
-    researchPurpose.setReasonForAllOfUs("reason for aou");
-    researchPurpose.setIntendedStudy("intended study");
-    researchPurpose.setAnticipatedFindings("anticipated findings");
-    researchPurpose.setTimeRequested(1000L);
-    researchPurpose.setTimeReviewed(1500L);
-    researchPurpose.setReviewRequested(true);
-    researchPurpose.setApproved(false);
-    Workspace workspace = new Workspace();
-    workspace.setId(workspaceName);
-    workspace.setName(workspaceName);
-    workspace.setNamespace(workspaceNameSpace);
-    workspace.setDataAccessLevel(DataAccessLevel.PROTECTED);
-    workspace.setResearchPurpose(researchPurpose);
-    workspace.setCdrVersionId(cdrVersionId);
-    workspace.setGoogleBucketName(BUCKET_NAME);
-    workspace.setBillingAccountName("billing-account");
-    return workspace;
+    return new Workspace()
+        .id(workspaceName)
+        .name(workspaceName)
+        .namespace(workspaceNameSpace)
+        .dataAccessLevel(DataAccessLevel.PROTECTED)
+        .cdrVersionId(cdrVersionId)
+        .googleBucketName(BUCKET_NAME)
+        .billingAccountName("billing-account")
+        .researchPurpose(
+            new ResearchPurpose()
+                .diseaseFocusedResearch(true)
+                .diseaseOfFocus("cancer")
+                .methodsDevelopment(true)
+                .controlSet(true)
+                .ancestry(true)
+                .commercialPurpose(true)
+                .socialBehavioral(true)
+                .populationHealth(true)
+                .educational(true)
+                .drugDevelopment(true)
+                .population(false)
+                .populationDetails(Collections.emptyList())
+                .additionalNotes("additional notes")
+                .reasonForAllOfUs("reason for aou")
+                .intendedStudy("intended study")
+                .anticipatedFindings("anticipated findings")
+                .timeRequested(1000L)
+                .timeReviewed(1500L)
+                .reviewRequested(true)
+                .approved(false));
   }
 
   public Cohort createDefaultCohort(String name) {
@@ -636,6 +637,8 @@ public class WorkspacesControllerTest {
             "projects/" + workspace.getNamespace(),
             new ProjectBillingInfo().setBillingAccountName("billing-account"));
     assertThat(workspace2.getBillingAccountName()).isEqualTo("billing-account");
+
+    verify(mockZendesk.createRequest(any()), times(1));
   }
 
   @Test
@@ -1075,6 +1078,8 @@ public class WorkspacesControllerTest {
     assertThat(clonedWorkspace.getNamespace()).isEqualTo(modWorkspace.getNamespace());
     assertThat(clonedWorkspace.getResearchPurpose()).isEqualTo(modPurpose);
     assertThat(clonedWorkspace.getBillingAccountName()).isEqualTo(newBillingAccountName);
+
+    verify(mockZendesk.createRequest(any()), times(1));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/zendesk/ZendeskRequestsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/zendesk/ZendeskRequestsTest.java
@@ -1,0 +1,115 @@
+package org.pmiops.workbench.zendesk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.SpecificPopulationEnum;
+import org.pmiops.workbench.model.Workspace;
+
+public class ZendeskRequestsTest {
+  private DbUser user;
+
+  @Before
+  public void setUp() {
+    user = new DbUser();
+    user.setGivenName("Falco");
+    user.setFamilyName("Lombardi");
+    user.setUsername("flaco@fake-research-aou.org");
+    user.setContactEmail("user@gmail.com");
+  }
+
+  @Test
+  public void testWorkspaceToReviewRequest_emptyResearchPurpose() {
+    assertThat(
+            ZendeskRequests.workspaceToReviewRequest(
+                user, new Workspace().researchPurpose(new ResearchPurpose())))
+        .isNotNull();
+  }
+
+  @Test
+  public void testWorkspaceToReviewRequest_fullResearchPurpose() {
+    assertThat(
+            ZendeskRequests.workspaceToReviewRequest(
+                user,
+                new Workspace()
+                    .name("my workspace")
+                    .namespace("fc-123")
+                    .id("wsid")
+                    .researchPurpose(
+                        new ResearchPurpose()
+                            .diseaseFocusedResearch(true)
+                            .diseaseOfFocus("cancer")
+                            .methodsDevelopment(true)
+                            .controlSet(true)
+                            .ancestry(true)
+                            .commercialPurpose(true)
+                            .socialBehavioral(true)
+                            .populationHealth(true)
+                            .educational(true)
+                            .drugDevelopment(true)
+                            .population(true)
+                            .populationDetails(
+                                ImmutableList.copyOf(SpecificPopulationEnum.values()))
+                            .additionalNotes("additional notes")
+                            .reasonForAllOfUs("reason for aou")
+                            .intendedStudy("intended study")
+                            .anticipatedFindings("anticipated findings")
+                            .timeRequested(1000L)
+                            .timeReviewed(1500L)
+                            .reviewRequested(true)
+                            .approved(false))))
+        .isNotNull();
+  }
+
+  @Test
+  public void testWorkspaceToReviewRequest_primaryPurpose() {
+    String zdBody =
+        mustStripRawResearchPurposeJSON(
+            ZendeskRequests.workspaceToReviewRequest(
+                    user,
+                    new Workspace()
+                        .researchPurpose(
+                            new ResearchPurpose()
+                                .otherPurpose(true)
+                                .otherPurposeDetails("my other details")
+                                .methodsDevelopment(true)
+                                .diseaseFocusedResearch(true)
+                                .diseaseOfFocus("greyscale")))
+                .getComment()
+                .getBody());
+    assertThat(zdBody).contains("my other details");
+    assertThat(zdBody).contains("Methods");
+    assertThat(zdBody).contains("greyscale");
+    assertThat(zdBody).doesNotContain("Educational");
+  }
+
+  @Test
+  public void testWorkspaceToReviewRequest_otherPopulation() {
+    String zdBody =
+        mustStripRawResearchPurposeJSON(
+            ZendeskRequests.workspaceToReviewRequest(
+                    user,
+                    new Workspace()
+                        .researchPurpose(
+                            new ResearchPurpose()
+                                .addPopulationDetailsItem(SpecificPopulationEnum.AGE_GROUPS)
+                                .addPopulationDetailsItem(SpecificPopulationEnum.OTHER)
+                                .otherPopulationDetails("targaryen bloodline")))
+                .getComment()
+                .getBody());
+    assertThat(zdBody).contains(SpecificPopulationEnum.AGE_GROUPS.toString());
+    assertThat(zdBody).contains("targaryen bloodline");
+    assertThat(zdBody).doesNotContain(SpecificPopulationEnum.GEOGRAPHY.toString());
+  }
+
+  private static String mustStripRawResearchPurposeJSON(String body) {
+    int index = body.indexOf(ZendeskRequests.RESEARCH_PURPOSE_RAW_JSON_HEADER);
+    assertWithMessage("failed to find raw JSON header in body").that(index).isGreaterThan(0);
+    return body.substring(0, index);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/zendesk/ZendeskRequestsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/zendesk/ZendeskRequestsTest.java
@@ -19,7 +19,7 @@ public class ZendeskRequestsTest {
     user = new DbUser();
     user.setGivenName("Falco");
     user.setFamilyName("Lombardi");
-    user.setUsername("flaco@fake-research-aou.org");
+    user.setUsername("falco@fake-research-aou.org");
     user.setContactEmail("user@gmail.com");
   }
 

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -19,6 +19,7 @@ public class WorkbenchConfig {
   public MandrillConfig mandrill;
   public ElasticsearchConfig elasticsearch;
   public MoodleConfig moodle;
+  public ZendeskConfig zendesk;
   public AccessConfig access;
   public CohortBuilderConfig cohortbuilder;
   public FeatureFlagsConfig featureFlags;
@@ -42,6 +43,7 @@ public class WorkbenchConfig {
     config.googleDirectoryService = new GoogleDirectoryServiceConfig();
     config.mandrill = new MandrillConfig();
     config.moodle = new MoodleConfig();
+    config.zendesk = new ZendeskConfig();
     config.server = new ServerConfig();
     config.billing = new BillingConfig();
     config.actionAudit = new ActionAuditConfig();
@@ -176,6 +178,10 @@ public class WorkbenchConfig {
     public boolean enableMoodleBackend;
     public String credentialsKeyV1;
     public String credentialsKeyV2;
+  }
+
+  public static class ZendeskConfig {
+    public String host;
   }
 
   // The access object specifies whether each of the following access requirements block access


### PR DESCRIPTION
- Note: this pulls in a new 3p Java library (ZD unofficial client library)
- Integrates using an unauthenticated Zendesk client via client lib. See Readme.md for details.
- On create/clone, if review is requested files a Zendesk request
- Zendesk request ticket contains both formatted workspace description (similar to edit/about pages) as well as a raw JSON view of the research purpose, in the event that we fail to update the ticket formatter when making changes to the workspace model.

Manually tested this in the sandbox env.

Future work:
- The Zendesk comment API supports HTML comments. A future version could integrate an HTML templating library to render a more readable view.
- A path for setting up an authenticated client is described in the readme, if we wanted to do subsequent ticket updates later.

Sample ticket output:
```
[Workspace name]
v5 Legit Workspace

[Workspace ID]
aou-rw-local1-94faadfb/v5legitworkspace

[Review requester]
CH Albach (calbach@fake-research-aou.org, null)

[Primary purpose of project]
- Disease focused research: cancerophobia
- Genetic Research
- Drug/Therapeutics Development Research
- For-Profit Purpose
- Educational Purpose
- Other Purpose: QA

[Provide the reason for choosing All of Us data for your investigation]
I would like to leverage the diversity of the data.

[What are the specific scientific question(s) you intend to study]
Whether X can affect Y.

[What are your anticipated findings from this study]
Huge scientific breakthroughs.

[Population area(s) of focus]
ACCESS_TO_CARE, RACE_ETHNICITY, SEX, GEOGRAPHY

[Raw research purpose JSON]
{
...
}
```