### PR TITLE
[RW-4422][risk=no] Keep sidebar from closing when navigating participants in review

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -62,10 +62,12 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
     this.setHelpContent();
     this.subscriptions.push(
       this.router.events.filter(event => event instanceof NavigationEnd)
-        .subscribe(event => {
+        .subscribe(() => {
           this.tabPath = this.getTabPath();
           this.setHelpContent();
-          this.sidebarOpen = false;
+          if (this.helpContent !== 'reviewParticipantDetail') {
+            this.sidebarOpen = false;
+          }
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.displayNavBar = !minimizeChrome;


### PR DESCRIPTION
The help tips sidebar closes when the route changes, but on route changes caused by navigating between participants in cohort review, we want it so stay open if it's already open so the annotations UI is still available.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
