### PR TITLE
[RW-4400][Risk=no] Add billing reminder to share workspcae

### DIFF
--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -25,6 +25,7 @@ import {ClrIcon, InfoIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {AnalyticsTracker} from 'app/utils/analytics';
+import {FlexRow} from 'app/components/flex';
 
 const styles = reactStyles( {
   tooltipLabel: {
@@ -36,7 +37,7 @@ const styles = reactStyles( {
     margin: '0',
     fontSize: '.91667rem',
     fontWeight: 600,
-    paddingBottom: '1rem'
+    paddingBottom: '0.25rem'
   },
 
   tooltipPoint: {
@@ -332,24 +333,30 @@ export const WorkspaceShare = withCurrentWorkspace()(class extends React.Compone
       <Modal width={450}>
         {this.state.saving && <SpinnerOverlay />}
         <ModalTitle style={styles.modalTitle}>
-          <div>
-          <label>Share {this.props.workspace.name}</label>
-          <TooltipTrigger content={<div style={styles.tooltipLabel}>
-            Search for a collaborator that has an <i>All of Us</i> research account. Collaborators can
-            be assigned different permissions within your Workspace.
-            <ul>
-              <li style={styles.tooltipPoint}>A <span style={{'textDecoration': 'underline'}}>
-                Reader</span> can view your notebooks, but not make edits, deletes or share
-                contents of the Workspace.</li>
-              <li style={styles.tooltipPoint}>A <span style={{'textDecoration': 'underline'}}>
-                Writer</span> can view, edit and delete content in the Workspace but not share
-                the Workspace with others.</li>
-              <li style={styles.tooltipPoint}>An <span style={{'textDecoration': 'underline'}}>
-                Owner</span> can view, edit, delete and share contents in the Workspace.</li>
-            </ul>
-          </div>}>
-            <InfoIcon style={{width: '13px', height: '14px', marginLeft: '.4rem'}}/>
-          </TooltipTrigger>
+          <FlexRow style={{alignItems: 'center', justifyContent: 'space-between'}}>
+            <div>
+              <label>Share {this.props.workspace.name}</label>
+            </div>
+            <TooltipTrigger content={<div style={styles.tooltipLabel}>
+              Search for a collaborator that has an <i>All of Us</i> research account. Collaborators can
+              be assigned different permissions within your Workspace.
+              <ul>
+                <li style={styles.tooltipPoint}>A <span style={{'textDecoration': 'underline'}}>
+                  Reader</span> can view your notebooks, but not make edits, deletes or share
+                  contents of the Workspace.</li>
+                <li style={styles.tooltipPoint}>A <span style={{'textDecoration': 'underline'}}>
+                  Writer</span> can view, edit and delete content in the Workspace but not share
+                  the Workspace with others.</li>
+                <li style={styles.tooltipPoint}>An <span style={{'textDecoration': 'underline'}}>
+                  Owner</span> can view, edit, delete and share contents in the Workspace.</li>
+              </ul>
+            </div>}>
+              <InfoIcon style={{width: '14px', height: '14px', marginLeft: '.4rem'}}/>
+            </TooltipTrigger>
+          </FlexRow>
+          <div style={{color: colors.primary, fontSize: 14, fontWeight: 400}}>
+              When you share this workspace as a ‘Writer’ or an ‘Owner’, the free credits of the creator of the
+              workspace ({this.props.workspace.creator}) will be used for all analysis in this workspace.
           </div>
         </ModalTitle>
         <ModalBody style={styles.sharingBody}>

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import {User} from 'generated';
 
 import {
+  BillingAccountType,
   UserRole,
   Workspace,
   WorkspaceAccessLevel,
@@ -354,10 +355,11 @@ export const WorkspaceShare = withCurrentWorkspace()(class extends React.Compone
               <InfoIcon style={{width: '14px', height: '14px', marginLeft: '.4rem'}}/>
             </TooltipTrigger>
           </FlexRow>
-          <div style={{color: colors.primary, fontSize: 14, fontWeight: 400}}>
-              When you share this workspace as a ‘Writer’ or an ‘Owner’, the free credits of the creator of the
-              workspace ({this.props.workspace.creator}) will be used for all analysis in this workspace.
-          </div>
+          {this.props.workspace.billingAccountType === BillingAccountType.FREETIER &&
+            <div style={{color: colors.primary, fontSize: 14, fontWeight: 400}}>
+                When you share this workspace as a ‘Writer’ or an ‘Owner’, the free credits of the creator of the
+                workspace ({this.props.workspace.creator}) will be used for all analysis in this workspace.
+            </div>}
         </ModalTitle>
         <ModalBody style={styles.sharingBody}>
           <div ref={node => this.searchingNode = node} style={styles.dropdown} >

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -21,11 +21,11 @@ import {
 } from 'generated/fetch/api';
 
 import {Button} from 'app/components/buttons';
+import {FlexRow} from 'app/components/flex';
 import {ClrIcon, InfoIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {AnalyticsTracker} from 'app/utils/analytics';
-import {FlexRow} from 'app/components/flex';
 
 const styles = reactStyles( {
   tooltipLabel: {


### PR DESCRIPTION
Description:
Does some moderate cleanup and adds the billing policy reminder. The modal looks like this: 
![Screen Shot 2020-03-06 at 5 13 16 PM](https://user-images.githubusercontent.com/15351021/76126691-ce29c600-5fcd-11ea-8613-5f3c902090e9.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
