### PR TITLE
[no ticket][risk=no] Fixing broken test case in Intellij

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
@@ -70,6 +70,9 @@ public abstract class BaseControllerTest {
   }
 
   private static WorkbenchConfig loadConfig(String filename) throws IOException {
+    // For some reason Resources.getResource(filename) works when running test from cmd line but
+    // fails to find the resource when running from Intellij. This is a work around that finds the
+    // config using a file path. This works for both cases.
     ObjectMapper jackson = new ObjectMapper();
     String rawJson =
         new String(Files.readAllBytes(Paths.get(BASE_PATH + filename)), Charset.defaultCharset());

--- a/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/BaseControllerTest.java
@@ -1,9 +1,11 @@
 package org.pmiops.workbench.api;
 
-import com.google.common.io.Resources;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Random;
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public abstract class BaseControllerTest {
 
   protected static WorkbenchConfig config;
+  public static final String BASE_PATH = "config/";
 
   @TestConfiguration
   static class Configuration {
@@ -67,9 +70,11 @@ public abstract class BaseControllerTest {
   }
 
   private static WorkbenchConfig loadConfig(String filename) throws IOException {
-    String testConfig =
-        Resources.toString(Resources.getResource(filename), Charset.defaultCharset());
-    WorkbenchConfig workbenchConfig = new Gson().fromJson(testConfig, WorkbenchConfig.class);
+    ObjectMapper jackson = new ObjectMapper();
+    String rawJson =
+        new String(Files.readAllBytes(Paths.get(BASE_PATH + filename)), Charset.defaultCharset());
+    WorkbenchConfig workbenchConfig =
+        new Gson().fromJson(jackson.readTree(rawJson).toString(), WorkbenchConfig.class);
     workbenchConfig.firecloud.debugEndpoints = true;
     return workbenchConfig;
   }


### PR DESCRIPTION
For some reason Resources.getResource(filename) works when running test from cmd line but fails to find the resource when running from Intellij. This is a work around that finds the json config using a file path. This works for both cases.