### PR TITLE
[RW-4418][risk=low] Add project.rb tool to delete workspaces

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -698,6 +698,16 @@ task exportWorkspaceData(type: JavaExec) {
   }
 }
 
+// See project.rb command: delete-workspaces
+task deleteWorkspaces(type: JavaExec) {
+  classpath = sourceSets.tools.runtimeClasspath
+  main = "org.pmiops.workbench.tools.DeleteWorkspaces"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
 // This task is called from a few different places:
 // - devstart.rb > load_config (used by "deploy" and "update_cloud_config" commands)
 // - directly via gradlew (used by "run-local-migrations" command)

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudUserInfo;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.model.UserRole;
@@ -44,6 +45,8 @@ public interface WorkspaceService {
   DbWorkspace getRequiredWithCohorts(String ns, String firecloudName);
 
   DbWorkspace saveWithLastModified(DbWorkspace workspace);
+
+  void deleteWorkspace(DbWorkspace dbWorkspace);
 
   /*
    * This function will call the Google Cloud Billing API to set the given billing

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -9,7 +9,6 @@ import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.FirecloudUserInfo;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.model.UserRole;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -57,7 +57,6 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.FirecloudUserInfo;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACL;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
@@ -291,7 +290,8 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
     // TODO: do we want to delete workspace resource references and save only metadata?
 
     // This automatically handles access control to the workspace.
-    fireCloudService.deleteWorkspace(dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
+    fireCloudService.deleteWorkspace(
+        dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
     dbWorkspace = saveWithLastModified(dbWorkspace);
     maybeDeleteRecentWorkspace(dbWorkspace.getWorkspaceId());

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -369,22 +369,12 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   public ResponseEntity<EmptyResponse> deleteWorkspace(
       String workspaceNamespace, String workspaceId) {
     recordOperationTime(
-        () -> deleteWorkspaceImpl(workspaceNamespace, workspaceId), "deleteWorkspace");
+        () -> {
+          DbWorkspace dbWorkspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
+          workspaceService.deleteWorkspace(dbWorkspace);
+          workspaceAuditor.fireDeleteAction(dbWorkspace);
+        }, "deleteWorkspace");
     return ResponseEntity.ok(new EmptyResponse());
-  }
-
-  private void deleteWorkspaceImpl(String workspaceNamespace, String workspaceId) {
-    // This deletes all Firecloud and google resources, however saves all references
-    // to the workspace and its resources in the Workbench database.
-    // This is for auditing purposes and potentially workspace restore.
-    // TODO: do we want to delete workspace resource references and save only metadata?
-    DbWorkspace dbWorkspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
-    // This automatically handles access control to the workspace.
-    fireCloudService.deleteWorkspace(workspaceNamespace, workspaceId);
-    dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    dbWorkspace = workspaceService.saveWithLastModified(dbWorkspace);
-    workspaceService.maybeDeleteRecentWorkspace(dbWorkspace.getWorkspaceId());
-    workspaceAuditor.fireDeleteAction(dbWorkspace);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspacesController.java
@@ -373,7 +373,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
           DbWorkspace dbWorkspace = workspaceService.getRequired(workspaceNamespace, workspaceId);
           workspaceService.deleteWorkspace(dbWorkspace);
           workspaceAuditor.fireDeleteAction(dbWorkspace);
-        }, "deleteWorkspace");
+        },
+        "deleteWorkspace");
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -160,7 +160,8 @@ public class DeleteWorkspaces {
                       workspaceService.deleteWorkspace(dbWorkspace);
                     }
 
-                    dryLog(dryRun,
+                    dryLog(
+                        dryRun,
                         "Deleted workspace ("
                             + dbWorkspace.getWorkspaceNamespace()
                             + ", "

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -1,0 +1,260 @@
+package org.pmiops.workbench.tools;
+
+import com.google.common.collect.Streams;
+import com.opencsv.bean.BeanField;
+import com.opencsv.bean.ColumnPositionMappingStrategy;
+import com.opencsv.bean.CsvBindByName;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.db.dao.DataSetDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserRecentResourceServiceImpl;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
+import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.db.model.DbConceptSet;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.firecloud.ApiException;
+import org.pmiops.workbench.firecloud.FireCloudConfig;
+import org.pmiops.workbench.firecloud.FirecloudTransforms;
+import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.monitoring.MonitoringServiceImpl;
+import org.pmiops.workbench.monitoring.MonitoringSpringConfiguration;
+import org.pmiops.workbench.monitoring.StackdriverStatsExporterService;
+import org.pmiops.workbench.notebooks.NotebooksService;
+import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+/** A tool that will generate a CSV export of our workspace data */
+@Configuration
+@Import({
+  MonitoringServiceImpl.class,
+  MonitoringSpringConfiguration.class,
+  NotebooksServiceImpl.class,
+  StackdriverStatsExporterService.class,
+  UserRecentResourceServiceImpl.class
+})
+@ComponentScan("org.pmiops.workbench.firecloud")
+public class ExportWorkspaceData {
+
+  private static final Logger log = Logger.getLogger(ExportWorkspaceData.class.getName());
+
+  private static Option exportFilenameOpt =
+      Option.builder()
+          .longOpt("export-filename")
+          .desc("Filename of export")
+          .required()
+          .hasArg()
+          .build();
+
+  private static Options options = new Options().addOption(exportFilenameOpt);
+
+  private static SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
+
+  // Short circuit the DI wiring here with a "mock" WorkspaceService
+  // Importing the real one requires importing a large subtree of dependencies
+  @Bean
+  public WorkspaceService workspaceService() {
+    return new WorkspaceServiceImpl(
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+  }
+
+  @Bean
+  ServiceAccountAPIClientFactory serviceAccountAPIClientFactory(WorkbenchConfig config) {
+    return new ServiceAccountAPIClientFactory(config.firecloud.baseUrl);
+  }
+
+  @Bean
+  @Primary
+  @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
+  WorkspacesApi workspaceApi(ServiceAccountAPIClientFactory factory) throws IOException {
+    return factory.workspacesApi();
+  }
+
+  private WorkspaceDao workspaceDao;
+  private CohortDao cohortDao;
+  private ConceptSetDao conceptSetDao;
+  private DataSetDao dataSetDao;
+  private NotebooksService notebooksService;
+  private WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
+  private UserDao userDao;
+  private WorkspacesApi workspacesApi;
+
+  @Bean
+  public CommandLineRunner run(
+      WorkspaceDao workspaceDao,
+      CohortDao cohortDao,
+      ConceptSetDao conceptSetDao,
+      DataSetDao dataSetDao,
+      NotebooksService notebooksService,
+      WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao,
+      UserDao userDao,
+      WorkspacesApi workspacesApi) {
+    this.workspaceDao = workspaceDao;
+    this.cohortDao = cohortDao;
+    this.conceptSetDao = conceptSetDao;
+    this.dataSetDao = dataSetDao;
+    this.notebooksService = notebooksService;
+    this.workspaceFreeTierUsageDao = workspaceFreeTierUsageDao;
+    this.userDao = userDao;
+    this.workspacesApi = workspacesApi;
+
+    return (args) -> {
+      CommandLine opts = new DefaultParser().parse(options, args);
+
+      List<WorkspaceExportRow> rows = new ArrayList<>();
+      Set<DbUser> usersWithoutWorkspaces =
+          Streams.stream(userDao.findAll()).collect(Collectors.toSet());
+
+      for (DbWorkspace workspace : this.workspaceDao.findAll()) {
+        rows.add(toWorkspaceExportRow(workspace));
+        usersWithoutWorkspaces.remove(workspace.getCreator());
+
+        if (rows.size() % 10 == 0) {
+          log.info("Processed " + rows.size() + "/" + this.workspaceDao.count() + " rows");
+        }
+      }
+
+      for (DbUser user : usersWithoutWorkspaces) {
+        rows.add(toWorkspaceExportRow(user));
+      }
+
+      final CustomMappingStrategy mappingStrategy = new CustomMappingStrategy();
+      mappingStrategy.setType(WorkspaceExportRow.class);
+
+      try (FileWriter writer =
+          new FileWriter(opts.getOptionValue(exportFilenameOpt.getLongOpt()))) {
+        new StatefulBeanToCsvBuilder(writer)
+            .withMappingStrategy(mappingStrategy)
+            .build()
+            .write(rows);
+      }
+    };
+  }
+
+  private WorkspaceExportRow toWorkspaceExportRow(DbWorkspace workspace) {
+    WorkspaceExportRow row = toWorkspaceExportRow(workspace.getCreator());
+
+    row.setProjectId(workspace.getWorkspaceNamespace());
+    row.setName(workspace.getName());
+    row.setCreatedDate(dateFormat.format(workspace.getCreationTime()));
+
+    try {
+      row.setCollaborators(
+          FirecloudTransforms.extractAclResponse(
+                  workspacesApi.getWorkspaceAcl(
+                      workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+              .entrySet().stream()
+              .map(entry -> entry.getKey() + " (" + entry.getValue().getAccessLevel() + ")")
+              .collect(Collectors.joining("\n")));
+    } catch (ApiException e) {
+      row.setCollaborators("Error: Not Found");
+    }
+
+    Collection<DbCohort> cohorts = cohortDao.findByWorkspaceId(workspace.getWorkspaceId());
+    row.setCohortNames(cohorts.stream().map(DbCohort::getName).collect(Collectors.joining(",\n")));
+    row.setCohortCount(String.valueOf(cohorts.size()));
+
+    Collection<DbConceptSet> conceptSets =
+        conceptSetDao.findByWorkspaceId(workspace.getWorkspaceId());
+    row.setConceptSetNames(
+        conceptSets.stream().map(DbConceptSet::getName).collect(Collectors.joining(",\n")));
+    row.setConceptSetCount(String.valueOf(conceptSets.size()));
+
+    Collection<DbDataset> datasets = dataSetDao.findByWorkspaceId(workspace.getWorkspaceId());
+    row.setDatasetNames(
+        datasets.stream().map(DbDataset::getName).collect(Collectors.joining(",\n")));
+    row.setDatasetCount(String.valueOf(datasets.size()));
+
+    try {
+      Collection<FileDetail> notebooks =
+          notebooksService.getNotebooks(
+              workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+      row.setNotebookNames(
+          notebooks.stream().map(FileDetail::getName).collect(Collectors.joining(",\n")));
+      row.setNotebooksCount(String.valueOf(notebooks.size()));
+    } catch (NotFoundException e) {
+      row.setNotebookNames("Error: Not Found");
+      row.setNotebooksCount("N/A");
+    }
+
+    DbWorkspaceFreeTierUsage usage = workspaceFreeTierUsageDao.findOneByWorkspace(workspace);
+    row.setWorkspaceSpending(usage == null ? "0" : String.valueOf(usage.getCost()));
+
+    row.setReviewForStigmatizingResearch(toYesNo(workspace.getReviewRequested()));
+    row.setWorkspaceLastUpdatedDate(dateFormat.format(workspace.getLastModifiedTime()));
+    row.setActive(toYesNo(workspace.isActive()));
+    return row;
+  }
+
+  private WorkspaceExportRow toWorkspaceExportRow(DbUser user) {
+    WorkspaceExportRow row = new WorkspaceExportRow();
+    row.setCreatorContactEmail(user.getContactEmail());
+    row.setCreatorUsername(user.getUsername());
+    row.setCreatorFirstSignIn(
+        user.getFirstSignInTime() == null ? "" : dateFormat.format(user.getFirstSignInTime()));
+    row.setCreatorRegistrationState(user.getDataAccessLevelEnum().toString());
+
+    return row;
+  }
+
+  public static void main(String[] args) {
+    CommandLineToolConfig.runCommandLine(ExportWorkspaceData.class, args);
+  }
+
+  private String toYesNo(boolean b) {
+    return b ? "Yes" : "No";
+  }
+}
+
+class CustomMappingStrategy<T> extends ColumnPositionMappingStrategy<T> {
+  @Override
+  public String[] generateHeader(T bean) {
+    super.setColumnMapping(new String[FieldUtils.getAllFields(bean.getClass()).length]);
+
+    final int numColumns = findMaxFieldIndex();
+
+    String[] header = new String[numColumns + 1];
+
+    BeanField<T> beanField;
+    for (int i = 0; i <= numColumns; i++) {
+      beanField = findField(i);
+      String columnHeaderName = extractHeaderName(beanField);
+      header[i] = columnHeaderName;
+    }
+    return header;
+  }
+
+  private String extractHeaderName(final BeanField<T> beanField) {
+    return beanField.getField().getDeclaredAnnotationsByType(CsvBindByName.class)[0].column();
+  }
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -1,69 +1,40 @@
 package org.pmiops.workbench.tools;
 
-import com.google.common.collect.Streams;
-import com.opencsv.bean.StatefulBeanToCsvBuilder;
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.dao.CohortDao;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
-import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.UserRecentResourceServiceImpl;
 import org.pmiops.workbench.db.dao.UserRecentWorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
-import org.pmiops.workbench.db.model.DbCohort;
-import org.pmiops.workbench.db.model.DbConceptSet;
-import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.ApiClient;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudConfig;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
-import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
-import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
-import org.pmiops.workbench.monitoring.MonitoringServiceImpl;
-import org.pmiops.workbench.monitoring.MonitoringSpringConfiguration;
-import org.pmiops.workbench.monitoring.StackdriverStatsExporterService;
-import org.pmiops.workbench.notebooks.NotebooksService;
-import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 
-/** A tool that will generate a CSV export of our workspace data */
 @Configuration
 @Import({
     FireCloudServiceImpl.class,
@@ -128,17 +99,11 @@ public class DeleteWorkspaces {
     return new ProfileApi(apiClient);
   }
 
-
-  private WorkspaceDao workspaceDao;
-  private UserDao userDao;
-
   @Bean
   public CommandLineRunner run(
       WorkspaceDao workspaceDao,
       UserDao userDao,
       WorkspaceService workspaceService) {
-    this.workspaceDao = workspaceDao;
-    this.userDao = userDao;
 
     return (args) -> {
       CommandLine opts = new DefaultParser().parse(options, args);
@@ -158,7 +123,12 @@ public class DeleteWorkspaces {
           }
 
           currentImpersonatedUser = dbWorkspace.getCreator();
-          workspaceService.deleteWorkspace(dbWorkspace);
+          try {
+            workspaceService.deleteWorkspace(dbWorkspace);
+          } catch (Exception e) {
+            log.log(Level.WARNING, "Could not delete workspace (" + namespace + ", " + fcName + ")", e);
+          }
+
           log.info("Deleted workspace (" + dbWorkspace.getWorkspaceNamespace() + ", " + dbWorkspace.getFirecloudName() + ")");
         });
       }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -1,44 +1,51 @@
 package org.pmiops.workbench.tools;
 
 import com.google.common.collect.Streams;
-import com.opencsv.bean.BeanField;
-import com.opencsv.bean.ColumnPositionMappingStrategy;
-import com.opencsv.bean.CsvBindByName;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.inject.Provider;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceServiceImpl;
+import org.pmiops.workbench.db.dao.UserRecentWorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.firecloud.ApiClient;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudConfig;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.firecloud.FirecloudTransforms;
+import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.monitoring.MonitoringServiceImpl;
 import org.pmiops.workbench.monitoring.MonitoringSpringConfiguration;
 import org.pmiops.workbench.monitoring.StackdriverStatsExporterService;
@@ -47,214 +54,119 @@ import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
 
 /** A tool that will generate a CSV export of our workspace data */
 @Configuration
 @Import({
-  MonitoringServiceImpl.class,
-  MonitoringSpringConfiguration.class,
-  NotebooksServiceImpl.class,
-  StackdriverStatsExporterService.class,
-  UserRecentResourceServiceImpl.class
+    FireCloudServiceImpl.class,
+    FireCloudConfig.class
 })
-@ComponentScan("org.pmiops.workbench.firecloud")
-public class ExportWorkspaceData {
+public class DeleteWorkspaces {
 
-  private static final Logger log = Logger.getLogger(ExportWorkspaceData.class.getName());
+  private static final Logger log = Logger.getLogger(DeleteWorkspaces.class.getName());
 
-  private static Option exportFilenameOpt =
+  private static Option deleteListFilename =
       Option.builder()
-          .longOpt("export-filename")
-          .desc("Filename of export")
+          .longOpt("delete-list-filename")
+          .desc("File containing list of workspaces to delete. Each line should contain a single workspace's namespace and firecloud name, separated by a comma"
+              + "Example: ws-namespace-1,fc-id-1 \n ws-namespace-2,fc-id-2 \n ws-namespace-3, fc-id-3")
           .required()
           .hasArg()
           .build();
 
-  private static Options options = new Options().addOption(exportFilenameOpt);
+  private static Options options = new Options().addOption(deleteListFilename);
 
-  private static SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
-
-  // Short circuit the DI wiring here with a "mock" WorkspaceService
-  // Importing the real one requires importing a large subtree of dependencies
   @Bean
-  public WorkspaceService workspaceService() {
+  public WorkspaceService workspaceService(FireCloudService fireCloudService,
+      Clock clock,
+      WorkspaceDao workspaceDao,
+      UserRecentWorkspaceDao userRecentWorkspaceDao,
+      Provider<DbUser> dbUserProvider) {
     return new WorkspaceServiceImpl(
-        null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        null, null, clock, null, null, null, fireCloudService, null, dbUserProvider, userRecentWorkspaceDao, null, workspaceDao, null, null);
   }
 
+  static DbUser currentImpersonatedUser;
+
   @Bean
-  ServiceAccountAPIClientFactory serviceAccountAPIClientFactory(WorkbenchConfig config) {
-    return new ServiceAccountAPIClientFactory(config.firecloud.baseUrl);
+  @Primary
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  DbUser user() {
+    return currentImpersonatedUser;
   }
 
   @Bean
   @Primary
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
-  WorkspacesApi workspaceApi(ServiceAccountAPIClientFactory factory) throws IOException {
-    return factory.workspacesApi();
+  WorkspacesApi workspaceApi(FireCloudService fireCloudService) throws IOException {
+    if (currentImpersonatedUser == null) {
+      return null;
+    }
+
+    ApiClient apiClient = fireCloudService.getApiClientWithImpersonation(currentImpersonatedUser.getUsername());
+    return new WorkspacesApi(apiClient);
   }
 
+  @Bean
+  @Primary
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  ProfileApi profileApi(FireCloudService fireCloudService) throws IOException {
+    if (currentImpersonatedUser == null) {
+      return null;
+    }
+
+    ApiClient apiClient = fireCloudService.getApiClientWithImpersonation(currentImpersonatedUser.getUsername());
+    return new ProfileApi(apiClient);
+  }
+
+
   private WorkspaceDao workspaceDao;
-  private CohortDao cohortDao;
-  private ConceptSetDao conceptSetDao;
-  private DataSetDao dataSetDao;
-  private NotebooksService notebooksService;
-  private WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
   private UserDao userDao;
-  private WorkspacesApi workspacesApi;
 
   @Bean
   public CommandLineRunner run(
       WorkspaceDao workspaceDao,
-      CohortDao cohortDao,
-      ConceptSetDao conceptSetDao,
-      DataSetDao dataSetDao,
-      NotebooksService notebooksService,
-      WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao,
       UserDao userDao,
-      WorkspacesApi workspacesApi) {
+      WorkspaceService workspaceService) {
     this.workspaceDao = workspaceDao;
-    this.cohortDao = cohortDao;
-    this.conceptSetDao = conceptSetDao;
-    this.dataSetDao = dataSetDao;
-    this.notebooksService = notebooksService;
-    this.workspaceFreeTierUsageDao = workspaceFreeTierUsageDao;
     this.userDao = userDao;
-    this.workspacesApi = workspacesApi;
 
     return (args) -> {
       CommandLine opts = new DefaultParser().parse(options, args);
 
-      List<WorkspaceExportRow> rows = new ArrayList<>();
-      Set<DbUser> usersWithoutWorkspaces =
-          Streams.stream(userDao.findAll()).collect(Collectors.toSet());
+      try (BufferedReader reader = new BufferedReader(new FileReader(opts.getOptionValue(deleteListFilename.getLongOpt())))) {
+        reader.lines().forEach(line -> {
+          String[] tokens = line.split(",");
+          String namespace = tokens[0].trim();
+          String fcName = tokens[1].trim();
 
-      for (DbWorkspace workspace : this.workspaceDao.findAll()) {
-        rows.add(toWorkspaceExportRow(workspace));
-        usersWithoutWorkspaces.remove(workspace.getCreator());
+          DbWorkspace dbWorkspace = workspaceDao.findByWorkspaceNamespaceAndFirecloudNameAndActiveStatus(namespace, fcName,
+              DbStorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE));
 
-        if (rows.size() % 10 == 0) {
-          log.info("Processed " + rows.size() + "/" + this.workspaceDao.count() + " rows");
-        }
-      }
+          if (dbWorkspace == null) {
+            log.info("Could not find active workspace with (namespace, fcId) of (" + namespace + ", " + fcName + ")");
+            return;
+          }
 
-      for (DbUser user : usersWithoutWorkspaces) {
-        rows.add(toWorkspaceExportRow(user));
-      }
-
-      final CustomMappingStrategy mappingStrategy = new CustomMappingStrategy();
-      mappingStrategy.setType(WorkspaceExportRow.class);
-
-      try (FileWriter writer =
-          new FileWriter(opts.getOptionValue(exportFilenameOpt.getLongOpt()))) {
-        new StatefulBeanToCsvBuilder(writer)
-            .withMappingStrategy(mappingStrategy)
-            .build()
-            .write(rows);
+          currentImpersonatedUser = dbWorkspace.getCreator();
+          workspaceService.deleteWorkspace(dbWorkspace);
+          log.info("Deleted workspace (" + dbWorkspace.getWorkspaceNamespace() + ", " + dbWorkspace.getFirecloudName() + ")");
+        });
       }
     };
   }
 
-  private WorkspaceExportRow toWorkspaceExportRow(DbWorkspace workspace) {
-    WorkspaceExportRow row = toWorkspaceExportRow(workspace.getCreator());
-
-    row.setProjectId(workspace.getWorkspaceNamespace());
-    row.setName(workspace.getName());
-    row.setCreatedDate(dateFormat.format(workspace.getCreationTime()));
-
-    try {
-      row.setCollaborators(
-          FirecloudTransforms.extractAclResponse(
-                  workspacesApi.getWorkspaceAcl(
-                      workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
-              .entrySet().stream()
-              .map(entry -> entry.getKey() + " (" + entry.getValue().getAccessLevel() + ")")
-              .collect(Collectors.joining("\n")));
-    } catch (ApiException e) {
-      row.setCollaborators("Error: Not Found");
-    }
-
-    Collection<DbCohort> cohorts = cohortDao.findByWorkspaceId(workspace.getWorkspaceId());
-    row.setCohortNames(cohorts.stream().map(DbCohort::getName).collect(Collectors.joining(",\n")));
-    row.setCohortCount(String.valueOf(cohorts.size()));
-
-    Collection<DbConceptSet> conceptSets =
-        conceptSetDao.findByWorkspaceId(workspace.getWorkspaceId());
-    row.setConceptSetNames(
-        conceptSets.stream().map(DbConceptSet::getName).collect(Collectors.joining(",\n")));
-    row.setConceptSetCount(String.valueOf(conceptSets.size()));
-
-    Collection<DbDataset> datasets = dataSetDao.findByWorkspaceId(workspace.getWorkspaceId());
-    row.setDatasetNames(
-        datasets.stream().map(DbDataset::getName).collect(Collectors.joining(",\n")));
-    row.setDatasetCount(String.valueOf(datasets.size()));
-
-    try {
-      Collection<FileDetail> notebooks =
-          notebooksService.getNotebooks(
-              workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
-      row.setNotebookNames(
-          notebooks.stream().map(FileDetail::getName).collect(Collectors.joining(",\n")));
-      row.setNotebooksCount(String.valueOf(notebooks.size()));
-    } catch (NotFoundException e) {
-      row.setNotebookNames("Error: Not Found");
-      row.setNotebooksCount("N/A");
-    }
-
-    DbWorkspaceFreeTierUsage usage = workspaceFreeTierUsageDao.findOneByWorkspace(workspace);
-    row.setWorkspaceSpending(usage == null ? "0" : String.valueOf(usage.getCost()));
-
-    row.setReviewForStigmatizingResearch(toYesNo(workspace.getReviewRequested()));
-    row.setWorkspaceLastUpdatedDate(dateFormat.format(workspace.getLastModifiedTime()));
-    row.setActive(toYesNo(workspace.isActive()));
-    return row;
-  }
-
-  private WorkspaceExportRow toWorkspaceExportRow(DbUser user) {
-    WorkspaceExportRow row = new WorkspaceExportRow();
-    row.setCreatorContactEmail(user.getContactEmail());
-    row.setCreatorUsername(user.getUsername());
-    row.setCreatorFirstSignIn(
-        user.getFirstSignInTime() == null ? "" : dateFormat.format(user.getFirstSignInTime()));
-    row.setCreatorRegistrationState(user.getDataAccessLevelEnum().toString());
-
-    return row;
-  }
-
   public static void main(String[] args) {
-    CommandLineToolConfig.runCommandLine(ExportWorkspaceData.class, args);
-  }
-
-  private String toYesNo(boolean b) {
-    return b ? "Yes" : "No";
+    CommandLineToolConfig.runCommandLine(DeleteWorkspaces.class, args);
   }
 }
 
-class CustomMappingStrategy<T> extends ColumnPositionMappingStrategy<T> {
-  @Override
-  public String[] generateHeader(T bean) {
-    super.setColumnMapping(new String[FieldUtils.getAllFields(bean.getClass()).length]);
-
-    final int numColumns = findMaxFieldIndex();
-
-    String[] header = new String[numColumns + 1];
-
-    BeanField<T> beanField;
-    for (int i = 0; i <= numColumns; i++) {
-      beanField = findField(i);
-      String columnHeaderName = extractHeaderName(beanField);
-      header[i] = columnHeaderName;
-    }
-    return header;
-  }
-
-  private String extractHeaderName(final BeanField<T> beanField) {
-    return beanField.getField().getDeclaredAnnotationsByType(CsvBindByName.class)[0].column();
-  }
-}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -14,7 +14,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -26,10 +25,7 @@ import org.springframework.context.annotation.Import;
  * domain-wide delegation to make FireCloud API calls impersonating other users.
  */
 @Configuration
-@Import({
-    FireCloudServiceImpl.class,
-    FireCloudConfig.class
-})
+@Import({FireCloudServiceImpl.class, FireCloudConfig.class})
 public class FetchFireCloudUserProfile {
   private static final Logger log =
       Logger.getLogger(org.pmiops.workbench.tools.FetchFireCloudUserProfile.class.getName());

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Import;
  * domain-wide delegation to make FireCloud API calls impersonating other users.
  */
 @Configuration
-//@ComponentScan("org.pmiops.workbench.firecloud")
 @Import({
     FireCloudServiceImpl.class,
     FireCloudConfig.class

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchFireCloudUserProfile.java
@@ -5,7 +5,9 @@ import java.util.logging.Logger;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.ApiClient;
+import org.pmiops.workbench.firecloud.FireCloudConfig;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.firecloud.api.NihApi;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
@@ -14,6 +16,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * A tool that takes an AoU username (e.g. gjordan) and fetches the FireCloud profile associated
@@ -23,7 +26,11 @@ import org.springframework.context.annotation.Configuration;
  * domain-wide delegation to make FireCloud API calls impersonating other users.
  */
 @Configuration
-@ComponentScan("org.pmiops.workbench.firecloud")
+//@ComponentScan("org.pmiops.workbench.firecloud")
+@Import({
+    FireCloudServiceImpl.class,
+    FireCloudConfig.class
+})
 public class FetchFireCloudUserProfile {
   private static final Logger log =
       Logger.getLogger(org.pmiops.workbench.tools.FetchFireCloudUserProfile.class.getName());


### PR DESCRIPTION
Example Usage
`./project.rb delete-workspaces --dry-run=false --delete-list-filename delete.txt --project all-of-us-rw-staging`

delete_list.txt
```
aou-rw-test-1, fcname
aou-rw-test-2, fcname2
aou-rw-test-3, fcname3
aou-rw-test-4, fcname4
```

Notes
- fetch-firecloud-user-profile was broken so I fixed that while I was in here
- High level approach (for importing a complex class like WorkspaceService) was to build the Bean directly in the tool class and manually providing the necessary dependencies and `null` for the unnecessary ones.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
