### PR TITLE
[risk=no] A grab bag of small refactorings while doing other work

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -505,7 +505,8 @@ Common.register_command({
 
 def connect_to_db()
   common = Common.new
-
+  common.status "Starting database if necessary..."
+  common.run_inline %W{docker-compose up -d db}
   cmd = "MYSQL_PWD=root-notasecret mysql --database=workbench"
   common.run_inline %W{docker-compose exec db sh -c #{cmd}}
 end

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -580,6 +580,18 @@ public class ProfileController implements ProfileApiDelegate {
       // See RW-1488.
       throw new BadRequestException("Changing email is not currently supported");
     }
+    updateInstitutionalAffiliations(updatedProfile, user);
+
+    // This does not update the name in Google.
+    saveUserWithConflictHandling(user);
+
+    final Profile appliedUpdatedProfile = profileService.getProfile(user);
+    profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile);
+
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  private void updateInstitutionalAffiliations(Profile updatedProfile, DbUser user) {
     List<DbInstitutionalAffiliation> newAffiliations =
         updatedProfile.getInstitutionalAffiliations().stream()
             .map(FROM_CLIENT_INSTITUTIONAL_AFFILIATION)
@@ -614,14 +626,6 @@ public class ProfileController implements ProfileApiDelegate {
         user.addInstitutionalAffiliation(affiliation);
       }
     }
-
-    // This does not update the name in Google.
-    saveUserWithConflictHandling(user);
-
-    final Profile appliedUpdatedProfile = profileService.getProfile(user);
-    profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile);
-
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
+import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
@@ -17,8 +18,8 @@ public interface UserService {
 
   DbUser createServiceAccountUser(String email);
 
-  // minimal version used by AuthInterceptor
-  DbUser createUser(String givenName, String familyName, String userName);
+  // version used by AuthInterceptor
+  DbUser createUser(Userinfoplus oAuth2Userinfo);
 
   DbUser createUser(
       String givenName,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -17,19 +17,13 @@ public interface UserService {
 
   DbUser createServiceAccountUser(String email);
 
-  DbUser createUser(
-      String givenName,
-      String familyName,
-      String email,
-      String contactEmail,
-      String currentPosition,
-      String organization,
-      String areaOfResearch);
+  // minimal version used by AuthInterceptor
+  DbUser createUser(String givenName, String familyName, String userName);
 
   DbUser createUser(
       String givenName,
       String familyName,
-      String email,
+      String userName,
       String contactEmail,
       String currentPosition,
       String organization,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.services.oauth2.model.Userinfoplus;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -290,9 +291,20 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public DbUser createUser(String givenName, String familyName, String userName) {
+  public DbUser createUser(final Userinfoplus oAuth2Userinfo) {
     return createUser(
-        givenName, familyName, userName, null, null, null, null, null, null, null, null, null);
+        oAuth2Userinfo.getGivenName(),
+        oAuth2Userinfo.getFamilyName(),
+        oAuth2Userinfo.getEmail(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -290,27 +290,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public DbUser createUser(
-      String givenName,
-      String familyName,
-      String userName,
-      String contactEmail,
-      String currentPosition,
-      String organization,
-      String areaOfResearch) {
+  public DbUser createUser(String givenName, String familyName, String userName) {
     return createUser(
-        givenName,
-        familyName,
-        userName,
-        contactEmail,
-        currentPosition,
-        organization,
-        areaOfResearch,
-        null,
-        null,
-        null,
-        null,
-        null);
+        givenName, familyName, userName, null, null, null, null, null, null, null, null, null);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -155,18 +155,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       // TODO(danrodney): start populating contact email in Google account, use it here.
       user =
           userService.createUser(
-              userInfo.getGivenName(),
-              userInfo.getFamilyName(),
-              userInfo.getEmail(),
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null);
+              userInfo.getGivenName(), userInfo.getFamilyName(), userInfo.getEmail());
     } else {
       if (user.getDisabled()) {
         throw new ForbiddenException(

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -109,53 +109,56 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       return false;
     }
 
-    String token = authorizationHeader.substring("Bearer".length()).trim();
-    Userinfoplus userInfo = userInfoService.getUserInfo(token);
+    final String token = authorizationHeader.substring("Bearer".length()).trim();
+    final Userinfoplus OAuth2Userinfo = userInfoService.getUserInfo(token);
+
+    // The Workbench user's userName is the AoU-generated email address, so it's an email from an
+    // OAUth2 perspective
+    // Don't confuse this with the user's Contact Email, which is entirely separate from this
+    // process
+    String userName = OAuth2Userinfo.getEmail();
 
     // TODO: check Google group membership to ensure user is in registered user group
 
-    String userEmail = userInfo.getEmail();
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    if (workbenchConfig.auth.serviceAccountApiUsers.contains(userEmail)) {
+    if (workbenchConfig.auth.serviceAccountApiUsers.contains(userName)) {
       // Whitelisted service accounts are able to make API calls, too.
       // TODO: stop treating service accounts as normal users, have a separate table for them,
       // administrators.
-      DbUser user = userDao.findUserByUsername(userEmail);
+      DbUser user = userDao.findUserByUsername(userName);
       if (user == null) {
-        user = userService.createServiceAccountUser(userEmail);
+        user = userService.createServiceAccountUser(userName);
       }
       SecurityContextHolder.getContext()
           .setAuthentication(
-              new UserAuthentication(user, userInfo, token, UserType.SERVICE_ACCOUNT));
-      log.log(Level.INFO, "{0} service account in use", userInfo.getEmail());
+              new UserAuthentication(user, OAuth2Userinfo, token, UserType.SERVICE_ACCOUNT));
+      log.log(Level.INFO, "{0} service account in use", userName);
       return true;
     }
     String gsuiteDomainSuffix = "@" + workbenchConfig.googleDirectoryService.gSuiteDomain;
-    if (!userEmail.endsWith(gsuiteDomainSuffix)) {
+    if (!userName.endsWith(gsuiteDomainSuffix)) {
       // Temporarily set the authentication with no user, so we can look up what user this
       // corresponds to in FireCloud.
       SecurityContextHolder.getContext()
           .setAuthentication(
-              new UserAuthentication(null, userInfo, token, UserType.SERVICE_ACCOUNT));
+              new UserAuthentication(null, OAuth2Userinfo, token, UserType.SERVICE_ACCOUNT));
       // If the email isn't in our GSuite domain, try FireCloud; we could be dealing with a
       // pet service account. In both AofU and FireCloud, the pet SA is treated as if it were
       // the user it was created for.
-      userEmail = fireCloudService.getMe().getUserInfo().getUserEmail();
-      if (!userEmail.endsWith(gsuiteDomainSuffix)) {
+      userName = fireCloudService.getMe().getUserInfo().getUserEmail();
+      if (!userName.endsWith(gsuiteDomainSuffix)) {
         log.log(
             Level.INFO,
             "User {0} isn't in domain {1}, can't access the workbench",
-            new Object[] {userEmail, gsuiteDomainSuffix});
+            new Object[] {userName, gsuiteDomainSuffix});
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         return false;
       }
     }
-    DbUser user = userDao.findUserByUsername(userEmail);
+    DbUser user = userDao.findUserByUsername(userName);
     if (user == null) {
       // TODO(danrodney): start populating contact email in Google account, use it here.
-      user =
-          userService.createUser(
-              userInfo.getGivenName(), userInfo.getFamilyName(), userInfo.getEmail());
+      user = userService.createUser(OAuth2Userinfo);
     } else {
       if (user.getDisabled()) {
         throw new ForbiddenException(
@@ -165,10 +168,11 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     }
 
     SecurityContextHolder.getContext()
-        .setAuthentication(new UserAuthentication(user, userInfo, token, UserType.RESEARCHER));
+        .setAuthentication(
+            new UserAuthentication(user, OAuth2Userinfo, token, UserType.RESEARCHER));
 
     // TODO: setup this in the context, get rid of log statement
-    log.log(Level.INFO, "{0} logged in", userInfo.getEmail());
+    log.log(Level.INFO, "{0} logged in", OAuth2Userinfo.getEmail());
 
     if (!hasRequiredAuthority(method, user)) {
       response.sendError(HttpServletResponse.SC_FORBIDDEN);

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -112,10 +112,8 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     final String token = authorizationHeader.substring("Bearer".length()).trim();
     final Userinfoplus OAuth2Userinfo = userInfoService.getUserInfo(token);
 
-    // The Workbench user's userName is the AoU-generated email address, so it's an email from an
-    // OAUth2 perspective
-    // Don't confuse this with the user's Contact Email, which is entirely separate from this
-    // process
+    // The Workbench considers the user's generated GSuite email to be their userName
+    // Don't confuse this with the user's Contact Email, which is unrelated
     String userName = OAuth2Userinfo.getEmail();
 
     // TODO: check Google group membership to ensure user is in registered user group

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -189,7 +189,7 @@ public class AuthInterceptorTest {
     userInfo.setEmail("bob@fake-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(null);
-    when(userService.createUser("Bob", "Jones", "bob@fake-domain.org")).thenReturn(user);
+    when(userService.createUser(userInfo)).thenReturn(user);
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -189,20 +189,7 @@ public class AuthInterceptorTest {
     userInfo.setEmail("bob@fake-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(null);
-    when(userService.createUser(
-            "Bob",
-            "Jones",
-            "bob@fake-domain.org",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null))
-        .thenReturn(user);
+    when(userService.createUser("Bob", "Jones", "bob@fake-domain.org")).thenReturn(user);
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 

--- a/common-api/src/main/java/org/pmiops/workbench/db/model/CommonStorageEnums.java
+++ b/common-api/src/main/java/org/pmiops/workbench/db/model/CommonStorageEnums.java
@@ -108,14 +108,6 @@ public class CommonStorageEnums {
     return CLIENT_TO_STORAGE_SURVEY.get(survey);
   }
 
-  public static String surveyToSurveyId(Surveys survey) {
-    return SURVEY_ID_MAP.get(survey);
-  }
-
-  public static Surveys surveyIdToSurvey(String survey) {
-    return SURVEY_ID_MAP.inverse().get(survey);
-  }
-
   private static final BiMap<PrePackagedConceptSetEnum, Short>
       CLIENT_TO_STORAGE_PRE_PACKAGED_CONCEPTSET =
           ImmutableBiMap.<PrePackagedConceptSetEnum, Short>builder()

--- a/common-api/src/test/java/org/pmiops/workbench/db/model/CommonStorageEnumsTest.java
+++ b/common-api/src/test/java/org/pmiops/workbench/db/model/CommonStorageEnumsTest.java
@@ -3,6 +3,10 @@ package org.pmiops.workbench.db.model;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import com.google.common.collect.BiMap;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +53,54 @@ public class CommonStorageEnumsTest {
       Short storageValue = toStorage.apply(v);
       assertWithMessage("unmapped enum value: " + v).that(storageValue).isNotNull();
       assertThat(v).isEqualTo(fromStorage.apply(storageValue));
+    }
+  }
+
+  // domain ID is stringly-typed so special-case this
+
+  @Test
+  public void testDomainIdBijectiveStorageMapping() {
+    for (Domain v : Domain.values()) {
+      String storageValue = CommonStorageEnums.domainToDomainId(v);
+      assertWithMessage("unmapped enum value: " + v).that(storageValue).isNotNull();
+      assertThat(v).isEqualTo(CommonStorageEnums.domainIdToDomain(storageValue));
+    }
+  }
+
+  // copied from api/StorageEnumsTest because the above tests are not comprehensive
+  @Test
+  public void noMissingMapEntries() throws Exception {
+    for (Field f : CommonStorageEnums.class.getDeclaredFields()) {
+      if (f.getType() != BiMap.class) {
+        continue;
+      }
+
+      Class enumClass =
+          (Class) ((ParameterizedType) f.getAnnotatedType().getType()).getActualTypeArguments()[0];
+
+      Method enumToShort = null;
+      Method shortToEnum = null;
+      for (Method m : CommonStorageEnums.class.getDeclaredMethods()) {
+        if (m.getParameterTypes()[0].equals(enumClass)) {
+          enumToShort = m;
+        }
+
+        if (m.getReturnType().equals(enumClass)) {
+          shortToEnum = m;
+        }
+      }
+
+      // stringly typed map - test with testDomainIdBijectiveStorageMapping instead
+      if (enumToShort.getName().equals("domainIdToDomain")) {
+        continue;
+      }
+
+      for (Object e : enumClass.getEnumConstants()) {
+        Short shortVal = (Short) enumToShort.invoke(null, e);
+
+        assertThat(shortVal).named(enumClass.getName() + ":" + e.toString()).isNotNull();
+        assertThat(shortToEnum.invoke(null, shortVal)).isEqualTo(e);
+      }
     }
   }
 }


### PR DESCRIPTION
Description:
1. About half of `ProfileController.updateProfile()` deals with old-style Institutional Affiliations, so I moved that into its own method.
2. The shorter version of `UserService.createUser()` exists solely for AuthInterceptor's use, and the parameter list now matches what it knows about.
3. CommonStorageEnumsTest did not comprehensively check for missing map values like StorageEnumsTest does.
4. project.rb connect-to-db now starts the local DB if it's not running

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
