### PR TITLE
[RW-4410][risk=no] Fix help sidebar state when navigating from a notebook

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -221,7 +221,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile())(
     constructor(props: Props) {
       super(props);
       this.state = {
-        activeIcon: 'help',
+        activeIcon: props.sidebarOpen ? 'help' : undefined,
         filteredContent: undefined,
         participant: undefined,
         searchTerm: '',


### PR DESCRIPTION
Issue comes from having the sidebar open by default when entering a workspace, but didn't take into account navigating from a page inside a workspace that doesn't contain the sidebar (only notebooks AFAIK)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
