### PR TITLE
Early draft for pattern review: render sub-functions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -5,6 +5,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.GetInstitutionsResponse;
+import org.pmiops.workbench.model.GetPublicInstitutionDetailsResponse;
 import org.pmiops.workbench.model.Institution;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +35,7 @@ public class InstitutionController implements InstitutionApiDelegate {
   }
 
   @Override
+  @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<Institution> getInstitution(final String shortName) {
     final Institution institution =
         institutionService
@@ -47,9 +49,20 @@ public class InstitutionController implements InstitutionApiDelegate {
   }
 
   @Override
+  @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<GetInstitutionsResponse> getInstitutions() {
     final GetInstitutionsResponse response =
         new GetInstitutionsResponse().institutions(institutionService.getInstitutions());
+    return ResponseEntity.ok(response);
+  }
+
+  // note: this endpoint is publicly accessible because it is needed for account creation
+
+  @Override
+  public ResponseEntity<GetPublicInstitutionDetailsResponse> getPublicInstitutionDetails() {
+    final GetPublicInstitutionDetailsResponse response =
+        new GetPublicInstitutionDetailsResponse()
+            .institutions(institutionService.getPublicInstitutionDetails());
     return ResponseEntity.ok(response);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -6,9 +6,12 @@ import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.model.PublicInstitutionDetails;
 
 public interface InstitutionService {
   List<Institution> getInstitutions();
+
+  List<PublicInstitutionDetails> getPublicInstitutionDetails();
 
   Optional<Institution> getInstitution(final String shortName);
 

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.model.PublicInstitutionDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,15 +23,18 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   private final InstitutionDao institutionDao;
   private final InstitutionMapper institutionMapper;
+  private final PublicInstitutionDetailsMapper publicInstitutionDetailsMapper;
   private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   @Autowired
   InstitutionServiceImpl(
       InstitutionDao institutionDao,
       InstitutionMapper institutionMapper,
+      PublicInstitutionDetailsMapper publicInstitutionDetailsMapper,
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao) {
     this.institutionDao = institutionDao;
     this.institutionMapper = institutionMapper;
+    this.publicInstitutionDetailsMapper = publicInstitutionDetailsMapper;
     this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
   }
 
@@ -38,6 +42,13 @@ public class InstitutionServiceImpl implements InstitutionService {
   public List<Institution> getInstitutions() {
     return StreamSupport.stream(institutionDao.findAll().spliterator(), false)
         .map(institutionMapper::dbToModel)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<PublicInstitutionDetails> getPublicInstitutionDetails() {
+    return StreamSupport.stream(institutionDao.findAll().spliterator(), false)
+        .map(publicInstitutionDetailsMapper::dbToModel)
         .collect(Collectors.toList());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
@@ -1,0 +1,10 @@
+package org.pmiops.workbench.institution;
+
+import org.mapstruct.Mapper;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.model.PublicInstitutionDetails;
+
+@Mapper(componentModel = "spring")
+public interface PublicInstitutionDetailsMapper {
+  PublicInstitutionDetails dbToModel(DbInstitution dbObject);
+}

--- a/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -46,10 +47,20 @@ public interface VerifiedInstitutionalAffiliationMapper {
                             modelObject.getInstitutionShortName()))));
   }
 
-  @Mapping(target = "institutionShortName", source = "institution")
+  @Mapping(target = "institutionShortName", source = "institution", qualifiedByName = "shortName")
+  @Mapping(
+      target = "institutionDisplayName",
+      source = "institution",
+      qualifiedByName = "displayName")
   VerifiedInstitutionalAffiliation dbToModel(DbVerifiedInstitutionalAffiliation dbObject);
 
+  @Named("shortName")
   default String toShortName(DbInstitution institution) {
     return institution.getShortName();
+  }
+
+  @Named("displayName")
+  default String toDisplayName(DbInstitution institution) {
+    return institution.getDisplayName();
   }
 }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2325,7 +2325,8 @@ paths:
       tags:
         - institution
       description: >
-        Gets a list of all Institutions.
+        Gets the list of all Institutions.
+        Requires INSTITUTION_ADMIN authority.
       operationId: "getInstitutions"
       responses:
         200:
@@ -2354,6 +2355,21 @@ paths:
           schema:
             $ref: "#/definitions/Institution"
 
+  /v1/institutions/publicDetails:
+    get:
+      tags:
+        - institution
+      description: >
+        Gets the public details for the list of all Institutions.
+      operationId: "getPublicInstitutionDetails"
+      security: []
+      responses:
+        200:
+          description: >
+            A list of all Institutions
+          schema:
+            $ref: "#/definitions/GetPublicInstitutionDetailsResponse"
+
   /v1/institutions/{shortName}:
     parameters:
       - in: path
@@ -2366,6 +2382,7 @@ paths:
         - institution
       description: >
         Gets the Institution corresponding to the shortName ID.
+        Requires INSTITUTION_ADMIN authority.
       operationId: "getInstitution"
       responses:
         200:
@@ -4374,7 +4391,9 @@ definitions:
 
   Institution:
     type: object
-    description: Represents an institution which has been approved to validate researchers who wish to use the system
+    description: >
+      Represents an institution which has been approved to validate researchers who wish to use the system,
+      including the email patterns which we use to validate users.
     required:
       - shortName
       - displayName
@@ -4407,6 +4426,28 @@ definitions:
         items:
           type: string
 
+  PublicInstitutionDetails:
+    type: object
+    description: >
+      Represents an institution which has been approved to validate researchers who wish to use the system.
+      Does not include the sensitive email patterns used to validate users.
+    required:
+      - shortName
+      - displayName
+      - organizationTypeEnum
+    properties:
+      shortName:
+        type: string
+        description: A short unique name for the Institution used as an identifier, such as 'VUMC'
+      displayName:
+        type: string
+        description: A more descriptive name for the Institution, such as 'Vanderbilt University Medical Center'
+      organizationTypeEnum:
+        $ref: '#/definitions/OrganizationType'
+        description: >
+          The Organization Type of this institution if it is one of the enumerated
+          OrganizationTypes, or OrganizationType.OTHER if it is not
+
   GetInstitutionsResponse:
     type: object
     required:
@@ -4416,6 +4457,16 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Institution"
+
+  GetPublicInstitutionDetailsResponse:
+    type: object
+    required:
+      - institutions
+    properties:
+      institutions:
+        type: "array"
+        items:
+          $ref: "#/definitions/PublicInstitutionDetails"
 
   OrganizationType:
     type: string

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -4443,6 +4443,11 @@ definitions:
       institutionShortName:
         type: string
         description: The unique Short Name of the Institution where the user has a Verified Affiliation, such as 'VUMC'
+      institutionDisplayName:
+        type: string
+        description: >
+          The longer, more descriptive name of the Institution where the user has a Verified Affiliation,
+          such as 'Vanderbilt University Medical Center'
       institutionalRoleEnum:
         $ref: '#/definitions/InstitutionalRole'
         description: >

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -446,6 +446,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
         new VerifiedInstitutionalAffiliation()
             .institutionShortName(broad.getShortName())
+            .institutionDisplayName(broad.getDisplayName())
             .institutionalRoleEnum(InstitutionalRole.PROJECT_PERSONNEL);
     createAccountRequest
         .getProfile()

--- a/api/src/test/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapperTest.java
@@ -76,6 +76,8 @@ public class VerifiedInstitutionalAffiliationMapperTest {
 
     assertThat(affiliation.getInstitutionShortName())
         .isEqualTo(dbAffiliation.getInstitution().getShortName());
+    assertThat(affiliation.getInstitutionDisplayName())
+        .isEqualTo(dbAffiliation.getInstitution().getDisplayName());
     assertThat(affiliation.getInstitutionalRoleEnum())
         .isEqualTo(dbAffiliation.getInstitutionalRoleEnum());
     assertThat(affiliation.getInstitutionalRoleOtherText())
@@ -98,6 +100,7 @@ public class VerifiedInstitutionalAffiliationMapperTest {
     final VerifiedInstitutionalAffiliation affiliation =
         new VerifiedInstitutionalAffiliation()
             .institutionShortName(testInstitution.getShortName())
+            .institutionDisplayName(testInstitution.getDisplayName())
             .institutionalRoleEnum(InstitutionalRole.FELLOW)
             .institutionalRoleOtherText("A fine fellow, specifically");
 
@@ -107,6 +110,8 @@ public class VerifiedInstitutionalAffiliationMapperTest {
 
     assertThat(dbAffiliation.getInstitution().getShortName())
         .isEqualTo(affiliation.getInstitutionShortName());
+    assertThat(dbAffiliation.getInstitution().getDisplayName())
+        .isEqualTo(affiliation.getInstitutionDisplayName());
     assertThat(dbAffiliation.getInstitutionalRoleEnum())
         .isEqualTo(affiliation.getInstitutionalRoleEnum());
     assertThat(dbAffiliation.getInstitutionalRoleOtherText())
@@ -116,6 +121,8 @@ public class VerifiedInstitutionalAffiliationMapperTest {
 
     assertThat(roundTrip.getInstitutionShortName())
         .isEqualTo(affiliation.getInstitutionShortName());
+    assertThat(roundTrip.getInstitutionDisplayName())
+        .isEqualTo(affiliation.getInstitutionDisplayName());
     assertThat(roundTrip.getInstitutionalRoleEnum())
         .isEqualTo(affiliation.getInstitutionalRoleEnum());
     assertThat(roundTrip.getInstitutionalRoleOtherText())

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -12,12 +12,12 @@ import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import { getRegistrationTasksMap } from 'app/pages/homepage/registration-dashboard';
 import { ProfileRegistrationStepStatus } from 'app/pages/profile/profile-registration-step-status';
-import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
+import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {serverConfigStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
-import {Institution, InstitutionalAffiliation, InstitutionalRole, Profile} from 'generated/fetch';
+import {InstitutionalAffiliation, InstitutionalRole, Profile} from 'generated/fetch';
 
 const styles = reactStyles({
   h1: {
@@ -71,7 +71,7 @@ const validators = {
 
 export const ProfilePage = withUserProfile()(class extends React.Component<
   { profileState: { profile: Profile, reload: Function } },
-  { profileEdits: Profile, updating: boolean, verifiedInstitution?: Institution }
+  { profileEdits: Profile, updating: boolean }
 > {
   static displayName = 'ProfilePage';
 
@@ -80,23 +80,13 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
 
     this.state = {
       profileEdits: props.profileState.profile || {},
-      updating: false,
-      verifiedInstitution: undefined
+      updating: false
     };
   }
 
   navigateToTraining(): void {
     window.location.assign(
       environment.trainingUrl + '/static/data-researcher.html?saml=on');
-  }
-
-  async componentDidMount() {
-    const {profileState: {profile: {verifiedInstitutionalAffiliation}}} = this.props;
-    if (verifiedInstitutionalAffiliation) {
-      await institutionApi().getInstitution(verifiedInstitutionalAffiliation.institutionShortName).then(institution =>
-        this.setState({verifiedInstitution: institution})
-      );
-    }
   }
 
   componentDidUpdate(prevProps) {
@@ -124,7 +114,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
 
   render() {
     const {profileState: {profile}} = this.props;
-    const {profileEdits, updating, verifiedInstitution} = this.state;
+    const {profileEdits, updating} = this.state;
     const {enableComplianceTraining, enableEraCommons, enableDataUseAgreement, requireInstitutionalVerification} =
       serverConfigStore.getValue();
     const {
@@ -195,13 +185,13 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
         return;
       }
 
-      const {institutionalRoleEnum, institutionalRoleOtherText} = verifiedInstitutionalAffiliation;
-      return verifiedInstitution && <React.Fragment>
+      const {institutionDisplayName, institutionalRoleEnum, institutionalRoleOtherText} = verifiedInstitutionalAffiliation;
+      return <React.Fragment>
         <div style={{...styles.h1, marginBottom: 24}}>Verified Institutional Affiliation</div>
         <FlexRow>
           <FlexColumn>
             <div style={styles.inputLabel}>Institution</div>
-            <div style={styles.uneditableProfileElement}>{verifiedInstitution.displayName}</div>
+            <div style={styles.uneditableProfileElement}>{institutionDisplayName}</div>
           </FlexColumn>
           <FlexColumn>
             <div style={styles.inputLabel}>Role</div>

--- a/ui/src/app/services/swagger-fetch-clients.ts
+++ b/ui/src/app/services/swagger-fetch-clients.ts
@@ -35,6 +35,7 @@ import {
   DataSetApi,
   FeaturedWorkspacesConfigApi,
   FetchAPI, // internal
+  InstitutionApi,
   ProfileApi,
   StatusAlertApi,
   StatusApi,
@@ -91,6 +92,7 @@ export const conceptsApi = bindCtor(ConceptsApi);
 export const conceptSetsApi = bindCtor(ConceptSetsApi);
 export const dataSetApi = bindCtor(DataSetApi);
 export const featuredWorkspacesConfigApi = bindCtor(FeaturedWorkspacesConfigApi);
+export const institutionApi = bindCtor(InstitutionApi);
 export const profileApi = bindCtor(ProfileApi);
 export const statusApi = bindCtor(StatusApi);
 export const statusAlertApi = bindCtor(StatusAlertApi);


### PR DESCRIPTION
Description:

I'm updating the Profile page to be agnostic to whether the user creation happened under the old (Demographics Survey page) Institutional Affiliation flow or the new Verified Institutional Affiliation flow.  It seems natural to me to break up the huge render() function into sub-functions, but I don't see this pattern a lot in our code.  Is there a reason for this?  LMK what you think about `renderInstitutionalAffiliationComponents()` and friends.

Some discussion on this topic which I found after a quick Google and will read now:
https://medium.com/front-end-weekly/react-quick-tip-split-up-your-render-method-5eb30e432e2
https://www.barrymichaeldoyle.com/sub-rendering/
https://silvenon.com/blog/dont-split-render-into-functions

I'll look at comments on other code here but that's not the primary purpose of this Draft.  Thanks!


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
