### PR TITLE
[risk=no] Fix some consistency issues in project.rb flags

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1229,7 +1229,7 @@ def fetch_workspace_details(cmd_name, *args)
   op.opts.project = TEST_PROJECT
 
   op.add_typed_option(
-      "--workspace-project-id [project-id]",
+      "--workspace-project-id [workspace-project-id]",
       String,
       ->(opts, v) { opts.workspace_project_id = v},
       "Fetches details for workspace(s) that match the given project ID / namespace (e.g. 'aou-rw-231823128'")

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1197,7 +1197,7 @@ def fetch_firecloud_user_profile(cmd_name, *args)
   op.opts.project = TEST_PROJECT
 
   op.add_typed_option(
-      "--user=[user]",
+      "--user [user]",
       String,
       ->(opts, v) { opts.user = v},
       "The AoU user to fetch FireCloud data for (e.g. 'gjordan@fake-research-aou.org'")
@@ -1229,9 +1229,9 @@ def fetch_workspace_details(cmd_name, *args)
   op.opts.project = TEST_PROJECT
 
   op.add_typed_option(
-      "--projectId=[projectId]",
+      "--workspace-project-id [project-id]",
       String,
-      ->(opts, v) { opts.projectId = v},
+      ->(opts, v) { opts.workspace_project_id = v},
       "Fetches details for workspace(s) that match the given project ID / namespace (e.g. 'aou-rw-231823128'")
 
   # Create a cloud context and apply the DB connection variables to the environment.
@@ -1244,7 +1244,7 @@ def fetch_workspace_details(cmd_name, *args)
 
   flags = ([
       ["--fc-base-url", fc_config["baseUrl"]],
-      ["--projectId", op.opts.projectId]
+      ["--workspace-project-id", op.opts.workspace_project_id]
   ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
   flags.map! { |f| "'#{f}'" }
 
@@ -1271,7 +1271,7 @@ def export_workspace_data(cmd_name, *args)
   op.add_typed_option(
       "--export-filename [export-filename]",
       String,
-      ->(opts, v) { opts.exportFilename = v},
+      ->(opts, v) { opts.export_filename = v},
       "Filename of export file to write to")
 
   # Create a cloud context and apply the DB connection variables to the environment.
@@ -1281,7 +1281,7 @@ def export_workspace_data(cmd_name, *args)
   gcc.validate()
 
   flags = ([
-      ["--export-filename", op.opts.exportFilename]
+      ["--export-filename", op.opts.export_filename]
   ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
   flags.map! { |f| "'#{f}'" }
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FetchWorkspaceDetails.java
@@ -35,10 +35,16 @@ public class FetchWorkspaceDetails {
           .hasArg()
           .build();
 
-  private static Option projectIdOpt =
-      Option.builder().longOpt("projectId").desc("Billing project ID").required().hasArg().build();
+  private static Option workspaceProjectIdOpt =
+      Option.builder()
+          .longOpt("workspace-project-id")
+          .desc("Workspace billing project ID to fetch details for")
+          .required()
+          .hasArg()
+          .build();
 
-  private static Options options = new Options().addOption(fcBaseUrlOpt).addOption(projectIdOpt);
+  private static Options options =
+      new Options().addOption(fcBaseUrlOpt).addOption(workspaceProjectIdOpt);
 
   @Bean
   public CommandLineRunner run(WorkspaceDao workspaceDao) {
@@ -54,7 +60,7 @@ public class FetchWorkspaceDetails {
 
       for (DbWorkspace workspace :
           workspaceDao.findAllByWorkspaceNamespace(
-              opts.getOptionValue(projectIdOpt.getLongOpt()))) {
+              opts.getOptionValue(workspaceProjectIdOpt.getLongOpt()))) {
         Map<String, FirecloudWorkspaceAccessEntry> acl =
             FirecloudTransforms.extractAclResponse(
                 workspacesApi.getWorkspaceAcl(


### PR DESCRIPTION
- Hyphenate flag names
- snakecase ruby vars
- drop "=" from flag syntax
- Rename one flag for clarity

Just noticed this when running some of the tools.