### PR TITLE
[risk=no] rm invalid JSON comments

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -1,4 +1,3 @@
-// Configuration for the local development environment.
 {
   "firecloud": {
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -1,4 +1,3 @@
-// Configuration for the all-of-us-workbench-test.
 {
   "firecloud": {
     "baseUrl": "https:\/\/firecloud-orchestration.dsde-dev.broadinstitute.org",


### PR DESCRIPTION
Comments are not a thing in JSON. Certain JSON parsing libraries, including `jq` CLI will choke on this.