### PR TITLE
[RW-4546][risk=low] Bump deploy/circle to use new development image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: ./gradlew spotlessCheck
       - save_cache:
           paths:
-            - ~/.gradle
+            - /.gradle
             - ~/.m2
             - ~/workbench/api/build/exploded-api/WEB-INF/lib/
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
@@ -103,7 +103,7 @@ jobs:
           command: ./project.rb start-local-api && ./project.rb run-local-api-tests && ./project.rb stop-local-api
       - save_cache:
           paths:
-            - ~/.gradle
+            - /.gradle
             - ~/.m2
             - ~/workbench/api/build/exploded-api/WEB-INF/lib/
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
@@ -176,7 +176,7 @@ jobs:
           command: ./project.rb integration
       - save_cache:
           paths:
-            - ~/.gradle
+            - /.gradle
             - ~/.m2
           key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
 
@@ -207,7 +207,7 @@ jobs:
           command: ./project.rb bigquerytest
       - save_cache:
           paths:
-            - ~/.gradle
+            - /.gradle
             - ~/.m2
           key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: allofustest/workbench:buildimage-0.0.13
+    - image: allofustest/workbench:buildimage-0.0.15
   working_directory: ~/workbench
 java_defaults: &java_defaults
   <<: *defaults
@@ -60,7 +60,7 @@ jobs:
 
   api-local-test:
     docker:
-      - image: allofustest/workbench:buildimage-0.0.13
+      - image: allofustest/workbench:buildimage-0.0.15
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -13,11 +13,11 @@
 #
 # We use OpenJDK 8, Node, and some common browsers from CircleCI's base image
 # see: https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-FROM circleci/openjdk:8-jdk-node-browsers
+FROM circleci/openjdk:8-buster-node-browsers
 
 USER circleci
 
-ENV CLOUD_SDK_VERSION 215.0.0
+ENV CLOUD_SDK_VERSION 260.0.0
 
 RUN cd && \
   wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -O gcloud.tgz && \
@@ -27,9 +27,8 @@ RUN cd && \
   rm -rf gcloud.tgz
 
 RUN sudo apt-get update
-RUN sudo apt-get install gettext ruby mysql-client python-pip
-RUN sudo pip install --upgrade pip
-RUN sudo pip install --upgrade pylint
+RUN sudo apt-get install gettext ruby default-mysql-client python-pip
+RUN sudo pip install --upgrade pip pylint
 
 ENV PATH=/home/circleci/node/bin:/home/circleci/google-cloud-sdk/bin:$PATH
 
@@ -46,4 +45,10 @@ RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin
   && sudo unzip /tmp/gradle.zip -d /opt/gradle
 ENV PATH="/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 
+# Force a lower concurrent-ruby version, as we only have Ruby 2.3.
 RUN sudo gem install jira-ruby
+
+# Create a gradle cache directory as a volume that can be read/written by any
+# container (including containers running as any user -- hence the a+rwx)
+RUN sudo mkdir /.gradle && sudo chmod a+rwx -R /.gradle
+ENV GRADLE_USER_HOME /.gradle

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   deploy:
-    image: allofustest/workbench:buildimage-0.0.13
+    image: allofustest/workbench:buildimage-0.0.15
     entrypoint: /bootstrap-docker.sh
     user: circleci
     environment:


### PR DESCRIPTION
(Updated: I forgot we separate Dockerfiles for local dev and for Circle/deploys)

- Upgrade our CircleCI base image out of the stone age. This was necessary for installing a newer Ruby than 2.3, which is now required by the jira-ruby gem.
- Export a variable for the gradle cache directory in the build image
- Mount/cache a consistent location for the gradle cache (across circle, local dev, deploy) in `/.gradle`
- Built and pushed a new buildimage: update references accordingly