### PR TITLE
[risk=no] Fix code preview UI bug in new dataset modal

### DIFF
--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -276,7 +276,7 @@ class NewDataSetModal extends React.Component<Props, State> {
                      })}/>
         </div>
         <TooltipTrigger content={this.props.billingLocked && ACTION_DISABLED_INVALID_BILLING}>
-          <div style={{display: 'inline-flex', alignItems: 'center', marginTop: '1rem', ...(this.props.billingLocked && {opacity: 0.5})}}>
+          <div style={{display: 'flex', alignItems: 'center', marginTop: '1rem', ...(this.props.billingLocked && {opacity: 0.5})}}>
             <CheckBox style={{height: 17, width: 17}}
                       disabled={this.props.billingLocked}
                       data-test-id='export-to-notebook'


### PR DESCRIPTION
Fixes a bug in the new dataset modal where the code preview button is on the wrong line.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
