### PR TITLE
[noTicket][RISK=NO]Fix RDR exportWorkspace error

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -286,7 +286,8 @@ public class RdrExportServiceImpl implements RdrExportService {
       List<UserRole> collaboratorsMap =
           workspaceService.getFirecloudUserRoles(
               dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
-
+      // Initializing it to empty array if for any reason firecloud sends an empty array
+      rdrWorkspace.setWorkspaceUsers(new ArrayList<RdrWorkspaceUser>());
       // Since the USERS cannot be deleted from workbench yet, hence sending the the status of
       // COLLABORATOR as ACTIVE
       collaboratorsMap.forEach(


### PR DESCRIPTION
There are some workspaces on test for which  firecloud User role is empty. In such cases RDR is expecting an empty array rather than null. 

This is important since we send WORKSPACE information to RDR in batches and if one fails all fails.