### PR TITLE
[risk=low][RW-4259]Enforce Verified Institutional Affiliation for new account creation if feature flag is set

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -97,7 +97,8 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": true
+    "enableMoodleV2Api": true,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName":"workbench-action-audit-local"

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -100,7 +100,8 @@
     "enableSumoLogicEventHandling": false,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": false
+    "enableMoodleV2Api": false,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -97,7 +97,8 @@
     "enableSumoLogicEventHandling": false,
     "useKeylessDelegatedCredentials": false,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": false
+    "enableMoodleV2Api": false,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName":"workbench-action-audit-prod"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -97,7 +97,8 @@
     "enableSumoLogicEventHandling": false,
     "useKeylessDelegatedCredentials": false,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": false
+    "enableMoodleV2Api": false,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName":"workbench-action-audit-stable"

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -97,7 +97,8 @@
     "enableSumoLogicEventHandling": false,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": false
+    "enableMoodleV2Api": false,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName":"workbench-action-audit-staging"

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -97,7 +97,8 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": false,
-    "enableMoodleV2Api": true
+    "enableMoodleV2Api": true,
+    "requireInstitutionalVerification": false
   },
   "actionAudit": {
     "logName":"workbench-action-audit-test"

--- a/api/db/changelog/db.changelog-131-user-verified-institutional-affiliation.xml
+++ b/api/db/changelog/db.changelog-131-user-verified-institutional-affiliation.xml
@@ -4,25 +4,24 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="thibault" id="changelog-131-verified-institutional-affiliation">
-
-    <createTable tableName="verified_institutional_affiliation">
-      <column name="verified_institutional_affiliation_id" type="bigint" autoIncrement="true">
+  <changeSet author="thibault" id="changelog-131-user-verified-institutional-affiliation">
+    <createTable tableName="user_verified_institutional_affiliation">
+      <column name="user_verified_institutional_affiliation_id" type="bigint" autoIncrement="true">
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="user_id" type="bigint">
         <constraints
           unique="true"
           nullable="false"
-          foreignKeyName="fk_verified_institutional_affiliation_user"
+          foreignKeyName="fk_user_verified_institutional_affiliation_user"
           references="user(user_id)"
           deleteCascade="true"
-          />
+        />
       </column>
       <column name="institution_id" type="bigint">
         <constraints
           nullable="false"
-          foreignKeyName="fk_verified_institutional_affiliation_institution"
+          foreignKeyName="fk_user_verified_institutional_affiliation_institution"
           references="institution(institution_id)"
           deleteCascade="true"
         />

--- a/api/db/changelog/db.changelog-131-verified-institutional-affiliation.xml
+++ b/api/db/changelog/db.changelog-131-verified-institutional-affiliation.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-131-verified-institutional-affiliation">
+
+    <createTable tableName="verified_institutional_affiliation">
+      <column name="verified_institutional_affiliation_id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_id" type="bigint">
+        <constraints
+          unique="true"
+          nullable="false"
+          foreignKeyName="fk_verified_institutional_affiliation_user"
+          references="user(user_id)"
+          deleteCascade="true"
+          />
+      </column>
+      <column name="institution_id" type="bigint">
+        <constraints
+          nullable="false"
+          foreignKeyName="fk_verified_institutional_affiliation_institution"
+          references="institution(institution_id)"
+          deleteCascade="true"
+        />
+      </column>
+      <column name="institutional_role_enum" type="tinyint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="institutional_role_other_text" type="VARCHAR(80)">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -138,7 +138,7 @@
     <include file="changelog/db.changelog-128-add-columns-workspace.xml"/>
     <include file="changelog/db.changelog-129-add-research-outcomes-workspace.xml"/>
     <include file="changelog/db.changelog-130-add-disseminate-research-workspace.xml"/>
-    <include file="changelog/db.changelog-131-verified-institutional-affiliation.xml"/>
+    <include file="changelog/db.changelog-131-user-verified-institutional-affiliation.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -138,6 +138,7 @@
     <include file="changelog/db.changelog-128-add-columns-workspace.xml"/>
     <include file="changelog/db.changelog-129-add-research-outcomes-workspace.xml"/>
     <include file="changelog/db.changelog-130-add-disseminate-research-workspace.xml"/>
+    <include file="changelog/db.changelog-131-verified-institutional-affiliation.xml"/>
     <!--
     Note: to update the DB locally, do the following:
     - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -33,6 +33,8 @@ public class ConfigController implements ConfigApiDelegate {
             .firecloudURL(config.firecloud.baseUrl)
             .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
             .enableNewAccountCreation(config.featureFlags.enableNewAccountCreation)
-            .requireInvitationKey(config.access.requireInvitationKey));
+            .requireInvitationKey(config.access.requireInvitationKey)
+            .requireInstitutionalVerification(
+                config.featureFlags.requireInstitutionalVerification));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import org.pmiops.workbench.annotations.AuthorityRequired;
-import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Authority;
@@ -30,23 +29,8 @@ public class InstitutionController implements InstitutionApiDelegate {
   @Override
   @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<Void> deleteInstitution(final String shortName) {
-    switch (institutionService.deleteInstitution(shortName)) {
-      case HAS_VERIFIED_AFFILIATIONS:
-        // TODO: 405 or 409?
-        // https://stackoverflow.com/questions/25122472/rest-http-status-code-if-delete-impossible
-        // https://stackoverflow.com/questions/45899743/proper-http-error-for-deleting-non-empty-resource
-        throw new ConflictException(
-            String.format(
-                "Could not delete Institution '%s' because it has verified user affiliations",
-                shortName));
-
-      case NOT_FOUND:
-        throw new NotFoundException(
-            String.format("Could not delete Institution '%s' because it was not found", shortName));
-      case SUCCESS:
-      default:
-        return ResponseEntity.noContent().build();
-    }
+    institutionService.deleteInstitution(shortName);
+    return ResponseEntity.noContent().build();
   }
 
   @Override
@@ -57,7 +41,7 @@ public class InstitutionController implements InstitutionApiDelegate {
             .orElseThrow(
                 () ->
                     new NotFoundException(
-                        String.format("Could not find Institution '%s", shortName)));
+                        String.format("Could not find Institution '%s'", shortName)));
 
     return ResponseEntity.ok(institution);
   }
@@ -79,7 +63,7 @@ public class InstitutionController implements InstitutionApiDelegate {
             .orElseThrow(
                 () ->
                     new NotFoundException(
-                        String.format("Could not update Institution '%s", shortName)));
+                        String.format("Could not update Institution '%s'", shortName)));
 
     return ResponseEntity.ok(institution);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.api;
 
 import org.pmiops.workbench.annotations.AuthorityRequired;
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Authority;
@@ -29,10 +30,22 @@ public class InstitutionController implements InstitutionApiDelegate {
   @Override
   @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<Void> deleteInstitution(final String shortName) {
-    if (institutionService.deleteInstitution(shortName)) {
-      return ResponseEntity.noContent().build();
-    } else {
-      throw new NotFoundException(String.format("Could not delete Institution %s", shortName));
+    switch (institutionService.deleteInstitution(shortName)) {
+      case HAS_VERIFIED_AFFILIATIONS:
+        // TODO: 405 or 409?
+        // https://stackoverflow.com/questions/25122472/rest-http-status-code-if-delete-impossible
+        // https://stackoverflow.com/questions/45899743/proper-http-error-for-deleting-non-empty-resource
+        throw new ConflictException(
+            String.format(
+                "Could not delete Institution '%s' because it has verified user affiliations",
+                shortName));
+
+      case NOT_FOUND:
+        throw new NotFoundException(
+            String.format("Could not delete Institution '%s' because it was not found", shortName));
+      case SUCCESS:
+      default:
+        return ResponseEntity.noContent().build();
     }
   }
 
@@ -44,7 +57,7 @@ public class InstitutionController implements InstitutionApiDelegate {
             .orElseThrow(
                 () ->
                     new NotFoundException(
-                        String.format("Could not find Institution %s", shortName)));
+                        String.format("Could not find Institution '%s", shortName)));
 
     return ResponseEntity.ok(institution);
   }
@@ -66,7 +79,7 @@ public class InstitutionController implements InstitutionApiDelegate {
             .orElseThrow(
                 () ->
                     new NotFoundException(
-                        String.format("Could not update Institution %s", shortName)));
+                        String.format("Could not update Institution '%s", shortName)));
 
     return ResponseEntity.ok(institution);
   }

--- a/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ProfileService.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
-import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
@@ -16,7 +16,6 @@ import org.pmiops.workbench.db.model.DbPageVisit;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
-import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperImpl;
 import org.pmiops.workbench.model.Address;
 import org.pmiops.workbench.model.DemographicSurvey;
 import org.pmiops.workbench.model.Disability;
@@ -24,11 +23,9 @@ import org.pmiops.workbench.model.InstitutionalAffiliation;
 import org.pmiops.workbench.model.PageVisit;
 import org.pmiops.workbench.model.Profile;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 
 @Service
-@Import({VerifiedInstitutionalAffiliationMapperImpl.class})
 public class ProfileService {
   private static final Function<DbInstitutionalAffiliation, InstitutionalAffiliation>
       TO_CLIENT_INSTITUTIONAL_AFFILIATION =
@@ -98,7 +95,7 @@ public class ProfileService {
   private final UserDao userDao;
   private final FreeTierBillingService freeTierBillingService;
   private final UserTermsOfServiceDao userTermsOfServiceDao;
-  private final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
+  private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
   private final VerifiedInstitutionalAffiliationMapper verifiedInstitutionalAffiliationMapper;
 
   @Autowired
@@ -106,12 +103,12 @@ public class ProfileService {
       UserDao userDao,
       FreeTierBillingService freeTierBillingService,
       UserTermsOfServiceDao userTermsOfServiceDao,
-      VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation,
+      VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao,
       VerifiedInstitutionalAffiliationMapper verifiedInstitutionalAffiliationMapper) {
     this.userDao = userDao;
     this.freeTierBillingService = freeTierBillingService;
     this.userTermsOfServiceDao = userTermsOfServiceDao;
-    this.verifiedInstitutionalAffiliation = verifiedInstitutionalAffiliation;
+    this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
     this.verifiedInstitutionalAffiliationMapper = verifiedInstitutionalAffiliationMapper;
   }
 
@@ -223,7 +220,7 @@ public class ProfileService {
             .map(TO_CLIENT_INSTITUTIONAL_AFFILIATION)
             .collect(Collectors.toList()));
 
-    verifiedInstitutionalAffiliation
+    verifiedInstitutionalAffiliationDao
         .findFirstByUser(user)
         .ifPresent(
             verifiedInstitutionalAffiliation ->

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -32,10 +32,10 @@ public interface UserService {
       String areaOfResearch,
       String professionalUrl,
       List<Degree> degrees,
-      DbAddress address,
-      DbDemographicSurvey demographicSurvey,
-      List<DbInstitutionalAffiliation> institutionalAffiliations,
-      DbVerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation);
+      DbAddress dbAddress,
+      DbDemographicSurvey dbDemographicSurvey,
+      List<DbInstitutionalAffiliation> dbAffiliations,
+      DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation);
 
   DbUser submitDataUseAgreement(
       DbUser user, Integer dataUseAgreementSignedVersion, String initials);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
@@ -33,7 +34,8 @@ public interface UserService {
       List<Degree> degrees,
       DbAddress address,
       DbDemographicSurvey demographicSurvey,
-      List<DbInstitutionalAffiliation> institutionalAffiliations);
+      List<DbInstitutionalAffiliation> institutionalAffiliations,
+      DbVerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation);
 
   DbUser submitDataUseAgreement(
       DbUser user, Integer dataUseAgreementSignedVersion, String initials);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliation.java
@@ -1,0 +1,15 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.springframework.data.repository.CrudRepository;
+
+public interface VerifiedInstitutionalAffiliation
+    extends CrudRepository<DbVerifiedInstitutionalAffiliation, Long> {
+  Collection<DbVerifiedInstitutionalAffiliation> findAllByInstitution(DbInstitution institution);
+
+  Optional<DbVerifiedInstitutionalAffiliation> findFirstByUser(DbUser user);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationDao.java
@@ -7,7 +7,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.springframework.data.repository.CrudRepository;
 
-public interface VerifiedInstitutionalAffiliation
+public interface VerifiedInstitutionalAffiliationDao
     extends CrudRepository<DbVerifiedInstitutionalAffiliation, Long> {
   Collection<DbVerifiedInstitutionalAffiliation> findAllByInstitution(DbInstitution institution);
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
@@ -1,18 +1,18 @@
 package org.pmiops.workbench.db.model;
 
 import com.google.common.collect.Sets;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
+import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.model.OrganizationType;
 
 @Entity
@@ -81,7 +81,7 @@ public class DbInstitution {
     return this;
   }
 
-  @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL)
   @NotNull
   public Set<DbInstitutionEmailDomain> getEmailDomains() {
     return emailDomains;
@@ -96,9 +96,10 @@ public class DbInstitution {
    *
    * <p>https://stackoverflow.com/questions/5587482/hibernate-a-collection-with-cascade-all-delete-orphan-was-no-longer-referenc
    *
-   * @param emailDomains the new set of domains for this Institution
+   * @param emailDomains the new collection of domains for this Institution
    */
-  public DbInstitution setEmailDomains(final Set<DbInstitutionEmailDomain> emailDomains) {
+  public DbInstitution setEmailDomains(
+      @NotNull final Collection<DbInstitutionEmailDomain> emailDomains) {
     final Set<DbInstitutionEmailDomain> attachedDomains =
         emailDomains.stream()
             .map(domain -> domain.setInstitution(this))
@@ -106,10 +107,11 @@ public class DbInstitution {
     // modifies this set so that its value is the intersection of the two sets
     this.emailDomains.retainAll(attachedDomains);
     this.emailDomains.addAll(Sets.difference(attachedDomains, this.emailDomains));
+
     return this;
   }
 
-  @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL)
   @NotNull
   public Set<DbInstitutionEmailAddress> getEmailAddresses() {
     return emailAddresses;
@@ -124,9 +126,10 @@ public class DbInstitution {
    *
    * <p>https://stackoverflow.com/questions/5587482/hibernate-a-collection-with-cascade-all-delete-orphan-was-no-longer-referenc
    *
-   * @param emailAddresses the new set of addresses for this Institution
+   * @param emailAddresses the new collection of addresses for this Institution
    */
-  public DbInstitution setEmailAddresses(final Set<DbInstitutionEmailAddress> emailAddresses) {
+  public DbInstitution setEmailAddresses(
+      @NotNull final Collection<DbInstitutionEmailAddress> emailAddresses) {
     final Set<DbInstitutionEmailAddress> attachedAddresses =
         emailAddresses.stream()
             .map(address -> address.setInstitution(this))
@@ -134,6 +137,7 @@ public class DbInstitution {
     // modifies this set so that its value is the intersection of the two sets
     this.emailAddresses.retainAll(attachedAddresses);
     this.emailAddresses.addAll(Sets.difference(attachedAddresses, this.emailAddresses));
+
     return this;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.DisseminateResearchEnum;
 import org.pmiops.workbench.model.EmailVerificationStatus;
+import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.OrganizationType;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
 import org.pmiops.workbench.model.ReviewStatus;
@@ -331,6 +332,32 @@ public final class DbStorageEnums {
 
   public static Short organizationTypeToStorage(OrganizationType organizationType) {
     return CLIENT_TO_STORAGE_ORGANIZATION_TYPE.get(organizationType);
+  }
+
+  private static final BiMap<InstitutionalRole, Short> CLIENT_TO_STORAGE_INSTITUTIONAL_ROLE =
+      ImmutableBiMap.<InstitutionalRole, Short>builder()
+          .put(InstitutionalRole.UNDERGRADUATE, (short) 0)
+          .put(InstitutionalRole.TRAINEE, (short) 1)
+          .put(InstitutionalRole.FELLOW, (short) 2)
+          .put(InstitutionalRole.EARLY_CAREER, (short) 3)
+          .put(InstitutionalRole.MID_CAREER, (short) 4)
+          .put(InstitutionalRole.LATE_CAREER, (short) 5)
+          .put(InstitutionalRole.PRE_DOCTORAL, (short) 6)
+          .put(InstitutionalRole.POST_DOCTORAL, (short) 7)
+          .put(InstitutionalRole.PI, (short) 8)
+          .put(InstitutionalRole.TEACHER, (short) 9)
+          .put(InstitutionalRole.STUDENT, (short) 10)
+          .put(InstitutionalRole.ADMIN, (short) 11)
+          .put(InstitutionalRole.PROJECT_PERSONNEL, (short) 12)
+          .put(InstitutionalRole.OTHER, (short) 13)
+          .build();
+
+  public static InstitutionalRole institutionalRoleFromStorage(Short institutionalRole) {
+    return CLIENT_TO_STORAGE_INSTITUTIONAL_ROLE.inverse().get(institutionalRole);
+  }
+
+  public static Short institutionalRoleToStorage(InstitutionalRole institutionalRole) {
+    return CLIENT_TO_STORAGE_INSTITUTIONAL_ROLE.get(institutionalRole);
   }
 
   /** Utility class. */

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
@@ -1,0 +1,104 @@
+package org.pmiops.workbench.db.model;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import org.pmiops.workbench.model.InstitutionalRole;
+
+@Entity
+@Table(name = "verified_institutional_affiliation")
+public class DbVerifiedInstitutionalAffiliation {
+
+  private long verifiedInstitutionalAffiliationId;
+  private DbUser user;
+  private DbInstitution institution;
+  private Short institutionalRoleEnum;
+  private String institutionalRoleOtherText;
+
+  public DbVerifiedInstitutionalAffiliation() {}
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "verified_institutional_affiliation_id")
+  public long getVerifiedInstitutionalAffiliationId() {
+    return verifiedInstitutionalAffiliationId;
+  }
+
+  public DbVerifiedInstitutionalAffiliation setVerifiedInstitutionalAffiliationId(
+      long verifiedUserInstitutionId) {
+    this.verifiedInstitutionalAffiliationId = verifiedUserInstitutionId;
+    return this;
+  }
+
+  @OneToOne()
+  @JoinColumn(name = "user_id", nullable = false, unique = true)
+  public DbUser getUser() {
+    return user;
+  }
+
+  public DbVerifiedInstitutionalAffiliation setUser(DbUser user) {
+    this.user = user;
+    return this;
+  }
+
+  @ManyToOne()
+  @JoinColumn(name = "institution_id", nullable = false)
+  public DbInstitution getInstitution() {
+    return institution;
+  }
+
+  public DbVerifiedInstitutionalAffiliation setInstitution(DbInstitution institution) {
+    this.institution = institution;
+    return this;
+  }
+
+  @Column(name = "institutional_role_enum", nullable = false)
+  public InstitutionalRole getInstitutionalRoleEnum() {
+    return DbStorageEnums.institutionalRoleFromStorage(institutionalRoleEnum);
+  }
+
+  public DbVerifiedInstitutionalAffiliation setInstitutionalRoleEnum(InstitutionalRole role) {
+    this.institutionalRoleEnum = DbStorageEnums.institutionalRoleToStorage(role);
+    return this;
+  }
+
+  @Column(name = "institutional_role_other_text")
+  public String getInstitutionalRoleOtherText() {
+    return institutionalRoleOtherText;
+  }
+
+  public DbVerifiedInstitutionalAffiliation setInstitutionalRoleOtherText(
+      String institutionalRoleOtherText) {
+    this.institutionalRoleOtherText = institutionalRoleOtherText;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DbVerifiedInstitutionalAffiliation)) {
+      return false;
+    }
+
+    DbVerifiedInstitutionalAffiliation that = (DbVerifiedInstitutionalAffiliation) o;
+
+    return Objects.equals(user, that.user)
+        && Objects.equals(institution, that.institution)
+        && Objects.equals(institutionalRoleEnum, that.institutionalRoleEnum)
+        && Objects.equals(institutionalRoleOtherText, that.institutionalRoleOtherText);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(user, institution, institutionalRoleEnum, institutionalRoleOtherText);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
@@ -13,7 +13,7 @@ import javax.persistence.Table;
 import org.pmiops.workbench.model.InstitutionalRole;
 
 @Entity
-@Table(name = "verified_institutional_affiliation")
+@Table(name = "user_verified_institutional_affiliation")
 public class DbVerifiedInstitutionalAffiliation {
 
   private long verifiedInstitutionalAffiliationId;
@@ -26,7 +26,7 @@ public class DbVerifiedInstitutionalAffiliation {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "verified_institutional_affiliation_id")
+  @Column(name = "user_verified_institutional_affiliation_id")
   public long getVerifiedInstitutionalAffiliationId() {
     return verifiedInstitutionalAffiliationId;
   }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
@@ -1,0 +1,50 @@
+package org.pmiops.workbench.institution;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbInstitutionEmailAddress;
+import org.pmiops.workbench.db.model.DbInstitutionEmailDomain;
+import org.pmiops.workbench.model.Institution;
+
+@Mapper(componentModel = "spring")
+public interface InstitutionMapper {
+  @Mapping(target = "institutionId", ignore = true)
+  DbInstitution modelToDb(Institution modelObject);
+
+  Institution dbToModel(DbInstitution dbObject);
+
+  default List<String> toModelDomains(@NotNull Set<DbInstitutionEmailDomain> dbDomains) {
+    return dbDomains.stream()
+        .map(DbInstitutionEmailDomain::getEmailDomain)
+        .collect(Collectors.toList());
+  }
+
+  default List<String> toModelAddresses(@NotNull Set<DbInstitutionEmailAddress> dbAddresses) {
+    return dbAddresses.stream()
+        .map(DbInstitutionEmailAddress::getEmailAddress)
+        .collect(Collectors.toList());
+  }
+
+  // Swagger-generated Lists are null by default, so we should handle that
+  default Set<DbInstitutionEmailDomain> toDbDomains(@Nullable Collection<String> modelDomains) {
+    return Optional.ofNullable(modelDomains).orElse(Collections.emptySet()).stream()
+        .map(domain -> new DbInstitutionEmailDomain().setEmailDomain(domain))
+        .collect(Collectors.toSet());
+  }
+
+  default Set<DbInstitutionEmailAddress> toDbAddresses(
+      @Nullable Collection<String> modelAddresses) {
+    return Optional.ofNullable(modelAddresses).orElse(Collections.emptySet()).stream()
+        .map(address -> new DbInstitutionEmailAddress().setEmailAddress(address))
+        .collect(Collectors.toSet());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
@@ -35,13 +35,14 @@ public interface InstitutionMapper {
   }
 
   // Swagger-generated Lists are null by default, so we should handle that
-  default Set<DbInstitutionEmailDomain> toDbDomains(@Nullable Collection<String> modelDomains) {
+  default Set<DbInstitutionEmailDomain> toDbDomainsWithoutInstitution(
+      @Nullable Collection<String> modelDomains) {
     return Optional.ofNullable(modelDomains).orElse(Collections.emptySet()).stream()
         .map(domain -> new DbInstitutionEmailDomain().setEmailDomain(domain))
         .collect(Collectors.toSet());
   }
 
-  default Set<DbInstitutionEmailAddress> toDbAddresses(
+  default Set<DbInstitutionEmailAddress> toDbAddressesWithoutInstitution(
       @Nullable Collection<String> modelAddresses) {
     return Optional.ofNullable(modelAddresses).orElse(Collections.emptySet()).stream()
         .map(address -> new DbInstitutionEmailAddress().setEmailAddress(address))

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.institution;
 
 import java.util.List;
 import java.util.Optional;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Institution;
 
 public interface InstitutionService {
@@ -9,10 +11,29 @@ public interface InstitutionService {
 
   Optional<Institution> getInstitution(final String shortName);
 
+  Optional<DbInstitution> getDbInstitution(final String shortName);
+
   Institution createInstitution(final Institution institutionToCreate);
 
-  boolean deleteInstitution(final String shortName);
+  enum DeletionResult {
+    SUCCESS,
+    NOT_FOUND,
+    HAS_VERIFIED_AFFILIATIONS
+  }
+
+  DeletionResult deleteInstitution(final String shortName);
 
   Optional<Institution> updateInstitution(
       final String shortName, final Institution institutionToUpdate);
+
+  /**
+   * Validates that the user's institutional affiliation is valid, by pattern-matching the user's
+   * contact email against the institution's set of whitelisted email domains or addresses.
+   *
+   * @param verifiedInstitutionalAffiliation the user's declared affiliation
+   * @param contactEmail the contact email to verify
+   * @return boolean - does the affiliation pass validation?
+   */
+  boolean validate(
+      DbVerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation, String contactEmail);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.institution;
 
 import java.util.List;
 import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Institution;
@@ -15,25 +16,20 @@ public interface InstitutionService {
 
   Institution createInstitution(final Institution institutionToCreate);
 
-  enum DeletionResult {
-    SUCCESS,
-    NOT_FOUND,
-    HAS_VERIFIED_AFFILIATIONS
-  }
-
-  DeletionResult deleteInstitution(final String shortName);
+  void deleteInstitution(final String shortName);
 
   Optional<Institution> updateInstitution(
       final String shortName, final Institution institutionToUpdate);
 
   /**
    * Validates that the user's institutional affiliation is valid, by pattern-matching the user's
-   * contact email against the institution's set of whitelisted email domains or addresses.
+   * contact email against the institution's set of whitelisted email domains or addresses. If the
+   * user has no affiliation (null) then it will return false
    *
-   * @param verifiedInstitutionalAffiliation the user's declared affiliation
+   * @param dbAffiliation the user's declared affiliation
    * @param contactEmail the contact email to verify
    * @return boolean - does the affiliation pass validation?
    */
-  boolean validate(
-      DbVerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation, String contactEmail);
+  boolean validateAffiliation(
+      @Nullable DbVerifiedInstitutionalAffiliation dbAffiliation, String contactEmail);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
@@ -1,0 +1,37 @@
+package org.pmiops.workbench.institution;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
+
+@Mapper(componentModel = "spring")
+public interface VerifiedInstitutionalAffiliationMapper {
+  @Mapping(target = "verifiedInstitutionalAffiliationId", ignore = true)
+  @Mapping(target = "institution", ignore = true) // set by setDbInstitution()
+  @Mapping(target = "user", ignore = true) // set by caller
+  DbVerifiedInstitutionalAffiliation modelToDbWithoutUser(
+      VerifiedInstitutionalAffiliation modelObject, @Context InstitutionService institutionService);
+
+  @AfterMapping
+  default void setDbInstitution(
+      @MappingTarget DbVerifiedInstitutionalAffiliation target,
+      VerifiedInstitutionalAffiliation modelObject,
+      @Context InstitutionService institutionService) {
+
+    institutionService
+        .getDbInstitution(modelObject.getInstitutionShortName())
+        .ifPresent(target::setInstitution);
+  }
+
+  @Mapping(target = "institutionShortName", source = "institution")
+  VerifiedInstitutionalAffiliation dbToModel(DbVerifiedInstitutionalAffiliation dbObject);
+
+  default String toShortName(DbInstitution institution) {
+    return institution.getShortName();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -15,7 +15,7 @@ import javax.inject.Provider;
 import main.java.org.pmiops.workbench.db.model.RdrEntityEnums;
 import org.pmiops.workbench.db.dao.RdrExportDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbRdrExport;
@@ -46,7 +46,7 @@ public class RdrExportServiceImpl implements RdrExportService {
   private WorkspaceDao workspaceDao;
   private UserDao userDao;
   private WorkspaceService workspaceService;
-  private final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
+  private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   private static final Logger log = Logger.getLogger(RdrExportService.class.getName());
   ZoneOffset offset = OffsetDateTime.now().getOffset();
@@ -60,7 +60,7 @@ public class RdrExportServiceImpl implements RdrExportService {
       WorkspaceDao workspaceDao,
       WorkspaceService workspaceService,
       UserDao userDao,
-      VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation) {
+      VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao) {
     this.clock = clock;
     this.fireCloudService = fireCloudService;
     this.rdrExportDao = rdrExportDao;
@@ -68,7 +68,7 @@ public class RdrExportServiceImpl implements RdrExportService {
     this.workspaceDao = workspaceDao;
     this.workspaceService = workspaceService;
     this.userDao = userDao;
-    this.verifiedInstitutionalAffiliation = verifiedInstitutionalAffiliation;
+    this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
   }
 
   /**
@@ -235,7 +235,7 @@ public class RdrExportServiceImpl implements RdrExportService {
                 })
             .collect(Collectors.toList()));
 
-    verifiedInstitutionalAffiliation
+    verifiedInstitutionalAffiliationDao
         .findFirstByUser(dbUser)
         .ifPresent(
             verifiedInstitutionalAffiliation -> {

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -233,7 +233,7 @@ definitions:
     properties:
       institutionShortName:
         type: string
-        description: The unique Short Name of the Institution where the user has a Verified Affiliation
+        description: The unique Short Name of the Institution where the user has a Verified Affiliation, such as 'VUMC'
       institutionalRole:
         type: string
         description: The user's Institutional Role at this Institution, as text

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -212,6 +212,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ResearcherAffiliation'
+      verifiedInstitutionalAffiliation:
+        $ref: '#/definitions/ResearcherVerifiedInstitutionalAffiliation'
 
   ResearcherAffiliation:
     type: object
@@ -222,6 +224,19 @@ definitions:
         type: string
       nonAcademicAffiliation:
         type: boolean
+
+  ResearcherVerifiedInstitutionalAffiliation:
+    type: object
+    required:
+      - institutionShortName
+      - institutionalRole
+    properties:
+      institutionShortName:
+        type: string
+        description: The unique Short Name of the Institution where the user has a Verified Affiliation
+      institutionalRole:
+        type: string
+        description: The user's Institutional Role at this Institution, as text
 
   Ethnicity:
     type: string

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -3789,9 +3789,17 @@ definitions:
       areaOfResearch:
         type: string
       institutionalAffiliations:
+        description: >
+          A list of institutions the user is affiliated with.
+          DEPRECATED in favor of the newer verifiedInstitutionalAffiliation
         type: "array"
         items:
           $ref: "#/definitions/InstitutionalAffiliation"
+      verifiedInstitutionalAffiliation:
+        description: >
+          The institution the user is verified to be affiliated with, based on their email.
+          Will be required for new users when this feature is enabled in all environments.
+        $ref: "#/definitions/VerifiedInstitutionalAffiliation"
       demographicSurvey:
         $ref: "#/definitions/DemographicSurvey"
       idVerificationCompletionTime:
@@ -4354,11 +4362,6 @@ definitions:
       type: integer
       format: int64
 
-  OrganizationType:
-    type: string
-    description: A categorization of institutions derived from CAPS requirements
-    enum: [ACADEMIC_RESEARCH_INSTITUTION, INDUSTRY, EDUCATIONAL_INSTITUTION, HEALTH_CENTER_NON_PROFIT, OTHER]
-
   Institution:
     type: object
     description: Represents an institution which has been approved to validate researchers who wish to use the system
@@ -4401,6 +4404,78 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Institution"
+
+  OrganizationType:
+    type: string
+    description: A categorization of institutions, derived from CAPS requirements
+    enum: [ACADEMIC_RESEARCH_INSTITUTION, INDUSTRY, EDUCATIONAL_INSTITUTION, HEALTH_CENTER_NON_PROFIT, OTHER]
+
+  InstitutionalRole:
+    type: string
+    description: >
+      The union of the roles researchers can have at Institutions of all OrganizationTypes,
+      derived from CAPS requirements.
+      InstitutionalRole_ARI, InstitutionalRole_IND_HCNP, and InstitutionalRole_EDU are
+      subsets of this enum, implemented using the same short-int values.
+    enum: [
+      UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, MID_CAREER, LATE_CAREER,
+      PRE_DOCTORAL, POST_DOCTORAL, PI,
+      TEACHER, STUDENT, ADMIN,
+      PROJECT_PERSONNEL, OTHER
+    ]
+
+  InstitutionalRole_ARI:
+    type: string
+    description: >
+      A categorization of the roles researchers can have at the OrganizationType
+      ACADEMIC_RESEARCH_INSTITUTION, derived from CAPS requirements.
+      A subset of InstitutionalRole, implemented using the same short-int values.
+    enum: [
+      UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, MID_CAREER, LATE_CAREER,
+      PROJECT_PERSONNEL, OTHER
+    ]
+
+  InstitutionalRole_IND_HCNP:
+    type: string
+    description: >
+      A categorization of the roles researchers can have at the OrganizationTypes
+      INDUSTRY and HEALTH_CENTER_NON_PROFIT, derived from CAPS requirements.
+      A subset of InstitutionalRole, implemented using the same short-int values.
+    enum: [
+      PRE_DOCTORAL, POST_DOCTORAL, PI,
+      PROJECT_PERSONNEL, OTHER
+    ]
+
+  InstitutionalRole_EDU:
+    type: string
+    description: >
+      A categorization of the roles researchers can have at the OrganizationType
+      EDUCATIONAL_INSTITUTION, derived from CAPS requirements.
+      A subset of InstitutionalRole, implemented using the same short-int values.
+    enum: [
+      TEACHER, STUDENT, ADMIN,
+      PROJECT_PERSONNEL, OTHER
+    ]
+
+  VerifiedInstitutionalAffiliation:
+    type: object
+    required:
+      - institutionShortName
+      - institutionalRoleEnum
+    properties:
+      institutionShortName:
+        type: string
+        description: The unique Short Name of the Institution where the user has a Verified Affiliation
+      institutionalRoleEnum:
+        $ref: '#/definitions/InstitutionalRole'
+        description: >
+          The user's Institutional Role at this Institution if it is one of the enumerated
+          InstitutionalRoles, or InstitutionalRole.OTHER if it is not
+      institutionalRoleOtherText:
+        type: string
+        description: >
+          The user's detailed Institutional Role at this Institution, as text,
+          if its enumerated type is OTHER
 
   AdminFederatedWorkspaceDetailsResponse:
     description: Admin-visible metadata about a workspace.

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2360,6 +2360,7 @@ paths:
         name: shortName
         required: true
         type: string
+        description: A short unique name for the Institution used as an identifier, such as 'VUMC'
     get:
       tags:
         - institution
@@ -2383,6 +2384,8 @@ paths:
         204:
           description: >
             Successful deletion of the Institution corresponding to the shortName ID.
+        409:
+          description: Could not delete the Institution because it has verified affiliations.
     patch:
       tags:
         - institution
@@ -2474,6 +2477,13 @@ definitions:
         type: boolean
         default: false
         description: Whether the current environment requires an invitation key for signup.
+      requireInstitutionalVerification:
+        type: boolean
+        default: false
+        description: >
+          Feature flag for verifying the institutional affiliation of new users by validating their
+          contact emails.
+
 
   FeaturedWorkspacesConfigResponse:
     type: object
@@ -4372,8 +4382,10 @@ definitions:
     properties:
       shortName:
         type: string
+        description: A short unique name for the Institution used as an identifier, such as 'VUMC'
       displayName:
         type: string
+        description: A more descriptive name for the Institution, such as 'Vanderbilt University Medical Center'
       organizationTypeEnum:
         $ref: '#/definitions/OrganizationType'
         description: >
@@ -4415,44 +4427,9 @@ definitions:
     description: >
       The union of the roles researchers can have at Institutions of all OrganizationTypes,
       derived from CAPS requirements.
-      InstitutionalRole_ARI, InstitutionalRole_IND_HCNP, and InstitutionalRole_EDU are
-      subsets of this enum, implemented using the same short-int values.
     enum: [
       UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, MID_CAREER, LATE_CAREER,
       PRE_DOCTORAL, POST_DOCTORAL, PI,
-      TEACHER, STUDENT, ADMIN,
-      PROJECT_PERSONNEL, OTHER
-    ]
-
-  InstitutionalRole_ARI:
-    type: string
-    description: >
-      A categorization of the roles researchers can have at the OrganizationType
-      ACADEMIC_RESEARCH_INSTITUTION, derived from CAPS requirements.
-      A subset of InstitutionalRole, implemented using the same short-int values.
-    enum: [
-      UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, MID_CAREER, LATE_CAREER,
-      PROJECT_PERSONNEL, OTHER
-    ]
-
-  InstitutionalRole_IND_HCNP:
-    type: string
-    description: >
-      A categorization of the roles researchers can have at the OrganizationTypes
-      INDUSTRY and HEALTH_CENTER_NON_PROFIT, derived from CAPS requirements.
-      A subset of InstitutionalRole, implemented using the same short-int values.
-    enum: [
-      PRE_DOCTORAL, POST_DOCTORAL, PI,
-      PROJECT_PERSONNEL, OTHER
-    ]
-
-  InstitutionalRole_EDU:
-    type: string
-    description: >
-      A categorization of the roles researchers can have at the OrganizationType
-      EDUCATIONAL_INSTITUTION, derived from CAPS requirements.
-      A subset of InstitutionalRole, implemented using the same short-int values.
-    enum: [
       TEACHER, STUDENT, ADMIN,
       PROJECT_PERSONNEL, OTHER
     ]
@@ -4465,7 +4442,7 @@ definitions:
     properties:
       institutionShortName:
         type: string
-        description: The unique Short Name of the Institution where the user has a Verified Affiliation
+        description: The unique Short Name of the Institution where the user has a Verified Affiliation, such as 'VUMC'
       institutionalRoleEnum:
         $ref: '#/definitions/InstitutionalRole'
         description: >

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -21,10 +21,12 @@ import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
+import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.UpdateUserDisabledRequest;
 import org.pmiops.workbench.test.FakeClock;
@@ -60,6 +62,8 @@ public class AuthDomainControllerTest {
   @Autowired private UserDao userDao;
   @Mock private UserDataUseAgreementDao userDataUseAgreementDao;
   @Mock private UserTermsOfServiceDao userTermsOfServiceDao;
+  @Mock private InstitutionService institutionService;
+  @Mock private VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
 
   private AuthDomainController authDomainController;
 
@@ -88,7 +92,9 @@ public class AuthDomainControllerTest {
             Providers.of(config),
             complianceService,
             directoryService,
-            mockUserServiceAuditAdapter);
+            mockUserServiceAuditAdapter,
+            institutionService,
+            verifiedInstitutionalAffiliation);
     this.authDomainController =
         new AuthDomainController(
             fireCloudService, userService, userDao, mockAuthDomainAuditAdapter);

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -21,7 +21,7 @@ import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
-import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
@@ -63,7 +63,7 @@ public class AuthDomainControllerTest {
   @Mock private UserDataUseAgreementDao userDataUseAgreementDao;
   @Mock private UserTermsOfServiceDao userTermsOfServiceDao;
   @Mock private InstitutionService institutionService;
-  @Mock private VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
+  @Mock private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   private AuthDomainController authDomainController;
 
@@ -94,7 +94,7 @@ public class AuthDomainControllerTest {
             directoryService,
             mockUserServiceAuditAdapter,
             institutionService,
-            verifiedInstitutionalAffiliation);
+            verifiedInstitutionalAffiliationDao);
     this.authDomainController =
         new AuthDomainController(
             fireCloudService, userService, userDao, mockAuthDomainAuditAdapter);

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -47,6 +47,8 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterConfig;
 import org.pmiops.workbench.model.ClusterLocalizeRequest;
@@ -102,7 +104,12 @@ public class ClusterControllerTest {
   private static DbUser user = new DbUser();
 
   @TestConfiguration
-  @Import({ClusterController.class, UserServiceImpl.class})
+  @Import({
+    ClusterController.class,
+    UserServiceImpl.class,
+    InstitutionServiceImpl.class,
+    InstitutionMapperImpl.class
+  })
   @MockBean({
     ClusterAuditor.class,
     FireCloudService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -61,6 +61,8 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.Concept;
@@ -192,7 +194,9 @@ public class CohortsControllerTest {
     ConceptSetsController.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
-    LogsBasedMetricServiceFakeImpl.class
+    LogsBasedMetricServiceFakeImpl.class,
+    InstitutionServiceImpl.class,
+    InstitutionMapperImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -54,6 +54,8 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.CreateConceptSetRequest;
@@ -228,7 +230,9 @@ public class ConceptSetsControllerTest {
     ConceptSetService.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
-    LogsBasedMetricServiceFakeImpl.class
+    LogsBasedMetricServiceFakeImpl.class,
+    InstitutionServiceImpl.class,
+    InstitutionMapperImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -96,6 +96,8 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.Concept;
@@ -273,7 +275,9 @@ public class DataSetControllerTest {
     WorkspaceServiceImpl.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
-    LogsBasedMetricServiceFakeImpl.class
+    LogsBasedMetricServiceFakeImpl.class,
+    InstitutionServiceImpl.class,
+    InstitutionMapperImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -27,6 +27,8 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.User;
 import org.pmiops.workbench.model.UserResponse;
@@ -56,7 +58,12 @@ public class UserControllerTest {
   private static long incrementedUserId = 1;
 
   @TestConfiguration
-  @Import({UserController.class, UserServiceImpl.class})
+  @Import({
+    UserController.class,
+    UserServiceImpl.class,
+    InstitutionServiceImpl.class,
+    InstitutionMapperImpl.class
+  })
   @MockBean({
     FireCloudService.class,
     ComplianceService.class,

--- a/api/src/test/java/org/pmiops/workbench/auth/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/auth/ProfileServiceTest.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
+import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperImpl;
 import org.pmiops.workbench.model.Profile;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -34,7 +35,7 @@ public class ProfileServiceTest {
 
   @TestConfiguration
   @MockBean({FreeTierBillingService.class})
-  @Import(ProfileService.class)
+  @Import({ProfileService.class, VerifiedInstitutionalAffiliationMapperImpl.class})
   static class Configuration {}
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/auth/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/auth/ProfileServiceTest.java
@@ -8,10 +8,12 @@ import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.billing.FreeTierBillingService;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
+import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
 import org.pmiops.workbench.model.Profile;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -27,6 +29,8 @@ public class ProfileServiceTest {
   @MockBean private UserTermsOfServiceDao mockUserTermsOfServiceDao;
 
   @Autowired ProfileService profileService;
+  @Autowired UserDao userDao;
+  @Autowired VerifiedInstitutionalAffiliationMapper verifiedInstitutionalAffiliationMapper;
 
   @TestConfiguration
   @MockBean({FreeTierBillingService.class})
@@ -35,7 +39,7 @@ public class ProfileServiceTest {
 
   @Test
   public void testGetProfile_empty() {
-    assertThat(profileService.getProfile(new DbUser())).isNotNull();
+    assertThat(profileService.getProfile(userDao.save(new DbUser()))).isNotNull();
   }
 
   @Test
@@ -43,6 +47,7 @@ public class ProfileServiceTest {
     // Regression coverage for RW-4219.
     DbUser user = new DbUser();
     user.setDemographicSurvey(new DbDemographicSurvey());
+    user = userDao.save(user);
     assertThat(profileService.getProfile(user)).isNotNull();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -30,6 +30,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
 import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV1;
@@ -75,7 +76,7 @@ public class UserServiceTest {
   @Autowired private UserDao userDao;
 
   @TestConfiguration
-  @Import({UserServiceImpl.class, InstitutionServiceImpl.class})
+  @Import({UserServiceImpl.class, InstitutionServiceImpl.class, InstitutionMapperImpl.class})
   static class Configuration {
     @Bean
     Clock clock() {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -30,6 +30,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV1;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
@@ -74,7 +75,7 @@ public class UserServiceTest {
   @Autowired private UserDao userDao;
 
   @TestConfiguration
-  @Import({UserServiceImpl.class})
+  @Import({UserServiceImpl.class, InstitutionServiceImpl.class})
   static class Configuration {
     @Bean
     Clock clock() {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationDaoTest.java
@@ -19,8 +19,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class VerifiedInstitutionalAffiliationTest {
-  @Autowired VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
+public class VerifiedInstitutionalAffiliationDaoTest {
+  @Autowired VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
   @Autowired InstitutionDao institutionDao;
   @Autowired UserDao userDao;
 
@@ -36,44 +36,44 @@ public class VerifiedInstitutionalAffiliationTest {
 
   @Test
   public void test_findAllByInstitution() {
-    assertThat(verifiedInstitutionalAffiliation.findAll()).isEmpty();
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst)).isEmpty();
+    assertThat(verifiedInstitutionalAffiliationDao.findAll()).isEmpty();
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(testInst)).isEmpty();
 
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
                 .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
 
-    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(testAffiliation);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+    assertThat(verifiedInstitutionalAffiliationDao.findAll()).containsExactly(testAffiliation);
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(testInst))
         .containsExactly(testAffiliation);
 
     DbInstitution otherInst =
         new DbInstitution().setShortName("Other").setDisplayName("Some Other Institute");
     otherInst = institutionDao.save(otherInst);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(otherInst)).isEmpty();
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(otherInst)).isEmpty();
   }
 
   @Test
   public void test_findAllByInstitution_oneAffiliationPerUser() {
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
                 .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
 
-    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(testAffiliation);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+    assertThat(verifiedInstitutionalAffiliationDao.findAll()).containsExactly(testAffiliation);
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(testInst))
         .containsExactly(testAffiliation);
 
     final DbInstitution newInst =
         institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
 
     final DbVerifiedInstitutionalAffiliation replacementAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             testAffiliation
                 .setUser(testUser)
                 .setInstitution(newInst)
@@ -81,10 +81,11 @@ public class VerifiedInstitutionalAffiliationTest {
                 .setInstitutionalRoleOtherText(
                     "Arbitrary and does not actually require enum to be OTHER"));
 
-    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(replacementAffiliation);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(newInst))
+    assertThat(verifiedInstitutionalAffiliationDao.findAll())
         .containsExactly(replacementAffiliation);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst)).isEmpty();
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(newInst))
+        .containsExactly(replacementAffiliation);
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(testInst)).isEmpty();
   }
 
   @Test
@@ -93,7 +94,7 @@ public class VerifiedInstitutionalAffiliationTest {
     testUser = userDao.save(testUser);
 
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
@@ -104,7 +105,7 @@ public class VerifiedInstitutionalAffiliationTest {
     newUser = userDao.save(newUser);
 
     final DbVerifiedInstitutionalAffiliation newAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(newUser)
                 .setInstitution(testInst)
@@ -112,55 +113,55 @@ public class VerifiedInstitutionalAffiliationTest {
                 .setInstitutionalRoleOtherText(
                     "Arbitrary and does not actually require enum to be OTHER"));
 
-    assertThat(verifiedInstitutionalAffiliation.findAll())
+    assertThat(verifiedInstitutionalAffiliationDao.findAll())
         .containsExactly(testAffiliation, newAffiliation);
-    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+    assertThat(verifiedInstitutionalAffiliationDao.findAllByInstitution(testInst))
         .containsExactly(testAffiliation, newAffiliation);
   }
 
   @Test
   public void test_findFirstByUser() {
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(userDao.save(new DbUser())))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(userDao.save(new DbUser())))
         .isEmpty();
 
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
                 .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
 
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(testUser))
         .hasValue(testAffiliation);
   }
 
   @Test
   public void test_findFirstByUser_oneAffiliationPerUser() {
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(userDao.save(new DbUser())))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(userDao.save(new DbUser())))
         .isEmpty();
 
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
                 .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
 
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(testUser))
         .hasValue(testAffiliation);
 
     final DbInstitution newInst =
         institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
 
     final DbVerifiedInstitutionalAffiliation replacementAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             testAffiliation
                 .setInstitution(newInst)
                 .setInstitutionalRoleEnum(InstitutionalRole.OTHER)
                 .setInstitutionalRoleOtherText(
                     "Arbitrary and does not actually require enum to be OTHER"));
 
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(testUser))
         .hasValue(replacementAffiliation);
   }
 
@@ -170,7 +171,7 @@ public class VerifiedInstitutionalAffiliationTest {
     testUser = userDao.save(testUser);
 
     final DbVerifiedInstitutionalAffiliation testAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(testUser)
                 .setInstitution(testInst)
@@ -181,7 +182,7 @@ public class VerifiedInstitutionalAffiliationTest {
     newUser = userDao.save(newUser);
 
     final DbVerifiedInstitutionalAffiliation newAffiliation =
-        verifiedInstitutionalAffiliation.save(
+        verifiedInstitutionalAffiliationDao.save(
             new DbVerifiedInstitutionalAffiliation()
                 .setUser(newUser)
                 .setInstitution(testInst)
@@ -189,17 +190,18 @@ public class VerifiedInstitutionalAffiliationTest {
                 .setInstitutionalRoleOtherText(
                     "Arbitrary and does not actually require enum to be OTHER"));
 
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(testUser))
         .hasValue(testAffiliation);
     assertThat(
-            verifiedInstitutionalAffiliation
+            verifiedInstitutionalAffiliationDao
                 .findFirstByUser(testUser)
                 .map(DbVerifiedInstitutionalAffiliation::getInstitution))
         .hasValue(testInst);
 
-    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(newUser)).hasValue(newAffiliation);
+    assertThat(verifiedInstitutionalAffiliationDao.findFirstByUser(newUser))
+        .hasValue(newAffiliation);
     assertThat(
-            verifiedInstitutionalAffiliation
+            verifiedInstitutionalAffiliationDao
                 .findFirstByUser(newUser)
                 .map(DbVerifiedInstitutionalAffiliation::getInstitution))
         .hasValue(testInst);
@@ -207,7 +209,7 @@ public class VerifiedInstitutionalAffiliationTest {
 
   @Test(expected = DataIntegrityViolationException.class)
   public void test_twoAffiliationsForUser() {
-    verifiedInstitutionalAffiliation.save(
+    verifiedInstitutionalAffiliationDao.save(
         new DbVerifiedInstitutionalAffiliation()
             .setUser(testUser)
             .setInstitution(testInst)
@@ -216,7 +218,7 @@ public class VerifiedInstitutionalAffiliationTest {
     final DbInstitution newInst =
         institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
 
-    verifiedInstitutionalAffiliation.save(
+    verifiedInstitutionalAffiliationDao.save(
         new DbVerifiedInstitutionalAffiliation()
             .setUser(testUser)
             .setInstitution(newInst)

--- a/api/src/test/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/VerifiedInstitutionalAffiliationTest.java
@@ -1,0 +1,227 @@
+package org.pmiops.workbench.db.dao;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.model.InstitutionalRole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class VerifiedInstitutionalAffiliationTest {
+  @Autowired VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
+  @Autowired InstitutionDao institutionDao;
+  @Autowired UserDao userDao;
+
+  private DbUser testUser = new DbUser();
+  private DbInstitution testInst =
+      new DbInstitution().setShortName("Broad").setDisplayName("The Broad Institute");
+
+  @Before
+  public void setUp() {
+    testUser = userDao.save(testUser);
+    testInst = institutionDao.save(testInst);
+  }
+
+  @Test
+  public void test_findAllByInstitution() {
+    assertThat(verifiedInstitutionalAffiliation.findAll()).isEmpty();
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst)).isEmpty();
+
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(testAffiliation);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+        .containsExactly(testAffiliation);
+
+    DbInstitution otherInst =
+        new DbInstitution().setShortName("Other").setDisplayName("Some Other Institute");
+    otherInst = institutionDao.save(otherInst);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(otherInst)).isEmpty();
+  }
+
+  @Test
+  public void test_findAllByInstitution_oneAffiliationPerUser() {
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(testAffiliation);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+        .containsExactly(testAffiliation);
+
+    final DbInstitution newInst =
+        institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
+
+    final DbVerifiedInstitutionalAffiliation replacementAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            testAffiliation
+                .setUser(testUser)
+                .setInstitution(newInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.OTHER)
+                .setInstitutionalRoleOtherText(
+                    "Arbitrary and does not actually require enum to be OTHER"));
+
+    assertThat(verifiedInstitutionalAffiliation.findAll()).containsExactly(replacementAffiliation);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(newInst))
+        .containsExactly(replacementAffiliation);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst)).isEmpty();
+  }
+
+  @Test
+  public void test_findAllByInstitution_manyAffiliationsPerInst() {
+    testUser.setUsername("Alice");
+    testUser = userDao.save(testUser);
+
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    DbUser newUser = new DbUser();
+    newUser.setUsername("Bob");
+    newUser = userDao.save(newUser);
+
+    final DbVerifiedInstitutionalAffiliation newAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(newUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.ADMIN)
+                .setInstitutionalRoleOtherText(
+                    "Arbitrary and does not actually require enum to be OTHER"));
+
+    assertThat(verifiedInstitutionalAffiliation.findAll())
+        .containsExactly(testAffiliation, newAffiliation);
+    assertThat(verifiedInstitutionalAffiliation.findAllByInstitution(testInst))
+        .containsExactly(testAffiliation, newAffiliation);
+  }
+
+  @Test
+  public void test_findFirstByUser() {
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(userDao.save(new DbUser())))
+        .isEmpty();
+
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+        .hasValue(testAffiliation);
+  }
+
+  @Test
+  public void test_findFirstByUser_oneAffiliationPerUser() {
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(userDao.save(new DbUser())))
+        .isEmpty();
+
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+        .hasValue(testAffiliation);
+
+    final DbInstitution newInst =
+        institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
+
+    final DbVerifiedInstitutionalAffiliation replacementAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            testAffiliation
+                .setInstitution(newInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.OTHER)
+                .setInstitutionalRoleOtherText(
+                    "Arbitrary and does not actually require enum to be OTHER"));
+
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+        .hasValue(replacementAffiliation);
+  }
+
+  @Test
+  public void test_findFirstByUser_manyAffiliationsPerInst() {
+    testUser.setUsername("Alice");
+    testUser = userDao.save(testUser);
+
+    final DbVerifiedInstitutionalAffiliation testAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(testUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    DbUser newUser = new DbUser();
+    newUser.setUsername("Bob");
+    newUser = userDao.save(newUser);
+
+    final DbVerifiedInstitutionalAffiliation newAffiliation =
+        verifiedInstitutionalAffiliation.save(
+            new DbVerifiedInstitutionalAffiliation()
+                .setUser(newUser)
+                .setInstitution(testInst)
+                .setInstitutionalRoleEnum(InstitutionalRole.ADMIN)
+                .setInstitutionalRoleOtherText(
+                    "Arbitrary and does not actually require enum to be OTHER"));
+
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(testUser))
+        .hasValue(testAffiliation);
+    assertThat(
+            verifiedInstitutionalAffiliation
+                .findFirstByUser(testUser)
+                .map(DbVerifiedInstitutionalAffiliation::getInstitution))
+        .hasValue(testInst);
+
+    assertThat(verifiedInstitutionalAffiliation.findFirstByUser(newUser)).hasValue(newAffiliation);
+    assertThat(
+            verifiedInstitutionalAffiliation
+                .findFirstByUser(newUser)
+                .map(DbVerifiedInstitutionalAffiliation::getInstitution))
+        .hasValue(testInst);
+  }
+
+  @Test(expected = DataIntegrityViolationException.class)
+  public void test_twoAffiliationsForUser() {
+    verifiedInstitutionalAffiliation.save(
+        new DbVerifiedInstitutionalAffiliation()
+            .setUser(testUser)
+            .setInstitution(testInst)
+            .setInstitutionalRoleEnum(InstitutionalRole.STUDENT));
+
+    final DbInstitution newInst =
+        institutionDao.save(new DbInstitution().setShortName("VUMC").setDisplayName("Vanderbilt"));
+
+    verifiedInstitutionalAffiliation.save(
+        new DbVerifiedInstitutionalAffiliation()
+            .setUser(testUser)
+            .setInstitution(newInst)
+            .setInstitutionalRoleEnum(InstitutionalRole.OTHER)
+            .setInstitutionalRoleOtherText(
+                "Arbitrary and does not actually require enum to be OTHER"));
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
@@ -1,0 +1,154 @@
+package org.pmiops.workbench.institution;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.repackaged.com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbInstitutionEmailAddress;
+import org.pmiops.workbench.db.model.DbInstitutionEmailDomain;
+import org.pmiops.workbench.model.Institution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@Import(InstitutionMapperImpl.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class InstitutionMapperTest {
+  @Autowired InstitutionMapper mapper;
+
+  private List<String> modelDomains;
+  private List<String> modelAddresses;
+  private Set<DbInstitutionEmailDomain> dbDomains;
+  private Set<DbInstitutionEmailAddress> dbAddresses;
+
+  @Before
+  public void setup() {
+    modelDomains = Lists.newArrayList("broad.org", "broadinst.org");
+    modelAddresses = Lists.newArrayList("joel@other-univ.org");
+
+    // note: these do NOT have their institutions set
+    // so they will match the withoutInstitution tests
+
+    dbDomains =
+        Sets.newHashSet(
+            new DbInstitutionEmailDomain().setEmailDomain("broad.org"),
+            new DbInstitutionEmailDomain().setEmailDomain("broadinst.org"));
+
+    dbAddresses =
+        Sets.newHashSet(new DbInstitutionEmailAddress().setEmailAddress("joel@other-univ.org"));
+  }
+
+  @Test
+  public void test_toModelDomains() {
+    final List<String> testModelDomains = mapper.toModelDomains(dbDomains);
+    assertThat(testModelDomains).containsExactlyElementsIn(modelDomains);
+
+    // round trip
+    assertThat(mapper.toDbDomainsWithoutInstitution(testModelDomains)).isEqualTo(dbDomains);
+  }
+
+  @Test
+  public void test_toDbDomainsWithoutInstitution() {
+    final Set<DbInstitutionEmailDomain> testDbDomains =
+        mapper.toDbDomainsWithoutInstitution(modelDomains);
+    assertThat(testDbDomains).containsExactlyElementsIn(dbDomains);
+
+    // round trip
+    assertThat(mapper.toModelDomains(testDbDomains)).isEqualTo(modelDomains);
+  }
+
+  @Test
+  public void test_toDbDomainsWithoutInstitution_null() {
+    assertThat(mapper.toDbDomainsWithoutInstitution(null)).isEmpty();
+  }
+
+  @Test
+  public void test_toModelAddresses() {
+    final List<String> testModelAddresses = mapper.toModelAddresses(dbAddresses);
+    assertThat(testModelAddresses).containsExactlyElementsIn(modelAddresses);
+
+    // round trip
+    assertThat(mapper.toDbAddressesWithoutInstitution(testModelAddresses)).isEqualTo(dbAddresses);
+  }
+
+  @Test
+  public void test_toDbAddressesWithoutInstitution() {
+    final Set<DbInstitutionEmailAddress> testDbAddresses =
+        mapper.toDbAddressesWithoutInstitution(modelAddresses);
+    assertThat(testDbAddresses).containsExactlyElementsIn(dbAddresses);
+
+    // round trip
+    assertThat(mapper.toModelAddresses(testDbAddresses)).isEqualTo(modelAddresses);
+  }
+
+  @Test
+  public void test_toDbAddressesWithoutInstitution_null() {
+    assertThat(mapper.toDbAddressesWithoutInstitution(null)).isEmpty();
+  }
+
+  @Test
+  public void test_modelToDb() {
+    final Institution inst =
+        new Institution()
+            .shortName("Test")
+            .displayName("Test State University")
+            .emailDomains(modelDomains)
+            .emailAddresses(modelAddresses);
+
+    final DbInstitution dbInst = mapper.modelToDb(inst);
+
+    assertThat(dbInst.getShortName()).isEqualTo(inst.getShortName());
+    assertThat(dbInst.getDisplayName()).isEqualTo(inst.getDisplayName());
+
+    // cannot assert that dbInst.getEmailDomains() matches dbDomains
+    // because the dbInst DbInstitutionEmailDomains are now associated with dbInst
+    // and the original dbDomains are not
+
+    // likewise for addresses
+
+    final Institution roundTrip = mapper.dbToModel(dbInst);
+
+    assertThat(roundTrip.getShortName()).isEqualTo(inst.getShortName());
+    assertThat(roundTrip.getDisplayName()).isEqualTo(inst.getDisplayName());
+    assertThat(roundTrip.getEmailDomains()).containsExactlyElementsIn(inst.getEmailDomains());
+    assertThat(roundTrip.getEmailAddresses()).containsExactlyElementsIn(inst.getEmailAddresses());
+  }
+
+  @Test
+  public void test_dbToModel() {
+    final DbInstitution dbInst =
+        new DbInstitution()
+            .setShortName("Test")
+            .setDisplayName("Test State University")
+            .setEmailDomains(dbDomains)
+            .setEmailAddresses(dbAddresses);
+
+    final Institution inst = mapper.dbToModel(dbInst);
+
+    assertThat(inst.getShortName()).isEqualTo(dbInst.getShortName());
+    assertThat(inst.getDisplayName()).isEqualTo(dbInst.getDisplayName());
+    assertThat(inst.getEmailDomains()).containsExactlyElementsIn(modelDomains);
+    assertThat(inst.getEmailAddresses()).containsExactlyElementsIn(modelAddresses);
+
+    final DbInstitution roundTrip = mapper.modelToDb(inst);
+
+    assertThat(roundTrip.getShortName()).isEqualTo(dbInst.getShortName());
+    assertThat(roundTrip.getDisplayName()).isEqualTo(dbInst.getDisplayName());
+
+    // cannot assert that roundTrip.getEmailDomains() matches dbInst.getEmailDomains()
+    // because the dbInst DbInstitutionEmailDomains are associated with dbInst
+    // and the roundTrip DbInstitutionEmailDomains are associated with roundTrip
+
+    // likewise for addresses
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -47,7 +47,7 @@ public class InstitutionServiceTest {
 
   @Before
   public void setUp() {
-    // will be retrieved as TEST_INST_AFTER_RT
+    // will be retrieved as roundTrippedTestInst
     service.createInstitution(testInst);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -4,14 +4,21 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.institution.InstitutionService.DeletionResult;
 import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.model.InstitutionalRole;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -20,71 +27,89 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
-@Import({InstitutionServiceImpl.class})
+@Import({InstitutionServiceImpl.class, InstitutionMapperImpl.class})
 public class InstitutionServiceTest {
   @Autowired private InstitutionService service;
+  @Autowired private UserDao userDao;
+  @Autowired private VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation;
 
-  private final Institution testInst =
+  private final Institution TEST_INST =
       new Institution().shortName("test").displayName("this is a test");
 
-  // the DB converts nulls to empty lists
-  private final Institution testInstAfterRT =
+  // the mapper converts nulls to empty sets
+  private final Institution TEST_INST_AFTER_RT =
       new Institution()
-          .shortName(testInst.getShortName())
-          .displayName(testInst.getDisplayName())
+          .shortName(TEST_INST.getShortName())
+          .displayName(TEST_INST.getDisplayName())
           .emailDomains(Collections.emptyList())
           .emailAddresses(Collections.emptyList());
 
   @Before
   public void setUp() {
-    service.createInstitution(testInst);
+    // will be retrieved as TEST_INST_AFTER_RT
+    service.createInstitution(TEST_INST);
   }
 
   @Test
   public void test_createInstitution() {
-    assertThat(service.getInstitutions()).hasSize(1);
-
-    service.createInstitution(
-        new Institution().shortName("otherInst").displayName("The Institution of testing"));
-    assertThat(service.getInstitutions()).hasSize(2);
-  }
-
-  @Test
-  public void test_deleteInstitution() {
-    assertThat(service.getInstitutions()).hasSize(1);
-
-    service.deleteInstitution(testInst.getShortName());
-    assertThat(service.getInstitutions()).hasSize(0);
-  }
-
-  @Test
-  public void test_getInstitutions() {
-    assertThat(service.getInstitutions()).containsExactly(testInstAfterRT);
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT);
 
     final Institution otherInst =
         new Institution()
             .shortName("otherInst")
             .displayName("The Institution of testing")
-            .emailDomains(new ArrayList<>())
-            .emailAddresses(new ArrayList<>());
-    service.createInstitution(otherInst);
-    assertThat(service.getInstitutions()).containsExactly(testInstAfterRT, otherInst);
+            .emailDomains(Collections.emptyList())
+            .emailAddresses(Collections.emptyList());
+    assertThat(service.createInstitution(otherInst)).isEqualTo(otherInst);
 
-    service.deleteInstitution(testInst.getShortName());
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT, otherInst);
+  }
+
+  @Test
+  public void test_deleteInstitution() {
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT);
+
+    assertThat(service.deleteInstitution(TEST_INST.getShortName()))
+        .isEqualTo(DeletionResult.SUCCESS);
+    assertThat(service.getInstitutions()).isEmpty();
+
+    service.createInstitution(TEST_INST);
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT);
+
+    createAffiliation(createUser("any email"), TEST_INST.getShortName());
+    assertThat(service.deleteInstitution(TEST_INST.getShortName()))
+        .isEqualTo(DeletionResult.HAS_VERIFIED_AFFILIATIONS);
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT);
+  }
+
+  @Test
+  public void test_getInstitutions() {
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT);
+
+    final Institution otherInst =
+        new Institution()
+            .shortName("otherInst")
+            .displayName("The Institution of testing")
+            .emailDomains(Collections.emptyList())
+            .emailAddresses(Collections.emptyList());
+    service.createInstitution(otherInst);
+    assertThat(service.getInstitutions()).containsExactly(TEST_INST_AFTER_RT, otherInst);
+
+    service.deleteInstitution(TEST_INST.getShortName());
     assertThat(service.getInstitutions()).containsExactly(otherInst);
   }
 
   @Test
   public void test_getInstitution() {
-    assertThat(service.getInstitution(testInst.getShortName())).hasValue(testInstAfterRT);
+    assertThat(service.getInstitution(TEST_INST.getShortName())).hasValue(TEST_INST_AFTER_RT);
     assertThat(service.getInstitution("otherInst")).isEmpty();
 
     final Institution otherInst =
         new Institution()
             .shortName("otherInst")
             .displayName("The Institution of testing")
-            .emailAddresses(new ArrayList<>())
-            .emailDomains(new ArrayList<>());
+            .emailAddresses(Collections.emptyList())
+            .emailDomains(Collections.emptyList());
     service.createInstitution(otherInst);
     assertThat(service.getInstitution("otherInst")).hasValue(otherInst);
   }
@@ -100,8 +125,8 @@ public class InstitutionServiceTest {
             .emailAddresses(
                 ImmutableList.of("joel@broad.org", "joel@broad.org", "joel@google.com"));
 
-    final Set<String> uniquifiedEmailDomains = new HashSet<>(instWithDupes.getEmailDomains());
-    final Set<String> uniquifiedEmailAddresses = new HashSet<>(instWithDupes.getEmailAddresses());
+    final Set<String> uniquifiedEmailDomains = Sets.newHashSet(instWithDupes.getEmailDomains());
+    final Set<String> uniquifiedEmailAddresses = Sets.newHashSet(instWithDupes.getEmailAddresses());
 
     final Institution uniquifiedInst = service.createInstitution(instWithDupes);
 
@@ -144,7 +169,7 @@ public class InstitutionServiceTest {
   public void test_InstitutionNotFound() {
     assertThat(service.getInstitution("missing")).isEmpty();
     assertThat(service.updateInstitution("missing", new Institution())).isEmpty();
-    assertThat(service.deleteInstitution("missing")).isFalse();
+    assertThat(service.deleteInstitution("missing")).isEqualTo(DeletionResult.NOT_FOUND);
   }
 
   @Test(expected = DataIntegrityViolationException.class)
@@ -152,5 +177,85 @@ public class InstitutionServiceTest {
     service.createInstitution(
         new Institution().shortName("test").displayName("We are all individuals"));
     service.createInstitution(new Institution().shortName("test").displayName("I'm not"));
+  }
+
+  @Test
+  public void test_emailValidation_domain() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .emailDomains(Lists.newArrayList("broad.org", "lab.broad.org")));
+
+    final DbUser user = createUser("user@broad.org");
+    final DbVerifiedInstitutionalAffiliation affiliation =
+        createAffiliation(user, inst.getShortName());
+
+    assertThat(service.validate(affiliation, user.getContactEmail())).isTrue();
+  }
+
+  @Test
+  public void test_emailValidation_address() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .emailDomains(Lists.newArrayList("broad.org", "mit.edu"))
+                .emailAddresses(
+                    Lists.newArrayList("external-researcher@sanger.uk", "science@aol.com")));
+
+    final DbUser user = createUser("external-researcher@sanger.uk");
+    final DbVerifiedInstitutionalAffiliation affiliation =
+        createAffiliation(user, inst.getShortName());
+
+    assertThat(service.validate(affiliation, user.getContactEmail())).isTrue();
+  }
+
+  @Test
+  public void test_emailValidation_null() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution().shortName("Broad").displayName("The Broad Institute"));
+
+    final DbUser user = userDao.save(new DbUser());
+    final DbVerifiedInstitutionalAffiliation affiliation =
+        createAffiliation(user, inst.getShortName());
+
+    assertThat(service.validate(affiliation, user.getContactEmail())).isFalse();
+  }
+
+  public void test_emailValidation_malformed() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .emailDomains(Lists.newArrayList("broad.org", "lab.broad.org")));
+
+    final DbUser user = createUser("user@hacker@broad.org");
+    final DbVerifiedInstitutionalAffiliation affiliation =
+        createAffiliation(user, inst.getShortName());
+
+    assertThat(service.validate(affiliation, user.getContactEmail())).isFalse();
+  }
+
+  private DbUser createUser(String contactEmail) {
+    DbUser user = new DbUser();
+    user.setContactEmail(contactEmail);
+    user = userDao.save(user);
+    return user;
+  }
+
+  private DbVerifiedInstitutionalAffiliation createAffiliation(
+      final DbUser user, final String instName) {
+    final DbInstitution inst = service.getDbInstitution(instName).get();
+    final DbVerifiedInstitutionalAffiliation affiliation =
+        new DbVerifiedInstitutionalAffiliation()
+            .setUser(user)
+            .setInstitution(inst)
+            .setInstitutionalRoleEnum(InstitutionalRole.FELLOW);
+    return verifiedInstitutionalAffiliation.save(affiliation);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -75,6 +75,7 @@ public class InstitutionServiceTest {
   @Test
   public void test_deleteAndRecreateInstitution() {
     service.deleteInstitution(testInst.getShortName());
+    assertThat(service.getInstitutions()).isEmpty();
     service.createInstitution(testInst);
     assertThat(service.getInstitutions()).containsExactly(roundTrippedTestInst);
   }

--- a/api/src/test/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapperTest.java
@@ -1,0 +1,124 @@
+package org.pmiops.workbench.institution;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.model.InstitutionalRole;
+import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@Import({
+  VerifiedInstitutionalAffiliationMapperImpl.class,
+  InstitutionServiceImpl.class,
+  InstitutionMapperImpl.class
+})
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class VerifiedInstitutionalAffiliationMapperTest {
+  @Autowired VerifiedInstitutionalAffiliationMapper mapper;
+
+  @Autowired InstitutionService institutionService;
+  @Autowired UserDao userDao;
+
+  private Institution testInstitution;
+
+  @Before
+  public void setUp() {
+    testInstitution =
+        institutionService.createInstitution(
+            new Institution().shortName("Broad").displayName("The Broad Institute"));
+  }
+
+  @Test
+  public void test_setDbInstitution() {
+    final VerifiedInstitutionalAffiliation source =
+        new VerifiedInstitutionalAffiliation().institutionShortName(testInstitution.getShortName());
+    final DbVerifiedInstitutionalAffiliation target = new DbVerifiedInstitutionalAffiliation();
+
+    mapper.setDbInstitution(target, source, institutionService);
+
+    assertThat(target.getInstitution().getShortName()).isEqualTo(testInstitution.getShortName());
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void test_setDbInstitution_missing() {
+    final VerifiedInstitutionalAffiliation source =
+        new VerifiedInstitutionalAffiliation().institutionShortName("not in DB");
+    final DbVerifiedInstitutionalAffiliation target = new DbVerifiedInstitutionalAffiliation();
+
+    mapper.setDbInstitution(target, source, institutionService);
+  }
+
+  @Test
+  public void test_dbToModel() {
+    final DbUser dbUser = userDao.save(new DbUser());
+    final DbVerifiedInstitutionalAffiliation dbAffiliation =
+        new DbVerifiedInstitutionalAffiliation()
+            .setUser(dbUser)
+            .setInstitution(
+                institutionService.getDbInstitution(testInstitution.getShortName()).get())
+            .setInstitutionalRoleEnum(InstitutionalRole.FELLOW)
+            .setInstitutionalRoleOtherText("A fine fellow, specifically");
+
+    final VerifiedInstitutionalAffiliation affiliation = mapper.dbToModel(dbAffiliation);
+
+    assertThat(affiliation.getInstitutionShortName())
+        .isEqualTo(dbAffiliation.getInstitution().getShortName());
+    assertThat(affiliation.getInstitutionalRoleEnum())
+        .isEqualTo(dbAffiliation.getInstitutionalRoleEnum());
+    assertThat(affiliation.getInstitutionalRoleOtherText())
+        .isEqualTo(dbAffiliation.getInstitutionalRoleOtherText());
+
+    // note: testInstitution needs to be saved in the DB for this call to work
+    final DbVerifiedInstitutionalAffiliation roundTrip =
+        mapper.modelToDbWithoutUser(affiliation, institutionService);
+
+    assertThat(roundTrip.getInstitution()).isEqualTo(dbAffiliation.getInstitution());
+    assertThat(roundTrip.getInstitutionalRoleEnum())
+        .isEqualTo(dbAffiliation.getInstitutionalRoleEnum());
+    assertThat(roundTrip.getInstitutionalRoleOtherText())
+        .isEqualTo(dbAffiliation.getInstitutionalRoleOtherText());
+  }
+
+  @Test
+  public void test_modelToDbWithoutUser() {
+    // final DbUser dbUser = userDao.save(new DbUser());
+    final VerifiedInstitutionalAffiliation affiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName(testInstitution.getShortName())
+            .institutionalRoleEnum(InstitutionalRole.FELLOW)
+            .institutionalRoleOtherText("A fine fellow, specifically");
+
+    // note: testInstitution needs to be saved in the DB for this call to work
+    final DbVerifiedInstitutionalAffiliation dbAffiliation =
+        mapper.modelToDbWithoutUser(affiliation, institutionService);
+
+    assertThat(dbAffiliation.getInstitution().getShortName())
+        .isEqualTo(affiliation.getInstitutionShortName());
+    assertThat(dbAffiliation.getInstitutionalRoleEnum())
+        .isEqualTo(affiliation.getInstitutionalRoleEnum());
+    assertThat(dbAffiliation.getInstitutionalRoleOtherText())
+        .isEqualTo(affiliation.getInstitutionalRoleOtherText());
+
+    final VerifiedInstitutionalAffiliation roundTrip = mapper.dbToModel(dbAffiliation);
+
+    assertThat(roundTrip.getInstitutionShortName())
+        .isEqualTo(affiliation.getInstitutionShortName());
+    assertThat(roundTrip.getInstitutionalRoleEnum())
+        .isEqualTo(affiliation.getInstitutionalRoleEnum());
+    assertThat(roundTrip.getInstitutionalRoleOtherText())
+        .isEqualTo(affiliation.getInstitutionalRoleOtherText());
+  }
+}

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -237,6 +237,10 @@ public class WorkbenchConfig {
     // Flag to indicate whether to use the new Moodle badges API
     // https://precisionmedicineinitiative.atlassian.net/browse/RW-2957
     public boolean enableMoodleV2Api;
+    // Do we require new users to have a contact email with a verified institutional affiliation,
+    // enforced by pattern-matching the user's contact email against the institution's
+    // set of whitelisted email domains or addresses
+    public boolean requireInstitutionalVerification;
   }
 
   public static class ActionAuditConfig {

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -109,7 +109,7 @@ definitions:
     enum: &Industry_Role [PRE_DOCTORAL, POST_DOCTORAL, EARLY, PI, FREE_TEXT]
     description: >
       This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
-      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_IND_HCNP.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is the UI-only InstitutionalRole_IND_HCNP.
       The two have slightly different values and are therefore NOT COMPATIBLE.
       This enum may be deleted in the future.
 
@@ -118,7 +118,7 @@ definitions:
     enum: &Educational_Role [TEACHER, STUDENT, ADMIN, FREE_TEXT]
     description: >
       This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
-      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_EDU.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is the UI-only InstitutionalRole_EDU.
       The two have slightly different values and are therefore NOT COMPATIBLE.
       This enum may be deleted in the future.
 
@@ -127,7 +127,7 @@ definitions:
     enum: &Role [UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, NON_TENURE, MID_CAREER, LATE_CAREER, PROJECT_PERSONNEL]
     description: >
       This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
-      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_ARI.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is the UI-only InstitutionalRole_ARI.
       The two have slightly different values and are therefore NOT COMPATIBLE.
       This enum may be deleted in the future.
 

--- a/common-api/src/main/resources/common_api.yaml
+++ b/common-api/src/main/resources/common_api.yaml
@@ -98,18 +98,38 @@ definitions:
   NonAcademicAffiliation:
     type: string
     enum: &Affiliation_Role [INDUSTRY, EDUCATIONAL_INSTITUTION, COMMUNITY_SCIENTIST, FREE_TEXT]
+    description: >
+      This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is OrganizationType.
+      The two have slightly different values and are therefore NOT COMPATIBLE.
+      This enum may be deleted in the future.
 
   IndustryRole:
     type: string
     enum: &Industry_Role [PRE_DOCTORAL, POST_DOCTORAL, EARLY, PI, FREE_TEXT]
+    description: >
+      This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_IND_HCNP.
+      The two have slightly different values and are therefore NOT COMPATIBLE.
+      This enum may be deleted in the future.
 
   EducationalRole:
     type: string
     enum: &Educational_Role [TEACHER, STUDENT, ADMIN, FREE_TEXT]
+    description: >
+      This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_EDU.
+      The two have slightly different values and are therefore NOT COMPATIBLE.
+      This enum may be deleted in the future.
 
   AcademicRole:
     type: string
     enum: &Role [UNDERGRADUATE, TRAINEE, FELLOW, EARLY_CAREER, NON_TENURE, MID_CAREER, LATE_CAREER, PROJECT_PERSONNEL]
+    description: >
+      This enum is used by the older Institutional Affiliation flow associated with the Demographic Survey.
+      The corresponding Verified Institutional Affiliation (newer flow) enum is InstitutionalRole_ARI.
+      The two have slightly different values and are therefore NOT COMPATIBLE.
+      This enum may be deleted in the future.
 
   FeaturedWorkspaceCategory:
     type: string


### PR DESCRIPTION
Description:

Add **verified_institutional_affiliation** DB table and **VerifiedInstitutionalAffiliation**.
Add Feature Flag **requireInstitutionalVerification**: when set, requires a VerifiedInstitutionalAffiliation in the Profile passed into the createAccount endpoint, and validates the user's contactEmail against the Institution's email patterns.
Prevents deletion of Institutions with affiliations.
Add **InstitutionMapper** and **VerifiedInstitutionalAffiliationMapper**
Add a **ResearcherVerifiedInstitutionalAffiliation** to the Researcher Directory if a VerifiedInstitutionalAffiliation is in the user's Profile

JIRA to add feature flag everywhere: https://precisionmedicineinitiative.atlassian.net/browse/RW-4465
JIRA to remove feature flag: https://precisionmedicineinitiative.atlassian.net/browse/RW-4361

Spring/Hibernate questions I could use some help with:
* How do I determine whether I should use Lazy or Eager fetching?  I had a LazyInitializationException bug that was fixed by turning off a transitive Eager fetch
* When do I need to `@Import` interface impls, and when will `@Autowired` or `@MockBean` handle this for me? 

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
