### PR TITLE
[RW-3685][risk=low] Add a config variable controlling invitation key verification

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -293,6 +293,7 @@ sourceSets {
     runtimeClasspath += generated.output
   }
   test {
+    // Allow unit tests to directly load config files.
     resources {
       srcDir "config/"
     }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -293,6 +293,9 @@ sourceSets {
     runtimeClasspath += generated.output
   }
   test {
+    resources {
+      srcDir "config/"
+    }
     compileClasspath += generated.output
     runtimeClasspath += generated.output
   }

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -84,7 +84,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": true
+    "unsafeAllowSelfBypass": true,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -87,7 +87,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": true
+    "unsafeAllowSelfBypass": true,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -84,7 +84,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": false
+    "unsafeAllowSelfBypass": false,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -84,7 +84,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": false
+    "unsafeAllowSelfBypass": false,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -84,7 +84,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": false
+    "unsafeAllowSelfBypass": false,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -84,7 +84,8 @@
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,
-    "unsafeAllowSelfBypass": true
+    "unsafeAllowSelfBypass": true,
+    "requireInvitationKey": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -32,6 +32,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableBillingLockout(config.featureFlags.enableBillingLockout)
             .firecloudURL(config.firecloud.baseUrl)
             .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
-            .enableNewAccountCreation(config.featureFlags.enableNewAccountCreation));
+            .enableNewAccountCreation(config.featureFlags.enableNewAccountCreation)
+            .requireInvitationKey(config.access.requireInvitationKey));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -311,7 +311,10 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<Profile> createAccount(CreateAccountRequest request) {
-    verifyInvitationKey(request.getInvitationKey());
+    if (workbenchConfigProvider.get().access.requireInvitationKey) {
+      verifyInvitationKey(request.getInvitationKey());
+    }
+
     String userName = request.getProfile().getUsername();
     if (userName == null || userName.length() < 3 || userName.length() > 64)
       throw new BadRequestException(

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2450,6 +2450,10 @@ definitions:
         type: boolean
         default: false
         description: Feature flag for collecting new demographics & TOS acknowledgement on user creation.
+      requireInvitationKey:
+        type: boolean
+        default: false
+        description: Whether the current environment requires an invitation key for signup.
 
   FeaturedWorkspacesConfigResponse:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
-public class BaseControllerTest {
+public abstract class BaseControllerTest {
 
   protected static WorkbenchConfig config;
 

--- a/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
@@ -17,6 +17,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
 
+/**
+ * A base class for functionality shared by many controller-level tests in the Workbench.
+ *
+ * <p>This class currently provides a simple way for test cases to use and modify the
+ * WorkbenchConfig, for testing differential controller behavior depending on the environment
+ * configuration.
+ *
+ * <p>Most or all controller tests should eventually extend this class, but adoption may proceed
+ * incrementally to avoid a large one-time refactoring cost.
+ *
+ * <p>This class is heavily inspired by the BaseIntegrationTest class; maybe there is some way for
+ * these two classes to share a common core, since they both care mostly about WorkbenchConfig bean
+ * management for tests.
+ *
+ * <p>TODO(RW-4443): update all controller tests to extend this class.
+ */
 @RunWith(SpringRunner.class)
 @DataJpaTest
 public abstract class BaseControllerTest {

--- a/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
@@ -1,25 +1,25 @@
-package org.pmiops.workbench;
+package org.pmiops.workbench.api;
 
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Random;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.test.FakeLongRandom;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringRunner.class)
-@WebAppConfiguration
-@Import({IntegrationTestConfig.class})
-public abstract class BaseIntegrationTest {
+@DataJpaTest
+public class BaseControllerTest {
 
   protected static WorkbenchConfig config;
 
@@ -32,6 +32,11 @@ public abstract class BaseIntegrationTest {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     WorkbenchConfig getIntegrationTestConfig() throws IOException {
       return config;
+    }
+
+    @Bean
+    Random random() {
+      return new FakeLongRandom(123);
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -126,6 +126,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Import({UserServiceImpl.class, ProfileService.class, ProfileController.class})
   static class Configuration {
     @Bean
+    @Primary
     Clock clock() {
       return fakeClock;
     }
@@ -502,6 +503,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test(expected = BadRequestException.class)
   public void updateCurrentPosition_badRequest() throws Exception {
+    // Server-side verification for this field is only used for old-style account creation.
     config.featureFlags.enableNewAccountCreation = false;
     createUser();
     Profile profile = profileController.getMe().getBody();
@@ -511,6 +513,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test(expected = BadRequestException.class)
   public void updateOrganization_badRequest() throws Exception {
+    // Server-side verification for this field is only used for old-style account creation.
     config.featureFlags.enableNewAccountCreation = false;
     createUser();
     Profile profile = profileController.getMe().getBody();

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -660,8 +660,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(user.getFamilyName()).isEqualTo(familyName);
     assertThat(user.getGivenName()).isEqualTo(givenName);
     assertThat(user.getDataAccessLevelEnum()).isEqualTo(dataAccessLevel);
-    assertThat(user.getFirstSignInTime().getTime()).isEqualTo(firstSignInTime.getTime());
-    // assertThat(user.getFirstSignInTime()).isEqualTo(firstSignInTime);
+    assertThat(user.getFirstSignInTime()).isEqualTo(firstSignInTime);
     assertThat(user.getDataAccessLevelEnum()).isEqualTo(dataAccessLevel);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -16,7 +16,6 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import javax.mail.MessagingException;
@@ -155,6 +154,8 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void setUp() throws IOException {
     super.setUp();
 
+    fakeClock.setInstant(NOW);
+
     Profile profile = new Profile();
     profile.setContactEmail(CONTACT_EMAIL);
     profile.setFamilyName(FAMILY_NAME);
@@ -278,7 +279,6 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Test
   public void testMe_success() throws Exception {
     createUser();
-
     Profile profile = profileController.getMe().getBody();
     assertProfile(
         profile,
@@ -419,7 +419,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Test
   public void updateContactEmail_forbidden() throws Exception {
     createUser();
-    dbUser.setFirstSignInTime(new Timestamp(new Date().getTime()));
+    dbUser.setFirstSignInTime(TIMESTAMP);
     String originalEmail = dbUser.getContactEmail();
 
     ResponseEntity<Void> response =
@@ -660,7 +660,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(user.getFamilyName()).isEqualTo(familyName);
     assertThat(user.getGivenName()).isEqualTo(givenName);
     assertThat(user.getDataAccessLevelEnum()).isEqualTo(dataAccessLevel);
-    assertThat(user.getFirstSignInTime()).isEqualTo(firstSignInTime);
+    assertThat(user.getFirstSignInTime().getTime()).isEqualTo(firstSignInTime.getTime());
+    // assertThat(user.getFirstSignInTime()).isEqualTo(firstSignInTime);
     assertThat(user.getDataAccessLevelEnum()).isEqualTo(dataAccessLevel);
   }
 }

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -190,6 +190,9 @@ public class WorkbenchConfig {
     // Allows a user to bypass their own access modules. This is used for testing purposes so that
     // We can give control over 3rd party access modules
     public boolean unsafeAllowSelfBypass;
+    // Controls whether an invitation key is required for a given environment.
+    public boolean requireInvitationKey;
+    // These booleans control whether each of our core access modules are enabled per environment.
     public boolean enableComplianceTraining;
     public boolean enableEraCommons;
     public boolean enableDataUseAgreement;

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -184,19 +184,21 @@ public class WorkbenchConfig {
     public String host;
   }
 
-  // The access object specifies whether each of the following access requirements block access
-  // to the workbench.
+  // Config related to user sign-up and registration, including access modules and controls around
+  // the sign-up flow.
   public static class AccessConfig {
     // Allows a user to bypass their own access modules. This is used for testing purposes so that
     // We can give control over 3rd party access modules
     public boolean unsafeAllowSelfBypass;
-    // Controls whether an invitation key is required for a given environment.
-    public boolean requireInvitationKey;
     // These booleans control whether each of our core access modules are enabled per environment.
     public boolean enableComplianceTraining;
     public boolean enableEraCommons;
     public boolean enableDataUseAgreement;
     public boolean enableBetaAccess;
+    // Controls whether an invitation key is required for user creation. When true, the account
+    // creation UI will show an invitation key form, and the server-side will valide the key before
+    // proceeding.
+    public boolean requireInvitationKey;
   }
 
   public static class CohortBuilderConfig {

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -196,7 +196,7 @@ public class WorkbenchConfig {
     public boolean enableDataUseAgreement;
     public boolean enableBetaAccess;
     // Controls whether an invitation key is required for user creation. When true, the account
-    // creation UI will show an invitation key form, and the server-side will valide the key before
+    // creation UI will show an invitation key form and the server will validate the key before
     // proceeding.
     public boolean requireInvitationKey;
   }

--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -20,6 +20,8 @@ describe('SignInReact', () => {
 
   const component = () => mount(<SignInReact {...props}/>);
 
+  // To correctly shallow-render this component wrapped by two HOCs, we need to add two extra
+  // .shallow() calls at the end.
   const shallowComponent = () => shallow(<SignInReact {...props}/>).shallow().shallow();
 
   const defaultConfig = {
@@ -78,8 +80,6 @@ describe('SignInReact', () => {
   });
 
   it('should handle sign-up flow for legacy account creation', () => {
-    // To correctly shallow-render this component wrapped by two HOCs, we need to add two extra
-    // .shallow() calls at the end.
     const wrapper = shallowComponent();
 
     // To start, the landing page / login component should be shown.
@@ -101,8 +101,6 @@ describe('SignInReact', () => {
   it('should handle sign-up flow for new account creation', () => {
     props.serverConfig = {...defaultConfig, enableNewAccountCreation: true};
 
-    // To correctly shallow-render this component wrapped by two HOCs, we need to add two extra
-    // .shallow() calls at the end.
     const wrapper = shallowComponent();
 
     // To start, the landing page / login component should be shown.

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -192,22 +192,27 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
    * Made visible for ease of unit-testing.
    */
   public getAccountCreationSteps(): Array<SignInStep> {
-    let steps = [
-      SignInStep.LANDING,
-      SignInStep.INVITATION_KEY,
-      SignInStep.TERMS_OF_SERVICE,
-      SignInStep.ACCOUNT_CREATION,
-      SignInStep.DEMOGRAPHIC_SURVEY,
-      SignInStep.SUCCESS_PAGE
-    ];
-
     const {enableNewAccountCreation, requireInvitationKey} = this.props.serverConfig;
 
-    if (!enableNewAccountCreation) {
-      steps = fp.remove(step => {
-        return [SignInStep.TERMS_OF_SERVICE, SignInStep.DEMOGRAPHIC_SURVEY].includes(step);
-      }, steps);
+    let steps: Array<SignInStep>;
+    if (enableNewAccountCreation) {
+      steps = [
+        SignInStep.LANDING,
+        SignInStep.INVITATION_KEY,
+        SignInStep.TERMS_OF_SERVICE,
+        SignInStep.ACCOUNT_CREATION,
+        SignInStep.DEMOGRAPHIC_SURVEY,
+        SignInStep.SUCCESS_PAGE
+      ];
+    } else {
+      steps = [
+        SignInStep.LANDING,
+        SignInStep.INVITATION_KEY,
+        SignInStep.ACCOUNT_CREATION,
+        SignInStep.SUCCESS_PAGE
+      ];
     }
+
     if (!requireInvitationKey) {
       steps = fp.remove(step => step === SignInStep.INVITATION_KEY, steps);
     }

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -75,7 +75,7 @@ const styles = reactStyles({
 
 // Tracks each major stage in the sign-in / sign-up flow. Most of the steps are related to new
 // account creation.
-enum SignInStep {
+export enum SignInStep {
   // Landing page. User can choose to sign in or create an account.
   LANDING,
   // Interstitial step, where a user must enter their invitation key.
@@ -127,127 +127,177 @@ interface SignInState {
   termsOfServiceVersion?: number;
 }
 
-export const SignInReact = fp.flow(withServerConfig(), withWindowSize())(
-  class extends React.Component<SignInProps, SignInState> {
+/**
+ * The inner / implementation SignIn component. This class should only be rendered via the
+ * SignInReact method, which wraps this with the expected higher-order components.
+ */
+export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
 
-    constructor(props: SignInProps) {
-      super(props);
-      this.state = {
-        currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
-        invitationKey: null,
-        termsOfServiceVersion: null,
-        // This defines the profile state for a new user flow. This will get passed to each
-        // step component as a prop. When each sub-step completes, it will pass the updated Profile
-        // data in its onComplete callback.
-        profile: this.createEmptyProfile()
-      };
-    }
+  constructor(props: SignInProps) {
+    super(props);
+    this.state = {
+      currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
+      invitationKey: null,
+      termsOfServiceVersion: null,
+      // This defines the profile state for a new user flow. This will get passed to each
+      // step component as a prop. When each sub-step completes, it will pass the updated Profile
+      // data in its onComplete callback.
+      profile: this.createEmptyProfile()
+    };
+  }
 
-    createEmptyProfile(): Profile {
-      return {
-        // Note: We abuse the "username" field here by omitting "@domain.org". After
-        // profile creation, this field is populated with the full email address.
-        username: '',
-        dataAccessLevel: DataAccessLevel.Unregistered,
-        givenName: '',
-        familyName: '',
-        contactEmail: '',
-        currentPosition: '',
-        organization: '',
-        areaOfResearch: '',
-        address: {
-          streetAddress1: '',
-          streetAddress2: '',
-          city: '',
-          state: '',
-          country: '',
-          zipCode: '',
+  private createEmptyProfile(): Profile {
+    return {
+      // Note: We abuse the "username" field here by omitting "@domain.org". After
+      // profile creation, this field is populated with the full email address.
+      username: '',
+      dataAccessLevel: DataAccessLevel.Unregistered,
+      givenName: '',
+      familyName: '',
+      contactEmail: '',
+      currentPosition: '',
+      organization: '',
+      areaOfResearch: '',
+      address: {
+        streetAddress1: '',
+        streetAddress2: '',
+        city: '',
+        state: '',
+        country: '',
+        zipCode: '',
+      },
+      institutionalAffiliations: [
+        // We only allow entering a single institutional affiliation from the create account
+        // page, so we pre-fill a single empty entry which will be bound to the AccountCreation
+        // form.
+        {
+          institution: undefined,
+          nonAcademicAffiliation: undefined,
+          role: undefined,
         },
-        institutionalAffiliations: [
-          // We only allow entering a single institutional affiliation from the create account
-          // page, so we pre-fill a single empty entry which will be bound to the AccountCreation
-          // form.
-          {
-            institution: undefined,
-            nonAcademicAffiliation: undefined,
-            role: undefined,
-          },
-        ],
-        demographicSurvey: {},
-        degrees: [] as Degree[],
-      };
+      ],
+      demographicSurvey: {},
+      degrees: [] as Degree[],
+    };
+  }
+
+  componentDidMount() {
+    document.body.style.backgroundColor = colors.light;
+    this.props.onInit();
+  }
+
+  /**
+   * Creates the appropriate set of steps based on the server-side config.
+   *
+   * Made visible for ease of unit-testing.
+   */
+  public getAccountCreationSteps(): Array<SignInStep> {
+    let steps = [
+      SignInStep.LANDING,
+      SignInStep.INVITATION_KEY,
+      SignInStep.TERMS_OF_SERVICE,
+      SignInStep.ACCOUNT_CREATION,
+      SignInStep.DEMOGRAPHIC_SURVEY,
+      SignInStep.SUCCESS_PAGE
+    ];
+
+    const {enableNewAccountCreation, requireInvitationKey} = this.props.serverConfig;
+
+    if (!enableNewAccountCreation) {
+      steps = fp.remove(step => {
+        return [SignInStep.TERMS_OF_SERVICE, SignInStep.DEMOGRAPHIC_SURVEY].includes(step);
+      }, steps);
     }
-
-    componentDidMount() {
-      document.body.style.backgroundColor = colors.light;
-      this.props.onInit();
+    if (!requireInvitationKey) {
+      steps = fp.remove(step => step === SignInStep.INVITATION_KEY, steps);
     }
+    return steps;
+  }
 
-    renderSignInStep(currentStep: SignInStep) {
-      const {enableNewAccountCreation} = this.props.serverConfig;
+  private getNextStep(currentStep: SignInStep) {
+    const steps = this.getAccountCreationSteps();
+    const index = steps.indexOf(currentStep);
+    if (index === -1) {
+      throw new Error('Unexpected sign-in step: ' + currentStep);
+    }
+    if (index === steps.length) {
+      throw new Error('No sign-in steps remaining after step ' + currentStep);
+    }
+    return steps[index + 1];
+  }
 
-      switch (currentStep) {
-        case SignInStep.LANDING:
-          return <LoginReactComponent signIn={this.props.signIn} onCreateAccount={() =>
-            this.setState({
-              currentStep: SignInStep.INVITATION_KEY
-            })}/>;
-        case SignInStep.INVITATION_KEY:
-          return <InvitationKey onInvitationKeyVerified={(key: string) => this.setState({
-            invitationKey: key,
-            // We skip over TERMS_OF_SERVICE if new-style account creation isn't enabled.
-            currentStep: enableNewAccountCreation ? SignInStep.TERMS_OF_SERVICE : SignInStep.ACCOUNT_CREATION
+  private getPreviousStep(currentStep: SignInStep) {
+    const steps = this.getAccountCreationSteps();
+    const index = steps.indexOf(currentStep);
+    if (index === -1) {
+      throw new Error('Unexpected sign-in step: ' + currentStep);
+    }
+    if (index === 0) {
+      throw new Error('No sign-in steps before step ' + currentStep);
+    }
+    return steps[index - 1];
+  }
+
+  private renderSignInStep(currentStep: SignInStep) {
+    switch (currentStep) {
+      case SignInStep.LANDING:
+        return <LoginReactComponent signIn={this.props.signIn} onCreateAccount={() =>
+          this.setState({
+            currentStep: this.getNextStep(currentStep)
           })}/>;
-        case SignInStep.TERMS_OF_SERVICE:
-          return <AccountCreationTos
-            pdfPath='/assets/documents/terms of service (draft).pdf'
-            onComplete={() => this.setState({
-              termsOfServiceVersion: 1,
-              currentStep: SignInStep.ACCOUNT_CREATION
-            })}/>;
-        case SignInStep.ACCOUNT_CREATION:
-          return <AccountCreation invitationKey={this.state.invitationKey}
-                                  profile={this.state.profile}
-                                  onComplete={(profile: Profile) => this.setState({
-                                    profile: profile,
-                                    // Skip over the demographic survey if new-style form isn't enabled.
-                                    currentStep: enableNewAccountCreation ? SignInStep.DEMOGRAPHIC_SURVEY :
-                                      SignInStep.SUCCESS_PAGE
-                                  })}/>;
-        case SignInStep.DEMOGRAPHIC_SURVEY:
-          return <AccountCreationSurvey
-            profile={this.state.profile}
-            invitationKey={this.state.invitationKey}
-            termsOfServiceVersion={this.state.termsOfServiceVersion}
-            onComplete={(profile: Profile) => this.setState({
-              profile: profile,
-              currentStep: SignInStep.SUCCESS_PAGE
-            })}
-            onPreviousClick={(profile: Profile) => this.setState({
-              profile: profile,
-              currentStep: SignInStep.ACCOUNT_CREATION
-            })}/>;
-        case SignInStep.SUCCESS_PAGE:
-          return <AccountCreationSuccess profile={this.state.profile}/>;
-        default:
-          return;
-      }
+      case SignInStep.INVITATION_KEY:
+        return <InvitationKey onInvitationKeyVerified={(key: string) => this.setState({
+          invitationKey: key,
+          currentStep: this.getNextStep(currentStep)
+        })}/>;
+      case SignInStep.TERMS_OF_SERVICE:
+        return <AccountCreationTos
+          pdfPath='/assets/documents/terms of service (draft).pdf'
+          onComplete={() => this.setState({
+            termsOfServiceVersion: 1,
+            currentStep: this.getNextStep(currentStep)
+          })}/>;
+      case SignInStep.ACCOUNT_CREATION:
+        return <AccountCreation invitationKey={this.state.invitationKey}
+                                profile={this.state.profile}
+                                onComplete={(profile: Profile) => this.setState({
+                                  profile: profile,
+                                  currentStep: this.getNextStep(currentStep)
+                                })}/>;
+      case SignInStep.DEMOGRAPHIC_SURVEY:
+        return <AccountCreationSurvey
+          profile={this.state.profile}
+          invitationKey={this.state.invitationKey}
+          termsOfServiceVersion={this.state.termsOfServiceVersion}
+          onComplete={(profile: Profile) => this.setState({
+            profile: profile,
+            currentStep: this.getNextStep(currentStep)
+          })}
+          onPreviousClick={(profile: Profile) => this.setState({
+            profile: profile,
+            currentStep: this.getPreviousStep(currentStep)
+          })}/>;
+      case SignInStep.SUCCESS_PAGE:
+        return <AccountCreationSuccess profile={this.state.profile}/>;
+      default:
+        return;
     }
+  }
 
-    render() {
-      const backgroundImages = StepToImageConfig.get(this.state.currentStep);
-      return <FlexColumn style={styles.signInContainer} data-test-id='sign-in-container'>
-        <FlexColumn data-test-id='sign-in-page'
-             style={backgroundStyleTemplate(this.props.windowSize, backgroundImages)}>
-          <div><img style={{height: '1.75rem', marginLeft: '1rem', marginTop: '1rem'}}
-                    src={HEADER_IMAGE}/></div>
-          {this.renderSignInStep(this.state.currentStep)}
-        </FlexColumn>
-      </FlexColumn>;
-    }
-  });
+  render() {
+    const backgroundImages = StepToImageConfig.get(this.state.currentStep);
+    return <FlexColumn style={styles.signInContainer} data-test-id='sign-in-container'>
+      <FlexColumn data-test-id='sign-in-page'
+                  style={backgroundStyleTemplate(this.props.windowSize, backgroundImages)}>
+        <div><img style={{height: '1.75rem', marginLeft: '1rem', marginTop: '1rem'}}
+                  src={HEADER_IMAGE}/></div>
+        {this.renderSignInStep(this.state.currentStep)}
+      </FlexColumn>
+    </FlexColumn>;
+  }
+}
 
-export default SignInReact;
+export const SignInReact = fp.flow(withServerConfig(), withWindowSize())(SignInReactImpl);
 
 @Component({
   template: '<div #root></div>'


### PR DESCRIPTION
In prep for launch, this PR adds a new config variable requireVerificationKey which controls the frontend & backend components which require a verification key to be input by users. When this is off, the frontend will not collect an invitation key & the backend will not verify it.

A few notes:

**Jira ticket**
I'm attaching this to the broader "enable feature flag for registration pages" issue, since it's thematically related and this is one more step on the way towards enabling that flag.

**Environment var vs. feature flag**
I'm modeling this flag as an "access" config variable rather than a feature flag, since we may wish to control access with an invitation key in lower environments (such as preprod) even once this is opened up in prod. Feature flags should have an expectation that they will be removed at some point in the future, which doesn't fit here.

**Controller tests**
I also took the opportunity to try and quickly clean up the ProfileControllerTest a bit. This was initially motivated by a desire to more easily change the WorkbenchConfig for individual test cases. I made two major changes: (1) create a BaseControllerTest class (similar to what I'd done in https://github.com/all-of-us/workbench/blob/master/api/src/integration/java/org/pmiops/workbench/BaseIntegrationTest.java), and (2) remove explicit constructors in favor of @Autowired and @MockBean. I think this came out a little cleaner on the other side, though it does add some extra weight to the PR – apologies!

**UI tests**
On the UI side, I had a bit of "fun" trying to find a way to gain access to the inner React component from Enzyme. First off, with higher-order components and shallow rendering, you need to make a few extra calls to shallow() to ensure the inner component gets rendered. Secondly, the core component was originally an anonymous inner class, which didn't allow me to call its public methods from the Enzyme test. This was fixed by bumping the class up to the top-level and exporting it – a pattern that we may want to use elsewhere.

---
**PR checklist**

- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [X] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers