### PR TITLE
[RW-4420][risk=low] Switch to new Leonardo AoU image, add docs

### DIFF
--- a/api/cluster-resources/README.md
+++ b/api/cluster-resources/README.md
@@ -11,7 +11,7 @@ To manually test updates to any notebook server assets (initialization script, U
 - Push a personal API server to test:
 
   ```
-  api$ ./project.rb deploy-api --no-promote --version "${USER}" --project all-of-us-workbench-test"
+  api$ ./project.rb deploy-api --no-promote --version "${USER}" --project all-of-us-workbench-test
   ```
   
   **Note**: This deployed API server will ONLY be used for serving your static assets. This approach

--- a/api/cluster-resources/initialize_notebook_cluster.sh
+++ b/api/cluster-resources/initialize_notebook_cluster.sh
@@ -21,36 +21,3 @@ jupyter nbextension enable snippets_menu/main
 # Section represents the jupyter page to which the extension will be applied to
 jupyter nbextension enable aou-upload-policy-extension/main --section=tree
 
-# reticulate is our preferred access method for the AoU client library - default
-# to python3 as our pyclient has better support for python3. Rprofile is executed
-# each time the R kernel starts.
-echo "Sys.setenv(RETICULATE_PYTHON = '$(which python3)')" >> ~/.Rprofile
-
-# The following are required for R packages to function:
-# - libmagick++-dev: summarytools
-# - gfortran-6: minqa (Leo base fix: https://broadworkbench.atlassian.net/browse/IA-1002)
-#
-# Must be installed from the cran repository, otherwise will receive install
-# errors. See: https://github.com/DataBiosphere/leonardo/issues/813
-# TODO: Figure out a less brittle approach here. The value "stretch-cran35" must
-# match the repo used by Leo, so this could break on a Leo image change. Either
-# push this into the Leo base image, set this repo name as an env var, or let
-# users install this themselves via root (https://github.com/DataBiosphere/leonardo/issues/840)
-# TODO: These steps are quite slow, we could also consider pushing this into the
-# base Leo image or a custom AoU docker image.
-apt-get update
-apt-get -t stretch-cran35 install -y --no-install-recommends libmagick++-dev gfortran-6
-apt-get install -y --no-install-recommends jq
-
-"pip3" install --upgrade \
-  plotnine \
-  'https://github.com/all-of-us/pyclient/archive/pyclient-v1-17.zip#egg=aou_workbench_client&subdirectory=py' \
-  statsmodels==0.10.0rc2
-
-# Install wondershaper for basic egress throttling.
-apt-get install -y --no-install-recommends iproute2
-(cd /usr/local/share &&
- git clone https://github.com/magnific0/wondershaper.git &&
- cd wondershaper &&
- make install
-)

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-gatk:0.0.11",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
     "welderDockerImage": "broadinstitute/welder-server:e6562d0"
   },
   "billing": {

--- a/api/doc/notebook-servers.md
+++ b/api/doc/notebook-servers.md
@@ -1,0 +1,81 @@
+# Notebook servers
+
+Notebook servers are lazily allocated per researcher, per workspace as needed.
+The primary function of these servers is to provide a secure environment to
+run analysis via the [Jupyter Notebooks UI](https://jupyter.org).
+
+All of Us leverages Terra's [Leonardo](https://github.com/DataBiosphere/leonardo)
+API to launch and manage notebook servers. This service handles server state
+tracking, monitoring, authenticated notebook UI access, and autopausing of idle
+servers, among other features.
+
+"Cluster" and "notebook server" will often be used interchangeably in code or
+discussion. "Cluster" is the RESTful name of the notebook server resource in
+Leonardo. In All of Us, we currently only allocate single-node "clusters" to fit
+our product requirements, but Leonardo is implemented on top of Dataproc which
+supports running a Spark cluster of multiple machines.
+
+## Configuration
+
+Leo notebook servers are configured [here](https://github.com/all-of-us/workbench/blob/30db5b4a2f4b255f3ddeec9d80f7abda7d4eac99/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java#L53-L68).
+All of Us uses a custom docker image for our notebook servers, which is defined
+[here](https://github.com/DataBiosphere/terra-docker/tree/master/terra-jupyter-aou).
+Notably, this image is configured for client-side [egress limiting via wondershaper](https://docs.google.com/document/d/1SO77UGE41lH5ffa0Gg6KoiMszc6I33dIbm48sA-_5-U/edit)
+Finally, All of Us configures all Leo clusters with a set of startup scripts and
+Jupyter extensions such as code snippets and data use reminders, as described
+[here](../cluster-resources).
+
+## Auth and access
+
+Notebook servers are created within a Terra billing project, which corresponds
+to a single AoU workspace (http://broad.io/1ppw). The Jupyter notebook UI on a
+notebook server is only accessible by the creator of that notebook server.
+However, some REST operations can be performed by OWNERs on the same billing
+project, e.g. start, stop, delete.
+
+For code that runs on the Notebook VM itself, application default credentials
+are initialized with the researcher's pet service account, which has access
+mirroring that of the researcher within Terra.
+
+### Browser authentication
+
+Leonardo proxies all access to the notebook server. It requires an oauth bearer
+token to be present for all proxied web requests. All of Us configures creds
+as follows for use with Leonardo.
+
+- AoU calls `/setCookie` on Leonardo, bootstrapping Workbench UI oauth2 token
+  for subsequent requests
+- AoU creates clusters with a `defaultClientId`, which gets injected into the
+  Leo Jupyter UI, and is used to periodically refresh the auth token while a
+  browser session is active.
+- For this reason, the Workbench UI client ID whitelists notebooks.firecloud.org
+  as a valid domain.
+
+By default, All of Us opens the Jupyter UI in an iframe, but the authentication
+approach also works in separate popped out Leonardo windows/tabs.
+
+## Notebook server lifecycle
+
+See this [writeup](https://github.com/all-of-us/workbench/blob/094523134b66952e17a35d9a60970c046615eb05/ui/src/app/utils/cluster-initializer.tsx#L93-L109)
+for details on how a notebook server is created.
+
+- When necessitated by a user action in the Workbench, e.g. opening a notebook
+  in a workspace, a new notebook server will be created if none exists.
+- If a notebook exists in the STOPPED state when needed (e.g. due to autopause)
+  it will be resumed.
+- If a notebook remains idle for >30m (no UI interaction or active kernels), it
+  will be autopaused.
+- A user can manually request a "reset" of their notebook server if there is an
+  issue, which is implemented as a deleteCluster -> createCluster.
+- Finally, a notebook server will be deleted by an offline cronjob after they
+  exceed a certain age. This ensures that all clusters have a maximum age which
+  allows us to reason about rolling out new cluster configurations/features. The
+  logic for cluster deletion is described [here](https://github.com/all-of-us/workbench/blob/30db5b4a2f4b255f3ddeec9d80f7abda7d4eac99/api/src/main/java/org/pmiops/workbench/api/OfflineClusterController.java#L53-L68).
+
+## Persistence
+
+Notebooks are persisted by an extension to the Jupyter server. Ultimately
+notebook files are synchronized from the notebook server to/from the
+corresponding workspace scratch bucket. See the [data sync design](
+https://docs.google.com/document/d/1rTq3DwsB2h7l_9f2I5pcpa9Z-PJJkMBw7APBqYs1NW8/edit)
+for more details.

--- a/api/doc/notebook-servers.md
+++ b/api/doc/notebook-servers.md
@@ -23,7 +23,11 @@ All of Us uses a custom docker image for our notebook servers, which is defined
 Notably, this image is configured for client-side [egress limiting via wondershaper](https://docs.google.com/document/d/1SO77UGE41lH5ffa0Gg6KoiMszc6I33dIbm48sA-_5-U/edit)
 Finally, All of Us configures all Leo clusters with a set of startup scripts and
 Jupyter extensions such as code snippets and data use reminders, as described
-[here](../cluster-resources).
+[here](../cluster-resources). These static assets are all hosted publicly via
+the Workench API server, allowing Leonardo to pull them onto the VM at runtime.
+
+Note: some of the configuration choices here are necessitated by our use of
+VPC-SC in production. See [details here](https://docs.google.com/document/d/1BLfrlNC6UpZuTU38QNBXrFcqIHewAx0i2mYaP3GIrV0/edit).
 
 ## Auth and access
 


### PR DESCRIPTION
- New image is defined here: https://github.com/DataBiosphere/terra-docker/tree/master/terra-jupyter-aou
- With the next Terra release, this image will be preloaded onto the Leo Dataproc image, which will improve startup time, however it can be used today.
- Most of the initialization script has been moved into the Dockerfile.

Functional changes to the VM:
- Installing the `bigrquery` fork with high priority PRs applied: https://github.com/all-of-us/bigrquery
- No longer installing the legacy pyclient library. I am instead installing the transitive deps of that library (this was the cause of regressions when I last tried removing the client lib)