### PR TITLE
[RW-3685][risk=no] Add some error handling for user registration and profile editing

### DIFF
--- a/ui/src/app/components/error-handler.tsx
+++ b/ui/src/app/components/error-handler.tsx
@@ -127,9 +127,11 @@ export const ErrorHandler = fp.flow(withUserProfile(), withGlobalError())(class 
   render() {
     const {globalError} = this.props;
     const {serverDownStatus: {apiDown, firecloudDown, notebooksDown}} = this.state;
-
+    console.log('Error handler render', this.props);
     return globalError !== undefined && <React.Fragment>
-      {globalError.statusCode === 500 && <div style={styles.errorHandler}>
+      {/* TODO(RW-RW-4392): this component should be revamped to be more generic, allowing display
+      of arbitrary error messages as well as response code based messaging. */}
+      {[400, 500].includes(globalError.statusCode) && <div style={styles.errorHandler}>
         <FlexRow style={styles.errorContent}>
           <FlexColumn>
           Unexpected Error

--- a/ui/src/app/components/error-handler.tsx
+++ b/ui/src/app/components/error-handler.tsx
@@ -127,7 +127,6 @@ export const ErrorHandler = fp.flow(withUserProfile(), withGlobalError())(class 
   render() {
     const {globalError} = this.props;
     const {serverDownStatus: {apiDown, firecloudDown, notebooksDown}} = this.state;
-    console.log('Error handler render', this.props);
     return globalError !== undefined && <React.Fragment>
       {/* TODO(RW-RW-4392): this component should be revamped to be more generic, allowing display
       of arbitrary error messages as well as response code based messaging. */}

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -103,7 +103,7 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     const {invitationKey, setProfile} = this.props;
     this.setState({creatingAccount: true});
     try {
-      await profileApi().createAccount({profile: this.profileObj, invitationKey: 'asdf'})
+      await profileApi().createAccount({profile: this.profileObj, invitationKey: invitationKey})
         .then((savedProfile) => {
           this.setState({profile: savedProfile, creatingAccount: false});
           setProfile(savedProfile, {stepName: 'accountCreationSuccess', backgroundImages: signedOutImages.login});

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -2,6 +2,7 @@ import {ListPageHeader} from 'app/components/headers';
 import * as fp from 'lodash/fp';
 import {Dropdown} from 'primereact/dropdown';
 import * as React from 'react';
+import * as validate from 'validate.js';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
@@ -21,11 +22,9 @@ import {
   profileApi
 } from 'app/services/swagger-fetch-clients';
 import {toggleIncludes} from 'app/utils';
-import * as validate from 'validate.js';
-import {AccountCreationOptions} from './account-creation-options';
-import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
-import {globalErrorStore} from 'app/utils/navigation';
 import {convertAPIError} from 'app/utils/errors';
+import {globalErrorStore} from 'app/utils/navigation';
+import {AccountCreationOptions} from './account-creation-options';
 
 
 const styles = {
@@ -104,7 +103,6 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     const {invitationKey, setProfile} = this.props;
     this.setState({creatingAccount: true});
     try {
-      console.log('Attempting account creation');
       await profileApi().createAccount({profile: this.profileObj, invitationKey: 'asdf'})
         .then((savedProfile) => {
           this.setState({profile: savedProfile, creatingAccount: false});

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -15,11 +15,10 @@ import { ProfileRegistrationStepStatus } from 'app/pages/profile/profile-registr
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {convertAPIError} from 'app/utils/errors';
 import {globalErrorStore, serverConfigStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {Profile} from 'generated/fetch';
-import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
-import {convertAPIError} from 'app/utils/errors';
 
 const styles = reactStyles({
   h1: {

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -18,6 +18,7 @@ import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {serverConfigStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {Profile} from 'generated/fetch';
+import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
 
 const styles = reactStyles({
   h1: {
@@ -96,7 +97,8 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
     this.setState({updating: true});
 
     try {
-      await profileApi().updateProfile(this.state.profileEdits);
+      await fetchWithGlobalErrorHandler(() => profileApi().updateProfile(this.state.profileEdits),
+        /* maxRetries */ 1);
       await reload();
     } catch (e) {
       console.error(e);
@@ -138,7 +140,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
       const inputProps = {
         value: fp.get(valueKey, profileEdits) || '',
         onChange: v => this.setState(fp.set(['profileEdits', ...valueKey], v)),
-        invalid: !!errorText,
+        invalid: String(!!errorText),
         ...props
       };
 

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -99,6 +99,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
 
     try {
       await profileApi().updateProfile(this.state.profileEdits);
+      await reload();
     } catch (e) {
       if (e instanceof Response) {
         await globalErrorStore.next(await convertAPIError(e));

--- a/ui/src/app/utils/errors.tsx
+++ b/ui/src/app/utils/errors.tsx
@@ -1,4 +1,4 @@
-import {ErrorCode} from 'generated/fetch';
+import {ErrorCode, ErrorResponse} from 'generated/fetch';
 import {StackdriverErrorReporter} from 'stackdriver-errors-js';
 
 let stackdriverReporter: StackdriverErrorReporter;
@@ -33,13 +33,13 @@ export function isAbortError(e: Error) {
 }
 
 // convert error response from API JSON to ErrorResponse object, otherwise, report parse error
-export async function convertAPIError(e) {
+export async function convertAPIError(e: Response): Promise<ErrorResponse> {
   try {
     const {errorClassName = null,
       errorCode = null,
       errorUniqueId = null,
       message = null,
-      statusCode = null} = await e.json();
+      statusCode = null} = await e.json() as ErrorResponse;
     return { errorClassName, errorCode, errorUniqueId, message, statusCode };
   }  catch {
     return { statusCode: e.status, errorCode: ErrorCode.PARSEERROR };

--- a/ui/src/app/utils/retry.tsx
+++ b/ui/src/app/utils/retry.tsx
@@ -37,7 +37,6 @@ export async function fetchWithGlobalErrorHandler<T>(fetchFn: () => Promise<T>, 
     try {
       return await fetchFn();
     } catch (e) {
-      console.log('Caught global error', e);
       retries++;
       const errorResponse = await convertAPIError(e);
       if (retries === maxRetries) {

--- a/ui/src/app/utils/retry.tsx
+++ b/ui/src/app/utils/retry.tsx
@@ -37,6 +37,7 @@ export async function fetchWithGlobalErrorHandler<T>(fetchFn: () => Promise<T>, 
     try {
       return await fetchFn();
     } catch (e) {
+      console.log('Caught global error', e);
       retries++;
       const errorResponse = await convertAPIError(e);
       if (retries === maxRetries) {


### PR DESCRIPTION
Small PR which I'm treating as part of the "get user registration ready for prime-time" ticket RW-3685.

This changes the profile page and user-registration page to do something more than console.log when an Ajax error occurs. In the long term we should aim to align with the overall Workbench user-facing error display story (see [this doc](https://docs.google.com/presentation/d/1vVK0s9AxXKyhcgZJqWAWrqiitsG-RTwh16DOTp47zEY/edit#slide=id.p) and [this ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-2820)).

Screenshots from local testing:

![Screen Shot 2020-02-05 at 10 39 30 AM](https://user-images.githubusercontent.com/51842/74042830-45037d00-4996-11ea-8e0b-891354ed7774.png)

![Screen Shot 2020-02-05 at 10 48 53 AM](https://user-images.githubusercontent.com/51842/74042837-492f9a80-4996-11ea-8996-aff4b0a40477.png)


---
**PR checklist**

- [X] I have run and tested this change locally