### PR TITLE
[RW-4535][risk=no] Workspace about edit icon fixes

### DIFF
--- a/ui/src/app/icons/edit.tsx
+++ b/ui/src/app/icons/edit.tsx
@@ -15,7 +15,6 @@ export interface EditComponentState {
 const defaultStyle = {
   height: 19,
   width: 19,
-  marginLeft: '.5rem',
   fill: colors.accent,
   cursor: 'pointer'
 };

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -53,7 +53,6 @@ const styles = reactStyles({
   navBarIcon: {
     height: '16px',
     width: '16px',
-    marginLeft: 0,
     marginRight: '5px'
   },
   previewDiv: {

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -286,6 +286,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                       {conceptSet.name}
                       <Clickable disabled={!WorkspacePermissionsUtil
                                   .canWrite(workspace.accessLevel)}
+                                 style={{marginLeft: '.5rem'}}
                                  data-test-id='edit-concept-set'
                                  onClick={() => this.setState({editing: true})}>
                         <EditComponentReact enableHoverEffect={true}
@@ -294,7 +295,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                                                 workspace.accessLevel
                                               )
                                             }
-                                            style={{marginLeft: '.5rem', marginTop: '0.1rem'}}/>
+                                            style={{marginTop: '0.1rem'}}/>
                       </Clickable>
                     </div>
                     <div style={{marginBottom: '1.5rem', color: colors.primary}} data-test-id='concept-set-description'>

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -294,7 +294,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
                                                 workspace.accessLevel
                                               )
                                             }
-                                            style={{marginTop: '0.1rem'}}/>
+                                            style={{marginLeft: '.5rem', marginTop: '0.1rem'}}/>
                       </Clickable>
                     </div>
                     <div style={{marginBottom: '1.5rem', color: colors.primary}} data-test-id='concept-set-description'>

--- a/ui/src/app/pages/workspace/research-purpose.tsx
+++ b/ui/src/app/pages/workspace/research-purpose.tsx
@@ -16,7 +16,7 @@ import {
   getSelectedResearchPurposeItems
 } from 'app/utils/research-purpose';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {WorkspacePermissions} from 'app/utils/workspace-permissions';
+import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 
 const styles = reactStyles({
   editIcon: {
@@ -25,7 +25,6 @@ const styles = reactStyles({
     width: 22,
     fill: colors.light,
     backgroundColor: colors.accent,
-    cursor: 'pointer',
     padding: '5px',
     borderRadius: '23px'
   },
@@ -56,82 +55,70 @@ const styles = reactStyles({
 
 
 export const ResearchPurpose = withCurrentWorkspace()(
-  class extends React.Component<
-    {workspace: WorkspaceData},
-    {workspacePermissions: WorkspacePermissions}> {
-    constructor(props) {
-      super(props);
-      this.state = {
-        workspacePermissions: new WorkspacePermissions(props.workspace)
-      };
-    }
+  ({workspace}: {workspace: WorkspaceData}) => {
+    const isOwner = WorkspacePermissionsUtil.isOwner(workspace.accessLevel);
+    const selectedResearchPurposeItems = getSelectedResearchPurposeItems(workspace.researchPurpose);
+    return <FadeBox>
+      <div style={styles.mainHeader}>Primary purpose of project
+        <Clickable disabled={!isOwner}
+                   style={{display: 'flex', alignItems: 'center', marginLeft: '.5rem'}}
+                   data-test-id='edit-workspace'
+                   onClick={() => navigate(
+                     ['workspaces',  workspace.namespace, workspace.id, 'edit'])}>
+          <EditComponentReact enableHoverEffect={true}
+                              disabled={!isOwner}
+                              style={styles.editIcon}/>
+        </Clickable>
+      </div>
+      <div style={styles.sectionContentContainer}>
+        {selectedResearchPurposeItems.map((selectedResearchPurposeItem, i) => <div key={i}>
+          <div style={{marginTop: '1rem'}}>{selectedResearchPurposeItem}</div>
+        </div>)}
+      </div>
+      <div style={styles.sectionHeader}>Summary of research purpose</div>
+      <div style={styles.sectionContentContainer}>
+        {/*Intended study section*/}
+        <div style={styles.sectionSubHeader}>{researchPurposeQuestions[2].header}</div>
+        <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
+          {workspace.researchPurpose.intendedStudy}</div>
 
-    render() {
-      const {workspace} = this.props;
-      const {workspacePermissions} = this.state;
-      const selectedResearchPurposeItems = getSelectedResearchPurposeItems(this.props.workspace.researchPurpose);
-      return <FadeBox>
-        <div style={styles.mainHeader}>Primary purpose of project
-          <Clickable disabled={!workspacePermissions.canWrite}
-                     style={{display: 'flex', alignItems: 'center'}}
-                     data-test-id='edit-workspace'
-                     onClick={() => navigate(
-                       ['workspaces',  workspace.namespace, workspace.id, 'edit'])}>
-            <EditComponentReact enableHoverEffect={true}
-                                disabled={!workspacePermissions.canWrite}
-                                style={styles.editIcon}/>
-          </Clickable>
+        {/*Scientific approach section*/}
+        <div style={styles.sectionSubHeader}>{researchPurposeQuestions[3].header}</div>
+        <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
+          {workspace.researchPurpose.scientificApproach}</div>
+
+        {/*Anticipated findings section*/}
+        <div style={styles.sectionSubHeader}>{researchPurposeQuestions[4].header}</div>
+        <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
+          {workspace.researchPurpose.anticipatedFindings}
         </div>
+      </div>
+
+      {/*Findings section*/}
+      <div style={styles.sectionHeader}>Findings will be disseminate by the following:</div>
+      <div style={styles.sectionContentContainer}>
+        {workspace.researchPurpose.disseminateResearchFindingList.map((disseminateFinding, i) =>
+          <div key={i} style={{...styles.sectionItemWithBackground, marginTop: '0.5rem'}}>{disseminateFindings
+            .find(finding => finding.shortName === disseminateFinding).label}</div>
+        )}
+      </div>
+
+      {/*Outcomes section*/}
+      <div style={styles.sectionHeader}>Outcomes anticipated from the research:</div>
+      <div style={styles.sectionContentContainer}>
+        {workspace.researchPurpose.researchOutcomeList.map((workspaceOutcome, i) =>
+          <div key={i} style={{...styles.sectionItemWithBackground, marginTop: '0.5rem'}}>{researchOutcomes
+            .find(outcome => outcome.shortName === workspaceOutcome).label}</div>
+        )}
+      </div>
+
+      {/*Underserved populations section*/}
+      {workspace.researchPurpose.population && <React.Fragment>
+        <div style={styles.sectionHeader}>Population of interest</div>
         <div style={styles.sectionContentContainer}>
-          {selectedResearchPurposeItems.map((selectedResearchPurposeItem, i) => <div key={i}>
-            <div style={{marginTop: '1rem'}}>{selectedResearchPurposeItem}</div>
-          </div>)}
+          <div style={{marginTop: '0.5rem'}}>{getSelectedPopulations(workspace.researchPurpose)}</div>
         </div>
-        <div style={styles.sectionHeader}>Summary of research purpose</div>
-        <div style={styles.sectionContentContainer}>
-          {/*Intended study section*/}
-          <div style={styles.sectionSubHeader}>{researchPurposeQuestions[2].header}</div>
-          <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
-            {workspace.researchPurpose.intendedStudy}</div>
-
-          {/*Scientific approach section*/}
-          <div style={styles.sectionSubHeader}>{researchPurposeQuestions[3].header}</div>
-          <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
-            {workspace.researchPurpose.scientificApproach}</div>
-
-          {/*Anticipated findings section*/}
-          <div style={styles.sectionSubHeader}>{researchPurposeQuestions[4].header}</div>
-          <div style={{...styles.sectionItemWithBackground, padding: '15px'}}>
-            {workspace.researchPurpose.anticipatedFindings}
-          </div>
-        </div>
-
-        {/*Findings section*/}
-        <div style={styles.sectionHeader}>Findings will be disseminate by the following:</div>
-        <div style={styles.sectionContentContainer}>
-          {workspace.researchPurpose.disseminateResearchFindingList.map((disseminateFinding, i) =>
-            <div key={i} style={{...styles.sectionItemWithBackground, marginTop: '0.5rem'}}>{disseminateFindings
-              .find(finding => finding.shortName === disseminateFinding).label}</div>
-          )}
-        </div>
-
-        {/*Outcomes section*/}
-        <div style={styles.sectionHeader}>Outcomes anticipated from the research:</div>
-        <div style={styles.sectionContentContainer}>
-          {workspace.researchPurpose.researchOutcomeList.map((workspaceOutcome, i) =>
-            <div key={i} style={{...styles.sectionItemWithBackground, marginTop: '0.5rem'}}>{researchOutcomes
-              .find(outcome => outcome.shortName === workspaceOutcome).label}</div>
-          )}
-        </div>
-
-        {/*Underserved populations section*/}
-        {workspace.researchPurpose.population && <React.Fragment>
-          <div style={styles.sectionHeader}>Population of interest</div>
-          <div style={styles.sectionContentContainer}>
-            <div style={{marginTop: '0.5rem'}}>{getSelectedPopulations(workspace.researchPurpose)}</div>
-          </div>
-        </React.Fragment>}
-      </FadeBox>;
-    }
+      </React.Fragment>}
+    </FadeBox>;
   }
 );


### PR DESCRIPTION
- **Functional fix**: Only owners can edit workspace metadata, disable the pencil for non-owners
- `ResearchPurpose` does not actually have state, refactor it to be a stateless functional component
- The edit icon should not encode a left margin, push this up to consumers.
--> Aside from bad separation of concerns, concretely this was causing weirdness with the `Clickable` target wrapping the icon, where the left margin was still styled as clickable even when disabled