### PR TITLE
[risk=no] Fix to allow compilation of the UI after wiping node_modules and yarn.lock

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -72,7 +72,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
-    "@types/color": "^3.0.0",
+    "@types/color": "3.0.0",
     "@types/core-js": "^2.5.0",
     "@types/geojson": "^1.0.6",
     "@types/js-cookie": "^2.2.2",

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import * as ReactModal from 'react-modal';
 
 import colors from 'app/styles/colors';
-import {withStyle} from 'app/utils/index';
+import {reactStyles, withStyle} from 'app/utils/index';
 import {SpinnerOverlay} from './spinners';
 
-const styles = {
+const styles = reactStyles({
   modal: {
     borderRadius: 8, position: 'relative',
     padding: '1rem', margin: 'auto', outline: 'none',
@@ -14,7 +14,7 @@ const styles = {
   },
 
   overlay: {
-    backgroundColor: Color(colors.dark).alpha(0.85), padding: '1rem', display: 'flex',
+    backgroundColor: Color(colors.dark).alpha(0.85).toString(), padding: '1rem', display: 'flex',
     position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
   },
 
@@ -38,7 +38,7 @@ const styles = {
     justifyContent: 'flex-end' as 'flex-end',
     marginTop: '1rem'
   }
-};
+});
 
 export const Modal = ({width = 450, loading = false, ...props}) => {
   return <ReactModal

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -483,9 +483,10 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
 
-"@types/color@^3.0.0":
+"@types/color@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.0.tgz#40f8a6bf2fd86e969876b339a837d8ff1b0a6e30"
+  integrity sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==
   dependencies:
     "@types/color-convert" "*"
 


### PR DESCRIPTION
Description:
`@types/color` has a bug in version 3.0.1 if you use a version of Typescript older than 3.7, which we do: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41612.

I also saw an error along the lines of "cannot convert Color to string" so I updated that line as well.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
