### PR TITLE
[risk=no] Bind docker ports to localhost

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     volumes:
       - db:/var/lib/mysql
     ports:
-      - 3306:3306
+      - 127.0.0.1:3306:3306
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
     ports:
@@ -49,8 +49,8 @@ services:
     env_file:
       - db/vars.env
     ports:
-      - 8081:8081
-      - 8001:8001
+      - 127.0.0.1:8081:8081
+      - 127.0.0.1:8001:8001
   es-scripts:
     depends_on:
       - elastic

--- a/ui/docker-compose.yaml
+++ b/ui/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/w/ui/sa-key.json
     ports:
-      - 4200:4200
+      - 127.0.0.1:4200:4200
   tests:
     build:
       context: ./src/dev/server
@@ -23,4 +23,4 @@ services:
       - ..:/w:cached
     command: yarn test
     ports:
-      - 9876:9876
+      - 127.0.0.1:9876:9876


### PR DESCRIPTION
This should prevent accepting connections from outside localhost. Tested locally manually.