### PR TITLE
[no ticket][risk=no] updating elastic image version to match dependency

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - 127.0.0.1:3306:3306
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.3
     ports:
       - 127.0.0.1:9200:9200
     environment:
@@ -110,22 +110,22 @@ services:
       - db-cdr/vars.env
 
   db-make-bq-tables:
-      depends_on:
-        - db
-      build:
-        context: ./src/dev/server
-      user: ${UID}
-      working_dir: /w/db-cdr
-      volumes:
-        - gradle-cache:/.gradle
-        - .:/w:cached
-        - ~/.config:/.config:cached
-        - ~/.gsutil:/.gsutil:cached
+    depends_on:
+      - db
+    build:
+      context: ./src/dev/server
+    user: ${UID}
+    working_dir: /w/db-cdr
+    volumes:
+      - gradle-cache:/.gradle
+      - .:/w:cached
+      - ~/.config:/.config:cached
+      - ~/.gsutil:/.gsutil:cached
 
-      environment:
-        - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
-      env_file:
-        - db-cdr/vars.env
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
+    env_file:
+      - db-cdr/vars.env
 
   db-cloudsql-import:
     build:


### PR DESCRIPTION
when running 
**`./project.rb docker-clean && ./project.rb dev-up && ./project.rb load-es-index`**  
creation of cdr_person index was throwing a 400 
https://github.com/all-of-us/workbench/blob/1a68804dbaace2b01fecdbde854da2796ec11619/api/tools/src/main/java/org/pmiops/workbench/tools/elastic/ElasticSearchIndexer.java#L178-L178
Noticed that we needed to update the version on the docker elasticsearch image to 6.8.3 to match
https://github.com/all-of-us/workbench/blob/1a68804dbaace2b01fecdbde854da2796ec11619/api/build.gradle#L210-L210

Created a jira ticket to address deprecated methods with move from 6.6.1 to 6.8.3:
[here](https://precisionmedicineinitiative.atlassian.net/browse/RW-4528)
