### PR TITLE
[RW-3994][risk=no] CB - Add rename option to search items

### DIFF
--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -622,6 +622,9 @@ definitions:
       id:
         description: Unique within the cohort definition
         type: string
+      name:
+        description: optional custom name set by user
+        type: string
       type:
         description: type of criteria
         type: string

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -3285,6 +3285,7 @@ definitions:
     enum:
       - NOTEBOOK
       - COHORT
+      - COHORT_SEARCH_ITEM
       - COHORT_REVIEW
       - CONCEPT_SET
       - DATASET

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.html
@@ -27,7 +27,7 @@
       <app-list-overview
         *ngIf="overview"
         [searchRequest]="criteria"
-        [updateCount]="triggerUpdate"
+        [updateCriteria]="updateCriteria"
         [updateSaving]="updateSaving"></app-list-overview>
     </div>
     <div *ngIf="loading" class="spinner root-spinner">

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.ts
@@ -25,7 +25,7 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
   error = false;
   overview = false;
   criteria = {includes: [], excludes: []};
-  triggerUpdate = 0;
+  updateCriteria = {update: 0, recalculate: true};
   cohort: any;
   resolve: Function;
   modalPromise: Promise<boolean> | null = null;
@@ -98,8 +98,8 @@ export class CohortSearchComponent implements OnInit, OnDestroy {
     wrapper.style.minHeight = pixel(window.innerHeight - top - ONE_REM);
   }
 
-  updateRequest = () => {
-    this.triggerUpdate++;
+  updateRequest = (recalculate: boolean) => {
+    this.updateCriteria = {update: this.updateCriteria.update + 1, recalculate};
   }
 
   updateSaving = (flag: boolean) => {

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -100,7 +100,7 @@ const styles = reactStyles({
 
 interface Props {
   searchRequest: any;
-  updateCount: number;
+  updateCriteria: any;
   updateSaving: Function;
 }
 
@@ -153,7 +153,8 @@ export const ListOverview = withCurrentWorkspace()(
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
-      if (this.props.updateCount > prevProps.updateCount && !this.definitionErrors) {
+      const {updateCriteria: {update, recalculate}} = this.props;
+      if (update > prevProps.updateCriteria.update && recalculate && !this.definitionErrors) {
         this.setState({loading: true, apiError: false});
         this.getTotalCount();
       }
@@ -441,10 +442,10 @@ export const ListOverview = withCurrentWorkspace()(
 })
 export class OverviewComponent extends ReactWrapperBase {
   @Input('searchRequest') searchRequest: Props['searchRequest'];
-  @Input('updateCount') updateCount: Props['updateCount'];
+  @Input('updateCriteria') updateCriteria: Props['updateCriteria'];
   @Input('updateSaving') updateSaving: Props['updateSaving'];
 
   constructor() {
-    super(ListOverview, ['searchRequest', 'updateCount', 'updateSaving']);
+    super(ListOverview, ['searchRequest', 'updateCriteria', 'updateSaving']);
   }
 }

--- a/ui/src/app/cohort-search/search-group/search-group.component.ts
+++ b/ui/src/app/cohort-search/search-group/search-group.component.ts
@@ -122,20 +122,20 @@ export class SearchGroupComponent implements OnInit {
     }
   }
 
-  update = () => {
+  update = (recalculate: boolean) => {
     // timeout prevents Angular 'value changed after checked' error
     setTimeout(() => {
       // prevent multiple total count calls when initializing multiple groups simultaneously
       // (on cohort edit or clone)
       const init = initExisting.getValue();
       if (!init || (init && this.index === 0)) {
-        this.updateRequest();
+        this.updateRequest(recalculate);
         if (init) {
           this.preventInputCalculate = true;
           initExisting.next(false);
         }
       }
-      if (this.activeItems && (!this.temporal || !this.temporalError)) {
+      if (recalculate && this.activeItems && (!this.temporal || !this.temporalError)) {
         this.loading = true;
         this.error = false;
         this.getGroupCount();

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -286,9 +286,12 @@ export function mapGroup(group: any) {
 }
 
 export function mapGroupItem(item: any, temporal: boolean) {
-  const {id, type, modifiers, temporalGroup} = item;
+  const {id, type, modifiers, name, temporalGroup} = item;
   const searchParameters = item.searchParameters.map(mapParameter);
   const searchGroupItem = <SearchGroupItem>{id, type, searchParameters, modifiers};
+  if (name) {
+    searchGroupItem.name = name;
+  }
   if (temporal) {
     searchGroupItem.temporalGroup = temporalGroup;
   }

--- a/ui/src/app/utils/resourceActions.ts
+++ b/ui/src/app/utils/resourceActions.ts
@@ -15,6 +15,8 @@ export function toDisplay(resourceType: ResourceType): string {
       return 'Notebook';
     case ResourceType.COHORT:
       return 'Cohort';
+    case ResourceType.COHORTSEARCHITEM:
+      return 'Item';
     case ResourceType.COHORTREVIEW:
       return 'Cohort Review';
     case ResourceType.CONCEPTSET:


### PR DESCRIPTION
Add an "Edit criteria name" option to the search item snowman menu to set a custom item name. Uses the `RenameModal` component used for renaming other resources.

<img width="658" alt="Screen Shot 2020-02-18 at 1 23 28 PM" src="https://user-images.githubusercontent.com/40036095/74770472-f2597900-5251-11ea-9894-c163558cc4be.png">


<img width="622" alt="Screen Shot 2020-02-18 at 1 23 50 PM" src="https://user-images.githubusercontent.com/40036095/74770487-f84f5a00-5251-11ea-86c2-43d10aeef10d.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
