### PR TITLE
[RW-3803][risk=no] Flatten side bar items for User Support

### DIFF
--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -210,10 +210,8 @@ export interface SideNavProps {
 
 export interface SideNavState {
   showAdminOptions: boolean;
-  showHelpOptions: boolean;
   showUserOptions: boolean;
   adminRef: React.RefObject<SideNavItem>;
-  helpRef: React.RefObject<SideNavItem>;
   userRef: React.RefObject<SideNavItem>;
 }
 
@@ -222,24 +220,14 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
     super(props);
     this.state = {
       showAdminOptions: false,
-      showHelpOptions: false,
       showUserOptions: false,
       adminRef: React.createRef(),
-      helpRef: React.createRef(),
       userRef: React.createRef(),
     };
   }
 
   onToggleUser() {
-    this.setState({showHelpOptions: false});
-    this.state.helpRef.current.closeSubItems();
     this.setState(previousState => ({showUserOptions: !previousState.showUserOptions}));
-  }
-
-  onToggleHelp() {
-    this.setState({showUserOptions: false});
-    this.state.userRef.current.closeSubItems();
-    this.setState(previousState => ({showHelpOptions: !previousState.showHelpOptions}));
   }
 
   onToggleAdmin() {
@@ -316,36 +304,16 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
       />
       <SideNavItem
         icon='help'
-        content='User Support'
-        parentOnClick={() => this.onToggleHelp()}
-        onToggleSideNav={() => this.props.onToggleSideNav()}
-        containsSubItems={true}
-        ref={this.state.helpRef}
-      />
-      <SideNavItem
-        content={'User Forum'}
+        content={'User Support'}
         onToggleSideNav={() => this.props.onToggleSideNav()}
         parentOnClick={() => this.redirectToZendesk()}
       />
       <SideNavItem
+        icon='envelope'
         content={'Contact Us'}
         onToggleSideNav={() => this.props.onToggleSideNav()}
         parentOnClick={() => this.openContactWidget()}
       />
-      {
-        this.state.showHelpOptions && <SideNavItem
-          content={'User Forum'}
-          onToggleSideNav={() => this.props.onToggleSideNav()}
-          parentOnClick={() => this.redirectToZendesk()}
-        />
-      }
-      {
-        this.state.showHelpOptions && <SideNavItem
-          content={'Contact Us'}
-          onToggleSideNav={() => this.props.onToggleSideNav()}
-          parentOnClick={() => this.openContactWidget()}
-        />
-      }
       {
         (profile.authorities.includes(Authority.ACCESSCONTROLADMIN)
           || profile.authorities.includes(Authority.COMMUNICATIONSADMIN)) && <SideNavItem

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -322,6 +322,16 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
         containsSubItems={true}
         ref={this.state.helpRef}
       />
+      <SideNavItem
+        content={'User Forum'}
+        onToggleSideNav={() => this.props.onToggleSideNav()}
+        parentOnClick={() => this.redirectToZendesk()}
+      />
+      <SideNavItem
+        content={'Contact Us'}
+        onToggleSideNav={() => this.props.onToggleSideNav()}
+        parentOnClick={() => this.openContactWidget()}
+      />
       {
         this.state.showHelpOptions && <SideNavItem
           content={'User Forum'}


### PR DESCRIPTION
Straightforward. Note, we should standardize our usage of icons soon. Switching in between clarity and fontawesome is getting confusing and also makes refactoring harder.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
