### PR TITLE
[RW-4462][risk=low] Add GCS traffic and hook up delete-cluster button to WS admin page.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -421,6 +421,8 @@ dependencies {
   compile 'com.google.apis:google-api-services-oauth2:v2-rev139-1.23.0'
   compile 'com.google.cloud:google-cloud-bigquery:1.51.0'
   compile 'com.google.cloud:google-cloud-iamcredentials:0.43.0-alpha'
+  compile 'com.google.cloud:google-cloud-logging:1.90.0'
+  compile 'com.google.cloud:google-cloud-monitoring:1.99.2'
   compile 'com.google.cloud:google-cloud-storage:1.51.0'
   compile 'com.google.cloud:google-cloud-tasks:1.27.0'
   compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.3'
@@ -463,9 +465,8 @@ dependencies {
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502
   compile 'org.json:json:20160810'
-
+  
   compile 'com.github.fge:json-patch:1.9'
-  compile 'com.google.cloud:google-cloud-logging:1.90.0'
   toolsCompile 'commons-cli:commons-cli:1.4'
   toolsCompile 'com.opencsv:opencsv:4.6'
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1400,15 +1400,14 @@ Common.register_command({
 })
 
 def set_authority_local(cmd_name, *args)
-  ensure_docker_api(cmd_name, args)
+  setup_local_environment
 
   op = authority_options(cmd_name, args)
   op.parse.validate
 
+  app_args = ["-PappArgs=['#{op.opts.email}','#{op.opts.authority}',#{op.opts.remove},#{op.opts.dry_run}]"]
   common = Common.new
-  common.run_inline %W{
-      gradle setAuthority
-     -PappArgs=['#{op.opts.email}','#{op.opts.authority}',#{op.opts.remove},#{op.opts.dry_run}]}
+  common.run_inline %W{docker-compose run api-scripts ./gradlew setAuthority} + app_args
 end
 
 Common.register_command({

--- a/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringService.java
@@ -1,8 +1,10 @@
 package org.pmiops.workbench.google;
 
 import com.google.monitoring.v3.TimeSeries;
+import java.time.Duration;
 
 public interface CloudMonitoringService {
 
-  Iterable<TimeSeries> getCloudStorageReceivedBytes(String workspaceNamespace);
+  Iterable<TimeSeries> getCloudStorageReceivedBytes(
+      String workspaceNamespace, Duration trailingTimeToQuery);
 }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringService.java
@@ -1,0 +1,8 @@
+package org.pmiops.workbench.google;
+
+import com.google.monitoring.v3.TimeSeries;
+
+public interface CloudMonitoringService {
+
+  Iterable<TimeSeries> getCloudStorageReceivedBytes(String workspaceNamespace);
+}

--- a/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudMonitoringServiceImpl.java
@@ -1,0 +1,59 @@
+package org.pmiops.workbench.google;
+
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.Aggregation;
+import com.google.monitoring.v3.ListTimeSeriesRequest;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.protobuf.util.Durations;
+import com.google.protobuf.util.Timestamps;
+import java.time.Duration;
+import java.time.Instant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CloudMonitoringServiceImpl implements CloudMonitoringService {
+
+  private static final Duration TRAILING_TIME_TO_QUERY = Duration.ofHours(6);
+
+  private final MetricServiceClient metricServiceClient;
+
+  @Autowired
+  public CloudMonitoringServiceImpl(MetricServiceClient metricServiceClient) {
+    this.metricServiceClient = metricServiceClient;
+  }
+
+  private static Aggregation getAggregation() {
+    return Aggregation.newBuilder()
+        .setPerSeriesAligner(Aggregation.Aligner.ALIGN_RATE)
+        .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_SUM)
+        .setAlignmentPeriod(Durations.fromMinutes(1))
+        .build();
+  }
+
+  private static TimeInterval getTimeInterval() {
+    long windowStartMillis = Instant.now().minus(TRAILING_TIME_TO_QUERY).toEpochMilli();
+    long windowEndMillis = Instant.now().toEpochMilli();
+
+    return TimeInterval.newBuilder()
+        .setStartTime(Timestamps.fromMillis(windowStartMillis))
+        .setEndTime(Timestamps.fromMillis(windowEndMillis))
+        .build();
+  }
+
+  @Override
+  public Iterable<TimeSeries> getCloudStorageReceivedBytes(String workspaceNamespace) {
+    ListTimeSeriesRequest request =
+        ListTimeSeriesRequest.newBuilder()
+            .setName(ProjectName.of(workspaceNamespace).toString())
+            .setFilter("metric.type = \"storage.googleapis.com/network/received_bytes_count\"")
+            .setAggregation(getAggregation())
+            .setInterval(getTimeInterval())
+            .setView(ListTimeSeriesRequest.TimeSeriesView.FULL)
+            .build();
+
+    return metricServiceClient.listTimeSeries(request).iterateAll();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/google/GoogleConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/google/GoogleConfig.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.google;
 
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
 import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,5 +14,10 @@ public class GoogleConfig {
   @Lazy
   public IamCredentialsClient getIamCredentialsClient() throws IOException {
     return IamCredentialsClient.create();
+  }
+
+  @Bean
+  public MetricServiceClient getMetricServiceClient() throws IOException {
+    return MetricServiceClient.create();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -1,5 +1,9 @@
 package org.pmiops.workbench.workspaceadmin;
 
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.protobuf.util.Timestamps;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -8,13 +12,16 @@ import org.pmiops.workbench.api.WorkspaceAdminApiDelegate;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
+import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.model.AdminFederatedWorkspaceDetailsResponse;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.AdminWorkspaceResources;
 import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.ListClusterResponse;
+import org.pmiops.workbench.model.TimeSeriesPoint;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.pmiops.workbench.utils.WorkspaceMapper;
@@ -26,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
+  private final CloudMonitoringService cloudMonitoringService;
   private final FireCloudService fireCloudService;
   private final LeonardoNotebooksClient leonardoNotebooksClient;
   private final WorkspaceAdminService workspaceAdminService;
@@ -34,16 +42,40 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   @Autowired
   public WorkspaceAdminController(
+      CloudMonitoringService cloudMonitoringService,
       FireCloudService fireCloudService,
       LeonardoNotebooksClient leonardoNotebooksClient,
       WorkspaceAdminService workspaceAdminService,
       WorkspaceMapper workspaceMapper,
       WorkspaceService workspaceService) {
+    this.cloudMonitoringService = cloudMonitoringService;
     this.fireCloudService = fireCloudService;
     this.leonardoNotebooksClient = leonardoNotebooksClient;
     this.workspaceAdminService = workspaceAdminService;
     this.workspaceMapper = workspaceMapper;
     this.workspaceService = workspaceService;
+  }
+
+  /** */
+  @Override
+  @AuthorityRequired({Authority.WORKSPACES_VIEW})
+  public ResponseEntity<CloudStorageTraffic> getCloudStorageTraffic(String workspaceNamespace) {
+    CloudStorageTraffic response = new CloudStorageTraffic();
+
+    for (TimeSeries timeSeries :
+        cloudMonitoringService.getCloudStorageReceivedBytes(workspaceNamespace)) {
+      for (Point point : timeSeries.getPointsList()) {
+        response.addReceivedBytesItem(
+            new TimeSeriesPoint()
+                .timestamp(Timestamps.toMillis(point.getInterval().getStartTime()))
+                .value(point.getValue().getDoubleValue()));
+      }
+    }
+
+    // Highcharts expects its data to be pre-sorted; we do this on the server side for convenience.
+    response.getReceivedBytes().sort(Comparator.comparing(TimeSeriesPoint::getTimestamp));
+
+    return ResponseEntity.ok(response);
   }
 
   @Override
@@ -89,12 +121,12 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
       FirecloudWorkspace fcWorkspace =
           fireCloudService.getWorkspace(workspaceNamespace, workspaceFirecloudName).getWorkspace();
-      AdminFederatedWorkspaceDetailsResponse response =
+
+      return ResponseEntity.ok(
           new AdminFederatedWorkspaceDetailsResponse()
               .workspace(workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace))
               .collaborators(collaborators)
-              .resources(resources);
-      return ResponseEntity.ok(response);
+              .resources(resources));
     } else {
       return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.workspaceadmin;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.protobuf.util.Timestamps;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
+
+  private static final Duration TRAILING_TIME_TO_QUERY = Duration.ofHours(6);
+
   private final CloudMonitoringService cloudMonitoringService;
   private final FireCloudService fireCloudService;
   private final LeonardoNotebooksClient leonardoNotebooksClient;
@@ -63,7 +67,8 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
     CloudStorageTraffic response = new CloudStorageTraffic();
 
     for (TimeSeries timeSeries :
-        cloudMonitoringService.getCloudStorageReceivedBytes(workspaceNamespace)) {
+        cloudMonitoringService.getCloudStorageReceivedBytes(
+            workspaceNamespace, TRAILING_TIME_TO_QUERY)) {
       for (Point point : timeSeries.getPointsList()) {
         response.addReceivedBytesItem(
             new TimeSeriesPoint()

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -61,7 +61,6 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
     this.workspaceService = workspaceService;
   }
 
-  /** */
   @Override
   @AuthorityRequired({Authority.WORKSPACES_VIEW})
   public ResponseEntity<CloudStorageTraffic> getCloudStorageTraffic(String workspaceNamespace) {

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -4,6 +4,7 @@ import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   @Override
   @AuthorityRequired({Authority.WORKSPACES_VIEW})
   public ResponseEntity<CloudStorageTraffic> getCloudStorageTraffic(String workspaceNamespace) {
-    CloudStorageTraffic response = new CloudStorageTraffic();
+    CloudStorageTraffic response = new CloudStorageTraffic().receivedBytes(new ArrayList<>());
 
     for (TimeSeries timeSeries :
         cloudMonitoringService.getCloudStorageReceivedBytes(

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -72,7 +72,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
       for (Point point : timeSeries.getPointsList()) {
         response.addReceivedBytesItem(
             new TimeSeriesPoint()
-                .timestamp(Timestamps.toMillis(point.getInterval().getStartTime()))
+                .timestamp(Timestamps.toMillis(point.getInterval().getEndTime()))
                 .value(point.getValue().getDoubleValue()));
       }
     }

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -1081,7 +1081,7 @@ paths:
         - workspaceAdmin
       description: >
         Given a workspace namespace (Google Cloud Platform  Project ID), returns workspace details.
-        Only accessible to privileged admin users.
+        Requires the WORKSPACES_VIEW authority.
       operationId: getFederatedWorkspaceDetails
       responses:
         200:
@@ -1092,6 +1092,22 @@ paths:
           description: Workspace not found for namespace
           schema:
             $ref: '#/definitions/ErrorResponse'
+
+  /v1/admin/workspaces/{workspaceNamespace}/cloudStorageTraffic:
+    parameters:
+      - $ref: '#/parameters/workspaceNamespace'
+    get:
+      tags:
+        - workspaceAdmin
+      description: >
+        Returns a time series of cloud storage traffic for the given project.
+        Requires the WORKSPACES_VIEW authority.
+      operationId: getCloudStorageTraffic
+      responses:
+        200:
+          description: success
+          schema:
+            $ref: "#/definitions/CloudStorageTraffic"
 
   /v1/admin/clusters/updateConfig:
     post:
@@ -4502,3 +4518,25 @@ definitions:
       storageBytesUsed:
         type: integer
         format: int64
+
+  CloudStorageTraffic:
+    type: object
+    properties:
+      receivedBytes:
+        type: array
+        items:
+          $ref: "#/definitions/TimeSeriesPoint"
+
+  TimeSeriesPoint:
+    type: object
+    description: Represents a floating-point valued time series point.
+    properties:
+      timestamp:
+        type: integer
+        format: int64
+        description: >
+          Timestamp, in milliseconds since Unix epoch, of the end point of the time window
+          covered by this time series point.
+      value:
+        type: number
+        format: double

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -171,11 +171,13 @@ public class WorkspaceAdminControllerTest {
                     .setInterval(TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(1000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .build();
+
     when(mockCloudMonitoringService.getCloudStorageReceivedBytes(anyString(), any(Duration.class)))
         .thenReturn(Arrays.asList(timeSeries));
 
     CloudStorageTraffic cloudStorageTraffic =
         workspaceAdminController.getCloudStorageTraffic(WORKSPACE_NAMESPACE).getBody();
+
     assertThat(
             cloudStorageTraffic.getReceivedBytes().stream()
                 .map(timeSeriesPoint -> timeSeriesPoint.getTimestamp())

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.workspaceadmin;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -9,6 +10,7 @@ import com.google.monitoring.v3.TimeInterval;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.monitoring.v3.TypedValue;
 import com.google.protobuf.util.Timestamps;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -171,7 +173,7 @@ public class WorkspaceAdminControllerTest {
                         TimeInterval.newBuilder().setStartTime(Timestamps.fromMillis(1000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .build();
-    when(mockCloudMonitoringService.getCloudStorageReceivedBytes(anyString()))
+    when(mockCloudMonitoringService.getCloudStorageReceivedBytes(anyString(), any(Duration.class)))
         .thenReturn(Arrays.asList(timeSeries));
 
     CloudStorageTraffic cloudStorageTraffic =

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -164,13 +164,11 @@ public class WorkspaceAdminControllerTest {
         TimeSeries.newBuilder()
             .addPoints(
                 Point.newBuilder()
-                    .setInterval(
-                        TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(2000)))
+                    .setInterval(TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(2000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .addPoints(
                 Point.newBuilder()
-                    .setInterval(
-                        TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(1000)))
+                    .setInterval(TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(1000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .build();
     when(mockCloudMonitoringService.getCloudStorageReceivedBytes(anyString(), any(Duration.class)))

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -165,12 +165,12 @@ public class WorkspaceAdminControllerTest {
             .addPoints(
                 Point.newBuilder()
                     .setInterval(
-                        TimeInterval.newBuilder().setStartTime(Timestamps.fromMillis(2000)))
+                        TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(2000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .addPoints(
                 Point.newBuilder()
                     .setInterval(
-                        TimeInterval.newBuilder().setStartTime(Timestamps.fromMillis(1000)))
+                        TimeInterval.newBuilder().setEndTime(Timestamps.fromMillis(1000)))
                     .setValue(TypedValue.newBuilder().setDoubleValue(1234)))
             .build();
     when(mockCloudMonitoringService.getCloudStorageReceivedBytes(anyString(), any(Duration.class)))

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -57,12 +57,10 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     };
   }
 
-  async getFederatedWorkspaceInformation(showLoadingSpinner: boolean = true) {
-    if (showLoadingSpinner) {
-      this.setState({
-        loadingData: true,
-      });
-    }
+  async getFederatedWorkspaceInformation() {
+    this.setState({
+      loadingData: true,
+    });
 
     // Fire off both requests in parallel
     const workspaceDetailsPromise = workspaceAdminApi().getFederatedWorkspaceDetails(this.state.googleProject);
@@ -162,8 +160,8 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     await clusterApi().deleteClustersInProject(
       this.state.googleProject,
       {clustersToDelete: [this.state.clusterToDelete.clusterName]});
-    await this.getFederatedWorkspaceInformation(false);
     this.setState({clusterToDelete: null});
+    await this.getFederatedWorkspaceInformation();
   }
 
   private cancelDeleteCluster() {

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -64,7 +64,7 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
       });
     }
 
-    // Fire off both promises in parallel
+    // Fire off both requests in parallel
     const workspaceDetailsPromise = workspaceAdminApi().getFederatedWorkspaceDetails(this.state.googleProject);
     const cloudStorageTrafficPromise = workspaceAdminApi().getCloudStorageTraffic(this.state.googleProject);
     // Wait for both promises to complete before updating state.

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -6,10 +6,7 @@ import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {
-  Error as ErrorDiv,
-  TextInput
-} from 'app/components/inputs';
+import {Error as ErrorDiv} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {clusterApi, workspaceAdminApi} from 'app/services/swagger-fetch-clients';

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -61,15 +61,21 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     };
   }
 
+  componentDidMount() {
+    this.getFederatedWorkspaceInformation();
+  }
+
   async getFederatedWorkspaceInformation() {
+    const {urlParams: { workspaceNamespace } } = this.props;
+
     this.setState({
       loadingData: true,
     });
 
     try {
       // Fire off both requests in parallel
-      const workspaceDetailsPromise = workspaceAdminApi().getFederatedWorkspaceDetails(this.state.googleProject);
-      const cloudStorageTrafficPromise = workspaceAdminApi().getCloudStorageTraffic(this.state.googleProject);
+      const workspaceDetailsPromise = workspaceAdminApi().getFederatedWorkspaceDetails(workspaceNamespace);
+      const cloudStorageTrafficPromise = workspaceAdminApi().getCloudStorageTraffic(workspaceNamespace);
       // Wait for both promises to complete before updating state.
       const workspaceDetails = await workspaceDetailsPromise;
       const cloudStorageTraffic = await cloudStorageTrafficPromise;
@@ -82,7 +88,6 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     } finally {
       this.setState({loadingData: false});
     }
-
   }
 
   maybeGetFederatedWorkspaceInformation(event: KeyboardEvent) {
@@ -171,7 +176,7 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
 
   private async deleteCluster() {
     await clusterApi().deleteClustersInProject(
-      this.state.googleProject,
+      this.props.urlParams.workspaceNamespace,
       {clustersToDelete: [this.state.clusterToDelete.clusterName]});
     this.setState({clusterToDelete: null});
     await this.getFederatedWorkspaceInformation();

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -1,23 +1,26 @@
-import * as React from 'react';
-
 import {Component} from '@angular/core';
+import * as HighCharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import * as moment from 'moment';
+import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {workspaceAdminApi} from 'app/services/swagger-fetch-clients';
+import {TextInput} from 'app/components/inputs';
+import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
+import {SpinnerOverlay} from 'app/components/spinners';
+import {clusterApi, workspaceAdminApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, UrlParamsProps, withUrlParams} from 'app/utils';
 import {
   getSelectedPopulations,
   getSelectedResearchPurposeItems
 } from 'app/utils/research-purpose';
-
 import {
-  AdminWorkspaceResources,
-  UserRole,
-  Workspace
+  AdminFederatedWorkspaceDetailsResponse,
+  CloudStorageTraffic, ListClusterResponse,
 } from 'generated/fetch';
-
+import {ReactFragment} from 'react';
 
 const styles = reactStyles({
   wideWithMargin: {
@@ -30,12 +33,6 @@ const styles = reactStyles({
   }
 });
 
-const FlexWithMargin = ({style = {}, children}) => {
-  return <FlexColumn style={{...styles.wideWithMargin, ...style}}>
-    {...children}
-  </FlexColumn>;
-};
-
 const PurpleLabel = ({style = {}, children}) => {
   return <label style={{color: colors.primary, ...style}}>
     {...children}
@@ -43,9 +40,11 @@ const PurpleLabel = ({style = {}, children}) => {
 };
 
 interface State {
-  workspace: Workspace;
-  collaborators: Array<UserRole>;
-  resources: AdminWorkspaceResources;
+  workspaceDetails?: AdminFederatedWorkspaceDetailsResponse;
+  cloudStorageTraffic?: CloudStorageTraffic;
+  loadingData?: boolean;
+  clusterToDelete?: ListClusterResponse;
+  confirmDeleteCluster?: boolean;
 }
 
 class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
@@ -53,26 +52,26 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     super(props);
 
     this.state = {
-      workspace: null,
-      collaborators: [],
-      resources: {},
+      workspaceDetails: {},
+      cloudStorageTraffic: null,
     };
   }
 
-  componentDidMount() {
-    this.getFederatedWorkspaceInformation();
-  }
+  async getFederatedWorkspaceInformation(showLoadingSpinner: boolean = true) {
+    if (showLoadingSpinner) {
+      this.setState({
+        loadingData: true,
+      });
+    }
 
-  getFederatedWorkspaceInformation() {
-    workspaceAdminApi().getFederatedWorkspaceDetails(this.props.urlParams.workspaceNamespace).then(
-      response => {
-        this.setState({
-          workspace: response.workspace,
-          collaborators: response.collaborators,
-          resources: response.resources
-        });
-      }
-    );
+    // Fire off both promises in parallel
+    const workspaceDetailsPromise = workspaceAdminApi().getFederatedWorkspaceDetails(this.state.googleProject);
+    const cloudStorageTrafficPromise = workspaceAdminApi().getCloudStorageTraffic(this.state.googleProject);
+    // Wait for both promises to complete before updating state.
+    const workspaceDetails = await workspaceDetailsPromise;
+    const cloudStorageTraffic = await cloudStorageTrafficPromise;
+
+    this.setState({cloudStorageTraffic, workspaceDetails, loadingData: false});
   }
 
   maybeGetFederatedWorkspaceInformation(event: KeyboardEvent) {
@@ -82,10 +81,11 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
   }
 
   workspaceInfoField(labelText, divContents) {
-    return <FlexRow style={{width: '100%'}}>
+    return <FlexRow style={{width: '80%', maxWidth: '1000px'}}>
       <PurpleLabel
         style={{
-          width: '40%',
+          width: '250px',
+          minWidth: '180px',
           textAlign: 'right',
           marginRight: '1rem',
         }}
@@ -94,7 +94,7 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
       </PurpleLabel>
       <div
         style={{
-          width: '60%',
+          flex: 1,
           wordWrap: 'break-word',
         }}
       >
@@ -103,34 +103,93 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
     </FlexRow>;
   }
 
-  researchPurposeField(labelText, divContents) {
-    return <FlexWithMargin>
-      <PurpleLabel>{labelText}</PurpleLabel>
-      <div style={{wordWrap: 'break-word'}}>{divContents}</div>
-    </FlexWithMargin>;
+  renderHighChart(cloudStorageTraffic: CloudStorageTraffic): ReactFragment {
+    HighCharts.setOptions({
+      global: {
+        useUTC: false,
+      },
+      lang: {
+        decimalPoint: '.',
+        thousandsSep: ','
+      },
+    });
+    const options = {
+      animation: false,
+      chart: {
+        animation: false,
+        height: '150px',
+      },
+      credits: {
+        enabled: false,
+      },
+      legend: {
+        enabled: false,
+      },
+      title: {
+        text: undefined,
+      },
+      tooltip: {
+        xDateFormat: '%A, %b %e, %H:%M',
+        valueDecimals: 0,
+      },
+      xAxis: {
+        min: moment().subtract(6, 'hours').valueOf(),
+        max: moment().valueOf(),
+        title: {
+          enabled: false,
+        },
+        type: 'datetime',
+        zoomEnabled: false,
+      },
+      yAxis: {
+        title: {
+          enabled: false,
+        },
+        zoomEnabled: false,
+      },
+      series: [{
+        data: cloudStorageTraffic.receivedBytes.map(x => [x.timestamp, x.value]),
+        lineWidth: 0.5,
+        name: 'GCS received bytes'
+      }]
+    };
+    return <div style={{width: '500px', zIndex: 1001}}>
+      <HighchartsReact highcharts={HighCharts} options={options}/>
+    </div>;
+  }
+
+  private async deleteCluster() {
+    await clusterApi().deleteClustersInProject(
+      this.state.googleProject,
+      {clustersToDelete: [this.state.clusterToDelete.clusterName]});
+    await this.getFederatedWorkspaceInformation(false);
+    this.setState({clusterToDelete: null});
+  }
+
+  private cancelDeleteCluster() {
+    this.setState({
+      confirmDeleteCluster: false,
+      clusterToDelete: null
+    });
   }
 
   render() {
-    const {workspace, collaborators, resources} = this.state;
+    const {
+      cloudStorageTraffic,
+      clusterToDelete,
+      confirmDeleteCluster,
+      loadingData,
+      workspaceDetails: {collaborators, resources, workspace},
+    } = this.state;
+    return <div style={{marginTop: '1rem', marginBottom: '1rem'}}>
 
-    return <div>
-      {
-        workspace && <FlexColumn>
-          <h3>Workspace Admin Actions</h3>
-          <FlexRow style={{justifyContent: 'space-between'}}>
-            <Button>Shut down all VMs</Button>
-            <Button>Disable workspace</Button>
-            <Button>Disable all collaborators</Button>
-            <Button>Exclude from public directory</Button>
-            <Button>Log administrative comment</Button>
-            <Button>Publish workspace</Button>
-          </FlexRow>
-        </FlexColumn>
-      }
-      {workspace && resources.workspaceObjects && resources.cloudStorage && collaborators &&
-        <FlexRow>
-          <FlexColumn style={styles.wideWithMargin}>
-            <h3>Basic Information</h3>
+      {loadingData && <SpinnerOverlay />}
+
+      <h2>Workspace</h2>
+      {workspace &&
+        <div>
+          <h3>Basic Information</h3>
+          <div className='basic-info' style={{marginTop: '1rem'}}>
             {this.workspaceInfoField('Workspace Name', workspace.name)}
             {this.workspaceInfoField('Google Project Id', workspace.namespace)}
             {this.workspaceInfoField('Billing Status', workspace.billingStatus)}
@@ -147,9 +206,17 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
               'Workspace Published',
               workspace.published ? 'Yes' : 'No'
             )}
-          </FlexColumn>
-          <FlexColumn style={styles.wideWithMargin}>
-            <h3>Workspace Objects</h3>
+          </div>
+          <h3>Collaborators</h3>
+          <div className='collaborators' style={{marginTop: '1rem'}}>
+            {collaborators.map((userRole, i) =>
+              <div key={i}>
+                {userRole.email + ': ' + userRole.role}
+              </div>
+            )}
+          </div>
+          <h3>Cohort Builder</h3>
+          <div className='cohort-builder' style={{marginTop: '1rem'}}>
             {
               this.workspaceInfoField(
                 '# of Cohorts',
@@ -168,9 +235,9 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
                 resources.workspaceObjects.datasetCount
               )
             }
-          </FlexColumn>
-          <FlexColumn style={styles.wideWithMargin}>
-            <h3>Cloud Storage</h3>
+          </div>
+          <h3>Cloud Storage Objects</h3>
+          <div className='cloud-storage-objects' style={{marginTop: '1rem'}}>
             {
               this.workspaceInfoField(
                 '# of Notebook Files',
@@ -189,22 +256,11 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
                 resources.cloudStorage.storageBytesUsed
               )
             }
-          </FlexColumn>
-          <FlexColumn style={styles.wideWithMargin}>
-            <h3>Workspace Collaborators</h3>
-            {collaborators.map((userRole, i) =>
-                <div key={i}>
-                  {userRole.email + ': ' + userRole.role}
-                </div>
-            )}
-          </FlexColumn>
-        </FlexRow>
-      }
-      {workspace && <FlexColumn>
+          </div>
           <h3>Research Purpose</h3>
-          <FlexRow style={{flex: '1 0 auto'}}>
+          <div className='research-purpose' style={{marginTop: '1rem'}}>
             {
-              this.researchPurposeField(
+              this.workspaceInfoField(
                 'Primary purpose of project',
                 getSelectedResearchPurposeItems(
                   workspace.researchPurpose).map(
@@ -215,34 +271,45 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
                 )
             }
             {
-              this.researchPurposeField(
+              this.workspaceInfoField(
                 'Reason for choosing All of Us',
                 workspace.researchPurpose.reasonForAllOfUs
               )
             }
             {
-              this.researchPurposeField(
+              this.workspaceInfoField(
                 'Area of intended study',
                 workspace.researchPurpose.intendedStudy
               )
             }
             {
-              this.researchPurposeField(
+              this.workspaceInfoField(
                 'Anticipated findings',
                 workspace.researchPurpose.anticipatedFindings
               )
             }
             {
-              workspace.researchPurpose.population && this.researchPurposeField(
+              workspace.researchPurpose.population && this.workspaceInfoField(
                 'Population area(s) of focus',
                 getSelectedPopulations(workspace.researchPurpose).map((selectedPopulation, i) => <div key={i}>{selectedPopulation}</div>)
               )
             }
-          </FlexRow>
-        </FlexColumn>
+          </div>
+        </div>
       }
-      {workspace && resources.clusters.length > 0 && <FlexColumn>
-          <h3>Clusters</h3>
+
+      <h2>Cloud Storage Traffic</h2>
+      {cloudStorageTraffic && cloudStorageTraffic.receivedBytes &&
+        <div>
+          <div>Cloud Storage <i>received_bytes_count</i> over the past 6 hours.</div>
+          {this.renderHighChart(cloudStorageTraffic)}
+        </div>
+      }
+
+      <h2>Clusters</h2>
+      {resources && resources.clusters.length === 0 &&
+      <p>No active clusters exist for this workspace.</p>}
+      {resources && resources.clusters.length > 0 && <FlexColumn>
           <FlexRow>
             <PurpleLabel style={styles.narrowWithMargin}>Cluster Name</PurpleLabel>
             <PurpleLabel style={styles.narrowWithMargin}>Google Project</PurpleLabel>
@@ -251,17 +318,39 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
             <PurpleLabel style={styles.narrowWithMargin}>Status</PurpleLabel>
           </FlexRow>
           {resources.clusters.map((cluster, i) =>
-              <FlexRow>
+              <FlexRow key={i}>
                 <div style={styles.narrowWithMargin}>{cluster.clusterName}</div>
                 <div style={styles.narrowWithMargin}>{cluster.googleProject}</div>
                 <div style={styles.narrowWithMargin}>{new Date(cluster.createdDate).toDateString()}</div>
                 <div style={styles.narrowWithMargin}>{new Date(cluster.dateAccessed).toDateString()}</div>
                 <div style={styles.narrowWithMargin}>{cluster.status}</div>
-                <Button>Disable</Button>
+                <Button onClick={() =>
+                  this.setState({clusterToDelete: cluster, confirmDeleteCluster: true})}
+                  disabled={clusterToDelete && clusterToDelete.clusterName === cluster.clusterName}>
+                  Delete
+                </Button>
               </FlexRow>
           )}
         </FlexColumn>
       }
+      {confirmDeleteCluster &&
+        <Modal onRequestClose={() => this.cancelDeleteCluster()}>
+          <ModalTitle>Delete Cluster</ModalTitle>
+          <ModalBody>
+            This will immediately delete the given cluster. This will disrupt the user's work
+            and may cause data loss.<br/><br/><b>Are you sure?</b>
+          </ModalBody>
+          <ModalFooter>
+            <Button type='secondary'
+                    onClick={() => this.cancelDeleteCluster()}>Cancel</Button>
+            <Button style={{marginLeft: '0.5rem'}}
+                    onClick={() => {
+                      this.setState({confirmDeleteCluster: false});
+                      this.deleteCluster();
+                    }}
+            >Delete</Button>
+          </ModalFooter>
+      </Modal>}
     </div>;
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4096,6 +4096,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
 highcharts-react-official@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/highcharts-react-official/-/highcharts-react-official-2.0.0.tgz#3e4a8a2cd9a894a55f72ff7967b6573e47ec30c1"
+  integrity sha512-pEf1HBCmkJlIY6lAkjKXjjxaqZWUwcNcKrEIM2CFhXtLcl5VntiSgiVXe/pkDXyZG94mM90c72Z+8rnJ8ua6Dw==
 
 highcharts@^5.0.7:
   version "5.0.15"


### PR DESCRIPTION
The main addition in this PR is to pipe cloud storage metrics into our Workspace admin page. I also made a handful of drive-by changes to the styling, and hooked up the button to delete a cluster. This gets us 95% of the way there to be able to respond quickly to an egress event. (The remaining piece is probably to change the routing to create a per-workspace page.)

I manually tested a full cluster deletion cycle:
 * Open a second tab with a notebook running, copying a large file to the bucket.
 * Refresh the ws-admin page, see the spike in GCS traffic.
 * (In the real-world, that signal would indicate that we should *not* shut down the cluster.)
 * To test the delete-cluster, I clicked "Delete" on the active cluster.
 * My notebook in the other tab stopped working after around ~10 seconds.

Screenshots:

<img width="100%" alt="cloud-storage-traffic" src="https://user-images.githubusercontent.com/51842/75352460-c81e4180-5877-11ea-9a20-94ebd607a283.png">

<img width="50%" alt="workspace-details-layout" src="https://user-images.githubusercontent.com/51842/75352466-c9e80500-5877-11ea-9f87-5eaf428b7e34.png">


<img width="50%" alt="delete-cluster-conf" src="https://user-images.githubusercontent.com/51842/75352416-b9378f00-5877-11ea-89b4-302349408f3d.png">


---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally