### PR TITLE
[RW-3895][Risk=no] Change error message for dataset builder preview

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -155,6 +155,8 @@ export const styles = reactStyles({
     flexDirection: 'column',
     alignItems: 'center',
     height: '10rem',
+    width: '40rem',
+    alignSelf: 'center',
     marginTop: '2rem',
     fontSize: 18,
     fontWeight: 600,
@@ -811,9 +813,12 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
           return <div>The preview table cannot be loaded because the query took too long to run.
             Please export this Dataset to a Notebook by clicking the Analyze button.</div>;
         default:
-          return <div>An unexpected error has occurred while running your Dataset query.
-            Please <Link style={{display: 'inline-block'}} onClick={() => this.openZendeskWidget()}>
-              create a bug report</Link> for our team.</div>;
+          return <div>
+            The preview table could not be loaded. Please try again by clicking the ‘View Preview Table’ as
+            some queries take longer to load. If the error keeps happening, please <Link style={{
+              display: 'inline-block'}} onClick={() => this.openZendeskWidget()}>contact us</Link>. You can also export
+            your dataset directly for analysis by clicking the ‘Analyze’ button, without viewing the preview table.
+          </div>;
       }
     }
 

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -190,6 +190,13 @@ export const styles = reactStyles({
     bottom: '0',
     height: '60px',
     width: '100%'
+  },
+  errorMessage: {
+    backgroundColor: colorWithWhiteness(colors.highlight, .5),
+    color: colors.primary,
+    fontSize: '12px',
+    padding: '0.5rem',
+    borderRadius: '0.5em'
   }
 });
 
@@ -813,12 +820,24 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
           return <div>The preview table cannot be loaded because the query took too long to run.
             Please export this Dataset to a Notebook by clicking the Analyze button.</div>;
         default:
-          return <div>
-            The preview table could not be loaded. Please try again by clicking the ‘View Preview Table’ as
-            some queries take longer to load. If the error keeps happening, please <Link style={{
-              display: 'inline-block'}} onClick={() => this.openZendeskWidget()}>contact us</Link>. You can also export
-            your dataset directly for analysis by clicking the ‘Analyze’ button, without viewing the preview table.
-          </div>;
+          return <FlexRow style={styles.errorMessage}>
+            <ClrIcon
+              shape={'warning-standard'}
+              class={'is-solid'}
+              size={26}
+              style={{
+                color: colors.warning,
+                flex: '0 0 auto'
+              }}
+            />
+            <div style={{paddingLeft: '0.25rem'}}>
+              The preview table could not be loaded. Please try again by clicking the ‘View Preview Table’ as
+              some queries take longer to load. If the error keeps happening, please <Link style={{
+                display: 'inline-block'}} onClick={() => this.openZendeskWidget()}>contact us</Link>. You can also
+              export your dataset directly for analysis by clicking the ‘Analyze’ button, without viewing the preview
+              table.
+            </div>
+          </FlexRow>;
       }
     }
 


### PR DESCRIPTION
Description:
This changes the error message for the dataset builder preview. It also adds a width to the message, otherwise it spreads across the entire page. 
<img width="1823" alt="Screen Shot 2020-02-13 at 11 53 23 AM" src="https://user-images.githubusercontent.com/15351021/74458380-9d83c000-4e57-11ea-8f05-77327dd5c57a.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
