### PR TITLE
[RW-3848][Risk=no] Disable links for unregistered user in sidenav

### DIFF
--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -34,9 +34,8 @@ describe('SideNav', () => {
     sideNavItems.forEach(sideNavItem => {
       const disabled = sideNavItem.props().disabled;
       const sideNavItemText = sideNavItem.text();
-      disabledItems = disabledItems.filterWhere(disabledItem => disabledItem.text() !== sideNavItem.text()
-        || !disabled);
       if (disabledItemText.includes(sideNavItemText)) {
+        disabledItems = disabledItems.filterWhere(disabledItem => disabledItem.text() !== sideNavItem.text());
         disabledItemText = disabledItemText.filter(textItem => textItem !== sideNavItemText);
         expect(disabled).toBeTruthy();
       }

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -1,0 +1,39 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {SideNav, SideNavItem, SideNavProps} from './side-nav';
+import {ProfileStubVariables} from "../../testing/stubs/profile-api-stub";
+import {DataAccessLevel} from "../../generated/fetch";
+
+
+describe('SideNav', () => {
+  const existingNames = [];
+  const props: SideNavProps = {
+    profile: ProfileStubVariables.PROFILE_STUB,
+    bannerAdminActive: false,
+    workspaceAdminActive: false,
+    homeActive: false,
+    libraryActive: false,
+    onToggleSideNav: () => {},
+    profileActive: false,
+    userAdminActive: false,
+    workspacesActive: false,
+  };
+  const component = () => mount(<SideNav {...props}/>);
+  it('should render', () => {
+    const wrapper = component();
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('disables options when user not registered', () => {
+    const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB,
+      dataAccessLevel: DataAccessLevel.Unregistered}}/>);
+    const disabledItems = ['Your Workspaces', 'Featured Workspaces', 'User Support'];
+    wrapper.find(SideNavItem).forEach(sideNavItem => {
+      if (disabledItems.includes(sideNavItem.text())) {
+        expect(sideNavItem.props().disabled).toBeTruthy();
+      }
+    });
+  });
+
+});

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -7,7 +7,6 @@ import {DataAccessLevel} from "../../generated/fetch";
 
 
 describe('SideNav', () => {
-  const existingNames = [];
   const props: SideNavProps = {
     profile: ProfileStubVariables.PROFILE_STUB,
     bannerAdminActive: false,
@@ -28,12 +27,24 @@ describe('SideNav', () => {
   it('disables options when user not registered', () => {
     const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB,
       dataAccessLevel: DataAccessLevel.Unregistered}}/>);
-    const disabledItems = ['Your Workspaces', 'Featured Workspaces', 'User Support'];
-    wrapper.find(SideNavItem).forEach(sideNavItem => {
-      if (disabledItems.includes(sideNavItem.text())) {
-        expect(sideNavItem.props().disabled).toBeTruthy();
+    // These are our expected items to be disabled when you are not registered
+    let disabledItemText = ['Your Workspaces', 'Featured Workspaces', 'User Support'];
+    const sideNavItems = wrapper.find(SideNavItem);
+    let disabledItems = sideNavItems.filterWhere(sideNavItem => sideNavItem.props().disabled);
+    sideNavItems.forEach(sideNavItem => {
+      const disabled = sideNavItem.props().disabled;
+      const sideNavItemText = sideNavItem.text();
+      disabledItems = disabledItems.filterWhere(disabledItem => disabledItem.text() !== sideNavItem.text()
+        || !disabled);
+      if (disabledItemText.includes(sideNavItemText)) {
+        disabledItemText = disabledItemText.filter(textItem => textItem !== sideNavItemText);
+        expect(disabled).toBeTruthy();
       }
     });
+    // Ensure all expected items to be found.
+    expect(disabledItemText.length).toBe(0);
+    // Ensure there are no other disabled items that we do not expect.
+    expect(disabledItems.length).toBe(0);
   });
 
 });

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -92,7 +92,7 @@ interface SideNavItemState {
   subItemsOpen: boolean;
 }
 
-class SideNavItem extends React.Component<SideNavItemProps, SideNavItemState> {
+export class SideNavItem extends React.Component<SideNavItemProps, SideNavItemState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -144,7 +144,7 @@ class SideNavItem extends React.Component<SideNavItemProps, SideNavItemState> {
       data-test-id={this.props.content.toString().replace(/\s/g, '') + '-menu-item'}
       style={this.getStyles(this.props.active, this.state.hovering, this.props.disabled)}
       onClick={() => {
-        if (this.props.parentOnClick) {
+        if (this.props.parentOnClick && !this.props.disabled) {
           this.props.parentOnClick();
         }
         this.onClick();
@@ -232,8 +232,6 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
   }
 
   onToggleAdmin() {
-    this.setState({showAdminOptions: false});
-    this.state.adminRef.current.closeSubItems();
     this.setState(previousState => ({showAdminOptions: !previousState.showAdminOptions}));
   }
 
@@ -302,12 +300,14 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
         onToggleSideNav={() => this.props.onToggleSideNav()}
         href={'/library'}
         active={this.props.libraryActive}
+        disabled={!hasRegisteredAccessFetch(profile.dataAccessLevel)}
       />
       <SideNavItem
         icon='help'
         content={'User Support'}
         onToggleSideNav={() => this.props.onToggleSideNav()}
         parentOnClick={() => this.redirectToZendesk()}
+        disabled={!hasRegisteredAccessFetch(profile.dataAccessLevel)}
       />
       <SideNavItem
         icon='envelope'


### PR DESCRIPTION
Description:
Changes the sidenav to disable more things when you aren't registered. Adds unit tests to test for that. Also driveby fixes a bug I found where the user can't close the admin dropdown. 


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
