### PR TITLE
[RW-4412][RISK=NO]Format Dataset builder SQL query for readability

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.engine.jdbc.internal.BasicFormatterImpl;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
@@ -675,7 +676,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   private static String generateSqlWithEnvironmentVariables(
       String query, KernelTypeEnum kernelTypeEnum) {
-    return query.replaceAll(CDR_STRING, KERNEL_TYPE_TO_ENV_VARIABLE_MAP.get(kernelTypeEnum));
+    return new BasicFormatterImpl()
+        .format(query.replaceAll(CDR_STRING, KERNEL_TYPE_TO_ENV_VARIABLE_MAP.get(kernelTypeEnum)));
   }
 
   // This takes the query, and string replaces in the values for each of the named

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -886,7 +886,9 @@ public class DataSetControllerTest {
             .generateCode(
                 workspace.getNamespace(), WORKSPACE_NAME, KernelTypeEnum.PYTHON.toString(), dataSet)
             .getBody();
-    assertThat(response.getCode()).contains("UNION\n" + "                        DISTINCT ");
+
+    assertThat(response.getCode()).containsMatch("UNION");
+    assertThat(response.getCode()).containsMatch("DISTINCT SELECT");
   }
 
   @Test
@@ -925,13 +927,14 @@ public class DataSetControllerTest {
          }
        }
     */
+
+    String queryToVerify = sqlFormatter.format("SELECT PERSON_ID FROM `all-of-us-ehr-dev.synthetic_cdr20180606.person` person");
     assertThat(response.getCode())
-        .contains(
-            sqlFormatter.format(
-                "person_sql = \"\"\"SELECT PERSON_ID FROM `" + TEST_CDR_TABLE + ".person` person"));
+        .contains("person_sql = ");
+    assertThat(response.getCode().contains(queryToVerify));
     // For demographic unlike other domains WHERE should be followed by person.person_id rather than
     // concept_id
-    assertThat(response.getCode()).contains("WHERE person.PERSON_ID");
+    assertThat(response.getCode()).contains("person.PERSON_ID IN (");
   }
 
   @Rule public ExpectedException expectedException = ExpectedException.none();


### PR DESCRIPTION
I used hibernate's BasicFormatterImpl that formats the SQL hence now we have query from dataset as follows in notebook 

For R: 

<img width="1028" alt="Screen Shot 2020-03-12 at 11 01 36 PM" src="https://user-images.githubusercontent.com/34481816/76585847-d4301300-64b5-11ea-983f-9e03b94c8a5b.png">

For python
<img width="1187" alt="Screen Shot 2020-03-12 at 10 58 28 PM" src="https://user-images.githubusercontent.com/34481816/76585854-de521180-64b5-11ea-81ca-5a5593604c65.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
