### PR TITLE
[RW-4558][risk=no] Add Google Analytics events for featured workspaces

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -78,7 +78,11 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
       <React.Fragment>
         <MenuItem icon='copy'
                   onClick={() => {
-                    AnalyticsTracker.Workspaces.OpenDuplicatePage('Card');
+                    // Using workspace.published here to identify Featured Workspaces. At some point, we will need a separate property for
+                    // this on the workspace object once users are able to publish their own workspaces
+                    workspace.published ?
+                      AnalyticsTracker.Workspaces.DuplicateFeatured(workspace.name) :
+                      AnalyticsTracker.Workspaces.OpenDuplicatePage('Card');
                     navigate([wsPathPrefix, 'duplicate']); }
                   }>
           Duplicate
@@ -256,7 +260,11 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
                   <div style={styles.workspaceName}
                        data-test-id='workspace-card-name'
                        onClick={() => {
-                         triggerEvent(EVENT_CATEGORY, 'navigate', 'Click on workspace name');
+                         // Using workspace.published here to identify Featured Workspaces. At some point, we will need a separate property
+                         // for this on the workspace object once users are able to publish their own workspaces
+                         workspace.published ?
+                          AnalyticsTracker.Workspaces.NavigateToFeatured(workspace.name) :
+                          triggerEvent(EVENT_CATEGORY, 'navigate', 'Click on workspace name');
                          navigate(['workspaces', workspace.namespace, workspace.id, 'data']);
                        }}>
                     {workspace.name}</div>

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -31,6 +31,7 @@ export function triggerEvent(
 
 enum ANALYTICS_CATEGORIES {
   WORKSPACES = 'Workspaces',
+  FEATURED_WORKSPACES = 'Featured Workspaces',
   DATASET_BUILDER = 'Dataset Builder',
   NOTEBOOKS = 'Notebooks',
   SIDEBAR = 'Sidebar Menu',
@@ -43,6 +44,10 @@ export const AnalyticsTracker = {
     Create: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Create'),
     OpenDuplicatePage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Duplicate Page', getCurrentPageLabel(suffix)),
     Duplicate: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Duplicate'),
+    DuplicateFeatured: (name) =>
+      triggerEvent(ANALYTICS_CATEGORIES.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - Duplicate - ${name}`),
+    NavigateToFeatured: (name) =>
+      triggerEvent(ANALYTICS_CATEGORIES.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - ${name}`),
     OpenEditPage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Edit Page', getCurrentPageLabel(suffix)),
     Edit: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Edit'),
     OpenShareModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Share Modal', getCurrentPageLabel(suffix)),


### PR DESCRIPTION
Add new events to use only with featured workspaces. 

Events based on Library tab of the [analytics doc](https://docs.google.com/spreadsheets/d/1V_Zp0ZtN8f237LNcaGQA-WZzYJu9g8ECq80gJCV8njA/edit#gid=51478853) with the change of using 'Featured Workspaces' for all events instead of specifying 'Phenotype' or 'Tutorial.'

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
