### PR TITLE
[risk=no][RW-4384] Disable closed billing accounts in dropdown

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -93,7 +93,7 @@
     "enableVpcServicePerimeter": true,
     "enableNewAccountCreation": true,
     "enableRdrExport": true,
-    "enableBillingLockout": false,
+    "enableBillingLockout": true,
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": false,

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -162,7 +162,9 @@ public class UserController implements UserApiDelegate {
                                 .isFreeTier(false)
                                 .displayName(googleBillingAccount.getDisplayName())
                                 .name(googleBillingAccount.getName())
-                                .isOpen(googleBillingAccount.getOpen())))
+                                .isOpen(
+                                    Optional.ofNullable(googleBillingAccount.getOpen())
+                                        .orElse(false))))
             .collect(Collectors.toList());
 
     return ResponseEntity.ok(

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -807,9 +807,20 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
     buildBillingAccountOptions() {
-      const options = this.state.billingAccounts.map(a => ({label: a.displayName, value: a.name}));
-      options.push({label: 'Create a new billing account', value: CREATE_BILLING_ACCOUNT_OPTION_VALUE});
+      const options = this.state.billingAccounts.map(a => ({
+        label: a.displayName,
+        value: a.name,
+        disabled: !a.isOpen
+      }));
+
+      options.push({
+        label: 'Create a new billing account',
+        value: CREATE_BILLING_ACCOUNT_OPTION_VALUE,
+        disabled: false
+      });
+
       return options;
+      
     }
 
     render() {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -820,7 +820,6 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       });
 
       return options;
-      
     }
 
     render() {


### PR DESCRIPTION
Description:

Note - I wanted to add a tooltip to the disabled options but it's difficult to do since we're using a library to handle our dropdowns. I think we should look into a more flexible library or roll our own. Even finding out if they support `disabled` was a struggle since it's not documented anywhere. I had to read their source to find out.

![image](https://user-images.githubusercontent.com/2770197/74566404-625dbb80-4f41-11ea-97d0-2156e8f363da.png)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
