### PR TITLE
[RW-3881][risk=no] Fix small typo in DbUserDataUseAgreement annotation.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserDataUseAgreement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserDataUseAgreement.java
@@ -23,7 +23,7 @@ public class DbUserDataUseAgreement {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  // TODO: rename this column with a Liquibase change once we're post-beta launch!
+  // TODO(RW-4391): rename this column with a Liquibase change once we're post-beta launch!
   @Column(name = "user_data_user_agreement_id")
   public long getUserDataUseAgreementId() {
     return userDataUseAgreementId;

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserDataUseAgreement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserDataUseAgreement.java
@@ -23,7 +23,8 @@ public class DbUserDataUseAgreement {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "user_data_use_agreement_id")
+  // TODO: rename this column with a Liquibase change once we're post-beta launch!
+  @Column(name = "user_data_user_agreement_id")
   public long getUserDataUseAgreementId() {
     return userDataUseAgreementId;
   }


### PR DESCRIPTION
I was taking a look at RW-3881 (API failure when updating a user profile), and this was the first error I ran into. There may be more reasons it's failing, but this one looks like a super simple fix.

I decided to update the entity annotation rather than write a Liquibase migration to rename the column, to avoid adding a Liquibase change that might affect our rollback-ability in next week's release.

---
**PR checklist**

- [X] I have run and tested this change locally