### PR TITLE
[RW-4484][RW-4485][risk=no] Account creation bugfixes

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
@@ -1,4 +1,4 @@
-import mount from 'enzyme';
+import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
@@ -1,24 +1,13 @@
-import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
+import mount from 'enzyme';
 import * as React from 'react';
 
-import {serverConfigStore} from 'app/utils/navigation';
 import {
   AccountCreationSurvey,
   AccountCreationSurveyProps,
 } from 'app/pages/login/account-creation/account-creation-survey';
 import {getEmptyProfile} from 'app/pages/login/test-utils';
+import {serverConfigStore} from 'app/utils/navigation';
 import {Ethnicity, GenderIdentity, Race, SexAtBirth} from 'generated/fetch';
-
-type AnyWrapper = (ShallowWrapper|ReactWrapper);
-const getPrivacyCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
-  return wrapper.find('CheckBox[data-test-id="privacy-statement-check"]');
-};
-const getTosCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
-  return wrapper.find('CheckBox[data-test-id="terms-of-service-check"]');
-};
-const getNextButton = (wrapper: AnyWrapper ): AnyWrapper => {
-  return wrapper.find('[data-test-id="next-button"]');
-};
 
 let props: AccountCreationSurveyProps;
 const onCompleteSpy = jest.fn();
@@ -48,7 +37,7 @@ it('should load existing profile data', async() => {
   demographicSurvey.genderIdentityList = [GenderIdentity.MAN];
   demographicSurvey.sexAtBirth = [SexAtBirth.MALE];
   demographicSurvey.identifiesAsLgbtq = true;
-  demographicSurvey.ethnicity = Ethnicity.HISPANIC
+  demographicSurvey.ethnicity = Ethnicity.HISPANIC;
   const wrapper = mount(<AccountCreationSurvey {...props} />);
 
   // Race

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
@@ -2,9 +2,12 @@ import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 
 import {serverConfigStore} from 'app/utils/navigation';
-import {AccountCreationSurvey, AccountCreationSurveyProps} from 'app/pages/login/account-creation/account-creation-survey';
+import {
+  AccountCreationSurvey,
+  AccountCreationSurveyProps,
+} from 'app/pages/login/account-creation/account-creation-survey';
 import {getEmptyProfile} from 'app/pages/login/test-utils';
-import {Ethnicity, Race} from 'generated/fetch';
+import {Ethnicity, GenderIdentity, Race, SexAtBirth} from 'generated/fetch';
 
 type AnyWrapper = (ShallowWrapper|ReactWrapper);
 const getPrivacyCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
@@ -40,16 +43,29 @@ it('should render', async() => {
 });
 
 it('should load existing profile data', async() => {
-  props.profile.demographicSurvey.race = [Race.AIAN, Race.AA];
-  props.profile.demographicSurvey.identifiesAsLgbtq = true;
-  props.profile.demographicSurvey.ethnicity = Ethnicity.HISPANIC
+  const {demographicSurvey} = props.profile;
+  demographicSurvey.race = [Race.AIAN, Race.AA];
+  demographicSurvey.genderIdentityList = [GenderIdentity.MAN];
+  demographicSurvey.sexAtBirth = [SexAtBirth.MALE];
+  demographicSurvey.identifiesAsLgbtq = true;
+  demographicSurvey.ethnicity = Ethnicity.HISPANIC
   const wrapper = mount(<AccountCreationSurvey {...props} />);
 
+  // Race
   expect(wrapper.find('CheckBox[data-test-id="checkbox-AIAN"]').prop('checked')).toBeTruthy();
   expect(wrapper.find('CheckBox[data-test-id="checkbox-AA"]').prop('checked')).toBeTruthy();
   expect(wrapper.find('CheckBox[data-test-id="checkbox-WHITE"]').prop('checked')).toBeFalsy();
 
+  // Gender identity
+  expect(wrapper.find('CheckBox[data-test-id="checkbox-MAN"]').prop('checked')).toBeTruthy();
+
+  // Sex at birth
+  expect(wrapper.find('CheckBox[data-test-id="checkbox-MALE"]').prop('checked')).toBeTruthy();
+
+  // LGBTQ
   // We use the .hostNodes() call to filter down to just the React component in the result set.
   expect(wrapper.find('[data-test-id="radio-lgbtq-yes"]').hostNodes().prop('checked')).toBeTruthy();
+
+  // Ethnicity
   expect(wrapper.find('[data-test-id="dropdown-ethnicity"]').prop('value')).toEqual(Ethnicity.HISPANIC);
 });

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
@@ -1,0 +1,55 @@
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
+import * as React from 'react';
+
+import {serverConfigStore} from 'app/utils/navigation';
+import {AccountCreationSurvey, AccountCreationSurveyProps} from 'app/pages/login/account-creation/account-creation-survey';
+import {getEmptyProfile} from 'app/pages/login/test-utils';
+import {Ethnicity, Race} from 'generated/fetch';
+
+type AnyWrapper = (ShallowWrapper|ReactWrapper);
+const getPrivacyCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
+  return wrapper.find('CheckBox[data-test-id="privacy-statement-check"]');
+};
+const getTosCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
+  return wrapper.find('CheckBox[data-test-id="terms-of-service-check"]');
+};
+const getNextButton = (wrapper: AnyWrapper ): AnyWrapper => {
+  return wrapper.find('[data-test-id="next-button"]');
+};
+
+let props: AccountCreationSurveyProps;
+const onCompleteSpy = jest.fn();
+const onPreviousSpy = jest.fn();
+
+const defaultConfig = {gsuiteDomain: 'researchallofus.org', enableNewAccountCreation: false};
+
+beforeEach(() => {
+  serverConfigStore.next(defaultConfig);
+
+  props = {
+    invitationKey: 'asdf',
+    profile: getEmptyProfile(),
+    onPreviousClick: onPreviousSpy,
+    onComplete: onCompleteSpy,
+  };
+});
+
+it('should render', async() => {
+  const wrapper = mount(<AccountCreationSurvey {...props} />);
+  expect(wrapper.exists()).toBeTruthy();
+});
+
+it('should load existing profile data', async() => {
+  props.profile.demographicSurvey.race = [Race.AIAN, Race.AA];
+  props.profile.demographicSurvey.identifiesAsLgbtq = true;
+  props.profile.demographicSurvey.ethnicity = Ethnicity.HISPANIC
+  const wrapper = mount(<AccountCreationSurvey {...props} />);
+
+  expect(wrapper.find('CheckBox[data-test-id="checkbox-AIAN"]').prop('checked')).toBeTruthy();
+  expect(wrapper.find('CheckBox[data-test-id="checkbox-AA"]').prop('checked')).toBeTruthy();
+  expect(wrapper.find('CheckBox[data-test-id="checkbox-WHITE"]').prop('checked')).toBeFalsy();
+
+  // We use the .hostNodes() call to filter down to just the React component in the result set.
+  expect(wrapper.find('[data-test-id="radio-lgbtq-yes"]').hostNodes().prop('checked')).toBeTruthy();
+  expect(wrapper.find('[data-test-id="dropdown-ethnicity"]').prop('value')).toEqual(Ethnicity.HISPANIC);
+});

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -62,7 +62,7 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     super(props);
     this.state = {
       creatingAccount: false,
-      profile: this.props.profile,
+      profile: {...this.props.profile},
     };
   }
 
@@ -88,21 +88,25 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       });
   }
 
-  updateList(attribute, value) {
+  updateList(key, value) {
     // Toggle Includes removes the element if it already exist and adds if not
-    const attributeList = toggleIncludes(value, this.state.profile.demographicSurvey[attribute]);
-    this.updateDemographicAttribute(attribute, attributeList);
+    const attributeList = toggleIncludes(value, this.state.profile.demographicSurvey[key] || []);
+    this.updateDemographicAttribute(key, attributeList);
   }
 
   updateDemographicAttribute(attribute, value) {
     this.setState(fp.set(['profile', 'demographicSurvey', attribute], value));
   }
 
-  createOptionCheckbox(checkboxLabel: string, optionKey: string, optionValue: any, key: string) {
-    return <CheckBox label={checkboxLabel}
-                     style={styles.checkbox} key={key}
+  createOptionCheckbox(optionKey: string, optionObject: any) {
+    const {profile: {demographicSurvey}} = this.state;
+    const initialValue = demographicSurvey[optionKey] && demographicSurvey[optionKey].includes(optionObject.value);
+
+    return <CheckBox label={optionObject.label} data-test-id={'checkbox-' + optionObject.value.toString()}
+                     style={styles.checkbox} key={optionObject.value.toString()}
+                     checked={initialValue}
                      wrapperStyle={styles.checkboxWrapper} labelStyle={styles.checkboxLabel}
-                     onChange={(value) => this.updateList(optionKey, optionValue)}
+                     onChange={(value) => this.updateList(optionKey, optionObject.value)}
     />;
   }
 
@@ -131,30 +135,31 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
       <Section header='Race'>
         <FlexColumn style={styles.checkboxAreaContainer}>
           {AccountCreationOptions.race.map((race) => {
-            return this.createOptionCheckbox(race.label, 'race', race.value, race.value.toString());
+            return this.createOptionCheckbox('race', race);
           })}
         </FlexColumn>
       </Section>
 
       {/*Ethnicity section*/}
-      <DropDownSection header='Ethnicity' options={AccountCreationOptions.ethnicity}
+      <DropDownSection data-test-id='dropdown-ethnicity'
+                       header='Ethnicity' options={AccountCreationOptions.ethnicity}
                        value={demographicSurvey.ethnicity}
                        onChange={(e) => this.updateDemographicAttribute('ethnicity', e)}/>
       <Section header='Do you identify as lesbian, gay, bisexual, transgender, queer (LGBTQ),
 or another sexual and/or gender minority?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton onChange={
+            <RadioButton data-test-id='radio-lgbtq-yes' id='identifiesAsLgbtqYes' onChange={
               (e) => this.updateDemographicAttribute('identifiesAsLgbtq', true)}
-                         checked={demographicSurvey.identifiesAsLgbtq}
+                         checked={demographicSurvey.identifiesAsLgbtq === true}
                          style={{marginRight: '0.5rem'}}/>
-            <label style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
+            <label htmlFor='identifiesAsLgbtqYes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
-                         checked={!demographicSurvey.identifiesAsLgbtq}
+            <RadioButton data-test-id='radio-lgbtq-no' id='identifiesAsLgbtqNo' onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
+                         checked={demographicSurvey.identifiesAsLgbtq === false}
                          style={{marginRight: '0.5rem'}}/>
-            <label style={{color: colors.primary}}>No</label>
+            <label htmlFor='identifiesAsLgbtqNo' style={{color: colors.primary}}>No</label>
           </FlexRow>
         </FlexColumn>
         <label></label>
@@ -169,8 +174,7 @@ or another sexual and/or gender minority?'>
       <Section header='Gender Identity'>
         <FlexColumn style={{...styles.checkboxAreaContainer, height: '5rem'}}>
           {AccountCreationOptions.genderIdentity.map((genderIdentity) => {
-            return this.createOptionCheckbox(genderIdentity.label, 'genderIdentityList',
-              genderIdentity.value, genderIdentity.value.toString());
+            return this.createOptionCheckbox('genderIdentityList', genderIdentity);
           })}
         </FlexColumn>
       </Section>
@@ -179,8 +183,7 @@ or another sexual and/or gender minority?'>
       <Section header='Sex at birth'>
         <FlexColumn style={{...styles.checkboxAreaContainer, height: '5rem'}}>
           {AccountCreationOptions.sexAtBirth.map((sexAtBirth) => {
-            return this.createOptionCheckbox(sexAtBirth.label, 'sexAtBirth',
-              sexAtBirth.value, sexAtBirth.value.toString());
+            return this.createOptionCheckbox('sexAtBirth', sexAtBirth);
           })}
         </FlexColumn>
       </Section>
@@ -194,17 +197,17 @@ or another sexual and/or gender minority?'>
       <Section header='Do you have a Physical or Cognitive disability?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton onChange={
+            <RadioButton id='disabilityYes' onChange={
               (e) => this.updateDemographicAttribute('disability', true)}
-                         checked={demographicSurvey.disability}
+                         checked={demographicSurvey.disability === true}
                          style={{marginRight: '0.5rem'}}/>
-            <label style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
+            <label htmlFor='disabilityYes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton onChange={(e) => this.updateDemographicAttribute('disability', false)}
-                         checked={!demographicSurvey.disability}
+            <RadioButton id='disabilityNo' onChange={(e) => this.updateDemographicAttribute('disability', false)}
+                         checked={demographicSurvey.disability === false}
                          style={{marginRight: '0.5rem'}}/>
-            <label style={{color: colors.primary}}>No</label>
+            <label htmlFor='disabilityNo' style={{color: colors.primary}}>No</label>
           </FlexRow>
         </FlexColumn>
       </Section>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -149,17 +149,17 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
 or another sexual and/or gender minority?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton data-test-id='radio-lgbtq-yes' id='identifiesAsLgbtqYes' onChange={
+            <RadioButton data-test-id='radio-lgbtq-yes' id='radio-lgbtq-yes' onChange={
               (e) => this.updateDemographicAttribute('identifiesAsLgbtq', true)}
                          checked={demographicSurvey.identifiesAsLgbtq === true}
                          style={{marginRight: '0.5rem'}}/>
-            <label htmlFor='identifiesAsLgbtqYes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
+            <label htmlFor='radio-lgbtq-yes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton data-test-id='radio-lgbtq-no' id='identifiesAsLgbtqNo' onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
+            <RadioButton data-test-id='radio-lgbtq-no' id='radio-lgbtq-no' onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
                          checked={demographicSurvey.identifiesAsLgbtq === false}
                          style={{marginRight: '0.5rem'}}/>
-            <label htmlFor='identifiesAsLgbtqNo' style={{color: colors.primary}}>No</label>
+            <label htmlFor='radio-lgbtq-no' style={{color: colors.primary}}>No</label>
           </FlexRow>
         </FlexColumn>
         <label></label>
@@ -197,17 +197,17 @@ or another sexual and/or gender minority?'>
       <Section header='Do you have a Physical or Cognitive disability?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton id='disabilityYes' onChange={
+            <RadioButton id='radio-disability-yes' onChange={
               (e) => this.updateDemographicAttribute('disability', true)}
                          checked={demographicSurvey.disability === true}
                          style={{marginRight: '0.5rem'}}/>
-            <label htmlFor='disabilityYes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
+            <label htmlFor='radio-disability-yes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton id='disabilityNo' onChange={(e) => this.updateDemographicAttribute('disability', false)}
+            <RadioButton id='radio-disability-no' onChange={(e) => this.updateDemographicAttribute('disability', false)}
                          checked={demographicSurvey.disability === false}
                          style={{marginRight: '0.5rem'}}/>
-            <label htmlFor='disabilityNo' style={{color: colors.primary}}>No</label>
+            <label htmlFor='radio-disability-no' style={{color: colors.primary}}>No</label>
           </FlexRow>
         </FlexColumn>
       </Section>

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -10,9 +10,7 @@ import {Profile} from 'generated/fetch';
 
 let props: AccountCreationProps;
 const component = () => {
-  return mount<AccountCreation,
-    AccountCreationProps,
-    AccountCreationState>(<AccountCreation {...props}/>);
+  return mount(<AccountCreation {...props}/>);
 };
 
 const defaultConfig = {gsuiteDomain: 'researchallofus.org', enableNewAccountCreation: false};

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -674,7 +674,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                 {Object.keys(errors).map((key) => <li key={errors[key][0]}>{errors[key][0]}</li>)}
               </ul>
             </React.Fragment>} disabled={!errors}>
-              <Button disabled={this.state.usernameCheckInProgress || this.isUsernameValidationError || errors}
+              <Button disabled={false}
                       style={{'height': '2rem', 'width': '10rem'}}
                       onClick={() => this.props.onComplete(this.state.profile)}>
                 Next

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -674,7 +674,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                 {Object.keys(errors).map((key) => <li key={errors[key][0]}>{errors[key][0]}</li>)}
               </ul>
             </React.Fragment>} disabled={!errors}>
-              <Button disabled={false}
+              <Button disabled={this.state.usernameCheckInProgress || this.isUsernameValidationError || errors}
                       style={{'height': '2rem', 'width': '10rem'}}
                       onClick={() => this.props.onComplete(this.state.profile)}>
                 Next

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -177,10 +177,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
           role: undefined,
         },
       ],
-      demographicSurvey: {
-
-
-      },
+      demographicSurvey: {},
       degrees: [] as Degree[],
     };
   }

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -18,7 +18,7 @@ import {
   withWindowSize,
 } from 'app/utils';
 
-import {DataAccessLevel, Degree, Profile} from 'generated/fetch';
+import {DataAccessLevel, Degree, Profile, Race} from 'generated/fetch';
 
 import {FlexColumn} from 'app/components/flex';
 import * as React from 'react';
@@ -137,7 +137,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
-      currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
+      currentStep: props.initialStep ? props.initialStep : SignInStep.DEMOGRAPHIC_SURVEY,
       invitationKey: null,
       termsOfServiceVersion: null,
       // This defines the profile state for a new user flow. This will get passed to each
@@ -177,7 +177,10 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
           role: undefined,
         },
       ],
-      demographicSurvey: {},
+      demographicSurvey: {
+        race: [Race.AA, Race.AIAN],
+
+      },
       degrees: [] as Degree[],
     };
   }
@@ -185,6 +188,12 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   componentDidMount() {
     document.body.style.backgroundColor = colors.light;
     this.props.onInit();
+  }
+
+  componentDidUpdate(prevProps: SignInProps, prevState: SignInState, snapshot) {
+    if (prevState.currentStep !== this.state.currentStep) {
+      window.scrollTo(0, 0);
+    }
   }
 
   /**

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -18,7 +18,7 @@ import {
   withWindowSize,
 } from 'app/utils';
 
-import {DataAccessLevel, Degree, Profile, Race} from 'generated/fetch';
+import {DataAccessLevel, Degree, Profile} from 'generated/fetch';
 
 import {FlexColumn} from 'app/components/flex';
 import * as React from 'react';
@@ -137,7 +137,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
-      currentStep: props.initialStep ? props.initialStep : SignInStep.DEMOGRAPHIC_SURVEY,
+      currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
       invitationKey: null,
       termsOfServiceVersion: null,
       // This defines the profile state for a new user flow. This will get passed to each
@@ -178,7 +178,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
         },
       ],
       demographicSurvey: {
-        race: [Race.AA, Race.AIAN],
+
 
       },
       degrees: [] as Degree[],


### PR DESCRIPTION
This PR fixes a couple issues with account creation that Eric uncovered:

1) When switching between steps, the window scroll position remains unchanged. It should scroll to the top of each new step.

The solution here was to add a componentDidUpdate method in sign-in.tsx, which resets the scroll position whenever a new step is reached.

2) Switching back and forth from account-creation to demographic survey appeared to clear out some existing data entry.

We do seem to be correctly persisting the Profile object between account creation steps, but the demographic survey component was missing some logic to auto-populate checkboxes with existing profile data. I added some unit tests to demonstrate the new behavior.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally