### PR TITLE
[RW-4508][risk=no] Allow a null value in the demographic survey 'disability' boolean

### DIFF
--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -3941,7 +3941,6 @@ definitions:
         $ref: '#/definitions/Education'
       disability:
         type: boolean
-        default: false
 
   Address:
     type: object


### PR DESCRIPTION
See my comment in https://precisionmedicineinitiative.atlassian.net/browse/RW-4508 for context – there is a small remaining issue with user registration, where a blank demographic survey will create non-null data in the 'demographics' table.

Allowing a null value on this boolean is more correct, since non-response is meaningfully different than true or false.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review