### PR TITLE
[RW-4488][risk=no] Add workspace-specific routes for WS admin page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/InterceptorUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/InterceptorUtils.java
@@ -17,7 +17,7 @@ public class InterceptorUtils {
           "org.pmiops.workbench.api.StatusAlertApiController",
               "org.pmiops.workbench.statusalerts.StatusAlertController",
           "org.pmiops.workbench.api.WorkspaceAdminApiController",
-              "org.pmiops.workbench.org.pmiops.workbench.workspaceadmin.WorkspaceAdminController");
+              "org.pmiops.workbench.workspaceadmin.WorkspaceAdminController");
 
   private InterceptorUtils() {}
 

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -11,6 +11,7 @@ import {AdminBannerComponent} from './pages/admin/admin-banner';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AdminUserComponent} from './pages/admin/admin-user';
 import {AdminWorkspaceComponent} from './pages/admin/admin-workspace';
+import {AdminWorkspaceSearchComponent} from './pages/admin/admin-workspace-search';
 import {NotebookListComponent} from './pages/analysis/notebook-list';
 import {NotebookRedirectComponent} from './pages/analysis/notebook-redirect';
 import {CookiePolicyComponent} from './pages/cookie-policy';
@@ -287,9 +288,13 @@ const routes: Routes = [
         component: AdminBannerComponent,
         data: {title: 'Create Banner'}
       }, {
-        path: 'admin/workspace',
+        path: 'admin/workspaces',
+        component: AdminWorkspaceSearchComponent,
+        data: { title: 'Workspace Admin'},
+      }, {
+        path: 'admin/workspaces/:workspaceNamespace',
         component: AdminWorkspaceComponent,
-        data: { title: 'Manage Workspaces'}
+        data: { title: 'Workspace Admin'}
       }, {
         path: 'profile',
         component: ProfilePageComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -71,6 +71,7 @@ import {
 } from 'notebooks-generated';
 
 import {TextModalComponent} from 'app/components/text-modal';
+import {AdminWorkspaceSearchComponent} from 'app/pages/admin/admin-workspace-search';
 import {InteractiveNotebookComponent} from 'app/pages/analysis/interactive-notebook';
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
@@ -130,6 +131,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
   declarations: [
     AdminBannerComponent,
     AdminWorkspaceComponent,
+    AdminWorkspaceSearchComponent,
     AdminReviewWorkspaceComponent,
     AdminUserComponent,
     AppComponent,

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -345,9 +345,9 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
       }
       {
         profile.authorities.includes(Authority.WORKSPACESVIEW) && this.state.showAdminOptions && <SideNavItem
-            content={'Manage Workspaces'}
+            content={'Workspaces'}
             onToggleSideNav={() => this.props.onToggleSideNav()}
-            href={'admin/workspace'}
+            href={'admin/workspaces'}
             active={this.props.workspaceAdminActive}
         />
       }

--- a/ui/src/app/pages/admin/admin-workspace-search.tsx
+++ b/ui/src/app/pages/admin/admin-workspace-search.tsx
@@ -1,0 +1,62 @@
+import {Component} from '@angular/core';
+import {Button} from 'app/components/buttons';
+import {FlexRow} from 'app/components/flex';
+import {TextInput} from 'app/components/inputs';
+import colors from 'app/styles/colors';
+import {ReactWrapperBase, UrlParamsProps, withUrlParams} from 'app/utils';
+import {navigate} from 'app/utils/navigation';
+import * as React from 'react';
+
+interface State {
+  workspaceNamespace: string;
+}
+
+class AdminWorkspaceSearchImpl extends React.Component<UrlParamsProps, State> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      workspaceNamespace: '',
+    };
+  }
+
+  navigateToWorkspace() {
+    navigate(['/admin/workspaces/' + this.state.workspaceNamespace]);
+  }
+
+  render() {
+    return <FlexRow style={{justifyContent: 'flex-start', alignItems: 'center', marginTop: '1rem'}}>
+        <label style={{color: colors.primary, marginRight: '1rem'}}>Workspace namespace</label>
+        <TextInput
+            style={{
+              width: '10rem',
+              marginRight: '1rem'
+            }}
+            onChange={value => this.setState({workspaceNamespace: value})}
+            onKeyDown={(event: KeyboardEvent) => {
+              if (event.key === 'Enter') {
+                this.navigateToWorkspace();
+              }
+            }}
+        />
+        <Button
+            style={{height: '1.5rem'}}
+            onClick={() => this.navigateToWorkspace()}
+        >
+          Load Workspace
+        </Button>
+      </FlexRow>;
+  }
+}
+
+export const AdminWorkspaceSearch = withUrlParams()(AdminWorkspaceSearchImpl);
+
+@Component({
+  template: '<div #root></div>'
+})
+export class AdminWorkspaceSearchComponent extends ReactWrapperBase {
+  constructor() {
+    super(AdminWorkspaceSearch, []);
+  }
+}
+

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -4,10 +4,9 @@ import {Component} from '@angular/core';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {TextInput} from 'app/components/inputs';
 import {workspaceAdminApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {reactStyles, ReactWrapperBase, UrlParamsProps, withUrlParams} from 'app/utils';
 import {
   getSelectedPopulations,
   getSelectedResearchPurposeItems
@@ -44,26 +43,28 @@ const PurpleLabel = ({style = {}, children}) => {
 };
 
 interface State {
-  googleProject: string;
   workspace: Workspace;
   collaborators: Array<UserRole>;
   resources: AdminWorkspaceResources;
 }
 
-export class AdminWorkspace extends React.Component<{}, State> {
+class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
   constructor(props) {
     super(props);
 
     this.state = {
-      googleProject: '',
       workspace: null,
       collaborators: [],
       resources: {},
     };
   }
 
+  componentDidMount() {
+    this.getFederatedWorkspaceInformation();
+  }
+
   getFederatedWorkspaceInformation() {
-    workspaceAdminApi().getFederatedWorkspaceDetails(this.state.googleProject).then(
+    workspaceAdminApi().getFederatedWorkspaceDetails(this.props.urlParams.workspaceNamespace).then(
       response => {
         this.setState({
           workspace: response.workspace,
@@ -74,7 +75,7 @@ export class AdminWorkspace extends React.Component<{}, State> {
     );
   }
 
-  maybeGetFederatedWorkspaceInformation(event) {
+  maybeGetFederatedWorkspaceInformation(event: KeyboardEvent) {
     if (event.key === 'Enter') {
       return this.getFederatedWorkspaceInformation();
     }
@@ -111,25 +112,8 @@ export class AdminWorkspace extends React.Component<{}, State> {
 
   render() {
     const {workspace, collaborators, resources} = this.state;
+
     return <div>
-      <h2 style={{margin: 'auto'}}>Manage Workspaces</h2>
-      <FlexRow style={{justifyContent: 'flex-start', alignItems: 'center'}}>
-        <PurpleLabel style={{marginRight: '1rem'}}>Google Project ID</PurpleLabel>
-        <TextInput
-            style={{
-              width: '10rem',
-              marginRight: '1rem'
-            }}
-            onChange={value => this.setState({googleProject: value})}
-            onKeyDown={event => this.maybeGetFederatedWorkspaceInformation(event)}
-        />
-        <Button
-            style={{height: '1.5rem'}}
-            onClick={() => this.getFederatedWorkspaceInformation()}
-        >
-          Search
-        </Button>
-      </FlexRow>
       {
         workspace && <FlexColumn>
           <h3>Workspace Admin Actions</h3>
@@ -281,6 +265,8 @@ export class AdminWorkspace extends React.Component<{}, State> {
     </div>;
   }
 }
+
+export const AdminWorkspace = withUrlParams()(AdminWorkspaceImpl);
 
 @Component({
   template: '<div #root></div>'

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -233,7 +233,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get workspaceAdminActive(): boolean {
-    return this.locationService.path() === '/admin/workspace';
+    return this.locationService.path() === '/admin/workspaces';
   }
 
   get homeActive(): boolean {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -369,6 +369,9 @@ export const withUserProfile = () => {
 export const withUrlParams = () => {
   return connectBehaviorSubject(urlParamsStore, 'urlParams');
 };
+export interface UrlParamsProps {
+  urlParams: { [key: string]: any; };
+}
 
 // HOC that provides a 'routeConfigData' prop with current route's data object
 export const withRouteConfigData = () => {


### PR DESCRIPTION
See the Jira ticket for a bit more context. We want to be able to have URLs of the form

http://researchallofus.org/admin/workspaces/aou-rw-0a95bc0e

that will land on the admin page for that given workspace.

It was a pretty straightforward task to split the view into a search & detail component. Down the line, we can expand the search component to actually search through workspaces & show a summary table before someone digs into any of the detailed pages.

Screenshots:

<img width="70%" alt="Screen Shot 2020-02-26 at 10 02 25 AM" src="https://user-images.githubusercontent.com/51842/75357553-8db8a280-587f-11ea-8050-1ed5101b04bc.png">

<img width="70%" alt="Screen Shot 2020-02-26 at 10 02 20 AM" src="https://user-images.githubusercontent.com/51842/75357571-9315ed00-587f-11ea-83fd-e73fe3ad981d.png">

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] I have run and tested this change locally