### PR TITLE
[risk=no] Fix text display on notebook loading page

### DIFF
--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -446,10 +446,12 @@ export const NotebookRedirect = fp.flow(withUserProfile(), withCurrentWorkspace(
           <div style={styles.reminderText}>
             <ReminderIcon
               style={{height: '80px', width: '80px', marginRight: '0.5rem'}}/>
-            It is <i>All of Us</i> data use policy that researchers should not make copies of
-            or download individual-level data (including taking screenshots or other means
-            of viewing individual-level data) outside of the <i>All of Us</i> research environment
-            without approval from <i>All of Us</i> Resource Access Board (RAB).
+            <div>
+              It is <i>All of Us</i> data use policy that researchers should not make copies of
+              or download individual-level data (including taking screenshots or other means
+              of viewing individual-level data) outside of the <i>All of Us</i> research environment
+              without approval from <i>All of Us</i> Resource Access Board (RAB).
+            </div>
           </div>
         </div> : <div style={{height: '100%'}}>
           <div style={{borderBottom: '5px solid #2691D0', width: '100%'}}/>


### PR DESCRIPTION
All the `<i>` tags were treated as flex items and getting `display: block` applied to them. Fixed by wrapping the entire text block in a `div` so that becomes the flex item and the `<i>` tags get their usual `display: inline` applied.

@gjuggler FYI