### PR TITLE
[risk=no] Fix search item delete/undo

### DIFF
--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -212,9 +212,9 @@ export const SearchGroupItem = withCurrentWorkspace()(
       triggerEvent('Delete', 'Click', 'Snowman - Delete Criteria - Cohort Builder');
       this.setState({status: 'pending'});
       this.props.item.status = 'pending';
-      this.updateSearchRequest(false, true);
+      this.updateSearchRequest(true);
       const timeout = setTimeout(() => {
-        this.updateSearchRequest(true);
+        this.updateSearchRequest(false, true);
       }, 10000);
       this.setState({timeout});
     }


### PR DESCRIPTION
Fixes bug where deleting a search group item does not give an "Undo" option and does not recalculate group or total count.