### PR TITLE
[risk=no] Reduce api-local-test memory limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           - MYSQL_PASSWORD=ubuntu
     working_directory: ~/workbench
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xmx1536m
       TERM: dumb
       MYSQL_ROOT_PASSWORD: ubuntu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,13 @@ jobs:
           - MYSQL_PASSWORD=ubuntu
     working_directory: ~/workbench
     environment:
+      # Drop to ~1.5G; the local API server starts two Java processes (the API
+      # server and the cron emulator). The default machine has 4GB, so we want
+      # the Java memory limit to be below half of that: other things on the
+      # machine need memory as well. Using 2G here manifested in 137 errors.
+      # If this limit proves to be too low, an alternative would be to use a
+      # larger resource class:
+      #   https://circleci.com/docs/2.0/configuration-reference/#resource_class
       JAVA_TOOL_OPTIONS: -Xmx1536m
       TERM: dumb
       MYSQL_ROOT_PASSWORD: ubuntu


### PR DESCRIPTION
I'm not sure if we're just using more virtual memory now, or if our machine size was somehow reduced with the CircleCI plan change. 

See inline comment for explanation. Also https://circleci.com/docs/2.0/java-oom/