### PR TITLE
[RW-4437][risk=no] Track sidebar state in local storage

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -404,11 +404,12 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile())(
           {icons.map((icon, i) => (!icon.page || icon.page === helpContent) && <div key={i} style={{display: 'table'}}>
             <TooltipTrigger content={<div>{tooltipId === i && icon.tooltip}</div>} side='left'>
               <div style={activeIcon === icon.id ? iconStyles.active : icon.disabled ? iconStyles.disabled : styles.icon}
+                   onClick={() => this.onIconClick(icon)}
                    onMouseOver={() => this.setState({tooltipId: i})}
                    onMouseOut={() => this.setState({tooltipId: undefined})}>
                 {icon.faIcon === null
                   ? <img src={proIcons[icon.id]} style={icon.style} />
-                  : <FontAwesomeIcon icon={icon.faIcon} style={icon.style} onClick={() => this.onIconClick(icon)} />
+                  : <FontAwesomeIcon icon={icon.faIcon} style={icon.style} />
                 }
               </div>
             </TooltipTrigger>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -32,7 +32,7 @@ const styles = reactStyles({
     right: 0,
     height: 'calc(100% - 60px)',
     minHeight: 'calc(100vh - 156px)',
-    width: 'calc(14rem + 45px)',
+    width: 'calc(14rem + 55px)',
     overflow: 'hidden',
     color: colors.primary,
     zIndex: -1,
@@ -49,7 +49,8 @@ const styles = reactStyles({
     overflow: 'auto',
     marginRight: 'calc(-14rem - 40px)',
     background: colorWithWhiteness(colors.primary, .87),
-    transition: 'margin-right 0.5s ease-out'
+    transition: 'margin-right 0.5s ease-out',
+    boxShadow: `-10px 0px 10px -8px ${colorWithWhiteness(colors.dark, .5)}`,
   },
   sidebarOpen: {
     marginRight: 0,

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -16,6 +16,8 @@ import {
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {ResourceType, UserRole, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
 
+const LOCAL_STORAGE_KEY_SIDEBAR_STATE = 'WORKSPACE_SIDEBAR_STATE';
+
 @Component({
   styleUrls: ['../../../styles/buttons.css',
     '../../../styles/headers.css'],
@@ -58,11 +60,12 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    if (!!localStorage.getItem('sidebarState')) {
-      this.sidebarOpen = localStorage.getItem('sidebarState') === 'open';
+    const sidebarState = localStorage.getItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE);
+    if (!!sidebarState) {
+      this.sidebarOpen = sidebarState === 'open';
     } else {
-      this.sidebarOpen = true;
-      localStorage.setItem('sidebarState', 'open');
+      // Default the sidebar to open if no localStorage value is set
+      this.setSidebarState(true);
     }
     this.tabPath = this.getTabPath();
     this.setHelpContent();
@@ -71,9 +74,9 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         .subscribe(() => {
           this.tabPath = this.getTabPath();
           this.setHelpContent();
+          // Close sidebar on route change unless navigating between participants in cohort review
           if (this.helpContent !== 'reviewParticipantDetail') {
-            this.sidebarOpen = false;
-            localStorage.setItem('sidebarState', 'closed');
+            this.setSidebarState(false);
           }
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
@@ -225,6 +228,6 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   setSidebarState = (sidebarOpen: boolean) => {
     this.sidebarOpen = sidebarOpen;
     const sidebarState = sidebarOpen ? 'open' : 'closed';
-    localStorage.setItem('sidebarState', sidebarState);
+    localStorage.setItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE, sidebarState);
   }
 }

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -38,7 +38,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   resourceType: ResourceType = ResourceType.WORKSPACE;
   userRoles?: UserRole[];
   helpContent = 'data';
-  sidebarOpen = true;
+  sidebarOpen = false;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -58,6 +58,12 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    if (!!localStorage.getItem('sidebarState')) {
+      this.sidebarOpen = localStorage.getItem('sidebarState') === 'open';
+    } else {
+      this.sidebarOpen = true;
+      localStorage.setItem('sidebarState', 'open');
+    }
     this.tabPath = this.getTabPath();
     this.setHelpContent();
     this.subscriptions.push(
@@ -67,6 +73,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
           this.setHelpContent();
           if (this.helpContent !== 'reviewParticipantDetail') {
             this.sidebarOpen = false;
+            localStorage.setItem('sidebarState', 'closed');
           }
         }));
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
@@ -217,5 +224,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
 
   setSidebarState = (sidebarOpen: boolean) => {
     this.sidebarOpen = sidebarOpen;
+    const sidebarState = sidebarOpen ? 'open' : 'closed';
+    localStorage.setItem('sidebarState', sidebarState);
   }
 }


### PR DESCRIPTION
Creates a local storage item to indicate whether the sidebar is open or closed. This way, the sidebar is open automatically only the first time a user logs in and enters a workspace. If the user re-enters a workspace or refreshes the page, it will get the sidebar state from local storage.

Also added a box-shadow in the sidebar so it's clearer that there is content being covered up.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
