### PR TITLE
[RW-4369][risk=no] Display concept name instead of criteria question in survey results

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptsController.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.cdr.model.DbConcept;
-import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.concept.ConceptService;
@@ -69,16 +68,14 @@ public class ConceptsController implements ConceptsApiDelegate {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 
-    Slice<DbCriteria> questionList =
+    List<DbConcept> questionList =
         conceptService.searchSurveys(
             request.getQuery(),
             request.getSurveyName(),
             calculateResultLimit(request.getMaxResults()),
             Optional.ofNullable(request.getPageNumber()).orElse(0));
     return ResponseEntity.ok(
-        questionList.getContent().stream()
-            .map(this::toClientSurveyQuestions)
-            .collect(Collectors.toList()));
+        questionList.stream().map(this::toClientSurveyQuestions).collect(Collectors.toList()));
   }
 
   @Override
@@ -150,10 +147,10 @@ public class ConceptsController implements ConceptsApiDelegate {
         .conceptSynonyms(dbConcept.getSynonyms());
   }
 
-  private SurveyQuestions toClientSurveyQuestions(DbCriteria dbCriteria) {
+  private SurveyQuestions toClientSurveyQuestions(DbConcept dbConcept) {
     return new SurveyQuestions()
-        .conceptId(dbCriteria.getLongConceptId())
-        .question(dbCriteria.getName());
+        .conceptId(dbConcept.getConceptId())
+        .question(dbConcept.getConceptName());
   }
 
   private DomainInfo toClientDomainInfo(DbDomainInfo dbDomainInfo) {

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -15,7 +15,6 @@ import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cdr.model.DbConcept;
-import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
 import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.db.model.CommonStorageEnums;
@@ -140,10 +139,10 @@ public class ConceptService {
     return conceptDao.findConcepts(keyword, conceptTypes, domain, pageable);
   }
 
-  public Slice<DbCriteria> searchSurveys(String query, String surveyName, int limit, int page) {
+  public List<DbConcept> searchSurveys(String query, String surveyName, int limit, int page) {
     final String keyword = modifyMultipleMatchKeyword(query);
     Pageable pageable = new PageRequest(page, limit, new Sort(Direction.ASC, "id"));
-    return cbCriteriaDao.findSurveys(keyword, surveyName, pageable);
+    return conceptDao.findSurveys(keyword, surveyName, pageable);
   }
 
   public List<DomainCount> countDomains(
@@ -187,7 +186,7 @@ public class ConceptService {
     }
     long conceptCount = 0;
     if (allConcepts) {
-      conceptCount = cbCriteriaDao.countSurveys(matchExp, surveyName);
+      conceptCount = conceptDao.countSurveys(matchExp, surveyName);
     }
     domainCountList.add(
         new DomainCount()

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -418,28 +418,6 @@ public class ConceptsControllerTest {
             toDomainCount(MEASUREMENT_DOMAIN, false),
             toDomainCount(OBSERVATION_DOMAIN, false),
             toDomainCount(PROCEDURE_DOMAIN, false),
-            toDomainCount(SURVEY_DOMAIN, false)));
-  }
-
-  @Test
-  public void testDomainCountSourceAndStandardWithSearchTerm() {
-    saveConcepts();
-    saveDomains();
-    ResponseEntity<DomainCountsListResponse> response =
-        conceptsController.domainCounts(
-            "ns",
-            "name",
-            new DomainCountsRequest()
-                .query("conceptA")
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
-    assertCounts(
-        response,
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 1),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(OBSERVATION_DOMAIN, 0),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
             toDomainCount(SURVEY_DOMAIN, 0)));
   }
 
@@ -487,28 +465,6 @@ public class ConceptsControllerTest {
   }
 
   @Test
-  public void testSurveyCountSourceAndStandardWithSearchTerm() {
-    saveConcepts();
-    saveDomains();
-    ResponseEntity<DomainCountsListResponse> response =
-        conceptsController.domainCounts(
-            "ns",
-            "name",
-            new DomainCountsRequest()
-                .query("test")
-                .standardConceptFilter(StandardConceptFilter.ALL_CONCEPTS));
-    assertCounts(
-        response,
-        ImmutableList.of(
-            toDomainCount(CONDITION_DOMAIN, 2),
-            toDomainCount(DRUG_DOMAIN, 0),
-            toDomainCount(MEASUREMENT_DOMAIN, 0),
-            toDomainCount(OBSERVATION_DOMAIN, 1),
-            toDomainCount(PROCEDURE_DOMAIN, 0),
-            toDomainCount(SURVEY_DOMAIN, 1)));
-  }
-
-  @Test
   public void testSurveyCountSourceAndStandardWithSurveyName() {
     saveConcepts();
     saveDomains();
@@ -527,7 +483,7 @@ public class ConceptsControllerTest {
             toDomainCount(MEASUREMENT_DOMAIN, false),
             toDomainCount(OBSERVATION_DOMAIN, false),
             toDomainCount(PROCEDURE_DOMAIN, false),
-            toDomainCount(SURVEY_DOMAIN, 1)));
+            toDomainCount(SURVEY_DOMAIN, 0)));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -31,7 +31,6 @@ public class CBCriteriaDaoTest {
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
   private DbCriteria surveyCriteria;
-  private DbCriteria questionCriteria;
   private DbCriteria sourceCriteria;
   private DbCriteria standardCriteria;
   private DbCriteria icd9Criteria;
@@ -53,18 +52,6 @@ public class CBCriteriaDaoTest {
                 .standard(false)
                 .selectable(true)
                 .name("The Basics"));
-    questionCriteria =
-        cbCriteriaDao.save(
-            new DbCriteria()
-                .domainId(DomainType.SURVEY.toString())
-                .type(CriteriaType.PPI.toString())
-                .subtype(CriteriaSubType.QUESTION.toString())
-                .group(false)
-                .standard(false)
-                .selectable(true)
-                .parentId(surveyCriteria.getId())
-                .synonyms("test")
-                .path(surveyCriteria.getId() + ".1"));
     sourceCriteria =
         cbCriteriaDao.save(
             new DbCriteria()
@@ -317,39 +304,5 @@ public class CBCriteriaDaoTest {
     assertThat(option6.getDomain()).isEqualTo(DomainType.SURVEY.toString());
     assertThat(option6.getType()).isEqualTo("PPI");
     assertThat(option6.getStandard()).isFalse();
-  }
-
-  @Test
-  public void countSurveyBySearchTerm() {
-    assertThat(cbCriteriaDao.countSurveyByKeyword("test")).isEqualTo(1);
-  }
-
-  @Test
-  public void findSurveysKeyword() {
-    PageRequest page = new PageRequest(0, 10);
-    assertThat(cbCriteriaDao.findSurveys("test", null, page)).containsExactly(questionCriteria);
-  }
-
-  @Test
-  public void countSurveyByName() {
-    assertThat(cbCriteriaDao.countSurveyByName("The Basics")).isEqualTo(1);
-  }
-
-  @Test
-  public void findSurveysByName() {
-    PageRequest page = new PageRequest(0, 10);
-    assertThat(cbCriteriaDao.findSurveys(null, "The Basics", page))
-        .containsExactly(questionCriteria);
-  }
-
-  @Test
-  public void findSurveysNoSurveyName() {
-    PageRequest page = new PageRequest(0, 10);
-    assertThat(cbCriteriaDao.findSurveys(null, null, page)).containsExactly(questionCriteria);
-  }
-
-  @Test
-  public void countSurveys() {
-    assertThat(cbCriteriaDao.countSurveys()).isEqualTo(1);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -2,10 +2,8 @@ package org.pmiops.workbench.cdr.dao;
 
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
@@ -238,83 +236,4 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select distinct domain_id as domain, type, is_standard as standard from cb_criteria order by domain, type, is_standard",
       nativeQuery = true)
   List<DbMenuOption> findMenuOptions();
-
-  @Query(
-      value =
-          "select count(c) "
-              + "from DbCriteria c "
-              + "where domainId = 'SURVEY' and type = 'PPI' and subtype = 'QUESTION' "
-              + "and match(synonyms, :term) > 0")
-  long countSurveyByKeyword(@Param("term") String term);
-
-  @Query(
-      value =
-          "select c "
-              + "from DbCriteria c "
-              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
-              + "and match(c.synonyms, :term) > 0")
-  Page<DbCriteria> findSurveys(@Param("term") String term, Pageable page);
-
-  @Query(
-      value =
-          "select count(c) "
-              + "from DbCriteria c "
-              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
-              + "and c.path like CONCAT((select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName), '.%')")
-  long countSurveyByName(@Param("surveyName") String surveyName);
-
-  @Query(
-      value =
-          "select c "
-              + "from DbCriteria c "
-              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION' "
-              + "and c.path like CONCAT((select dc.id from DbCriteria dc where dc.domainId = 'SURVEY' and dc.type = 'PPI' and dc.name = :surveyName), '.%')")
-  Page<DbCriteria> findSurveysByName(@Param("surveyName") String surveyName, Pageable page);
-
-  @Query(
-      value =
-          "select c "
-              + "from DbCriteria c "
-              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
-  Page<DbCriteria> findSurveys(Pageable page);
-
-  @Query(
-      value =
-          "select count(c) "
-              + "from DbCriteria c "
-              + "where c.domainId = 'SURVEY' and c.type = 'PPI' and c.subtype = 'QUESTION'")
-  long countSurveys();
-
-  /**
-   * Find surveys by specified keyword or surveyName. If both keyword and surveyName are blank
-   * return all surveys.
-   *
-   * @param keyword
-   * @param surveyName
-   * @param pageable
-   * @return
-   */
-  default Page<DbCriteria> findSurveys(String keyword, String surveyName, Pageable pageable) {
-    if (StringUtils.isBlank(keyword)) {
-      return StringUtils.isBlank(surveyName)
-          ? findSurveys(pageable)
-          : findSurveysByName(surveyName, pageable);
-    }
-    return findSurveys(keyword, pageable);
-  }
-
-  /**
-   * Count surveys by specified keyword or surveyName. If both keyword and surveyName are blank
-   * count all surveys.
-   *
-   * @param keyword
-   * @param surveyName
-   * @return
-   */
-  default long countSurveys(String keyword, String surveyName) {
-    if (StringUtils.isBlank(keyword)) {
-      return StringUtils.isBlank(surveyName) ? countSurveys() : countSurveyByName(surveyName);
-    }
-    return countSurveyByKeyword(keyword);
-  }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.cdr.dao;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.db.model.CommonStorageEnums;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface ConceptDao extends CrudRepository<DbConcept, Long> {
 
@@ -104,5 +106,192 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
     return StringUtils.isBlank(keyword)
         ? findConcepts(conceptTypes, toDomainId, pageable)
         : findConcepts(keyword, conceptTypes, toDomainId, pageable);
+  }
+
+  @Query(
+      value =
+          "select count(*) "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "          and match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against (:term in boolean mode)"
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1",
+      nativeQuery = true)
+  long countSurveys(@Param("term") String term);
+
+  @Query(
+      value =
+          "select concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "          and match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against (:term in boolean mode)"
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1 "
+              + "order by id "
+              + "limit :limit offset :offset",
+      nativeQuery = true)
+  List<DbConcept> findSurveys(
+      @Param("term") String term, @Param("limit") int limit, @Param("offset") int offset);
+
+  @Query(
+      value =
+          "select count(*) "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "          and cr.path like CONCAT( "
+              + "            (select dc.id "
+              + "              from cb_criteria dc "
+              + "              where dc.domain_id = 'SURVEY' "
+              + "                and dc.type = 'PPI' "
+              + "                and dc.name = :surveyName), '.%' "
+              + "          ) "
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1",
+      nativeQuery = true)
+  long countSurveyByName(@Param("surveyName") String surveyName);
+
+  @Query(
+      value =
+          "select concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "          and cr.path like CONCAT( "
+              + "            (select dc.id "
+              + "              from cb_criteria dc "
+              + "              where dc.domain_id = 'SURVEY' "
+              + "                and dc.type = 'PPI' "
+              + "                and dc.name = :surveyName), '.%' "
+              + "          ) "
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1 "
+              + "order by id "
+              + "limit :limit offset :offset",
+      nativeQuery = true)
+  List<DbConcept> findSurveysByName(
+      @Param("surveyName") String surveyName,
+      @Param("limit") int limit,
+      @Param("offset") int offset);
+
+  @Query(
+      value =
+          "select concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1 "
+              + "order by id "
+              + "limit :limit offset :offset",
+      nativeQuery = true)
+  List<DbConcept> findSurveys(@Param("limit") int limit, @Param("offset") int offset);
+
+  @Query(
+      value =
+          "select count(*) "
+              + "from "
+              + "  (select case when @curType = concept_name then @curRow \\:= @curRow + 1 else @curRow \\:= 1 end as rank, "
+              + "   id, @curType \\:= concept_name as concept_name, concept_id, domain_id, vocabulary_id, concept_class_id, standard_concept, concept_code, count_value, prevalence, source_count_value, synonyms "
+              + "    from "
+              + "      (select cr.id, c.* "
+              + "        from cb_criteria cr "
+              + "        join concept c on c.concept_id = cr.concept_id "
+              + "        where cr.domain_id = 'SURVEY' "
+              + "          and cr.type = 'PPI' "
+              + "          and cr.subtype = 'ANSWER' "
+              + "      ) a, "
+              + "      (select @curRow \\:= 0, @curType \\:= '') r "
+              + "    order by concept_name, id "
+              + "  ) as x "
+              + "where rank = 1",
+      nativeQuery = true)
+  long countSurveys();
+
+  /**
+   * Find surveys by specified keyword or surveyName. If both keyword and surveyName are blank
+   * return all surveys.
+   *
+   * @param keyword
+   * @param surveyName
+   * @param pageable
+   * @return
+   */
+  default List<DbConcept> findSurveys(String keyword, String surveyName, Pageable pageable) {
+    int limit = pageable.getPageSize();
+    int offset = pageable.getPageNumber() * limit;
+    if (StringUtils.isBlank(keyword)) {
+      return StringUtils.isBlank(surveyName)
+          ? findSurveys(limit, offset)
+          : findSurveysByName(surveyName, limit, offset);
+    }
+    return findSurveys(keyword, limit, offset);
+  }
+
+  /**
+   * Count surveys by specified keyword or surveyName. If both keyword and surveyName are blank
+   * count all surveys.
+   *
+   * @param keyword
+   * @param surveyName
+   * @return
+   */
+  default long countSurveys(String keyword, String surveyName) {
+    if (StringUtils.isBlank(keyword)) {
+      return StringUtils.isBlank(surveyName) ? countSurveys() : countSurveyByName(surveyName);
+    }
+    return countSurveys(keyword);
   }
 }


### PR DESCRIPTION
Display concept name instead of criteria question in survey results

- Move dao call from CBCriteriaDao to ConceptDao
- Change queries to use mysql rank that allows for same ordering as criteria table
- Change queries to be native since JPQL doesn't handle rank functions