### PR TITLE
[RW-4370][risk=no] updating the current CDR.

### DIFF
--- a/api/config/cdr_versions_perf.json
+++ b/api/config/cdr_versions_perf.json
@@ -8,7 +8,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -21,7 +21,7 @@
     "creationTime": "2018-09-20 00:00:01Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -56,7 +56,7 @@
     "bigqueryDataset": "R2019Q4R3",
     "creationTime": "2019-10-21 00:00:00Z",
     "releaseNumber": 3,
-    "numParticipants": 242299,
-    "cdrDbName": "r_2020q1_1"
+    "numParticipants": 224350,
+    "cdrDbName": "r_2020q1_2"
   }
 ]

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -9,7 +9,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -22,7 +22,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -34,7 +34,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -47,7 +47,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -9,7 +9,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -22,7 +22,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -34,7 +34,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   },
   {
@@ -47,7 +47,7 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -8,8 +8,8 @@
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
-    "elasticIndexBaseName": "synth_r_2019q1_1"
+    "cdrDbName": "synth_r_2020q1_3",
+    "elasticIndexBaseName": "synth_r_2020q1_1"
   },
   {
     "cdrVersionId": 2,
@@ -21,7 +21,7 @@
     "creationTime": "2018-09-20 00:00:01Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_1",
+    "cdrDbName": "synth_r_2020q1_3",
     "elasticIndexBaseName": "synth_r_2019q1_1"
   }
 ]


### PR DESCRIPTION
Some participants have been removed from the current CDR, so we recreated the cloud CDR. I've also recreated and moved all the cb_, ds_ tables to `aou-res-curation-output-prod`.  So for the release Monday it will be a good exercise for the on-call engineer @NehaBroad to publish the **full CDR** since the OMOP tables have changed as well. Documented in the [CDR Playbook](https://docs.google.com/document/d/1St6pG_EUFB9oRQUQaOSO7a9UPxPkQ5n4qAVyKF9j9tk/edit#heading=h.wp54m0aomidu). 

@NehaBroad The publish command for Monday: run from the api directory
`db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-prod --bq-dataset R2019Q4R3 | tee R2019Q4R3.log.txt`

@calbach Want to confirm that this all looks correct?

This also includes changing the synth cloud cdr - we added a new table (cb_person) in cloud cdr for CB.