### PR TITLE
[risk=no] Fix circleci: revert gradle home, bump gradle revision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: allofustest/workbench:buildimage-0.0.15
+    - image: allofustest/workbench:buildimage-0.0.16
   working_directory: ~/workbench
 java_defaults: &java_defaults
   <<: *defaults
@@ -53,14 +53,14 @@ jobs:
           command: ./gradlew spotlessCheck
       - save_cache:
           paths:
-            - /.gradle
+            - ~/.gradle
             - ~/.m2
             - ~/workbench/api/build/exploded-api/WEB-INF/lib/
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
 
   api-local-test:
     docker:
-      - image: allofustest/workbench:buildimage-0.0.15
+      - image: allofustest/workbench:buildimage-0.0.16
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu
@@ -103,7 +103,7 @@ jobs:
           command: ./project.rb start-local-api && ./project.rb run-local-api-tests && ./project.rb stop-local-api
       - save_cache:
           paths:
-            - /.gradle
+            - ~/.gradle
             - ~/.m2
             - ~/workbench/api/build/exploded-api/WEB-INF/lib/
           key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
@@ -176,7 +176,7 @@ jobs:
           command: ./project.rb integration
       - save_cache:
           paths:
-            - /.gradle
+            - ~/.gradle
             - ~/.m2
           key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
 
@@ -207,7 +207,7 @@ jobs:
           command: ./project.rb bigquerytest
       - save_cache:
           paths:
-            - /.gradle
+            - ~/.gradle
             - ~/.m2
           key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,6 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
       - run:
           name: Validate swagger definitions
           working_directory: ~/workbench/api
@@ -83,10 +79,6 @@ jobs:
       - run:
           name: Fetch Submodules
           command: git submodule update --init --recursive
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
       - run:
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
@@ -119,10 +111,6 @@ jobs:
       # workspaces, but that seemed to have a negligible effect on speed. It's
       # also tricky to pick specific sub directories since the API deploy
       # touches several top level folders {common,}api.
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
       - run:
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
@@ -163,10 +151,6 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
-      - restore_cache:
-          keys:
-          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
       - run:
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
@@ -194,10 +178,6 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
-      - restore_cache:
-          keys:
-          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
       - run:
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
@@ -293,10 +273,6 @@ jobs:
       - checkout
       - run:
           command: git submodule update --init --recursive
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
       - deploy:
           working_directory: ~/workbench/deploy
           command: |
@@ -316,10 +292,6 @@ jobs:
       - checkout
       - run:
           command: git submodule update --init --recursive
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
       - deploy:
           working_directory: ~/workbench/deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
+      - restore_cache:
+          keys:
+          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-cache-
       - run:
           name: Validate swagger definitions
           working_directory: ~/workbench/api
@@ -79,6 +83,10 @@ jobs:
       - run:
           name: Fetch Submodules
           command: git submodule update --init --recursive
+      - restore_cache:
+          keys:
+          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-cache-
       - run:
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
@@ -111,6 +119,10 @@ jobs:
       # workspaces, but that seemed to have a negligible effect on speed. It's
       # also tricky to pick specific sub directories since the API deploy
       # touches several top level folders {common,}api.
+      - restore_cache:
+          keys:
+          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-cache-
       - run:
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
@@ -151,6 +163,10 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
+      - restore_cache:
+          keys:
+          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-integration-cache-
       - run:
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
@@ -178,6 +194,10 @@ jobs:
               echo No relevant changes on non-master branch, skipping
               circleci step halt
             fi
+      - restore_cache:
+          keys:
+          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-integration-cache-
       - run:
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
@@ -273,6 +293,10 @@ jobs:
       - checkout
       - run:
           command: git submodule update --init --recursive
+      - restore_cache:
+          keys:
+          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-cache-
       - deploy:
           working_directory: ~/workbench/deploy
           command: |
@@ -292,6 +316,10 @@ jobs:
       - checkout
       - run:
           command: git submodule update --init --recursive
+      - restore_cache:
+          keys:
+          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-cache-
       - deploy:
           working_directory: ~/workbench/deploy
           command: |

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -781,6 +781,7 @@ task updateCdrVersions(type: JavaExec) {
   }
 }
 
+// This can be run directly or via the deploy command.
 task loadDataDictionary(type: JavaExec) {
   classpath sourceSets.tools.runtimeClasspath
   main = "org.pmiops.workbench.tools.LoadDataDictionary"

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -47,8 +47,3 @@ ENV PATH="/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 
 # Force a lower concurrent-ruby version, as we only have Ruby 2.3.
 RUN sudo gem install jira-ruby
-
-# Create a gradle cache directory as a volume that can be read/written by any
-# container (including containers running as any user -- hence the a+rwx)
-RUN sudo mkdir /.gradle && sudo chmod a+rwx -R /.gradle
-ENV GRADLE_USER_HOME /.gradle

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   deploy:
-    image: allofustest/workbench:buildimage-0.0.15
+    image: allofustest/workbench:buildimage-0.0.16
     entrypoint: /bootstrap-docker.sh
     user: circleci
     environment:


### PR DESCRIPTION
Reverts gradle home changes per https://github.com/all-of-us/workbench/pull/3217 .

I can't currently explain why that didn't work, but it was just a nice-to-have and should be safe to revert. build.gradle needed to be modified in this PR in order to invalidate the previous cache version (based on build.gradle checksum).

In this case we actually had a bad cached artifact. To force a new rebuild of the cache, I used this commit: https://github.com/all-of-us/workbench/pull/3238/commits/f6cb6aa677b8ad65fc70f37ce4ca7454dd0299fa