### PR TITLE
[RW-3861][risk=no] Allow graphs to use sex at birth and different age types

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/cb_search_person.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/cb_search_person.json
@@ -11,6 +11,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "sex_at_birth",
+    "type": "string"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "race",
     "type": "string"
   },

--- a/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
@@ -39,7 +39,7 @@ then
 fi
 
 # Check that bq_project exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=150)
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
 if [ -z "$datasets" ]
 then
   echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
@@ -53,7 +53,7 @@ else
 fi
 
 # Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=150)
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
 if [ -z "$datasets" ]
 then
   echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."

--- a/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
+++ b/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
@@ -8,7 +8,7 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
 # Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=150)
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
 if [ -z "$datasets" ]
 then
   echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
@@ -8,7 +8,7 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
 # Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=150)
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
 if [ -z "$datasets" ]
 then
   echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
@@ -8,7 +8,7 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
 # Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=150)
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
 if [ -z "$datasets" ]
 then
   echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
@@ -31,25 +31,41 @@ bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_person.json 
 bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_all_events
 bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_all_events.json --time_partitioning_type=DAY --clustering_fields concept_id $BQ_DATASET.cb_search_all_events
 
-
 ################################################
 # insert person data into cb_search_person
 ################################################
 echo "Inserting person data into cb_search_person"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ]
+then
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
     (person_id, gender, sex_at_birth, race, ethnicity, dob)
-SELECT p.person_id,
+  SELECT p.person_id,
+    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
+    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as sex_at_birth,
+    case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
+    case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
+    date(birth_datetime) as dob
+  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+else
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+    (person_id, gender, sex_at_birth, race, ethnicity, dob)
+  SELECT p.person_id,
     case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
     case when p.sex_at_birth_concept_id = 0 then 'Unknown' else s.concept_name end as sex_at_birth,
     case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
     case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
     date(birth_datetime) as dob
-FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+fi
 
 ################################################
 # set age_at_consent and age_at_cdr to each subject

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -45,6 +45,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.CloudStorageServiceImpl;
+import org.pmiops.workbench.model.AgeType;
 import org.pmiops.workbench.model.AttrName;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.CriteriaMenuOption;
@@ -54,6 +55,7 @@ import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DemoChartInfo;
 import org.pmiops.workbench.model.DemoChartInfoListResponse;
 import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.Operator;
@@ -1923,13 +1925,67 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     DemoChartInfoListResponse response =
-        controller.getDemoChartInfo(cdrVersion.getCdrVersionId(), searchRequest).getBody();
+        controller
+            .getDemoChartInfo(
+                cdrVersion.getCdrVersionId(),
+                GenderOrSexType.GENDER.toString(),
+                AgeType.AGE.toString(),
+                searchRequest)
+            .getBody();
     assertEquals(2, response.getItems().size());
     assertEquals(
-        new DemoChartInfo().gender("MALE").race("Asian").ageRange("45-64").count(1L),
+        new DemoChartInfo().name("MALE").race("Asian").ageRange("45-64").count(1L),
         response.getItems().get(0));
     assertEquals(
-        new DemoChartInfo().gender("MALE").race("Caucasian").ageRange("18-44").count(1L),
+        new DemoChartInfo().name("MALE").race("Caucasian").ageRange("18-44").count(1L),
+        response.getItems().get(1));
+  }
+
+  @Test
+  public void getDemoChartInfoGenderAgeAtConsent() {
+    SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
+    SearchRequest searchRequest =
+        createSearchRequests(
+            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+
+    DemoChartInfoListResponse response =
+        controller
+            .getDemoChartInfo(
+                cdrVersion.getCdrVersionId(),
+                GenderOrSexType.GENDER.toString(),
+                AgeType.AGE_AT_CONSENT.toString(),
+                searchRequest)
+            .getBody();
+    assertEquals(2, response.getItems().size());
+    assertEquals(
+        new DemoChartInfo().name("MALE").race("Asian").ageRange("45-64").count(1L),
+        response.getItems().get(0));
+    assertEquals(
+        new DemoChartInfo().name("MALE").race("Caucasian").ageRange("18-44").count(1L),
+        response.getItems().get(1));
+  }
+
+  @Test
+  public void getDemoChartInfoSexAtBirthAgeAtCdr() {
+    SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
+    SearchRequest searchRequest =
+        createSearchRequests(
+            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+
+    DemoChartInfoListResponse response =
+        controller
+            .getDemoChartInfo(
+                cdrVersion.getCdrVersionId(),
+                GenderOrSexType.SEX_AT_BIRTH.toString(),
+                AgeType.AGE_AT_CDR.toString(),
+                searchRequest)
+            .getBody();
+    assertEquals(2, response.getItems().size());
+    assertEquals(
+        new DemoChartInfo().name("MALE").race("Asian").ageRange("45-64").count(1L),
+        response.getItems().get(0));
+    assertEquals(
+        new DemoChartInfo().name("MALE").race("Caucasian").ageRange("18-44").count(1L),
         response.getItems().get(1));
   }
 

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
@@ -2,6 +2,7 @@
   {
     "person_id": 1,
     "gender": "MALE",
+    "sex_at_birth": "MALE",
     "race": "Caucasian",
     "dob": "1980-08-01",
     "age_at_consent": 30,
@@ -10,6 +11,7 @@
   {
     "person_id": 2,
     "gender": "MALE",
+    "sex_at_birth": "MALE",
     "race": "African American",
     "dob": "1980-08-01",
     "age_at_consent": 30,
@@ -18,6 +20,7 @@
   {
     "person_id": 102246,
     "gender": "FEMALE",
+    "sex_at_birth": "FEMALE",
     "race": "African American",
     "dob": "1980-02-17",
     "age_at_consent": 30,
@@ -26,6 +29,7 @@
   {
     "person_id": 99,
     "gender": "MALE",
+    "sex_at_birth": "MALE",
     "race": "Asian",
     "dob": "1970-02-17",
     "age_at_consent": 55,

--- a/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
@@ -10,6 +10,11 @@
     "mode": "nullable"
   },
   {
+    "mode": "NULLABLE",
+    "name": "sex_at_birth",
+    "type": "string"
+  },
+  {
     "type": "string",
     "name": "race",
     "mode": "nullable"

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cohortbuilder.util.CriteriaLookupUtil;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.model.AgeType;
 import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchParameter;
@@ -23,38 +24,31 @@ import org.springframework.stereotype.Service;
 @Service
 public class CohortQueryBuilder {
   private static final String REVIEW_TABLE = "cb_review_all_events";
-  private static final String COUNT_SQL_TEMPLATE =
-      "select count(*) as count\n"
-          + "from `${projectId}.${dataSetId}.${table}` ${table}\n"
-          + "where\n";
-
   private static final String SEARCH_PERSON_TABLE = "cb_search_person";
   private static final String PERSON_TABLE = "person";
 
+  private static final String COUNT_SQL_TEMPLATE =
+      "select count(*) as count\n"
+          + "from `${projectId}.${dataSetId}.cb_search_person` cb_search_person\n"
+          + "where\n";
+
   private static final String DEMO_CHART_INFO_SQL_TEMPLATE =
-      "select gender, \n"
-          + "race, \n"
-          + "case "
-          + getAgeRangeSql(18, 44)
-          + "\n"
-          + getAgeRangeSql(45, 64)
-          + "\n"
+      "select ${genderOrSex} as name,\n"
+          + "race,\n"
+          + "case ${ageRange1}\n"
+          + "${ageRange2}\n"
           + "else '> 65'\n"
           + "end as ageRange,\n"
           + "count(*) as count\n"
-          + "from `${projectId}.${dataSetId}.${table}` ${table}\n"
+          + "from `${projectId}.${dataSetId}.cb_search_person` cb_search_person\n"
           + "where\n";
 
   private static final String DEMO_CHART_INFO_SQL_GROUP_BY =
-      "group by gender, race, ageRange\n" + "order by gender, race, ageRange\n";
+      "group by name, race, ageRange\n" + "order by name, race, ageRange\n";
 
   private static final String DOMAIN_CHART_INFO_SQL_TEMPLATE =
       "select standard_name as name, standard_concept_id as conceptId, count(distinct person_id) as count\n"
-          + "from `${projectId}.${dataSetId}."
-          + REVIEW_TABLE
-          + "` "
-          + REVIEW_TABLE
-          + "\n"
+          + "from `${projectId}.${dataSetId}.cb_review_all_events` cb_review_all_events\n"
           + "where\n";
 
   private static final String DOMAIN_CHART_INFO_SQL_GROUP_BY =
@@ -65,9 +59,9 @@ public class CohortQueryBuilder {
           + "limit ${limit}\n";
 
   private static final String RANDOM_SQL_TEMPLATE =
-      "select rand() as x, ${table}.person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime, case when death.person_id is null then false else true end as deceased\n"
-          + "from `${projectId}.${dataSetId}.${table}` ${table}\n"
-          + "left join `${projectId}.${dataSetId}.death` death on (${table}.person_id = death.person_id)\n"
+      "select rand() as x, person.person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, birth_datetime, case when death.person_id is null then false else true end as deceased\n"
+          + "from `${projectId}.${dataSetId}.person` person\n"
+          + "left join `${projectId}.${dataSetId}.death` death on (person.person_id = death.person_id)\n"
           + "where\n";
 
   private static final String RANDOM_SQL_ORDER_BY = "order by x\nlimit";
@@ -75,7 +69,7 @@ public class CohortQueryBuilder {
   private static final String OFFSET_SUFFIX = " offset ";
 
   private static final String ID_SQL_TEMPLATE =
-      "select person_id\n" + "from `${projectId}.${dataSetId}.${table}` ${table}\n" + "where\n";
+      "select person_id\n from `${projectId}.${dataSetId}.person` person\n where\n";
 
   private static final String UNION_TEMPLATE = "union all\n";
 
@@ -103,10 +97,8 @@ public class CohortQueryBuilder {
   /** Provides counts of unique subjects defined by the provided {@link ParticipantCriteria}. */
   public QueryJobConfiguration buildParticipantCounterQuery(
       ParticipantCriteria participantCriteria) {
-    String sqlTemplate = COUNT_SQL_TEMPLATE.replace("${table}", SEARCH_PERSON_TABLE);
     Map<String, QueryParameterValue> params = new HashMap<>();
-    StringBuilder queryBuilder =
-        new StringBuilder(sqlTemplate.replace("${mainTable}", SEARCH_PERSON_TABLE));
+    StringBuilder queryBuilder = new StringBuilder(COUNT_SQL_TEMPLATE);
     addWhereClause(participantCriteria, SEARCH_PERSON_TABLE, queryBuilder, params);
 
     return QueryJobConfiguration.newBuilder(queryBuilder.toString())
@@ -121,12 +113,15 @@ public class CohortQueryBuilder {
    */
   public QueryJobConfiguration buildDemoChartInfoCounterQuery(
       ParticipantCriteria participantCriteria) {
-    String sqlTemplate = DEMO_CHART_INFO_SQL_TEMPLATE.replace("${table}", SEARCH_PERSON_TABLE);
     Map<String, QueryParameterValue> params = new HashMap<>();
-    StringBuilder queryBuilder =
-        new StringBuilder(sqlTemplate.replace("${mainTable}", SEARCH_PERSON_TABLE));
+    String sqlTemplate =
+        DEMO_CHART_INFO_SQL_TEMPLATE
+            .replace("${genderOrSex}", participantCriteria.getGenderOrSexType().toString())
+            .replace("${ageRange1}", getAgeRangeSql(18, 44, participantCriteria.getAgeType()))
+            .replace("${ageRange2}", getAgeRangeSql(45, 64, participantCriteria.getAgeType()));
+    StringBuilder queryBuilder = new StringBuilder(sqlTemplate);
     addWhereClause(participantCriteria, SEARCH_PERSON_TABLE, queryBuilder, params);
-    queryBuilder.append(DEMO_CHART_INFO_SQL_GROUP_BY.replace("${mainTable}", SEARCH_PERSON_TABLE));
+    queryBuilder.append(DEMO_CHART_INFO_SQL_GROUP_BY);
 
     return QueryJobConfiguration.newBuilder(queryBuilder.toString())
         .setNamedParameters(params)
@@ -145,11 +140,10 @@ public class CohortQueryBuilder {
             .replace("${limit}", Integer.toString(chartLimit))
             .replace("${tableId}", "standard_concept_id")
             .replace("${domain}", domainType.name());
-    StringBuilder queryBuilder =
-        new StringBuilder(DOMAIN_CHART_INFO_SQL_TEMPLATE.replace("${mainTable}", REVIEW_TABLE));
+    StringBuilder queryBuilder = new StringBuilder(DOMAIN_CHART_INFO_SQL_TEMPLATE);
     Map<String, QueryParameterValue> params = new HashMap<>();
     addWhereClause(participantCriteria, REVIEW_TABLE, queryBuilder, params);
-    queryBuilder.append(endSqlTemplate.replace("${mainTable}", REVIEW_TABLE));
+    queryBuilder.append(endSqlTemplate);
 
     return QueryJobConfiguration.newBuilder(queryBuilder.toString())
         .setNamedParameters(params)
@@ -163,10 +157,8 @@ public class CohortQueryBuilder {
     if (offset > 0) {
       endSql += OFFSET_SUFFIX + offset;
     }
-    String sqlTemplate = RANDOM_SQL_TEMPLATE.replace("${table}", PERSON_TABLE);
     Map<String, QueryParameterValue> params = new HashMap<>();
-    StringBuilder queryBuilder =
-        new StringBuilder(sqlTemplate.replace("${mainTable}", PERSON_TABLE));
+    StringBuilder queryBuilder = new StringBuilder(RANDOM_SQL_TEMPLATE);
     addWhereClause(participantCriteria, PERSON_TABLE, queryBuilder, params);
     queryBuilder.append(endSql.replace("${mainTable}", PERSON_TABLE));
 
@@ -180,10 +172,8 @@ public class CohortQueryBuilder {
   // preferred solution
   // https://docs.google.com/document/d/1-wzSCHDM_LSaBRARyLFbsTGcBaKi5giRs-eDmaMBr0Y/edit#
   public QueryJobConfiguration buildParticipantIdQuery(ParticipantCriteria participantCriteria) {
-    String sqlTemplate = ID_SQL_TEMPLATE.replace("${table}", PERSON_TABLE);
     Map<String, QueryParameterValue> params = new HashMap<>();
-    StringBuilder queryBuilder =
-        new StringBuilder(sqlTemplate.replace("${mainTable}", PERSON_TABLE));
+    StringBuilder queryBuilder = new StringBuilder(ID_SQL_TEMPLATE);
     addWhereClause(participantCriteria, PERSON_TABLE, queryBuilder, params);
 
     return QueryJobConfiguration.newBuilder(queryBuilder.toString())
@@ -274,21 +264,15 @@ public class CohortQueryBuilder {
    *
    * @param lo - lower bound of the age range
    * @param hi - upper bound of the age range
+   * @param ageType - age type enum
    * @return
    */
-  private static String getAgeRangeSql(int lo, int hi) {
-    return "when CAST(FLOOR(DATE_DIFF(CURRENT_DATE, "
-        + SEARCH_PERSON_TABLE
-        + ".dob, MONTH)/12) as INT64) >= "
-        + lo
-        + " and CAST(FLOOR(DATE_DIFF(CURRENT_DATE, "
-        + SEARCH_PERSON_TABLE
-        + ".dob, MONTH)/12) as INT64) <= "
-        + hi
-        + " then '"
-        + lo
-        + "-"
-        + hi
-        + "'";
+  private static String getAgeRangeSql(int lo, int hi, AgeType ageType) {
+    String ageSql =
+        AgeType.AGE.equals(ageType)
+            ? "CAST(FLOOR(DATE_DIFF(CURRENT_DATE, cb_search_person.dob, MONTH)/12) as INT64)"
+            : ageType.toString();
+    return "when " + ageSql + " >= " + lo + " and " + ageSql + " <= " + hi + " then '" + lo + "-"
+        + hi + "'";
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCriteria.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/ParticipantCriteria.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.pmiops.workbench.model.AgeType;
+import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.SearchRequest;
 
 /**
@@ -25,21 +27,36 @@ public class ParticipantCriteria {
   private final SearchRequest searchRequest;
   private final Set<Long> participantIdsToInclude;
   private final Set<Long> participantIdsToExclude;
+  private final GenderOrSexType genderOrSexType;
+  private final AgeType ageType;
 
   public ParticipantCriteria(SearchRequest searchRequest) {
     this(searchRequest, NO_PARTICIPANTS_TO_EXCLUDE);
+  }
+
+  public ParticipantCriteria(
+      SearchRequest searchRequest, GenderOrSexType genderOrSexType, AgeType ageType) {
+    this.searchRequest = searchRequest;
+    this.participantIdsToExclude = NO_PARTICIPANTS_TO_EXCLUDE;
+    this.participantIdsToInclude = null;
+    this.genderOrSexType = genderOrSexType;
+    this.ageType = ageType;
   }
 
   public ParticipantCriteria(SearchRequest searchRequest, Set<Long> participantIdsToExclude) {
     this.searchRequest = searchRequest;
     this.participantIdsToExclude = participantIdsToExclude;
     this.participantIdsToInclude = null;
+    this.genderOrSexType = null;
+    this.ageType = null;
   }
 
   public ParticipantCriteria(Set<Long> participantIdsToInclude) {
     this.participantIdsToInclude = participantIdsToInclude;
     this.searchRequest = null;
     this.participantIdsToExclude = null;
+    this.genderOrSexType = null;
+    this.ageType = null;
   }
 
   @Nullable
@@ -57,9 +74,20 @@ public class ParticipantCriteria {
     return participantIdsToExclude;
   }
 
+  @Nullable
+  public GenderOrSexType getGenderOrSexType() {
+    return genderOrSexType;
+  }
+
+  @Nullable
+  public AgeType getAgeType() {
+    return ageType;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(searchRequest, participantIdsToExclude, participantIdsToExclude);
+    return Objects.hash(
+        searchRequest, participantIdsToExclude, participantIdsToExclude, genderOrSexType, ageType);
   }
 
   @Override
@@ -70,6 +98,8 @@ public class ParticipantCriteria {
     ParticipantCriteria that = (ParticipantCriteria) obj;
     return Objects.equals(this.searchRequest, that.searchRequest)
         && Objects.equals(this.participantIdsToExclude, that.participantIdsToExclude)
-        && Objects.equals(this.participantIdsToInclude, that.participantIdsToInclude);
+        && Objects.equals(this.participantIdsToInclude, that.participantIdsToInclude)
+        && Objects.equals(this.genderOrSexType, that.genderOrSexType)
+        && Objects.equals(this.ageType, that.ageType);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/AggregationUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/AggregationUtils.java
@@ -68,7 +68,7 @@ public class AggregationUtils {
           for (Terms.Bucket raceBucket : race.getBuckets()) {
             demoInformation.add(
                 new DemoChartInfo()
-                    .gender(genderBucket.getKeyAsString().substring(0, 1))
+                    .name(genderBucket.getKeyAsString().substring(0, 1))
                     .race(raceBucket.getKeyAsString())
                     .ageRange(RANGE_GT_65.equals(ageRange) ? "> " + ageRange : ageRange)
                     .count(raceBucket.getDocCount()));

--- a/api/src/main/resources/cb_search_api.yaml
+++ b/api/src/main/resources/cb_search_api.yaml
@@ -297,7 +297,7 @@ paths:
             type: integer
             format: int64
 
-  /v1/cohortbuilder/{cdrVersionId}/chartinfo:
+  /v1/cohortbuilder/{cdrVersionId}/chartinfo/{genderOrSex}/{age}:
     parameters:
       - $ref: '#/parameters/cdrVersionId'
     post:
@@ -308,6 +308,16 @@ paths:
       description: Searches for demographic info about subjects.
       operationId: "getDemoChartInfo"
       parameters:
+        - in: path
+          name: genderOrSex
+          type: string
+          required: true
+          description: represents gender or sex at birth
+        - in: path
+          name: age
+          type: string
+          required: true
+          description: represents age, age at consent or age at cdr
         - in: body
           name: request
           description: object of parameters by which to perform the search
@@ -907,6 +917,16 @@ definitions:
     description: Name that descibes the type of attribute
     enum: [ANY, NUM, CAT, AGE, AGE_AT_CONSENT, AGE_AT_CDR]
 
+  AgeType:
+    type: string
+    description: Different age types
+    enum: [AGE, AGE_AT_CONSENT, AGE_AT_CDR]
+
+  GenderOrSexType:
+    type: string
+    description: represents gender or sex at birth
+    enum: [GENDER, SEX_AT_BIRTH]
+
   DemoChartInfoListResponse:
     type: object
     required:
@@ -920,13 +940,13 @@ definitions:
   DemoChartInfo:
     type: object
     required:
-      - gender
+      - name
       - race
       - ageRange
       - count
     properties:
-      gender:
-        description: gender of subject
+      name:
+        description: gender or sex at birth of subject
         type: string
       race:
         description: race of subject

--- a/ui/src/app/cohort-common/combo-chart/combo-chart.component.tsx
+++ b/ui/src/app/cohort-common/combo-chart/combo-chart.component.tsx
@@ -87,7 +87,7 @@ export class ComboChart extends React.Component<Props, State> {
       'No matching concept': 'Unknown'
     };
     const getKey = (dat) => {
-      const gender = !!codeMap[dat.gender] ? codeMap[dat.gender] : dat.gender;
+      const gender = !!codeMap[dat.name] ? codeMap[dat.name] : dat.name;
       return `${gender} ${dat.ageRange || 'Unknown'}`;
     };
     const categories = data.reduce((acc, datum) => {

--- a/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
+++ b/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
@@ -87,7 +87,7 @@ export class GenderChart extends React.Component<Props, State> {
     };
     const colors = ['#a8385d', '#7aa3e5', '#a27ea8', '#aae3f5'];
     const chartData = data.reduce((acc, datum) => {
-      const gender = !!genderCodes[datum.gender] ? genderCodes[datum.gender] : datum.gender;
+      const gender = !!genderCodes[datum.name] ? genderCodes[datum.name] : datum.name;
       if (!acc.categories.includes(gender)) {
         acc.categories.push(gender);
       }

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -15,7 +15,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortStore, currentWorkspaceStore, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
-import {Cohort, ResourceType, TemporalTime} from 'generated/fetch';
+import {AgeType, Cohort, GenderOrSexType, ResourceType, TemporalTime} from 'generated/fetch';
 import {Menu} from 'primereact/menu';
 import * as React from 'react';
 
@@ -168,15 +168,16 @@ export const ListOverview = withCurrentWorkspace()(
         const {cdrVersionId} = currentWorkspaceStore.getValue();
         const request = mapRequest(searchRequest);
         if (request.includes.length > 0) {
-          cohortBuilderApi().getDemoChartInfo(+cdrVersionId, request).then(response => {
-            if (localCheck === this.state.apiCallCheck) {
-              this.setState({
-                chartData: response.items,
-                total: response.items.reduce((sum, data) => sum + data.count, 0),
-                loading: false
-              });
-            }
-          });
+          cohortBuilderApi().getDemoChartInfo(+cdrVersionId, GenderOrSexType[GenderOrSexType.GENDER],
+            AgeType[AgeType.AGE], request).then(response => {
+              if (localCheck === this.state.apiCallCheck) {
+                this.setState({
+                  chartData: response.items,
+                  total: response.items.reduce((sum, data) => sum + data.count, 0),
+                  loading: false
+                });
+              }
+            });
         } else {
           this.setState({chartData: [], total: 0, loading: false});
         }

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -9,7 +9,14 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {navigate, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Cohort, CohortReview, DomainType, SearchRequest} from 'generated/fetch';
+import {
+  AgeType,
+  Cohort,
+  CohortReview,
+  DomainType,
+  GenderOrSexType,
+  SearchRequest
+} from 'generated/fetch';
 import * as moment from 'moment';
 import * as React from 'react';
 
@@ -212,7 +219,7 @@ export const QueryReport = withCurrentWorkspace()(
         this.setState({cdrName});
       });
       const request = (JSON.parse(review.cohortDefinition)) as SearchRequest;
-      cohortBuilderApi().getDemoChartInfo(+cdrVersionId, request)
+      cohortBuilderApi().getDemoChartInfo(+cdrVersionId, GenderOrSexType[GenderOrSexType.GENDER], AgeType[AgeType.AGE], request)
         .then(response => {
           this.groupChartData(response.items);
           this.setState({data: response.items, loading: false});


### PR DESCRIPTION
Allow graphs to use sex at birth and different age types
- Added new column sex_at_birth to BQ table cb_search_person
- Updated the sh files to assure that sex_at_birth is populated when building cb_search_person
- Updated CohortBuilderController graphs endpoint to allow sex at birth, age at consent and age at cdr
- Updated relevant test cases
- Updated cb_search_api.yaml swagger definition
- Updated UI calls to default to gender and current age

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers