### PR TITLE
[RW-4464][risk=low] Plumb proper agent details to audit system

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditEvent.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditEvent.kt
@@ -1,11 +1,9 @@
 package org.pmiops.workbench.actionaudit
 
-import java.lang.IllegalArgumentException
-
 data class ActionAuditEvent constructor(
     val timestamp: Long,
     val agentType: AgentType,
-    val agentId: Long,
+    val agentIdMaybe: Long?,
     val agentEmailMaybe: String?,
     val actionId: String,
     val actionType: ActionType,
@@ -22,7 +20,7 @@ data class ActionAuditEvent constructor(
     data class Builder internal constructor(
         var timestamp: Long? = null,
         var agentType: AgentType? = null,
-        var agentId: Long? = null,
+        var agentIdMaybe: Long? = null,
         var agentEmailMaybe: String? = null,
         var actionId: String? = null,
         var actionType: ActionType? = null,
@@ -34,7 +32,7 @@ data class ActionAuditEvent constructor(
     ) {
         fun timestamp(timestamp: Long) = apply { this.timestamp = timestamp }
         fun agentType(agentType: AgentType) = apply { this.agentType = agentType }
-        fun agentId(agentId: Long) = apply { this.agentId = agentId }
+        fun agentIdMaybe(agentIdMaybe: Long?) = apply { this.agentIdMaybe = agentIdMaybe }
         fun agentEmailMaybe(agentEmailMaybe: String?) = apply { this.agentEmailMaybe = agentEmailMaybe }
         fun actionId(actionId: String) = apply { this.actionId = actionId }
         fun actionType(actionType: ActionType) = apply { this.actionType = actionType }
@@ -46,11 +44,10 @@ data class ActionAuditEvent constructor(
 
         private fun verifyRequiredFields() {
             if (timestamp == null ||
-                agentType == null ||
-                agentId == null ||
-                actionId == null ||
-                actionType == null ||
-                targetType == null) {
+                    agentType == null ||
+                    actionId == null ||
+                    actionType == null ||
+                    targetType == null) {
                 throw IllegalArgumentException("Missing required arguments.")
             }
         }
@@ -60,7 +57,7 @@ data class ActionAuditEvent constructor(
             return ActionAuditEvent(
                     timestamp = this.timestamp!!,
                     agentType = agentType!!,
-                    agentId = agentId!!,
+                    agentIdMaybe = agentIdMaybe,
                     agentEmailMaybe = agentEmailMaybe,
                     actionId = actionId!!,
                     actionType = actionType!!,
@@ -71,6 +68,7 @@ data class ActionAuditEvent constructor(
                     newValueMaybe = newValueMaybe)
         }
     }
+
     companion object {
         @JvmStatic
         fun builder(): Builder {

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditServiceImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditServiceImpl.kt
@@ -5,13 +5,13 @@ import com.google.cloud.logging.LogEntry
 import com.google.cloud.logging.Logging
 import com.google.cloud.logging.Payload.JsonPayload
 import com.google.cloud.logging.Severity
+import org.pmiops.workbench.config.WorkbenchConfig
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
 import java.util.HashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Provider
-import org.pmiops.workbench.config.WorkbenchConfig
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Service
 
 @Service
 class ActionAuditServiceImpl @Autowired
@@ -47,11 +47,11 @@ constructor(private val configProvider: Provider<WorkbenchConfig>, private val c
         jsonValuesByColumn[AuditColumn.ACTION_ID.name] = auditEvent.actionId
         jsonValuesByColumn[AuditColumn.ACTION_TYPE.name] = auditEvent.actionType
         jsonValuesByColumn[AuditColumn.AGENT_TYPE.name] = auditEvent.agentType
-        jsonValuesByColumn[AuditColumn.AGENT_ID.name] = auditEvent.agentId
+        jsonValuesByColumn[AuditColumn.AGENT_ID.name] = auditEvent.agentIdMaybe
         jsonValuesByColumn[AuditColumn.AGENT_EMAIL.name] = auditEvent.agentEmailMaybe
         jsonValuesByColumn[AuditColumn.TARGET_TYPE.name] = auditEvent.targetType
         jsonValuesByColumn[AuditColumn.TARGET_ID.name] = auditEvent.targetIdMaybe
-        jsonValuesByColumn[AuditColumn.AGENT_ID.name] = auditEvent.agentId
+        jsonValuesByColumn[AuditColumn.AGENT_ID.name] = auditEvent.agentIdMaybe
         jsonValuesByColumn[AuditColumn.TARGET_PROPERTY.name] = auditEvent.targetPropertyMaybe
         jsonValuesByColumn[AuditColumn.PREV_VALUE.name] = auditEvent.previousValueMaybe
         jsonValuesByColumn[AuditColumn.NEW_VALUE.name] = auditEvent.newValueMaybe

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/Agent.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/Agent.kt
@@ -1,0 +1,33 @@
+package org.pmiops.workbench.actionaudit
+
+import org.pmiops.workbench.db.model.DbUser
+
+data class Agent constructor(
+    val agentType: AgentType,
+    val idMaybe: Long? = null,
+    val emailMaybe: String? = null
+) {
+
+    companion object {
+        @JvmStatic
+        fun asUser(u: DbUser): Agent {
+            return Agent(
+                    agentType = AgentType.USER,
+                    idMaybe = u.userId,
+                    emailMaybe = u.username)
+        }
+
+        @JvmStatic
+        fun asAdmin(u: DbUser): Agent {
+            return Agent(
+                    agentType = AgentType.ADMINISTRATOR,
+                    idMaybe = u.userId,
+                    emailMaybe = u.username)
+        }
+
+        @JvmStatic
+        fun asSystem(): Agent {
+            return Agent(agentType = AgentType.SYSTEM)
+        }
+    }
+}

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AuthDomainAuditorImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AuthDomainAuditorImpl.java
@@ -41,7 +41,7 @@ public class AuthDomainAuditorImpl implements AuthDomainAuditor {
         ActionAuditEvent.builder()
             .timestamp(clock.millis())
             .agentType(AgentType.ADMINISTRATOR)
-            .agentId(adminDbUserProvider.get().getUserId())
+            .agentIdMaybe(adminDbUserProvider.get().getUserId())
             .agentEmailMaybe(adminDbUserProvider.get().getUsername())
             .actionId(actionIdProvider.get())
             .actionType(ActionType.EDIT)

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ClusterAuditorImpl.java
@@ -44,7 +44,7 @@ public class ClusterAuditorImpl implements ClusterAuditor {
                         .timestamp(clock.millis())
                         .actionId(actionId)
                         .agentType(AgentType.ADMINISTRATOR)
-                        .agentId(userProvider.get().getUserId())
+                        .agentIdMaybe(userProvider.get().getUserId())
                         .agentEmailMaybe(userProvider.get().getUsername())
                         .actionType(ActionType.DELETE)
                         .newValueMaybe(clusterName)

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorImpl.kt
@@ -154,7 +154,7 @@ constructor(
                 actionId = actionIdProvider.get(),
                 actionType = ActionType.DETECT_HIGH_EGRESS_EVENT,
                 agentType = AgentType.SYSTEM,
-                agentIdMaybe = 0,
+                agentIdMaybe = null,
                 agentEmailMaybe = null,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = null

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorImpl.kt
@@ -93,7 +93,7 @@ constructor(
                 actionId = actionId,
                 actionType = ActionType.DETECT_HIGH_EGRESS_EVENT,
                 agentType = AgentType.USER,
-                agentId = agentId,
+                agentIdMaybe = agentId,
                 agentEmailMaybe = agentEmail,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = dbWorkspace.workspaceId
@@ -154,7 +154,7 @@ constructor(
                 actionId = actionIdProvider.get(),
                 actionType = ActionType.DETECT_HIGH_EGRESS_EVENT,
                 agentType = AgentType.SYSTEM,
-                agentId = 0,
+                agentIdMaybe = 0,
                 agentEmailMaybe = null,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = null

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorImpl.kt
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.actionaudit.auditors
 
-import java.time.Clock
-import javax.inject.Provider
 import org.pmiops.workbench.actionaudit.ActionAuditEvent
 import org.pmiops.workbench.actionaudit.ActionAuditService
 import org.pmiops.workbench.actionaudit.ActionType
@@ -14,6 +12,8 @@ import org.pmiops.workbench.model.Profile
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
+import java.time.Clock
+import javax.inject.Provider
 
 @Service
 class ProfileAuditorImpl @Autowired
@@ -33,17 +33,17 @@ constructor(
         val createEvents = propertiesByName.entries
                 .map {
                     ActionAuditEvent(
-                        timestamp = clock.millis(),
-                        actionId = actionId,
-                        actionType = ActionType.CREATE,
-                        agentType = AgentType.USER,
-                        agentId = createdProfile.userId,
-                        agentEmailMaybe = createdProfile.contactEmail,
-                        targetType = TargetType.PROFILE,
-                        targetIdMaybe = createdProfile.userId,
-                        targetPropertyMaybe = it.key,
-                        previousValueMaybe = null,
-                        newValueMaybe = it.value)
+                            timestamp = clock.millis(),
+                            actionId = actionId,
+                            actionType = ActionType.CREATE,
+                            agentType = AgentType.USER,
+                            agentIdMaybe = createdProfile.userId,
+                            agentEmailMaybe = createdProfile.contactEmail,
+                            targetType = TargetType.PROFILE,
+                            targetIdMaybe = createdProfile.userId,
+                            targetPropertyMaybe = it.key,
+                            previousValueMaybe = null,
+                            newValueMaybe = it.value)
                 }
         actionAuditService.send(createEvents)
     }
@@ -61,7 +61,7 @@ constructor(
                             actionId = actionIdProvider.get(),
                             actionType = ActionType.EDIT,
                             agentType = AgentType.USER,
-                            agentId = userProvider.get().userId,
+                            agentIdMaybe = userProvider.get().userId,
                             agentEmailMaybe = userProvider.get().username,
                             targetType = TargetType.PROFILE,
                             targetIdMaybe = userProvider.get().userId,
@@ -80,7 +80,7 @@ constructor(
                 actionId = actionIdProvider.get(),
                 actionType = ActionType.DELETE,
                 agentType = AgentType.USER,
-                agentId = userId,
+                agentIdMaybe = userId,
                 agentEmailMaybe = userEmail,
                 targetType = TargetType.PROFILE,
                 targetIdMaybe = userId,
@@ -96,7 +96,7 @@ constructor(
                 actionId = actionIdProvider.get(),
                 actionType = ActionType.LOGIN,
                 agentType = AgentType.USER,
-                agentId = dbUser.userId,
+                agentIdMaybe = dbUser.userId,
                 agentEmailMaybe = dbUser.username,
                 targetType = TargetType.WORKBENCH,
                 targetIdMaybe = null,

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditAdapterImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditAdapterImpl.java
@@ -26,19 +26,19 @@ public class UserServiceAuditAdapterImpl implements UserServiceAuditor {
 
   private final ActionAuditService actionAuditService;
   private final Clock clock;
-  private Provider<String> actionIdProvider;
   private Provider<DbUser> dbUserProvider;
+  private Provider<String> actionIdProvider;
 
   @Autowired
   public UserServiceAuditAdapterImpl(
       ActionAuditService actionAuditService,
       Clock clock,
-      @Qualifier("ACTION_ID") Provider<String> actionIdProvider,
-      Provider<DbUser> dbUserProvider) {
+      Provider<DbUser> dbUserProvider,
+      @Qualifier("ACTION_ID") Provider<String> actionIdProvider) {
     this.actionAuditService = actionAuditService;
     this.clock = clock;
-    this.actionIdProvider = actionIdProvider;
     this.dbUserProvider = dbUserProvider;
+    this.actionIdProvider = actionIdProvider;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditor.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditor.java
@@ -2,13 +2,17 @@ package org.pmiops.workbench.actionaudit.auditors;
 
 import java.time.Instant;
 import java.util.Optional;
+import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.DataAccessLevel;
 
 public interface UserServiceAuditor {
   void fireUpdateDataAccessAction(
-      DbUser targetUser, DataAccessLevel dataAccessLevel, DataAccessLevel previousDataAccessLevel);
+      DbUser targetUser,
+      DataAccessLevel dataAccessLevel,
+      DataAccessLevel previousDataAccessLevel,
+      AgentType agentType);
 
   void fireAdministrativeBypassTime(
       long userId, BypassTimeTargetProperty bypassTimeTargetProperty, Optional<Instant> bypassTime);

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditor.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditor.java
@@ -2,7 +2,7 @@ package org.pmiops.workbench.actionaudit.auditors;
 
 import java.time.Instant;
 import java.util.Optional;
-import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.DataAccessLevel;
@@ -12,7 +12,7 @@ public interface UserServiceAuditor {
       DbUser targetUser,
       DataAccessLevel dataAccessLevel,
       DataAccessLevel previousDataAccessLevel,
-      AgentType agentType);
+      Agent agent);
 
   void fireAdministrativeBypassTime(
       long userId, BypassTimeTargetProperty bypassTimeTargetProperty, Optional<Instant> bypassTime);

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorImpl.kt
@@ -1,8 +1,5 @@
 package org.pmiops.workbench.actionaudit.auditors
 
-import java.time.Clock
-import java.util.logging.Logger
-import javax.inject.Provider
 import org.pmiops.workbench.actionaudit.ActionAuditEvent
 import org.pmiops.workbench.actionaudit.ActionAuditService
 import org.pmiops.workbench.actionaudit.ActionType
@@ -17,7 +14,10 @@ import org.pmiops.workbench.model.Workspace
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
+import java.time.Clock
 import java.util.logging.Level
+import java.util.logging.Logger
+import javax.inject.Provider
 
 @Service
 class WorkspaceAuditorImpl @Autowired
@@ -33,18 +33,19 @@ constructor(
         val propertyValues = TargetPropertyExtractor.getPropertyValuesByName(
                 WorkspaceTargetProperty.values(), createdWorkspace)
         val events = propertyValues.entries
-                .map { ActionAuditEvent(
-                        actionId = info.actionId,
-                        agentEmailMaybe = info.userEmail,
-                        actionType = ActionType.CREATE,
-                        agentType = AgentType.USER,
-                        agentId = info.userId,
-                        targetType = TargetType.WORKSPACE,
-                        targetPropertyMaybe = it.key,
-                        targetIdMaybe = dbWorkspaceId,
-                        previousValueMaybe = null,
-                        newValueMaybe = it.value,
-                        timestamp = info.timestamp)
+                .map {
+                    ActionAuditEvent(
+                            actionId = info.actionId,
+                            agentEmailMaybe = info.userEmail,
+                            actionType = ActionType.CREATE,
+                            agentType = AgentType.USER,
+                            agentIdMaybe = info.userId,
+                            targetType = TargetType.WORKSPACE,
+                            targetPropertyMaybe = it.key,
+                            targetIdMaybe = dbWorkspaceId,
+                            previousValueMaybe = null,
+                            newValueMaybe = it.value,
+                            timestamp = info.timestamp)
                 }
         actionAuditService.send(events)
     }
@@ -65,19 +66,21 @@ constructor(
                 editedWorkspace)
 
         val actionAuditEvents = propertyToChangedValue.entries
-                .map { ActionAuditEvent(
-                        actionId = info.actionId,
-                        agentEmailMaybe = info.userEmail,
-                        actionType = ActionType.EDIT,
-                        agentType = AgentType.USER,
-                        agentId = info.userId,
-                        targetType = TargetType.WORKSPACE,
-                        targetPropertyMaybe = it.key,
-                        targetIdMaybe = workspaceId,
-                        previousValueMaybe = it.value.previousValue,
-                        newValueMaybe = it.value.newValue,
-                        timestamp = info.timestamp
-                ) }
+                .map {
+                    ActionAuditEvent(
+                            actionId = info.actionId,
+                            agentEmailMaybe = info.userEmail,
+                            actionType = ActionType.EDIT,
+                            agentType = AgentType.USER,
+                            agentIdMaybe = info.userId,
+                            targetType = TargetType.WORKSPACE,
+                            targetPropertyMaybe = it.key,
+                            targetIdMaybe = workspaceId,
+                            previousValueMaybe = it.value.previousValue,
+                            newValueMaybe = it.value.newValue,
+                            timestamp = info.timestamp
+                    )
+                }
         actionAuditService.send(actionAuditEvents)
     }
 
@@ -91,7 +94,7 @@ constructor(
                 agentEmailMaybe = info.userEmail,
                 actionType = ActionType.DELETE,
                 agentType = AgentType.USER,
-                agentId = info.userId,
+                agentIdMaybe = info.userId,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = dbWorkspace.workspaceId,
                 timestamp = info.timestamp)
@@ -115,7 +118,7 @@ constructor(
                 agentEmailMaybe = info.userEmail,
                 actionType = ActionType.DUPLICATE_FROM,
                 agentType = AgentType.USER,
-                agentId = info.userId,
+                agentIdMaybe = info.userId,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = sourceWorkspaceId,
                 timestamp = info.timestamp
@@ -124,18 +127,20 @@ constructor(
                 WorkspaceTargetProperty.values(), destinationWorkspace)
 
         val destinationEvents: List<ActionAuditEvent> = destinationPropertyValues.entries
-                .map { ActionAuditEvent(
-                        actionId = info.actionId,
-                        agentEmailMaybe = info.userEmail,
-                        actionType = ActionType.DUPLICATE_TO,
-                        agentType = AgentType.USER,
-                        agentId = info.userId,
-                        targetType = TargetType.WORKSPACE,
-                        targetPropertyMaybe = it.key,
-                        targetIdMaybe = destinationWorkspaceId,
-                        newValueMaybe = it.value,
-                        timestamp = info.timestamp
-                        ) }
+                .map {
+                    ActionAuditEvent(
+                            actionId = info.actionId,
+                            agentEmailMaybe = info.userEmail,
+                            actionType = ActionType.DUPLICATE_TO,
+                            agentType = AgentType.USER,
+                            agentIdMaybe = info.userId,
+                            targetType = TargetType.WORKSPACE,
+                            targetPropertyMaybe = it.key,
+                            targetIdMaybe = destinationWorkspaceId,
+                            newValueMaybe = it.value,
+                            timestamp = info.timestamp
+                    )
+                }
 
         val allEvents = listOf(listOf(sourceEvent), destinationEvents).flatten()
         actionAuditService.send(allEvents)
@@ -155,7 +160,7 @@ constructor(
                 actionType = ActionType.COLLABORATE,
                 agentType = AgentType.USER,
                 agentEmailMaybe = info.userEmail,
-                agentId = info.userId,
+                agentIdMaybe = info.userId,
                 timestamp = info.timestamp,
                 targetType = TargetType.WORKSPACE,
                 targetIdMaybe = sourceWorkspaceId,
@@ -165,18 +170,20 @@ constructor(
         )
 
         val inviteeEvents = aclStringsByUserId.entries
-                .map { ActionAuditEvent(
-                        actionId = info.actionId,
-                        actionType = ActionType.COLLABORATE,
-                        agentType = AgentType.USER,
-                        agentEmailMaybe = info.userEmail,
-                        agentId = info.userId,
-                        timestamp = info.timestamp,
-                        targetType = TargetType.USER,
-                        targetIdMaybe = it.key,
-                        targetPropertyMaybe = AclTargetProperty.ACCESS_LEVEL.name,
-                        newValueMaybe = it.value
-                ) }
+                .map {
+                    ActionAuditEvent(
+                            actionId = info.actionId,
+                            actionType = ActionType.COLLABORATE,
+                            agentType = AgentType.USER,
+                            agentEmailMaybe = info.userEmail,
+                            agentIdMaybe = info.userId,
+                            timestamp = info.timestamp,
+                            targetType = TargetType.USER,
+                            targetIdMaybe = it.key,
+                            targetPropertyMaybe = AclTargetProperty.ACCESS_LEVEL.name,
+                            newValueMaybe = it.value
+                    )
+                }
         val allEvents = listOf(listOf(workspaceTargetEvent), inviteeEvents).flatten()
         actionAuditService.send(allEvents)
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.json.JSONObject;
-import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ClusterAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -346,7 +346,7 @@ public class ClusterController implements ClusterApiDelegate {
           return u;
         },
         user,
-        AgentType.ADMINISTRATOR);
+        Agent.asAdmin(userProvider.get()));
     userService.logAdminUserAction(
         user.getUserId(), "cluster config override", oldOverride, new Gson().toJson(override));
     return ResponseEntity.ok(new EmptyResponse());

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.json.JSONObject;
+import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.actionaudit.auditors.ClusterAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -344,7 +345,8 @@ public class ClusterController implements ClusterApiDelegate {
           u.setClusterConfigDefault(override);
           return u;
         },
-        user);
+        user,
+        AgentType.ADMINISTRATOR);
     userService.logAdminUserAction(
         user.getUserId(), "cluster config override", oldOverride, new Gson().toJson(override));
     return ResponseEntity.ok(new EmptyResponse());

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -8,6 +8,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
@@ -74,9 +75,9 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
         DbUser updatedUser;
         if (workbenchConfigProvider.get().featureFlags.enableMoodleV2Api) {
-          updatedUser = userService.syncComplianceTrainingStatusV2(user);
+          updatedUser = userService.syncComplianceTrainingStatusV2(user, AgentType.SYSTEM);
         } else {
-          updatedUser = userService.syncComplianceTrainingStatusV1(user);
+          updatedUser = userService.syncComplianceTrainingStatusV1(user, AgentType.SYSTEM);
         }
 
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
@@ -98,10 +99,11 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         }
       } catch (org.pmiops.workbench.moodle.ApiException | NotFoundException e) {
         errorCount++;
-        log.severe(
+        log.log(
+            Level.SEVERE,
             String.format(
-                "Error syncing compliance training status for user %s: %s",
-                user.getUsername(), e.getMessage()));
+                "Error syncing compliance training status for user %s", user.getUsername()),
+            e);
       }
     }
 
@@ -136,7 +138,8 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp oldTime = user.getEraCommonsCompletionTime();
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 
-        DbUser updatedUser = userService.syncEraCommonsStatusUsingImpersonation(user);
+        DbUser updatedUser =
+            userService.syncEraCommonsStatusUsingImpersonation(user, AgentType.SYSTEM);
 
         Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
@@ -200,7 +203,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 
-        DbUser updatedUser = userService.syncTwoFactorAuthStatus(user);
+        DbUser updatedUser = userService.syncTwoFactorAuthStatus(user, AgentType.SYSTEM);
 
         Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -8,7 +8,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
@@ -75,9 +75,9 @@ public class OfflineUserController implements OfflineUserApiDelegate {
 
         DbUser updatedUser;
         if (workbenchConfigProvider.get().featureFlags.enableMoodleV2Api) {
-          updatedUser = userService.syncComplianceTrainingStatusV2(user, AgentType.SYSTEM);
+          updatedUser = userService.syncComplianceTrainingStatusV2(user, Agent.asSystem());
         } else {
-          updatedUser = userService.syncComplianceTrainingStatusV1(user, AgentType.SYSTEM);
+          updatedUser = userService.syncComplianceTrainingStatusV1(user, Agent.asSystem());
         }
 
         Timestamp newTime = updatedUser.getComplianceTrainingCompletionTime();
@@ -139,7 +139,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 
         DbUser updatedUser =
-            userService.syncEraCommonsStatusUsingImpersonation(user, AgentType.SYSTEM);
+            userService.syncEraCommonsStatusUsingImpersonation(user, Agent.asSystem());
 
         Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();
@@ -203,7 +203,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();
         DataAccessLevel oldLevel = user.getDataAccessLevelEnum();
 
-        DbUser updatedUser = userService.syncTwoFactorAuthStatus(user, AgentType.SYSTEM);
+        DbUser updatedUser = userService.syncTwoFactorAuthStatus(user, Agent.asSystem());
 
         Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         DataAccessLevel newLevel = user.getDataAccessLevelEnum();

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.config;
 
 import com.google.api.services.oauth2.model.Userinfoplus;
+import java.util.Optional;
 import javax.servlet.ServletContext;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.db.model.DbUser;
@@ -61,20 +62,14 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public Userinfoplus userInfo(UserAuthentication userAuthentication) {
-    if (userAuthentication == null) {
-      return null;
-    }
-    return userAuthentication.getPrincipal();
+  public Userinfoplus userInfo(Optional<UserAuthentication> userAuthentication) {
+    return userAuthentication.map(UserAuthentication::getPrincipal).orElse(null);
   }
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public DbUser user(UserAuthentication userAuthentication) {
-    if (userAuthentication == null) {
-      return null;
-    }
-    return userAuthentication.getUser();
+  public DbUser user(Optional<UserAuthentication> userAuthentication) {
+    return userAuthentication.map(UserAuthentication::getUser).orElse(null);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -51,18 +52,28 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public UserAuthentication userAuthentication() {
-    return (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth == null) {
+      return null;
+    }
+    return (UserAuthentication) auth;
   }
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public Userinfoplus userInfo(UserAuthentication userAuthentication) {
+    if (userAuthentication == null) {
+      return null;
+    }
     return userAuthentication.getPrincipal();
   }
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public DbUser user(UserAuthentication userAuthentication) {
+    if (userAuthentication == null) {
+      return null;
+    }
     return userAuthentication.getUser();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.function.Function;
+import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
@@ -15,7 +16,8 @@ import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
-  DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier, DbUser dbUser);
+  DbUser updateUserWithRetries(
+      Function<DbUser, DbUser> userModifier, DbUser dbUser, AgentType agentType);
 
   DbUser createServiceAccountUser(String email);
 
@@ -73,21 +75,21 @@ public interface UserService {
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   @Deprecated
-  DbUser syncComplianceTrainingStatusV1(DbUser user)
+  DbUser syncComplianceTrainingStatusV1(DbUser user, AgentType agentType)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   DbUser syncComplianceTrainingStatusV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
-  DbUser syncComplianceTrainingStatusV2(DbUser user)
+  DbUser syncComplianceTrainingStatusV2(DbUser user, AgentType agentType)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   DbUser syncEraCommonsStatus();
 
-  DbUser syncEraCommonsStatusUsingImpersonation(DbUser user)
+  DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, AgentType agentType)
       throws IOException, org.pmiops.workbench.firecloud.ApiException;
 
   void syncTwoFactorAuthStatus();
 
-  DbUser syncTwoFactorAuthStatus(DbUser targetUser);
+  DbUser syncTwoFactorAuthStatus(DbUser targetUser, AgentType agentType);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.function.Function;
-import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
@@ -16,8 +16,7 @@ import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
-  DbUser updateUserWithRetries(
-      Function<DbUser, DbUser> userModifier, DbUser dbUser, AgentType agentType);
+  DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier, DbUser dbUser, Agent agent);
 
   DbUser createServiceAccountUser(String email);
 
@@ -75,21 +74,21 @@ public interface UserService {
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   @Deprecated
-  DbUser syncComplianceTrainingStatusV1(DbUser user, AgentType agentType)
+  DbUser syncComplianceTrainingStatusV1(DbUser user, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   DbUser syncComplianceTrainingStatusV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
-  DbUser syncComplianceTrainingStatusV2(DbUser user, AgentType agentType)
+  DbUser syncComplianceTrainingStatusV2(DbUser user, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   DbUser syncEraCommonsStatus();
 
-  DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, AgentType agentType)
+  DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, Agent agent)
       throws IOException, org.pmiops.workbench.firecloud.ApiException;
 
   void syncTwoFactorAuthStatus();
 
-  DbUser syncTwoFactorAuthStatus(DbUser targetUser, AgentType agentType);
+  DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent);
 }

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/ActionAuditEventTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/ActionAuditEventTest.java
@@ -27,7 +27,7 @@ public class ActionAuditEventTest {
             .agentType(AgentType.USER)
             .actionId(ACTION_ID)
             .actionType(ActionType.EDIT)
-            .agentId(USER_ID)
+            .agentIdMaybe(USER_ID)
             .agentEmailMaybe(USER_EMAIL)
             .targetType(TargetType.COHORT)
             .targetPropertyMaybe(TARGET_PROPERTY)
@@ -37,7 +37,7 @@ public class ActionAuditEventTest {
     assertThat(event.getAgentType()).isEqualTo(AgentType.USER);
     assertThat(event.getActionId()).isEqualTo(ACTION_ID);
     assertThat(event.getActionType()).isEqualTo(ActionType.EDIT);
-    assertThat(event.getAgentId()).isEqualTo(USER_ID);
+    assertThat(event.getAgentIdMaybe()).isEqualTo(USER_ID);
     assertThat(event.getAgentEmailMaybe()).isEqualTo(USER_EMAIL);
     assertThat(event.getTargetType()).isEqualTo(TargetType.COHORT);
     assertThat(event.getTargetPropertyMaybe()).isEqualTo(TARGET_PROPERTY);

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/ActionAuditServiceTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/ActionAuditServiceTest.kt
@@ -1,20 +1,17 @@
 package org.pmiops.workbench.actionaudit
 
-import com.google.common.truth.Truth.assertThat
-
 import com.google.cloud.logging.LogEntry
 import com.google.cloud.logging.Logging
 import com.google.cloud.logging.Payload.JsonPayload
 import com.google.cloud.logging.Payload.Type
 import com.google.common.collect.ImmutableList
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import java.util.Arrays
-import javax.inject.Provider
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +19,8 @@ import org.pmiops.workbench.config.WorkbenchConfig
 import org.pmiops.workbench.config.WorkbenchConfig.ActionAuditConfig
 import org.pmiops.workbench.config.WorkbenchConfig.ServerConfig
 import org.springframework.test.context.junit4.SpringRunner
+import java.util.Arrays
+import javax.inject.Provider
 
 @RunWith(SpringRunner::class)
 class ActionAuditServiceTest {
@@ -34,14 +33,14 @@ class ActionAuditServiceTest {
     @Before
     fun setUp() {
         val actionAuditConfig = ActionAuditConfig()
-            .apply { logName = "log_path_1" }
+                .apply { logName = "log_path_1" }
 
         val serverConfig = ServerConfig()
-            .apply { projectId = "gcp-project-id" }
+                .apply { projectId = "gcp-project-id" }
 
         val workbenchConfig = WorkbenchConfig()
-            .apply { actionAudit = actionAuditConfig }
-            .apply { server = serverConfig }
+                .apply { actionAudit = actionAuditConfig }
+                .apply { server = serverConfig }
         whenever(mockConfigProvider.get()).thenReturn(workbenchConfig)
 
         actionAuditService = ActionAuditServiceImpl(mockConfigProvider, mockLogging)
@@ -125,7 +124,7 @@ class ActionAuditServiceTest {
                 targetType = TargetType.DATASET,
                 targetIdMaybe = 1L,
                 agentType = AgentType.USER,
-                agentId = AGENT_ID_1,
+                agentIdMaybe = AGENT_ID_1,
                 actionId = ACTION_ID,
                 actionType = ActionType.EDIT,
                 targetPropertyMaybe = "foot",
@@ -138,7 +137,7 @@ class ActionAuditServiceTest {
                 targetType = TargetType.DATASET,
                 targetIdMaybe = 2L,
                 agentType = AgentType.USER,
-                agentId = AGENT_ID_2,
+                agentIdMaybe = AGENT_ID_2,
                 actionId = ACTION_ID,
                 actionType = ActionType.EDIT,
                 targetPropertyMaybe = "height",

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/AuthDomainAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/AuthDomainAuditorTest.java
@@ -41,7 +41,7 @@ public class AuthDomainAuditorTest {
 
     assertThat(event.getTimestamp()).isEqualTo(ActionAuditTestConfig.INSTANT.toEpochMilli());
     assertThat(event.getAgentType()).isEqualTo(AgentType.ADMINISTRATOR);
-    assertThat(event.getAgentId()).isEqualTo(ActionAuditTestConfig.ADMINISTRATOR_USER_ID);
+    assertThat(event.getAgentIdMaybe()).isEqualTo(ActionAuditTestConfig.ADMINISTRATOR_USER_ID);
     assertThat(event.getAgentEmailMaybe()).contains(ActionAuditTestConfig.ADMINISTRATOR_EMAIL);
     assertThat(event.getActionId()).contains(ActionAuditTestConfig.ACTION_ID);
     assertThat(event.getActionType()).isEqualTo(ActionType.EDIT);

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
@@ -114,7 +114,7 @@ public class EgressEventAuditorTest {
         .containsExactly(AgentType.USER);
     assertThat(events.stream().map(event -> event.getActionType()).collect(Collectors.toSet()))
         .containsExactly(ActionType.DETECT_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.getAgentId()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(event -> event.getAgentIdMaybe()).collect(Collectors.toSet()))
         .containsExactly(USER_ID);
     assertThat(events.stream().map(event -> event.getAgentEmailMaybe()).collect(Collectors.toSet()))
         .containsExactly(USER_EMAIL);
@@ -156,7 +156,7 @@ public class EgressEventAuditorTest {
 
     // Some of the properties should be nulled out, since we can't identify the target workspace
     // for the egress event.
-    assertThat(events.stream().map(event -> event.getAgentId()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(event -> event.getAgentIdMaybe()).collect(Collectors.toSet()))
         .containsExactly(0);
     assertThat(
             events.stream()

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
@@ -5,10 +5,6 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-
-import java.time.Clock
-import java.time.Instant
-import javax.inject.Provider
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +24,9 @@ import org.pmiops.workbench.model.Profile
 import org.pmiops.workbench.model.Race
 import org.springframework.test.context.junit4.SpringRunner
 import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import javax.inject.Provider
 
 @RunWith(SpringRunner::class)
 class ProfileAuditorTest {
@@ -43,8 +42,8 @@ class ProfileAuditorTest {
     @Before
     fun setUp() {
         user = DbUser()
-            .apply { userId = 1001 }
-            .apply { username = USER_EMAIL }
+                .apply { userId = 1001 }
+                .apply { username = USER_EMAIL }
 
         profileAuditAdapter = ProfileAuditorImpl(
                 userProvider = mockUserProvider,
@@ -71,41 +70,41 @@ class ProfileAuditorTest {
 
     private fun buildProfile(): Profile {
         val caltechAffiliation = InstitutionalAffiliation()
-            .apply { institution = "Caltech" }
-            .apply { role = "T.A." }
-            .apply { nonAcademicAffiliation = NonAcademicAffiliation.COMMUNITY_SCIENTIST }
-            .apply { other = "They are all fine houses." }
+                .apply { institution = "Caltech" }
+                .apply { role = "T.A." }
+                .apply { nonAcademicAffiliation = NonAcademicAffiliation.COMMUNITY_SCIENTIST }
+                .apply { other = "They are all fine houses." }
 
         val mitAffiliation = InstitutionalAffiliation()
-            .apply { institution = "MIT" }
-            .apply { role = "Professor" }
-            .apply { nonAcademicAffiliation = NonAcademicAffiliation.EDUCATIONAL_INSTITUTION }
+                .apply { institution = "MIT" }
+                .apply { role = "Professor" }
+                .apply { nonAcademicAffiliation = NonAcademicAffiliation.EDUCATIONAL_INSTITUTION }
 
         val demographicSurvey1 = DemographicSurvey()
-            .apply { disability = false }
-            .apply { ethnicity = Ethnicity.NOT_HISPANIC }
-            .apply { yearOfBirth = BigDecimal.valueOf(1999) }
-            .apply { race = listOf(Race.PREFER_NO_ANSWER) }
-            .apply { education = Education.MASTER }
-            .apply { identifiesAsLgbtq = true }
-            .apply { lgbtqIdentity = "gay" }
+                .apply { disability = false }
+                .apply { ethnicity = Ethnicity.NOT_HISPANIC }
+                .apply { yearOfBirth = BigDecimal.valueOf(1999) }
+                .apply { race = listOf(Race.PREFER_NO_ANSWER) }
+                .apply { education = Education.MASTER }
+                .apply { identifiesAsLgbtq = true }
+                .apply { lgbtqIdentity = "gay" }
 
         return Profile()
-            .apply { userId = 444 }
-            .apply { username = "slim_shady" }
-            .apply { contactEmail = USER_EMAIL }
-            .apply { dataAccessLevel = DataAccessLevel.REGISTERED }
-            .apply { givenName = "Robert" }
-            .apply { familyName = "Paulson" }
-            .apply { phoneNumber = "867-5309" }
-            .apply { currentPosition = "Grad Student" }
-            .apply { organization = "Classified" }
-            .apply { disabled = false }
-            .apply { aboutYou = "Nobody in particular" }
-            .apply { areaOfResearch = "Aliens" }
-            .apply { professionalUrl = "linkedin.com" }
-            .apply { institutionalAffiliations = listOf(caltechAffiliation, mitAffiliation) }
-            .apply { demographicSurvey = demographicSurvey1 }
+                .apply { userId = 444 }
+                .apply { username = "slim_shady" }
+                .apply { contactEmail = USER_EMAIL }
+                .apply { dataAccessLevel = DataAccessLevel.REGISTERED }
+                .apply { givenName = "Robert" }
+                .apply { familyName = "Paulson" }
+                .apply { phoneNumber = "867-5309" }
+                .apply { currentPosition = "Grad Student" }
+                .apply { organization = "Classified" }
+                .apply { disabled = false }
+                .apply { aboutYou = "Nobody in particular" }
+                .apply { areaOfResearch = "Aliens" }
+                .apply { professionalUrl = "linkedin.com" }
+                .apply { institutionalAffiliations = listOf(caltechAffiliation, mitAffiliation) }
+                .apply { demographicSurvey = demographicSurvey1 }
     }
 
     @Test
@@ -117,7 +116,7 @@ class ProfileAuditorTest {
 
             assertThat(eventSent.targetType).isEqualTo(TargetType.PROFILE)
             assertThat(eventSent.agentType).isEqualTo(AgentType.USER)
-            assertThat(eventSent.agentId).isEqualTo(USER_ID)
+            assertThat(eventSent.agentIdMaybe).isEqualTo(USER_ID)
             assertThat(eventSent.targetIdMaybe).isEqualTo(USER_ID)
             assertThat(eventSent.actionType).isEqualTo(ActionType.DELETE)
             assertThat(eventSent.timestamp).isEqualTo(Y2K_EPOCH_MILLIS)

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
@@ -1,59 +1,35 @@
 package org.pmiops.workbench.actionaudit.auditors;
 
-import static org.mockito.ArgumentMatchers.argThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
 
-import java.time.Clock;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.pmiops.workbench.actionaudit.ActionAuditEvent;
 import org.pmiops.workbench.actionaudit.ActionAuditService;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.DataAccessLevel;
-import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 public class UserServiceAuditorTest {
-  static DbUser USER = null;
-
   @TestConfiguration
-  @Import({UserServiceAuditAdapterImpl.class})
+  @Import({UserServiceAuditAdapterImpl.class, ActionAuditTestConfig.class})
   @MockBean(ActionAuditService.class)
-  static class Configuration {
-    @Bean
-    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public DbUser getUser() {
-      return USER;
-    }
+  static class Configuration {}
 
-    @Bean(name = "ACTION_ID")
-    public String getActionId() {
-      return ActionAuditTestConfig.ACTION_ID;
-    }
-
-    @Bean
-    public Clock getClock() {
-      return new FakeClock(ActionAuditTestConfig.INSTANT);
-    }
-  }
+  @Captor ArgumentCaptor<ActionAuditEvent> eventArg;
 
   @Autowired UserServiceAuditor userServiceAuditor;
   @Autowired ActionAuditService mockActionAuditService;
-
-  @After
-  public void tearDown() {
-    USER = null;
-  }
 
   private static DbUser createUser() {
     final DbUser user = new DbUser();
@@ -64,28 +40,26 @@ public class UserServiceAuditorTest {
 
   @Test
   public void testFireUpdateDataAccessAction_userAgent() {
-    USER = createUser();
+    DbUser user = createUser();
     userServiceAuditor.fireUpdateDataAccessAction(
-        USER, DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, AgentType.USER);
-    verify(mockActionAuditService)
-        .send(
-            argThat(
-                (ActionAuditEvent a) ->
-                    a.getAgentId() == USER.getUserId()
-                        && USER.getUsername().equals(a.getAgentEmailMaybe())
-                        && a.getAgentType() == AgentType.USER));
+        user, DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, Agent.asUser(user));
+    verify(mockActionAuditService).send(eventArg.capture());
+
+    ActionAuditEvent event = eventArg.getValue();
+    assertThat(event.getAgentType()).isEqualTo(AgentType.USER);
+    assertThat(event.getAgentIdMaybe()).isEqualTo(user.getUserId());
+    assertThat(event.getAgentEmailMaybe()).isEqualTo(user.getUsername());
   }
 
   @Test
   public void testFireUpdateDataAccessAction_systemAgent() {
     userServiceAuditor.fireUpdateDataAccessAction(
-        createUser(), DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, AgentType.SYSTEM);
-    verify(mockActionAuditService)
-        .send(
-            argThat(
-                (ActionAuditEvent a) ->
-                    a.getAgentId() == 0
-                        && a.getAgentEmailMaybe() == null
-                        && a.getAgentType() == AgentType.SYSTEM));
+        createUser(), DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, Agent.asSystem());
+    verify(mockActionAuditService).send(eventArg.capture());
+
+    ActionAuditEvent event = eventArg.getValue();
+    assertThat(event.getAgentType()).isEqualTo(AgentType.SYSTEM);
+    assertThat(event.getAgentIdMaybe()).isNull();
+    assertThat(event.getAgentEmailMaybe()).isNull();
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
@@ -1,0 +1,79 @@
+package org.pmiops.workbench.actionaudit.auditors;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.actionaudit.ActionAuditEvent;
+import org.pmiops.workbench.actionaudit.ActionAuditService;
+import org.pmiops.workbench.actionaudit.AgentType;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class UserServiceAuditorTest {
+  static DbUser USER = null;
+
+  @TestConfiguration
+  @Import({UserServiceAuditAdapterImpl.class, ActionAuditTestConfig.class})
+  @MockBean(ActionAuditService.class)
+  static class Configuration {
+    @Primary
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public DbUser getUser() {
+      return USER;
+    }
+  }
+
+  @Autowired UserServiceAuditor userServiceAuditor;
+  @Autowired ActionAuditService mockActionAuditService;
+
+  @After
+  public void tearDown() {
+    USER = null;
+  }
+
+  private static DbUser createUser() {
+    final DbUser user = new DbUser();
+    user.setUserId(3L);
+    user.setUsername("foo@gmail.com");
+    return user;
+  }
+
+  @Test
+  public void testFireUpdateDataAccessAction_userAgent() {
+    USER = createUser();
+    userServiceAuditor.fireUpdateDataAccessAction(
+        USER, DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, AgentType.USER);
+    verify(mockActionAuditService)
+        .send(
+            argThat(
+                (ActionAuditEvent a) ->
+                    a.getAgentId() == USER.getUserId()
+                        && USER.getUsername().equals(a.getAgentEmailMaybe())
+                        && a.getAgentType() == AgentType.USER));
+  }
+
+  @Test
+  public void testFireUpdateDataAccessAction_systemAgent() {
+    userServiceAuditor.fireUpdateDataAccessAction(
+        createUser(), DataAccessLevel.UNREGISTERED, DataAccessLevel.REGISTERED, AgentType.SYSTEM);
+    verify(mockActionAuditService)
+        .send(
+            argThat(
+                (ActionAuditEvent a) ->
+                    a.getAgentId() == 0
+                        && USER.getUsername() == null
+                        && a.getAgentType() == AgentType.SYSTEM));
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.actionaudit.auditors;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
+import java.time.Clock;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,12 +12,13 @@ import org.pmiops.workbench.actionaudit.ActionAuditService;
 import org.pmiops.workbench.actionaudit.AgentType;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -25,13 +27,23 @@ public class UserServiceAuditorTest {
   static DbUser USER = null;
 
   @TestConfiguration
-  @Import({UserServiceAuditAdapterImpl.class, ActionAuditTestConfig.class})
+  @Import({UserServiceAuditAdapterImpl.class})
   @MockBean(ActionAuditService.class)
   static class Configuration {
-    @Primary
+    @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public DbUser getUser() {
       return USER;
+    }
+
+    @Bean(name = "ACTION_ID")
+    public String getActionId() {
+      return ActionAuditTestConfig.ACTION_ID;
+    }
+
+    @Bean
+    public Clock getClock() {
+      return new FakeClock(ActionAuditTestConfig.INSTANT);
     }
   }
 
@@ -73,7 +85,7 @@ public class UserServiceAuditorTest {
             argThat(
                 (ActionAuditEvent a) ->
                     a.getAgentId() == 0
-                        && USER.getUsername() == null
+                        && a.getAgentEmailMaybe() == null
                         && a.getAgentType() == AgentType.SYSTEM));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -83,9 +83,9 @@ public class OfflineUserControllerTest {
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     workbenchConfig.featureFlags.enableMoodleV2Api = false;
     // Mock out the service under test to simply return the passed user argument.
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV1(any());
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV1(any(), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
-    verify(userService, times(3)).syncComplianceTrainingStatusV1(any());
+    verify(userService, times(3)).syncComplianceTrainingStatusV1(any(), any());
   }
 
   @Test
@@ -93,59 +93,63 @@ public class OfflineUserControllerTest {
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     workbenchConfig.featureFlags.enableMoodleV2Api = true;
     // Mock out the service under test to simply return the passed user argument.
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any());
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any(), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
-    verify(userService, times(3)).syncComplianceTrainingStatusV2(any());
+    verify(userService, times(3)).syncComplianceTrainingStatusV2(any(), any());
   }
 
   @Test(expected = ServerErrorException.class)
   public void testBulkSyncTrainingStatusWithSingleUserErrorV1()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     workbenchConfig.featureFlags.enableMoodleV2Api = false;
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV1(any());
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV1(any(), any());
     doThrow(new org.pmiops.workbench.moodle.ApiException("Unknown error"))
         .when(userService)
         .syncComplianceTrainingStatusV1(
-            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")));
+            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
     // Even when a single call throws an exception, we call the service for all users.
-    verify(userService, times(3)).syncComplianceTrainingStatusV1(any());
+    verify(userService, times(3)).syncComplianceTrainingStatusV1(any(), any());
   }
 
   @Test(expected = ServerErrorException.class)
   public void testBulkSyncTrainingStatusWithSingleUserErrorV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     workbenchConfig.featureFlags.enableMoodleV2Api = true;
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any());
+    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any(), any());
     doThrow(new org.pmiops.workbench.moodle.ApiException("Unknown error"))
         .when(userService)
         .syncComplianceTrainingStatusV2(
-            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")));
+            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
     // Even when a single call throws an exception, we call the service for all users.
-    verify(userService, times(3)).syncComplianceTrainingStatusV2(any());
+    verify(userService, times(3)).syncComplianceTrainingStatusV2(any(), any());
   }
 
   @Test
   public void testBulkSyncEraCommonsStatus()
       throws IOException, org.pmiops.workbench.firecloud.ApiException {
-    doAnswer(i -> i.getArgument(0)).when(userService).syncEraCommonsStatusUsingImpersonation(any());
+    doAnswer(i -> i.getArgument(0))
+        .when(userService)
+        .syncEraCommonsStatusUsingImpersonation(any(), any());
     offlineUserController.bulkSyncEraCommonsStatus();
-    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any());
+    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
   }
 
   @Test(expected = ServerErrorException.class)
   public void testBulkSyncEraCommonsStatusWithSingleUserError()
       throws ApiException, NotFoundException, IOException,
           org.pmiops.workbench.firecloud.ApiException {
-    doAnswer(i -> i.getArgument(0)).when(userService).syncEraCommonsStatusUsingImpersonation(any());
+    doAnswer(i -> i.getArgument(0))
+        .when(userService)
+        .syncEraCommonsStatusUsingImpersonation(any(), any());
     doThrow(new org.pmiops.workbench.firecloud.ApiException("Unknown error"))
         .when(userService)
         .syncEraCommonsStatusUsingImpersonation(
-            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")));
+            argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
     offlineUserController.bulkSyncEraCommonsStatus();
     // Even when a single call throws an exception, we call the service for all users.
-    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any());
+    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
   }
 
   @Test


### PR DESCRIPTION
Two-pronged fix:
- Plumb the proper agent details through higher interfaces. After looking more closely, it was clear that the default of "administrator" was incorrect in most cases here.
- Produce null (injectable as Optional) if there is no user. Longer term fix might use a different wrapper object for this. This should make the failure mode clearer and provides a pattern if we need this in the future. Longer term fix is https://precisionmedicineinitiative.atlassian.net/browse/RW-4496


Learnings:

- `Optional` has special magic semantics in Spring, it can be used to express an "optional" injected dependency, as [described here](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html).
  - This means that providing an Optional typed Bean is problematic, I couldn't get it working properly
  - ~~A `Provider<Optional>` doesn't appear to be a thing that I could get working~~
  - `Provider<Optional> works`
  - Even if your injected bean type is totally bogus, injecting `Optional` works for an empty optional
- A `Provider` is allowed to produce a null value. 
- A Bean cannot be declared as an `Optional` type, as far as I could tell.