### PR TITLE
[RW-3790][RW-3587][Risk=low] Remove named params and move to bigrquery

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -279,7 +279,7 @@ public class DataSetController implements DataSetApiDelegate {
     // TODO(jaycarlton): return better error information form this function for common validation
     // scenarios
     final Map<String, QueryJobConfiguration> bigQueryJobConfigsByDomain =
-        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest);
+        dataSetService.domainToBigQueryConfig(dataSetRequest);
 
     if (bigQueryJobConfigsByDomain.isEmpty()) {
       log.warning("Empty query map generated for this DataSetRequest");
@@ -323,15 +323,9 @@ public class DataSetController implements DataSetApiDelegate {
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     DataSetPreviewResponse previewQueryResponse = new DataSetPreviewResponse();
     DataSetRequest dataSetRequest = generateDataSetRequestFromPreviewRequest(dataSetPreviewRequest);
+    // Generate a query for the preview.
     Map<String, QueryJobConfiguration> bigQueryJobConfig =
-        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest).entrySet()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    stringQueryJobConfigurationEntry ->
-                        bigQueryService.filterBigQueryConfig(
-                            stringQueryJobConfigurationEntry.getValue())));
+        dataSetService.domainToBigQueryConfig(dataSetRequest);
 
     if (bigQueryJobConfig.size() > 1) {
       throw new BadRequestException(
@@ -500,7 +494,7 @@ public class DataSetController implements DataSetApiDelegate {
     }
 
     Map<String, QueryJobConfiguration> queriesByDomain =
-        dataSetService.generateQueryJobConfigurationsByDomainName(
+        dataSetService.domainToBigQueryConfig(
             dataSetExportRequest.getDataSetRequest());
 
     String qualifier = generateRandomEightCharacterQualifier();

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -494,8 +494,7 @@ public class DataSetController implements DataSetApiDelegate {
     }
 
     Map<String, QueryJobConfiguration> queriesByDomain =
-        dataSetService.domainToBigQueryConfig(
-            dataSetExportRequest.getDataSetRequest());
+        dataSetService.domainToBigQueryConfig(dataSetExportRequest.getDataSetRequest());
 
     String qualifier = generateRandomEightCharacterQualifier();
 

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -324,7 +324,14 @@ public class DataSetController implements DataSetApiDelegate {
     DataSetPreviewResponse previewQueryResponse = new DataSetPreviewResponse();
     DataSetRequest dataSetRequest = generateDataSetRequestFromPreviewRequest(dataSetPreviewRequest);
     Map<String, QueryJobConfiguration> bigQueryJobConfig =
-        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest);
+        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest).entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    stringQueryJobConfigurationEntry ->
+                        bigQueryService.filterBigQueryConfig(
+                            stringQueryJobConfigurationEntry.getValue())));
 
     if (bigQueryJobConfig.size() > 1) {
       throw new BadRequestException(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
@@ -27,8 +27,7 @@ public interface DataSetService {
       long creatorId,
       Timestamp creationTime);
 
-  Map<String, QueryJobConfiguration> domainToBigQueryConfig(
-      DataSetRequest dataSet);
+  Map<String, QueryJobConfiguration> domainToBigQueryConfig(DataSetRequest dataSet);
 
   List<String> generateCodeCells(
       KernelTypeEnum kernelTypeEnum,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetService.java
@@ -27,7 +27,7 @@ public interface DataSetService {
       long creatorId,
       Timestamp creationTime);
 
-  Map<String, QueryJobConfiguration> generateQueryJobConfigurationsByDomainName(
+  Map<String, QueryJobConfiguration> domainToBigQueryConfig(
       DataSetRequest dataSet);
 
   List<String> generateCodeCells(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -55,7 +55,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   private static final String CDR_STRING = "\\$\\{projectId}.\\$\\{dataSetId}";
-  private static final String PYTHON_CDR_ENV_VARIABLE = "\"\"\" + os.environ[\"WORKSPACE_CDR\"] + \"\"\"";
+  private static final String PYTHON_CDR_ENV_VARIABLE =
+      "\"\"\" + os.environ[\"WORKSPACE_CDR\"] + \"\"\"";
   private static final String R_CDR_ENV_VARIABLE = "\", Sys.getenv(\"WORKSPACE_CDR\"), \"";
 
   private static final String SELECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST =
@@ -231,8 +232,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
           .build();
 
   @Override
-  public Map<String, QueryJobConfiguration> domainToBigQueryConfig(
-      DataSetRequest dataSetRequest) {
+  public Map<String, QueryJobConfiguration> domainToBigQueryConfig(DataSetRequest dataSetRequest) {
     final boolean includesAllParticipants =
         getBuiltinBooleanFromNullable(dataSetRequest.getIncludesAllParticipants());
     final ImmutableList<DbCohort> cohortsSelected =
@@ -673,11 +673,9 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       String query, KernelTypeEnum kernelTypeEnum) {
     switch (kernelTypeEnum) {
       case PYTHON:
-        return query.replaceAll(
-            CDR_STRING, PYTHON_CDR_ENV_VARIABLE);
+        return query.replaceAll(CDR_STRING, PYTHON_CDR_ENV_VARIABLE);
       case R:
-        return query.replaceAll(
-            CDR_STRING, R_CDR_ENV_VARIABLE);
+        return query.replaceAll(CDR_STRING, R_CDR_ENV_VARIABLE);
       default:
         return query;
     }
@@ -701,14 +699,16 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 arraySqlFromQueryParameter(value));
           } else {
             // This handles the replacement of non-array parameters.
-            // getValue should always work, because it handles all value types except arrays and structs.
+            // getValue should always work, because it handles all value types except arrays and
+            // structs.
             // We do not use structs.
             String stringToReplace = "@".concat(key);
             int startingIndex = stringBuilder.indexOf(stringToReplace);
-            Optional.ofNullable(value.getValue()).ifPresent(v -> stringBuilder.replace(
-                startingIndex,
-                startingIndex + stringToReplace.length(),
-                v));
+            Optional.ofNullable(value.getValue())
+                .ifPresent(
+                    v ->
+                        stringBuilder.replace(
+                            startingIndex, startingIndex + stringToReplace.length(), v));
           }
         });
     return stringBuilder.toString();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -54,11 +54,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
-  private static final String CDR_STRING = "\\$\\{projectId}.\\$\\{dataSetId}";
+  private static final String CDR_STRING = "\\$\\{projectId}.\\$\\{dataSetId}.";
   private static final String PYTHON_CDR_ENV_VARIABLE =
-      "\"\"\" + os.environ[\"WORKSPACE_CDR\"] + \"\"\"";
-  private static final String R_CDR_ENV_VARIABLE = "\", Sys.getenv(\"WORKSPACE_CDR\"), \"";
-  private static final Map<KernelTypeEnum, String> KERNEL_TYPE_TO_ENV_VARIABLE_MAP = ImmutableMap.of(KernelTypeEnum.R, R_CDR_ENV_VARIABLE, KernelTypeEnum.PYTHON, PYTHON_CDR_ENV_VARIABLE);
+      "\"\"\" + os.environ[\"WORKSPACE_CDR\"] + \"\"\".";
+  // This is implicitly handled by bigrquery, so we don't need this variable.
+  private static final String R_CDR_ENV_VARIABLE = "";
+  private static final Map<KernelTypeEnum, String> KERNEL_TYPE_TO_ENV_VARIABLE_MAP =
+      ImmutableMap.of(
+          KernelTypeEnum.R, R_CDR_ENV_VARIABLE, KernelTypeEnum.PYTHON, PYTHON_CDR_ENV_VARIABLE);
 
   private static final String SELECT_ALL_FROM_DS_LINKING_WHERE_DOMAIN_MATCHES_LIST =
       "SELECT * FROM `${projectId}.${dataSetId}.ds_linking` "
@@ -713,9 +716,11 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   @NotNull
   private static String arraySqlFromQueryParameter(QueryParameterValue value) {
-    return String.format("(%s)", nullableListToEmpty(value.getArrayValues()).stream()
-        .map(QueryParameterValue::getValue)
-        .collect(Collectors.joining(", ")));
+    return String.format(
+        "(%s)",
+        nullableListToEmpty(value.getArrayValues()).stream()
+            .map(QueryParameterValue::getValue)
+            .collect(Collectors.joining(", ")));
   }
 
   private static String generateNotebookUserCode(
@@ -775,7 +780,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             namespace
                 + "df <- bq_table_download(bq_dataset_query(Sys.getenv(\"WORKSPACE_CDR\"), "
                 + namespace
-                + "sql, billing=Sys.getenv(\"GOOGLE_PROJECT\")))";
+                + "sql, billing=Sys.getenv(\"GOOGLE_PROJECT\")), bigint=\"integer64\")";
         displayHeadSection = "head(" + namespace + "df, 5)";
         break;
       default:

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -227,7 +227,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
           .build();
 
   @Override
-  public Map<String, QueryJobConfiguration> generateQueryJobConfigurationsByDomainName(
+  public Map<String, QueryJobConfiguration> domainToBigQueryConfig(
       DataSetRequest dataSetRequest) {
     final boolean includesAllParticipants =
         getBuiltinBooleanFromNullable(dataSetRequest.getIncludesAllParticipants());

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -159,9 +159,11 @@ public class DataSetControllerTest {
   private static final String TEST_CDR_DATA_SET_ID = "synthetic_cdr20180606";
   private static final String TEST_CDR_TABLE = TEST_CDR_PROJECT_ID + "." + TEST_CDR_DATA_SET_ID;
   private static final String NAMED_PARAMETER_NAME = "p1_1";
-  private static final QueryParameterValue NAMED_PARAMETER_VALUE = QueryParameterValue.string("ICD9");
+  private static final QueryParameterValue NAMED_PARAMETER_VALUE =
+      QueryParameterValue.string("ICD9");
   private static final String NAMED_PARAMETER_ARRAY_NAME = "p2_1";
-  private static final QueryParameterValue NAMED_PARAMETER_ARRAY_VALUE = QueryParameterValue.array(new Integer[] {2, 5}, StandardSQLTypeName.INT64);
+  private static final QueryParameterValue NAMED_PARAMETER_ARRAY_VALUE =
+      QueryParameterValue.array(new Integer[] {2, 5}, StandardSQLTypeName.INT64);
 
   private Long COHORT_ONE_ID;
   private Long COHORT_TWO_ID;
@@ -546,7 +548,11 @@ public class DataSetControllerTest {
     when(cohortQueryBuilder.buildParticipantIdQuery(any()))
         .thenReturn(
             QueryJobConfiguration.newBuilder(
-                "SELECT * FROM person_id from `${projectId}.${dataSetId}.person` person WHERE @" + NAMED_PARAMETER_NAME + " IN unnest(@" + NAMED_PARAMETER_ARRAY_NAME + ")")
+                    "SELECT * FROM person_id from `${projectId}.${dataSetId}.person` person WHERE @"
+                        + NAMED_PARAMETER_NAME
+                        + " IN unnest(@"
+                        + NAMED_PARAMETER_ARRAY_NAME
+                        + ")")
                 .addNamedParameter(NAMED_PARAMETER_NAME, NAMED_PARAMETER_VALUE)
                 .addNamedParameter(NAMED_PARAMETER_ARRAY_NAME, NAMED_PARAMETER_ARRAY_VALUE)
                 .build());
@@ -722,7 +728,9 @@ public class DataSetControllerTest {
                 + "condition_source_concept_id IN (123)) \n"
                 + "AND (c_occurrence.PERSON_ID IN (SELECT * FROM person_id from `"
                 + TEST_CDR_TABLE
-                + ".person` person WHERE " + NAMED_PARAMETER_VALUE.getValue() + " IN (2, 5))) "
+                + ".person` person WHERE "
+                + NAMED_PARAMETER_VALUE.getValue()
+                + " IN (2, 5))) "
                 + "\n"
                 + "LIMIT \"\"\" + max_number_of_rows\n"
                 + "\n"
@@ -771,7 +779,9 @@ public class DataSetControllerTest {
                 + "condition_source_concept_id IN (123)) \n"
                 + "AND (c_occurrence.PERSON_ID IN (SELECT * FROM person_id from `"
                 + TEST_CDR_TABLE
-                + ".person` person WHERE " + NAMED_PARAMETER_VALUE.getValue() + " IN (2, 5))) \n"
+                + ".person` person WHERE "
+                + NAMED_PARAMETER_VALUE.getValue()
+                + " IN (2, 5))) \n"
                 + "LIMIT \", max_number_of_rows, sep=\"\")\n"
                 + "\n"
                 + prefix

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -787,7 +787,7 @@ public class DataSetControllerTest {
                 + prefix
                 + "df <- bq_table_download(bq_dataset_query(Sys.getenv(\"WORKSPACE_CDR\"), "
                 + prefix
-                + "sql, billing=Sys.getenv(\"GOOGLE_PROJECT\")))"
+                + "sql, billing=Sys.getenv(\"GOOGLE_PROJECT\")), bigint=\"integer64\")"
                 + "\n"
                 + "\n"
                 + "head("

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -703,7 +703,7 @@ public class DataSetControllerTest {
     String prefix = "dataset_00000000_condition_";
     assertThat(response.getCode())
         .isEqualTo(
-            "import pandas\n\n"
+            "import pandas\nimport os\n\n"
                 + "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n"
                 + "# If you increase the limit and run into responsiveness issues, please request a VM size upgrade.\n"
                 + "max_number_of_rows = '1000000'\n\n"
@@ -721,22 +721,9 @@ public class DataSetControllerTest {
                 + "LIMIT \"\"\" + max_number_of_rows\n"
                 + "\n"
                 + prefix
-                + "query_config = {\n"
-                + "  'query': {\n"
-                + "  'parameterMode': 'NAMED',\n"
-                + "  'queryParameters': [\n\n"
-                + "    ]\n"
-                + "  }\n"
-                + "}\n"
-                + "\n"
-                + "\n"
-                + "\n"
-                + prefix
                 + "df = pandas.read_gbq("
                 + prefix
-                + "sql, dialect=\"standard\", configuration="
-                + prefix
-                + "query_config)"
+                + "sql, dialect=\"standard\")"
                 + "\n"
                 + "\n"
                 + prefix
@@ -765,10 +752,7 @@ public class DataSetControllerTest {
     String prefix = "dataset_00000000_condition_";
     assertThat(response.getCode())
         .isEqualTo(
-            "require(devtools)\n"
-                + "devtools::install_github(\"rstudio/reticulate\", ref=\"00172079\")\n"
-                + "library(reticulate)\n"
-                + "pd <- reticulate::import(\"pandas\")\n\n"
+            "library(bigrquery)\n\n"
                 + "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n"
                 + "# If you increase the limit and run into responsiveness issues, please request a VM size upgrade.\n"
                 + "max_number_of_rows = '1000000'\n\n"
@@ -782,23 +766,12 @@ public class DataSetControllerTest {
                 + "AND (c_occurrence.PERSON_ID IN (SELECT * FROM person_id from `"
                 + TEST_CDR_TABLE
                 + ".person` person)) \n"
-                + "LIMIT \", max_number_of_rows)\n"
+                + "LIMIT \", max_number_of_rows, sep=\"\")\n"
                 + "\n"
                 + prefix
-                + "query_config <- list(\n"
-                + "  query = list(\n"
-                + "    parameterMode = 'NAMED',\n"
-                + "    queryParameters = list(\n\n"
-                + "    )\n"
-                + "  )\n"
-                + ")\n"
-                + "\n"
+                + "df <- bq_table_download(bq_dataset_query(Sys.getenv(\"WORKSPACE_CDR\"), "
                 + prefix
-                + "df <- pd$read_gbq("
-                + prefix
-                + "sql, dialect=\"standard\", configuration="
-                + prefix
-                + "query_config)"
+                + "sql, billing=Sys.getenv(\"GOOGLE_PROJECT\")))"
                 + "\n"
                 + "\n"
                 + "head("

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -1043,7 +1043,7 @@ public class DataSetControllerTest {
     mockLinkingTableQuery(tables);
 
     final Map<String, QueryJobConfiguration> result =
-        dataSetService.generateQueryJobConfigurationsByDomainName(dataSetRequest);
+        dataSetService.domainToBigQueryConfig(dataSetRequest);
     assertThat(result).isNotEmpty();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -125,7 +125,7 @@ public class DataSetServiceTest {
   @Test(expected = BadRequestException.class)
   public void testThrowsForNoCohortOrConcept() {
     final DataSetRequest invalidRequest = buildEmptyRequest();
-    dataSetServiceImpl.generateQueryJobConfigurationsByDomainName(invalidRequest);
+    dataSetServiceImpl.domainToBigQueryConfig(invalidRequest);
   }
 
   @Test


### PR DESCRIPTION
Description:
This adds cdr env variable support, moves us to bigrquery, and removes the named parameters section. This has been tested locally with cohorts with both list variables, variables with single values, and queries with no named parameters, in both R and Python


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
