### PR TITLE
[RW-4244][Risk=no] Show cookie banner only on signin page

### DIFF
--- a/ui/src/app/pages/login/login.tsx
+++ b/ui/src/app/pages/login/login.tsx
@@ -1,8 +1,11 @@
 import {Button} from 'app/components/buttons';
 import {Header, SmallHeader} from 'app/components/headers';
 import colors from 'app/styles/colors';
-import {reactStyles} from 'app/utils';
+import {cookiesEnabled, reactStyles} from 'app/utils';
 
+import {faTimes} from '@fortawesome/free-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {FlexRow} from 'app/components/flex';
 import * as React from 'react';
 
 const googleIcon = '/assets/icons/google-icon.png';
@@ -42,58 +45,122 @@ export const styles = reactStyles({
   fismaSection: {
     fontWeight: 400,
     marginBottom: '0.5rem'
+  },
+  cookiePolicyMessage: {
+    position: 'fixed',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    padding: '0.5rem 1rem',
+    borderTop: `7px solid ${colors.secondary}`,
+    bottom: 0,
+    backgroundColor: colors.light
+  },
+  iconStyles: {
+    height: 24,
+    width: 24,
+    color: colors.accent,
+    cursor: 'pointer'
   }
 });
 
+const cookieKey = 'aou-cookie-banner-dismissed';
 
-export const LoginReactComponent: React.FunctionComponent<{
-  signIn: Function, onCreateAccount: Function }> = ({ signIn, onCreateAccount}) => {
-    return <div data-test-id='login' style={{marginTop: '5.5rem',  paddingLeft: '3rem'}}>
-      <div>
-        <Header>
-          Already have an account?
-        </Header>
+interface LoginReactComponentProps {
+  signIn: Function;
+  onCreateAccount: Function;
+}
+
+interface LoginReactComponentState {
+  cookieBannerClosed: boolean;
+}
+
+export class LoginReactComponent extends React.Component<LoginReactComponentProps, LoginReactComponentState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      // This is only used to handle the removal of the cookie banner after x is clicked, without a refresh.
+      cookieBannerClosed: false
+    };
+  }
+  
+  handleCloseCookies() {
+    if (cookiesEnabled()) {
+      this.setState({cookieBannerClosed: true});
+      localStorage.setItem(cookieKey, 'cookie-banner-dismissed');
+    }
+  }
+
+  cookieBannerVisible() {
+    if (cookiesEnabled()) {
+      return !localStorage.getItem(cookieKey) && !this.state.cookieBannerClosed;
+    } else {
+      return true;
+    }
+  }
+  render() {
+    const {signIn, onCreateAccount} = this.props;
+    return <React.Fragment>
+      <div data-test-id='login' style={{marginTop: '5.5rem',  paddingLeft: '3rem'}}>
         <div>
-          <Button type='primary' style={styles.button} onClick={signIn}>
-            <img src={googleIcon}
+          <Header>
+            Already have an account?
+          </Header>
+          <div>
+            <Button type='primary' style={styles.button} onClick={signIn}>
+              <img src={googleIcon}
                    style={{ height: '54px', width: '54px', margin: '-3px 19px -3px -3px'}}/>
-            <div>
-              Sign In with Google
-            </div>
+              <div>
+                Sign In with Google
+              </div>
+            </Button>
+          </div>
+        </div>
+        <div style={{paddingTop: '1.25rem'}}>
+          <SmallHeader>
+            Don't have an account?
+          </SmallHeader>
+          <Button type='secondary' style={{fontSize: '10px', margin: '.25rem .5rem .25rem 0',
+            border: `1px solid ${colors.primary}`, height: '48px'}}
+                  onClick={onCreateAccount}>
+            Create Account
           </Button>
         </div>
-      </div>
-      <div style={{paddingTop: '1.25rem'}}>
-        <SmallHeader>
-          Don't have an account?
-        </SmallHeader>
-        <Button type='secondary' style={{fontSize: '10px', margin: '.25rem .5rem .25rem 0',
-          border: `1px solid ${colors.primary}`, height: '48px'}}
-                onClick={onCreateAccount}>
-          Create Account
-        </Button>
-      </div>
-      <div style={{width: '400px'}}>
-        <h4 style={{...styles.fismaCommon, ...styles.fismaHeader}}>Warning Notice</h4>
-        <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
-          You are accessing a US Government web site which may contain information that must be
-          protected under the US Privacy Act or other sensitive information and is intended for
-          Government authorized use only.
-        </div>
-        <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
-          Unauthorized attempts to upload information, change information, or use of this web site
-          may result in disciplinary action, civil, and/or criminal penalties. Unauthorized users
-          of this website should have no expectation of privacy regarding any communications or
-          data processed by this website.
-        </div>
-        <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
-          By continuing to log in, anyone accessing this website expressly consents to monitoring
-          of their actions and all communications or data transiting or stored on related to this
-          website and is advised that if such monitoring reveals possible evidence of criminal
-          activity, NIH may provide that evidence to law enforcement officials.
+        <div style={{width: '400px'}}>
+          <h4 style={{...styles.fismaCommon, ...styles.fismaHeader}}>Warning Notice</h4>
+          <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
+            You are accessing a US Government web site which may contain information that must be
+            protected under the US Privacy Act or other sensitive information and is intended for
+            Government authorized use only.
+          </div>
+          <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
+            Unauthorized attempts to upload information, change information, or use of this web site
+            may result in disciplinary action, civil, and/or criminal penalties. Unauthorized users
+            of this website should have no expectation of privacy regarding any communications or
+            data processed by this website.
+          </div>
+          <div style={{...styles.fismaCommon, ...styles.fismaSection}}>
+            By continuing to log in, anyone accessing this website expressly consents to monitoring
+            of their actions and all communications or data transiting or stored on related to this
+            website and is advised that if such monitoring reveals possible evidence of criminal
+            activity, NIH may provide that evidence to law enforcement officials.
+          </div>
         </div>
       </div>
-    </div>;
-  };
+      {this.cookieBannerVisible() && <div style={styles.cookiePolicyMessage}>
+          <FlexRow style={{alignItems: 'center'}}>
+              <img src='assets/images/cookies.png'/>
+              <div style={{paddingLeft: '1rem', color: colors.primary}}>
+                  We use cookies to help provide you with the best experience we can. By continuing to use our site, you consent
+                  to our <a href='/cookie-policy' target='_blank'
+                            style={{display: 'inline-block'}}>Cookie Policy</a>.
+              </div>
+          </FlexRow>
+          <FontAwesomeIcon icon={faTimes} style={styles.iconStyles} onClick={() => this.handleCloseCookies()} />
+      </div>}
+    </React.Fragment>;
+  }
+}
 
 export default LoginReactComponent;

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -11,7 +11,6 @@ import {LoginReactComponent} from 'app/pages/login/login';
 import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
 import {
-  cookiesEnabled,
   reactStyles,
   ReactWrapperBase, ServerConfigProps,
   WindowSizeProps,
@@ -21,9 +20,7 @@ import {
 
 import {DataAccessLevel, Degree, Profile} from 'generated/fetch';
 
-import {faTimes} from '@fortawesome/free-solid-svg-icons';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {FlexColumn, FlexRow} from 'app/components/flex';
+import {FlexColumn} from 'app/components/flex';
 import * as React from 'react';
 
 // A template function which returns the appropriate style config based on window size and
@@ -73,23 +70,6 @@ const styles = reactStyles({
     alignItems: 'flex-start',
     width: 'auto',
     minHeight: '100vh'
-  },
-  cookiePolicyMessage: {
-    position: 'fixed',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    width: '100%',
-    padding: '0.5rem 1rem',
-    borderTop: `7px solid ${colors.secondary}`,
-    bottom: 0,
-    backgroundColor: colors.light
-  },
-  iconStyles: {
-    height: 24,
-    width: 24,
-    color: colors.accent,
-    cursor: 'pointer'
   }
 });
 
@@ -130,7 +110,6 @@ export const StepToImageConfig: Map<SignInStep, BackgroundImageConfig> = new Map
 
 export const SIGNED_OUT_HEADER_IMAGE = '/assets/images/logo-registration-non-signed-in.svg';
 
-const cookieKey = 'aou-cookie-banner-dismissed';
 
 export interface SignInProps extends ServerConfigProps, WindowSizeProps {
   initialStep?: SignInStep;
@@ -139,7 +118,6 @@ export interface SignInProps extends ServerConfigProps, WindowSizeProps {
 }
 
 interface SignInState {
-  cookieBannerClosed: boolean;
   currentStep: SignInStep;
   // Tracks the invitation key provided by the user. This is a required parameter in the createUser
   // API call.
@@ -159,8 +137,6 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
-      // This is only used to handle the removal of the cookie banner after x is clicked, without a refresh.
-      cookieBannerClosed: false,
       currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
       invitationKey: null,
       termsOfServiceVersion: null,
@@ -314,20 +290,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
     }
   }
 
-  handleCloseCookies() {
-    if (cookiesEnabled()) {
-      this.setState({cookieBannerClosed: true});
-      localStorage.setItem(cookieKey, 'cookie-banner-dismissed');
-    }
-  }
 
-  cookieBannerVisible() {
-    if (cookiesEnabled()) {
-      return !localStorage.getItem(cookieKey) && !this.state.cookieBannerClosed;
-    } else {
-      return true;
-    }
-  }
 
   render() {
     const backgroundImages = StepToImageConfig.get(this.state.currentStep);
@@ -338,17 +301,6 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
                   src={SIGNED_OUT_HEADER_IMAGE}/></div>
         {this.renderSignInStep(this.state.currentStep)}
       </FlexColumn>
-      {this.cookieBannerVisible() && <div style={styles.cookiePolicyMessage}>
-        <FlexRow style={{alignItems: 'center'}}>
-          <img src='assets/images/cookies.png'/>
-          <div style={{paddingLeft: '1rem', color: colors.primary}}>
-            We use cookies to help provide you with the best experience we can. By continuing to use our site, you consent
-            to our <a href='/cookie-policy' target='_blank'
-                         style={{display: 'inline-block'}}>Cookie Policy</a>.
-          </div>
-        </FlexRow>
-        <FontAwesomeIcon icon={faTimes} style={styles.iconStyles} onClick={() => this.handleCloseCookies()} />
-      </div>}
     </FlexColumn>;
   }
 }


### PR DESCRIPTION
Description:
Moves the cookie banner to the LoginComponent, as opposed to the SignInComponent so that it is only visible on the login page.


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
