### PR TITLE
[RW-4525][risk=no] Fix input width issues in user registration form

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -27,7 +27,7 @@ const styles = reactStyles({
     fontSize: 12,
     fontWeight: 400
   },
-  dropdown: {
+  wideInputSize: {
     width: '50%',
     minWidth: '600px'
   },
@@ -202,7 +202,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
             </div>
             <Dropdown
                 data-test-id='institution-dropdown'
-                style={styles.dropdown}
+                style={styles.wideInputSize}
                 options={institutions.map(inst => ({'value': inst.shortName, 'label': inst.displayName}))}
                 value={institutionShortName}
                 onChange={(e) => {
@@ -226,6 +226,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
                                 value={contactEmail}
                                 inputId='contact-email'
                                 inputName='contactEmail'
+                                inputStyle={{width: '14rem'}}
                                 labelContent={<div>
                                   <label style={styles.boldText}>
                                     Your institutional email address
@@ -251,7 +252,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
               </label>
               <div>
                 <Dropdown data-test-id='role-dropdown'
-                          style={styles.dropdown}
+                          style={styles.wideInputSize}
                           placeholder={this.getRoleOptions() ?
                             '' : 'First select an institution above'}
                           options={this.getRoleOptions()}
@@ -267,6 +268,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
                 </i>
               </label>
               <TextInputWithLabel value={institutionalRoleOtherText}
+                                  inputStyle={styles.wideInputSize}
                                   inputId='institutionalRoleOtherText'
                                   inputName='institutionalRoleOtherText'
                                   onChange={v => this.updateAffiliationValue('institutionalRoleOtherText', v)}/>

--- a/ui/src/app/pages/login/account-creation/common.tsx
+++ b/ui/src/app/pages/login/account-creation/common.tsx
@@ -51,7 +51,7 @@ export const commonStyles = reactStyles({
     fontSize: 18,
   },
   sectionInput: {
-    width: '14rem',
+    width: '12rem',
     height: '1.5rem'
   },
 });
@@ -77,7 +77,7 @@ export const WhyWillSomeInformationBePublic: React.FunctionComponent = () => {
  * @constructor
  */
 export function TextInputWithLabel(props) {
-  return <div style={{width: '12rem', ...props.containerStyle}}>
+  return <div style={{...props.containerStyle}}>
     {props.labelContent}
     {props.labelText && <label style={{...commonStyles.text, fontWeight: 600}}>{props.labelText}</label>}
     <div style={{marginTop: '0.1rem'}}>


### PR DESCRIPTION
There was a visual regression with https://github.com/all-of-us/workbench/pull/3251, where the input fields for the second registration step were off. This PR fixes that.

Screenshot demonstrating the issue: 

<img width="866" alt="Screen Shot 2020-03-16 at 2 55 53 PM" src="https://user-images.githubusercontent.com/51842/76790974-4181c380-6796-11ea-94a8-f85202d3d9da.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
