### PR TITLE
[RW-4446][risk=no] Clean up the enableNewAccountCreation flag

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -89,7 +89,6 @@
     "unsafeAllowDeleteUser": true,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": true,
     "enableBillingLockout": true,
     "enableSumoLogicEventHandling": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -92,7 +92,6 @@
     "unsafeAllowDeleteUser": true,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": false,
     "enableBillingLockout": false,
     "enableSumoLogicEventHandling": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -89,7 +89,6 @@
     "unsafeAllowDeleteUser": false,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": false,
     "enableBillingLockout": false,
     "enableSumoLogicEventHandling": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -89,7 +89,6 @@
     "unsafeAllowDeleteUser": false,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": false,
     "enableBillingLockout": false,
     "enableSumoLogicEventHandling": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -89,7 +89,6 @@
     "unsafeAllowDeleteUser": false,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": false,
     "enableBillingLockout": false,
     "enableSumoLogicEventHandling": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -89,7 +89,6 @@
     "unsafeAllowDeleteUser": true,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableNewAccountCreation": true,
     "enableRdrExport": true,
     "enableBillingLockout": true,
     "enableSumoLogicEventHandling": true,

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -32,7 +32,6 @@ public class ConfigController implements ConfigApiDelegate {
             .enableBillingLockout(config.featureFlags.enableBillingLockout)
             .firecloudURL(config.firecloud.baseUrl)
             .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
-            .enableNewAccountCreation(config.featureFlags.enableNewAccountCreation)
             .requireInvitationKey(config.access.requireInvitationKey)
             .requireInstitutionalVerification(config.featureFlags.requireInstitutionalVerification)
             .enableCBAgeTypeOptions(config.featureFlags.enableCBAgeTypeOptions));

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -248,9 +248,7 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   private void validateAndCleanProfile(Profile profile) throws BadRequestException {
-    if (profile.getDemographicSurvey() == null) {
-      profile.setDemographicSurvey(new DemographicSurvey());
-    }
+    profile.setDemographicSurvey(Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
     if (profile.getInstitutionalAffiliations() == null) {
       profile.setInstitutionalAffiliations(new ArrayList<>());
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -248,8 +249,10 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   private void validateAndCleanProfile(Profile profile) throws BadRequestException {
-    profile.setDemographicSurvey(Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
-    profile.setInstitutionalAffiliations(Optional.ofNullable(profile.getInstitutionalAffiliations()).orElse(new ArrayList()));
+    profile.setDemographicSurvey(
+        Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
+    profile.setInstitutionalAffiliations(
+        Optional.ofNullable(profile.getInstitutionalAffiliations()).orElse(new ArrayList()));
 
     String userName = profile.getUsername();
     if (userName == null || userName.length() < 3 || userName.length() > 64) {
@@ -333,7 +336,8 @@ public class ProfileController implements ProfileApiDelegate {
 
     // We don't include this check in validateAndCleanProfile since some existing user profiles
     // may have empty addresses. So we only check this on user creation, not update.
-    Optional.ofNullable(profile.getAddress()).orElseThrow(() -> new BadRequestException("Address must not be empty"));
+    Optional.ofNullable(profile.getAddress())
+        .orElseThrow(() -> new BadRequestException("Address must not be empty"));
 
     validateAndCleanProfile(profile);
 

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -249,22 +249,22 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   private void validateAndCleanProfile(Profile profile) throws BadRequestException {
-    profile.setDemographicSurvey(
-        Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
-    profile.setInstitutionalAffiliations(
-        Optional.ofNullable(profile.getInstitutionalAffiliations()).orElse(new ArrayList()));
-
+    // Validation steps, which yield a BadRequestException if errors are found.
     String userName = profile.getUsername();
     if (userName == null || userName.length() < 3 || userName.length() > 64) {
       throw new BadRequestException(
           "Username should be at least 3 characters and not more than 64 characters");
     }
-
-    // We always store the username as all lowercase.
-    profile.setUsername(profile.getUsername().toLowerCase());
-
     validateStringLength(profile.getGivenName(), "Given Name", 80, 1);
     validateStringLength(profile.getFamilyName(), "Family Name", 80, 1);
+
+    // Cleaning steps, which provide non-null fields or apply some cleanup / transformation.
+    profile.setDemographicSurvey(
+        Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
+    profile.setInstitutionalAffiliations(
+        Optional.ofNullable(profile.getInstitutionalAffiliations()).orElse(new ArrayList()));
+    // We always store the username as all lowercase.
+    profile.setUsername(profile.getUsername().toLowerCase());
   }
 
   private DbUser saveUserWithConflictHandling(DbUser dbUser) {

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -249,9 +249,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   private void validateAndCleanProfile(Profile profile) throws BadRequestException {
     profile.setDemographicSurvey(Optional.ofNullable(profile.getDemographicSurvey()).orElse(new DemographicSurvey()));
-    if (profile.getInstitutionalAffiliations() == null) {
-      profile.setInstitutionalAffiliations(new ArrayList<>());
-    }
+    profile.setInstitutionalAffiliations(Optional.ofNullable(profile.getInstitutionalAffiliations()).orElse(new ArrayList()));
 
     String userName = profile.getUsername();
     if (userName == null || userName.length() < 3 || userName.length() > 64) {

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -335,9 +335,7 @@ public class ProfileController implements ProfileApiDelegate {
 
     // We don't include this check in validateAndCleanProfile since some existing user profiles
     // may have empty addresses. So we only check this on user creation, not update.
-    if (profile.getAddress() == null) {
-      throw new BadRequestException("Address must not be empty");
-    }
+    Optional.ofNullable(profile.getAddress()).orElseThrow(() -> new BadRequestException("Address must not be empty"));
 
     validateAndCleanProfile(profile);
 

--- a/api/src/main/resources/workbench.yaml
+++ b/api/src/main/resources/workbench.yaml
@@ -2506,10 +2506,6 @@ definitions:
         type: boolean
         default: false
         description: Feature flag for billing lockout and upgrade
-      enableNewAccountCreation:
-        type: boolean
-        default: false
-        description: Feature flag for collecting new demographics & TOS acknowledgement on user creation.
       requireInvitationKey:
         type: boolean
         default: false

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import javax.mail.MessagingException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +54,7 @@ import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperIm
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.Address;
 import org.pmiops.workbench.model.CreateAccountRequest;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.EmailVerificationStatus;
@@ -95,6 +95,12 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final String CONTACT_EMAIL = "bob@example.com";
   private static final String INVITATION_KEY = "secretpassword";
   private static final String PRIMARY_EMAIL = "bob@researchallofus.org";
+  private static final String STREET_ADDRESS = "1 Example Lane";
+  private static final String CITY = "Exampletown";
+  private static final String STATE = "EX";
+  private static final String COUNTRY = "Example";
+  private static final String ZIP_CODE = "12345";
+
   private static final String ORGANIZATION = "Test";
   private static final String CURRENT_POSITION = "Tester";
   private static final String RESEARCH_PURPOSE = "To test things";
@@ -176,6 +182,13 @@ public class ProfileControllerTest extends BaseControllerTest {
     profile.setCurrentPosition(CURRENT_POSITION);
     profile.setOrganization(ORGANIZATION);
     profile.setAreaOfResearch(RESEARCH_PURPOSE);
+    profile.setAddress(
+        new Address()
+            .streetAddress1(STREET_ADDRESS)
+            .city(CITY)
+            .state(STATE)
+            .country(COUNTRY)
+            .zipCode(ZIP_CODE));
 
     createAccountRequest = new CreateAccountRequest();
     createAccountRequest.setProfile(profile);
@@ -595,26 +608,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     String newName =
         "obladidobladalifegoesonyalalalalalifegoesonobladioblada" + "lifegoesonrahlalalalifegoeson";
     profile.setFamilyName(newName);
-    profileController.updateProfile(profile);
-  }
-
-  @Test(expected = BadRequestException.class)
-  public void updateCurrentPosition_badRequest() {
-    // Server-side verification for this field is only used for old-style account creation.
-    config.featureFlags.enableNewAccountCreation = false;
-    createUser();
-    Profile profile = profileController.getMe().getBody();
-    profile.setCurrentPosition(RandomStringUtils.random(256));
-    profileController.updateProfile(profile);
-  }
-
-  @Test(expected = BadRequestException.class)
-  public void updateOrganization_badRequest() {
-    // Server-side verification for this field is only used for old-style account creation.
-    config.featureFlags.enableNewAccountCreation = false;
-    createUser();
-    Profile profile = profileController.getMe().getBody();
-    profile.setOrganization(RandomStringUtils.random(256));
     profileController.updateProfile(profile);
   }
 

--- a/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/common-api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -211,9 +211,6 @@ public class WorkbenchConfig {
     // Whether or not AoU should request Terra to create GCP projects inside a VPC
     // security perimeter.
     public boolean enableVpcServicePerimeter;
-    // Flag to indicate whether to enable the new Create Account flow
-    // See RW-3284.
-    public boolean enableNewAccountCreation;
     // Flag to indicate if USER/WORKSPACE data is exported to RDR
     public boolean enableRdrExport;
     // Setting this to true will prevent users from making compute increasing operations on

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -13,10 +13,7 @@ const component = () => {
   return mount(<AccountCreation {...props}/>);
 };
 
-const defaultConfig = {
-  gsuiteDomain: 'researchallofus.org',
-  enableNewAccountCreation: false,
-};
+const defaultConfig = {gsuiteDomain: 'researchallofus.org'};
 
 beforeEach(() => {
   serverConfigStore.next(defaultConfig);
@@ -45,24 +42,6 @@ it('should handle family name validity', () => {
   expect(wrapper.exists('#familyNameError')).toBeFalsy();
   wrapper.find('input#familyName').simulate('change', {target: {value: testInput}});
   expect(wrapper.exists('#familyNameError')).toBeTruthy();
-});
-
-it('should handle organization validity', () => {
-  const wrapper = component();
-  const testInput = fp.repeat(300, 'a');
-  expect(wrapper.exists('#organization')).toBeTruthy();
-  expect(wrapper.exists('#organizationError')).toBeFalsy();
-  wrapper.find('input#organization').simulate('change', {target: {value: testInput}});
-  expect(wrapper.exists('#organizationError')).toBeTruthy();
-});
-
-it('should handle current position validity', () => {
-  const wrapper = component();
-  const testInput = fp.repeat(300, 'a');
-  expect(wrapper.exists('#currentPosition')).toBeTruthy();
-  expect(wrapper.exists('#currentPositionError')).toBeFalsy();
-  wrapper.find('input#currentPosition').simulate('change', {target: {value: testInput}});
-  expect(wrapper.exists('#currentPositionError')).toBeTruthy();
 });
 
 it('should handle username validity starts with .', () => {
@@ -128,7 +107,7 @@ it('should handle invalid Email', () => {
 
 // TODO remove after we switch to verified institutional affiliation
 it('should display Institution name and role option by default', () => {
-  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true, requireInstitutionalVerification: false});
+  serverConfigStore.next({...defaultConfig, requireInstitutionalVerification: false});
   const wrapper = component();
   const institutionName = wrapper.find('[data-test-id="institutionname"]');
   expect(institutionName).toBeTruthy();
@@ -140,7 +119,7 @@ it('should display Institution name and role option by default', () => {
 
 // TODO remove after we switch to verified institutional affiliation
 it('should display Affiliation information if No is selected', () => {
-  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true, requireInstitutionalVerification: false});
+  serverConfigStore.next({...defaultConfig, requireInstitutionalVerification: false});
   const wrapper = component();
   const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
     .find('input');
@@ -155,7 +134,7 @@ it('should display Affiliation information if No is selected', () => {
 
 // TODO remove after we switch to verified institutional affiliation
 it('should display Affiliation Roles should change as per affiliation', () => {
-  serverConfigStore.next({...defaultConfig, enableNewAccountCreation: true, requireInstitutionalVerification: false});
+  serverConfigStore.next({...defaultConfig, requireInstitutionalVerification: false});
   const wrapper = component();
   const institutionAffilationOption = wrapper.find('[data-test-id="show-institution-no"]')
     .find('input');

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -249,38 +249,6 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     return state;
   }
 
-  // This method will be deleted once we enable new account pages
-  createAccount(): void {
-    const {invitationKey, onComplete} = this.props;
-    const profile = this.state.profile;
-    profile.institutionalAffiliations = [];
-    const emailValidRegex = new RegExp(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/);
-    this.setState({showAllFieldsRequiredError: false});
-    this.setState({invalidEmail: false});
-    const requiredFields =
-      [profile.givenName, profile.familyName, profile.username, profile.contactEmail,
-        profile.currentPosition, profile.organization, profile.areaOfResearch];
-    if (requiredFields.some(isBlank)) {
-      this.setState({showAllFieldsRequiredError: true});
-      return;
-    } else if (this.isUsernameValidationError) {
-      return;
-    } else if (!emailValidRegex.test(profile.contactEmail)) {
-      this.setState({invalidEmail: true});
-      return;
-    }
-    this.setState({creatingAccount: true});
-    profileApi().createAccount({profile, invitationKey})
-      .then((savedProfile) => {
-        this.setState({profile: savedProfile, creatingAccount: false});
-        onComplete(savedProfile);
-      })
-      .catch(error => {
-        console.log(error);
-        this.setState({creatingAccount: false});
-      });
-  }
-
   get usernameValid(): boolean {
     if (isBlank(this.state.profile.username) || this.state.usernameCheckInProgress) {
       return undefined;
@@ -420,18 +388,6 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
       this.setState({nonAcademicAffiliationRole: role, showNonAcademicAffiliationOther: false});
     }
     this.updateInstitutionAffiliation('role', role);
-  }
-
-  // This will be deleted once enableAccountPages is set to true for prod
-  validate() {
-    const {profile} = this.state;
-    const requiredFields =
-      [profile.givenName, profile.familyName, profile.username, profile.contactEmail,
-        profile.currentPosition, profile.organization, profile.areaOfResearch];
-    if (requiredFields.some(isBlank)) {
-      this.setState({showAllFieldsRequiredError: true});
-      return;
-    }
   }
 
   validateAccountCreation() {

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -521,14 +521,14 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
   render() {
     const {
       profile: {
-        givenName, familyName, currentPosition, organization,
+        givenName, familyName,
         contactEmail, username, areaOfResearch, professionalUrl,
         address: {
           streetAddress1, streetAddress2, city, state, zipCode, country
         },
       },
     } = this.state;
-    const {enableNewAccountCreation, gsuiteDomain, requireInstitutionalVerification} = serverConfigStore.getValue();
+    const {gsuiteDomain, requireInstitutionalVerification} = serverConfigStore.getValue();
 
     const usernameLabelText =
       <div>New Username
@@ -693,11 +693,10 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     };
 
     return <div id='account-creation'
-                style={{paddingTop: enableNewAccountCreation ? '1.5rem' :
-                      '3rem', paddingRight: '3rem', paddingLeft: '3rem'}}>
+                style={{paddingTop: '1.5rem', paddingRight: '3rem', paddingLeft: '3rem'}}>
       <div style={{fontSize: 28, fontWeight: 400, color: colors.primary}}>Create your account</div>
       {renderVerifiedInstitutionalAffiliation()}
-      {enableNewAccountCreation && <FlexRow>
+      <FlexRow>
         <FlexColumn style={{marginTop: '0.5rem'}}>
           <div style={{...styles.text, fontSize: 16, marginTop: '1rem'}}>
             Please complete Step {requireInstitutionalVerification ? '2 of 3' : '1 of 2'}
@@ -885,123 +884,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
             </ul>
           </FlexColumn>
         </FlexColumn>
-      </FlexRow>}
-      {/*The following will be deleted once enableAccountPages is set to true in prod*/}
-      {!enableNewAccountCreation && <div>
-        <FormSection>
-          <TextInput id='givenName' name='givenName' autoFocus
-                     placeholder='First Name'
-                     value={givenName}
-                     invalid={String(givenName.length > 80)}
-                     style={{width: '16rem'}}
-                     onChange={v => this.updateProfileToBeDeleted('givenName', v)}/>
-          {givenName.length > 80 &&
-          <ErrorMessage id='givenNameError'>
-            First Name must be 80 characters or less.
-          </ErrorMessage>}
-        </FormSection>
-        <FormSection>
-          <TextInput id='familyName' name='familyName' placeholder='Last Name'
-                     value={familyName}
-                     invalid={String(familyName.length > 80)}
-                     style={{width: '16rem'}}
-                     onChange={v => this.updateProfileToBeDeleted('familyName', v)}/>
-          {familyName.length > 80 &&
-          <ErrorMessage id='familyNameError'>
-            Last Name must be 80 character or less.
-          </ErrorMessage>}
-        </FormSection>
-        <FormSection>
-          <TextInput id='contactEmail' name='contactEmail'
-                     placeholder='Email Address'
-                     value={contactEmail}
-                     style={{width: '16rem'}}
-                     onChange={v => this.updateProfileToBeDeleted('contactEmail', v)}/>
-          {this.state.invalidEmail &&
-          <ErrorDiv id='invalidEmailError'>
-            Contact Email Id is invalid
-          </ErrorDiv>}
-        </FormSection>
-        <FormSection>
-          <TextInput id='currentPosition' name='currentPosition'
-                     placeholder='Your Current Position'
-                     value={currentPosition}
-                     invalid={currentPosition.length > 255}
-                     style={{width: '16rem'}}
-                     onChange={v => this.updateProfileToBeDeleted('currentPosition', v)}/>
-          {currentPosition.length > 255 &&
-          <ErrorMessage id='currentPositionError'>
-            Current Position must be 255 characters or less.
-          </ErrorMessage>}
-        </FormSection>
-        <FormSection>
-          <TextInput id='organization' name='organization'
-                     placeholder='Your Organization'
-                     value={organization}
-                     invalid={organization.length > 255}
-                     style={{width: '16rem'}}
-                     onChange={v => this.updateProfileToBeDeleted('organization', v)}/>
-          {organization.length > 255 &&
-          <ErrorMessage id='organizationError'>
-            Organization must be 255 characters of less.
-          </ErrorMessage>}
-        </FormSection>
-        <FormSection style={{display: 'flex'}}>
-              <TextArea style={{height: '10em', resize: 'none', width: '16rem'}}
-                        id='areaOfResearch'
-                        name='areaOfResearch'
-                        placeholder='Describe Your Current Research'
-                        value={areaOfResearch}
-                        onChange={v => this.updateProfileToBeDeleted('areaOfResearch', v)}/>
-          <TooltipTrigger content={<span>You are required to describe your current research in
-            order to help <i>All of Us</i> improve the Researcher Workbench.</span>}>
-            <InfoIcon style={{
-              'height': '22px',
-              'marginTop': '2.2rem',
-              'paddingLeft': '2px'
-            }}/>
-          </TooltipTrigger>
-        </FormSection>
-        <FormSection>
-          <TextInput id='username' name='username' placeholder='New Username'
-                     value={username}
-                     onChange={v => this.usernameChanged(v)}
-                     invalid={this.state.usernameConflictError || this.usernameInvalidError()}
-                     style={{width: '16rem'}}/>
-          <div style={inputStyles.iconArea}>
-            <ValidationIcon validSuccess={this.usernameValid}/>
-          </div>
-          <TooltipTrigger content={<div>Usernames can contain only letters (a-z),
-            numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)
-            (minimum of 3 characters and maximum of 64 characters).<br/>Usernames cannot
-            begin or end with a period (.) and may not contain more than one period (.) in a row.
-          </div>}>
-            <InfoIcon style={{'height': '22px', 'paddingLeft': '2px'}}/>
-          </TooltipTrigger>
-          <div style={{height: '1.5rem'}}>
-            {this.state.usernameConflictError &&
-            <ErrorDiv id='usernameConflictError'>
-              Username is already taken.
-            </ErrorDiv>}
-            {this.usernameInvalidError() &&
-            <ErrorDiv id='usernameError'>
-              Username is not a valid username.
-            </ErrorDiv>}
-          </div>
-        </FormSection>
-        <FormSection>
-          <Button disabled={this.state.creatingAccount || this.state.usernameCheckInProgress ||
-          this.isUsernameValidationError}
-                  style={{'height': '2rem', 'width': '10rem'}}
-                  onClick={() => this.createAccount()}>
-            Next
-          </Button>
-        </FormSection>
-      </div>}
-      {!enableNewAccountCreation && this.state.showAllFieldsRequiredError &&
-      <ErrorDiv>
-        All fields are required.
-      </ErrorDiv>}
+      </FlexRow>
     </div>;
   }
 }

--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -25,7 +25,6 @@ describe('SignInReact', () => {
 
   const defaultConfig = {
     gsuiteDomain: 'researchallofus.org',
-    enableNewAccountCreation: false,
     requireInvitationKey: true
   };
 
@@ -78,58 +77,7 @@ describe('SignInReact', () => {
     const templateImage = wrapper.find('[data-test-id="sign-in-page"]');
   });
 
-  it('should handle sign-up flow for legacy account creation', () => {
-    const wrapper = shallowComponent();
-
-    // To start, the landing page / login component should be shown.
-    expect(wrapper.exists(LoginReactComponent)).toBeTruthy();
-    // Simulate the "create account" button being clicked by firing the callback method.
-    wrapper.find(LoginReactComponent).props().onCreateAccount();
-
-    // Invitation key step is next.
-    expect(wrapper.exists(InvitationKey)).toBeTruthy();
-    wrapper.find(InvitationKey).props().onInvitationKeyVerified('asdf');
-
-    expect(wrapper.exists(AccountCreation)).toBeTruthy();
-    wrapper.find(AccountCreation).props().onComplete(createEmptyProfile());
-
-    // Success!
-    expect(wrapper.exists(AccountCreationSuccess)).toBeTruthy();
-  });
-
-  it('should handle sign-up flow for new account creation without institutional verification', () => {
-    props.serverConfig = {...defaultConfig, enableNewAccountCreation: true};
-    const requireInstitutionalVerification = false;
-
-    const wrapper = shallowComponent();
-
-    // To start, the landing page / login component should be shown.
-    expect(wrapper.exists(LoginReactComponent)).toBeTruthy();
-    // Simulate the "create account" button being clicked by firing the callback method.
-    wrapper.find(LoginReactComponent).props().onCreateAccount();
-
-    // Invitation key step is next.
-    expect(wrapper.exists(InvitationKey)).toBeTruthy();
-    wrapper.find(InvitationKey).props().onInvitationKeyVerified('asdf');
-
-    // Terms of Service is part of the new-style flow.
-    expect(wrapper.exists(AccountCreationTos)).toBeTruthy();
-    wrapper.find(AccountCreationTos).props().onComplete();
-
-    expect(wrapper.exists(AccountCreation)).toBeTruthy();
-    wrapper.find(AccountCreation).props().onComplete(createEmptyProfile(requireInstitutionalVerification));
-
-    // Account Creation Survey (e.g. demographics) is part of the new-style flow.
-    expect(wrapper.exists(AccountCreationSurvey)).toBeTruthy();
-    wrapper.find(AccountCreationSurvey).props().onComplete(createEmptyProfile(requireInstitutionalVerification));
-
-    expect(wrapper.exists(AccountCreationSuccess)).toBeTruthy();
-  });
-
-  it('should handle sign-up flow for new account creation with institutional verification', () => {
-    props.serverConfig = {...defaultConfig, enableNewAccountCreation: true};
-    const requireInstitutionalVerification = true;
-
+  it('should handle sign-up flow', () => {
     const wrapper = shallowComponent();
 
     // To start, the landing page / login component should be shown.
@@ -160,7 +108,7 @@ describe('SignInReact', () => {
     // and step-incrementing logic are wired up correctly. Rather than repeating all of the above
     // boilerplate, this test focuses on the logic of creating the sign-in step order, ensuring
     // that INVITATION_KEY is removed when the flag is false.
-    props.serverConfig = {...defaultConfig, requireInvitationKey: false, enableNewAccountCreation: true};
+    props.serverConfig = {...defaultConfig, requireInvitationKey: false};
 
     const wrapper = shallowComponent();
     const signInImpl = wrapper.instance() as SignInReactImpl;

--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -25,7 +25,8 @@ describe('SignInReact', () => {
 
   const defaultConfig = {
     gsuiteDomain: 'researchallofus.org',
-    requireInvitationKey: true
+    requireInvitationKey: true,
+    requireInstitutionalVerification: false,
   };
 
   beforeEach(() => {
@@ -77,7 +78,46 @@ describe('SignInReact', () => {
     const templateImage = wrapper.find('[data-test-id="sign-in-page"]');
   });
 
-  it('should handle sign-up flow', () => {
+  it('should handle sign-up flow without institutional verification', () => {
+    // This test is meant to validate the high-level flow through the sign-in component by checking
+    // that each step of the user registration flow is correctly rendered in order.
+    //
+    // As this is simply a high-level test of this component's ability to render each sub-component,
+    // we use Enzyme's shallow rendering to avoid needing to deal with the DOM-level details of
+    // each of the sub-components. Tests within the 'account-creation' folder should cover those
+    // details.
+    props.serverConfig = {...defaultConfig, requireInstitutionalVerification: false};
+    const requireInstitutionalVerification = false;
+
+    const wrapper = shallowComponent();
+
+    // To start, the landing page / login component should be shown.
+    expect(wrapper.exists(LoginReactComponent)).toBeTruthy();
+    // Simulate the "create account" button being clicked by firing the callback method.
+    wrapper.find(LoginReactComponent).props().onCreateAccount();
+
+    // Invitation key step is next.
+    expect(wrapper.exists(InvitationKey)).toBeTruthy();
+    wrapper.find(InvitationKey).props().onInvitationKeyVerified('asdf');
+
+    // Terms of Service is part of the new-style flow.
+    expect(wrapper.exists(AccountCreationTos)).toBeTruthy();
+    wrapper.find(AccountCreationTos).props().onComplete();
+
+    expect(wrapper.exists(AccountCreation)).toBeTruthy();
+    wrapper.find(AccountCreation).props().onComplete(createEmptyProfile(requireInstitutionalVerification));
+
+    // Account Creation Survey (e.g. demographics) is part of the new-style flow.
+    expect(wrapper.exists(AccountCreationSurvey)).toBeTruthy();
+    wrapper.find(AccountCreationSurvey).props().onComplete(createEmptyProfile(requireInstitutionalVerification));
+
+    expect(wrapper.exists(AccountCreationSuccess)).toBeTruthy();
+  });
+
+  it('should handle sign-up flow with institutional verification', () => {
+    props.serverConfig = {...defaultConfig, requireInstitutionalVerification: true};
+    const requireInstitutionalVerification = true;
+
     const wrapper = shallowComponent();
 
     // To start, the landing page / login component should be shown.

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -206,26 +206,16 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
    * Made visible for ease of unit-testing.
    */
   public getAccountCreationSteps(): Array<SignInStep> {
-    const {enableNewAccountCreation, requireInvitationKey} = this.props.serverConfig;
+    const {requireInvitationKey} = this.props.serverConfig;
 
-    let steps: Array<SignInStep>;
-    if (enableNewAccountCreation) {
-      steps = [
-        SignInStep.LANDING,
-        SignInStep.INVITATION_KEY,
-        SignInStep.TERMS_OF_SERVICE,
-        SignInStep.ACCOUNT_CREATION,
-        SignInStep.DEMOGRAPHIC_SURVEY,
-        SignInStep.SUCCESS_PAGE
-      ];
-    } else {
-      steps = [
-        SignInStep.LANDING,
-        SignInStep.INVITATION_KEY,
-        SignInStep.ACCOUNT_CREATION,
-        SignInStep.SUCCESS_PAGE
-      ];
-    }
+    let steps = [
+      SignInStep.LANDING,
+      SignInStep.INVITATION_KEY,
+      SignInStep.TERMS_OF_SERVICE,
+      SignInStep.ACCOUNT_CREATION,
+      SignInStep.DEMOGRAPHIC_SURVEY,
+      SignInStep.SUCCESS_PAGE
+    ];
 
     if (!requireInvitationKey) {
       steps = fp.remove(step => step === SignInStep.INVITATION_KEY, steps);


### PR DESCRIPTION
This flag was pushed to prod with last week's release (see https://github.com/all-of-us/workbench/pull/3130). We should clean this up sooner than later, since the verified institutional affiliation stuff will soon add some extra config-driven complexity to the account creation page.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] I have run and tested this change locally
