### PR TITLE
[RW-4450][Risk=no] Remove limit on SQL query in notebooks

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -742,13 +742,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             .append(domainAsString)
             .append("\"")
             .toString();
-    String sqlLimitSection =
-        new StringBuilder(
-                "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n")
-            .append(
-                "# If you increase the limit and run into responsiveness issues, please request a VM size upgrade.\n")
-            .append("max_number_of_rows = '1000000'")
-            .toString();
     String sqlSection;
     String dataFrameSection;
     String displayHeadSection;
@@ -762,7 +755,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                     generateSqlWithEnvironmentVariables(
                         queryJobConfiguration.getQuery(), kernelTypeEnum),
                     queryJobConfiguration.getNamedParameters())
-                + " \nLIMIT \"\"\" + max_number_of_rows";
+                + "\"\"\"";
         dataFrameSection =
             namespace + "df = pandas.read_gbq(" + namespace + "sql, dialect=\"standard\")";
         displayHeadSection = namespace + "df.head(5)";
@@ -775,7 +768,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                     generateSqlWithEnvironmentVariables(
                         queryJobConfiguration.getQuery(), kernelTypeEnum),
                     queryJobConfiguration.getNamedParameters())
-                + " \nLIMIT \", max_number_of_rows, sep=\"\")";
+                + "\", sep=\"\")";
         dataFrameSection =
             namespace
                 + "df <- bq_table_download(bq_dataset_query(Sys.getenv(\"WORKSPACE_CDR\"), "
@@ -787,9 +780,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         throw new BadRequestException("Language " + kernelTypeEnum.toString() + " not supported.");
     }
 
-    return sqlLimitSection
-        + "\n\n"
-        + descriptiveComment
+    return descriptiveComment
         + "\n"
         + sqlSection
         + "\n\n"

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -732,9 +732,6 @@ public class DataSetControllerTest {
     assertThat(response.getCode())
         .isEqualTo(
             "import pandas\nimport os\n\n"
-                + "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n"
-                + "# If you increase the limit and run into responsiveness issues, please request a VM size upgrade.\n"
-                + "max_number_of_rows = '1000000'\n\n"
                 + "# This query represents dataset \"blah\" for domain \"condition\"\n"
                 + prefix
                 + "sql = \"\"\"SELECT PERSON_ID FROM `"
@@ -746,9 +743,8 @@ public class DataSetControllerTest {
                 + TEST_CDR_TABLE
                 + ".person` person WHERE "
                 + NAMED_PARAMETER_VALUE.getValue()
-                + " IN (2, 5))) "
-                + "\n"
-                + "LIMIT \"\"\" + max_number_of_rows\n"
+                + " IN (2, 5)))"
+                + "\"\"\"\n"
                 + "\n"
                 + prefix
                 + "df = pandas.read_gbq("
@@ -783,9 +779,6 @@ public class DataSetControllerTest {
     assertThat(response.getCode())
         .isEqualTo(
             "library(bigrquery)\n\n"
-                + "# The ‘max_number_of_rows’ parameter limits the number of rows in the query so that the result set can fit in memory.\n"
-                + "# If you increase the limit and run into responsiveness issues, please request a VM size upgrade.\n"
-                + "max_number_of_rows = '1000000'\n\n"
                 + "# This query represents dataset \"blah\" for domain \"condition\"\n"
                 + prefix
                 + "sql <- paste(\"SELECT PERSON_ID FROM `"
@@ -797,8 +790,8 @@ public class DataSetControllerTest {
                 + TEST_CDR_TABLE
                 + ".person` person WHERE "
                 + NAMED_PARAMETER_VALUE.getValue()
-                + " IN (2, 5))) \n"
-                + "LIMIT \", max_number_of_rows, sep=\"\")\n"
+                + " IN (2, 5)))"
+                + "\", sep=\"\")\n"
                 + "\n"
                 + prefix
                 + "df <- bq_table_download(bq_dataset_query(Sys.getenv(\"WORKSPACE_CDR\"), "


### PR DESCRIPTION
Description:
This removes the limit for our generated SQL queries. I tested to make sure large queries fail loudly with both Python and R. R failed loudly, Python failed not as loudly, but its hard to tell if it is because my computer went to sleep or there were memory problems. I did successfully download about 43 million rows though. My test query was `SELECT * FROM condition_occurrence`

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
