### PR TITLE
[RW-4144][risk=no] Move the new VUMC billing account for new projects and for spending checks

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -17,7 +17,7 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "00293C_5DEA2D_6887E7",
+    "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-local1-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -17,9 +17,9 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "014D91-FCB792-33D2C0",
+    "accountId": "00293C_5DEA2D_6887E7",
     "projectNamePrefix": "aou-rw-local1-",
-    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
+    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
     "bufferCapacity": 2,
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -18,7 +18,7 @@
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-perf-",
-    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_00293C-5DEA2D-6887E7",
+    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 4,
     "bufferCapacity": 300,
     "bufferRefillProjectsPerTask": 5,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -16,7 +16,7 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "00293C_5DEA2D_6887E7",
+    "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -16,9 +16,9 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "015EAA-E95687-1F8614",
+    "accountId": "00293C_5DEA2D_6887E7",
     "projectNamePrefix": "aou-rw-",
-    "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.gcp_billing_export_v1_015EAA_E95687_1F8614",
+    "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,
     "bufferCapacity": 200,
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -16,9 +16,9 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "014D91-FCB792-33D2C0",
+    "accountId": "00293C_5DEA2D_6887E7",
     "projectNamePrefix": "aou-rw-stable-",
-    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
+    "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
     "bufferCapacity": 10,
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -16,7 +16,7 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "00293C_5DEA2D_6887E7",
+    "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-stable-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -16,9 +16,9 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "014D91-FCB792-33D2C0",
+    "accountId": "00293C_5DEA2D_6887E7",
     "projectNamePrefix": "aou-rw-staging-",
-    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
+    "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
     "bufferCapacity": 50,
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -16,7 +16,7 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "00293C_5DEA2D_6887E7",
+    "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-staging-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -17,9 +17,9 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "014D91-FCB792-33D2C0",
+    "accountId": "00293C_5DEA2D_6887E7",
     "projectNamePrefix": "aou-rw-test-",
-    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.gcp_billing_export_v1_014D91_FCB792_33D2C0",
+    "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
     "bufferCapacity": 100,
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -17,7 +17,7 @@
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {
-    "accountId": "00293C_5DEA2D_6887E7",
+    "accountId": "00293C-5DEA2D-6887E7",
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,


### PR DESCRIPTION
As this reaches each environment with the next release:
- Will run https://github.com/all-of-us/workbench-devops/pull/12
- Will run SQL to manually billing-unlock all workspaces