### PR TITLE
[RW-4569][risk=no] Add user-facing error message when user creation fails

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.spec.tsx
@@ -1,4 +1,4 @@
-import {mount} from 'enzyme';
+import {mount, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 
 import {
@@ -8,21 +8,32 @@ import {
 import {serverConfigStore} from 'app/utils/navigation';
 import {Ethnicity, GenderIdentity, Race, SexAtBirth} from 'generated/fetch';
 import {createEmptyProfile} from 'app/pages/login/sign-in';
+import {profileApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {ProfileApi} from 'generated/fetch';
+import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
+import SpyInstance = jest.SpyInstance;
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 
 let props: AccountCreationSurveyProps;
-const onCompleteSpy = jest.fn();
-const onPreviousSpy = jest.fn();
+let mockCreateAccount: SpyInstance;
 
 const defaultConfig = {gsuiteDomain: 'researchallofus.org', enableNewAccountCreation: true};
+
+function getSubmitButton(wrapper: ReactWrapper): ReactWrapper {
+  return wrapper.find('[data-test-id="submit-button"]');
+}
 
 beforeEach(() => {
   serverConfigStore.next(defaultConfig);
 
+  registerApiClient(ProfileApi, new ProfileApiStub());
+  mockCreateAccount = jest.spyOn(profileApi(), 'createAccount');
+
   props = {
     invitationKey: 'asdf',
     profile: createEmptyProfile(),
-    onPreviousClick: onPreviousSpy,
-    onComplete: onCompleteSpy,
+    onPreviousClick: () => {},
+    onComplete: () => {},
   };
 });
 
@@ -57,4 +68,29 @@ it('should load existing profile data', async() => {
 
   // Ethnicity
   expect(wrapper.find('[data-test-id="dropdown-ethnicity"]').prop('value')).toEqual(Ethnicity.HISPANIC);
+});
+
+it('should handle error when creating an account', async() => {
+  const errorResponseJson = {
+    message: 'Could not create account: invalid institutional affiliation',
+    statusCode: 412
+  };
+  mockCreateAccount.mockRejectedValueOnce(
+    new Response(JSON.stringify(errorResponseJson), {status: 412}));
+
+  const wrapper = mount(<AccountCreationSurvey {...props} />);
+  // Note: mostly unrelated to this test, but here we call a method to 'register' a Captcha response.
+  // Without this, the submit button won't work since it's disabled until captcha is complete.
+  const surveyComponent: AccountCreationSurvey = wrapper.instance() as AccountCreationSurvey;
+  surveyComponent.captureCaptchaResponse('asdf');
+
+  getSubmitButton(wrapper).simulate('click');
+  // We need to await one tick to allow async processing of the error response to resolve.
+  await waitOneTickAndUpdate(wrapper);
+
+  const errorModal = wrapper.find('Modal[data-test-id="create-account-error"]');
+  // Ensure the error modal contains explanatory intro text.
+  expect(errorModal.getDOMNode().textContent).toContain('An error occurred while creating your account');
+  // Ensure the error modal contains the server-side error message.
+  expect(errorModal.getDOMNode().textContent).toContain('Could not create account: invalid institutional affiliation');
 });

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -76,7 +76,6 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
   createAccount(): void {
     const {invitationKey, termsOfServiceVersion, onComplete} = this.props;
     this.setState({creatingAccount: true});
-    console.log('creating account...', invitationKey);
     profileApi().createAccount({
       profile: this.state.profile,
       captchaVerificationToken: this.state.captchaToken,

--- a/ui/src/app/utils/errors.tsx
+++ b/ui/src/app/utils/errors.tsx
@@ -1,4 +1,4 @@
-import {ErrorCode} from 'generated/fetch';
+import {ErrorCode, ErrorResponse} from 'generated/fetch';
 import {StackdriverErrorReporter} from 'stackdriver-errors-js';
 
 let stackdriverReporter: StackdriverErrorReporter;
@@ -33,7 +33,7 @@ export function isAbortError(e: Error) {
 }
 
 // convert error response from API JSON to ErrorResponse object, otherwise, report parse error
-export async function convertAPIError(e) {
+export async function convertAPIError(e): Promise<ErrorResponse> {
   try {
     const {errorClassName = null,
       errorCode = null,

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -1,12 +1,12 @@
 import {
   AccessBypassRequest,
-  AccessModule,
+  AccessModule, CreateAccountRequest,
   DataAccessLevel,
   InstitutionalRole,
   InvitationVerificationRequest,
   NihToken,
   Profile,
-  ProfileApi
+  ProfileApi,
 } from 'generated/fetch';
 
 import {EmptyResponse} from 'generated/fetch/api';
@@ -59,6 +59,10 @@ export class ProfileApiStub extends ProfileApi {
       const err = new Error('Invalid invitation code');
       return Promise.reject(response => { throw err; });
     }
+  }
+
+  public createAccount(request?: CreateAccountRequest, options?: any): Promise<Profile> {
+    return Promise.resolve(this.profile);
   }
 
   public updateNihToken(token?: NihToken, options?: any) {


### PR DESCRIPTION
Currently, all we do on a server-side error during user registration is console.error the response.

This PR adds a modal dialog, similar in spirit to what we have for failed workspace creation.

Screenshot:

<img width="493" alt="Screen Shot 2020-03-15 at 10 45 14 PM" src="https://user-images.githubusercontent.com/51842/76797147-47ca6c80-67a3-11ea-8799-d7a8ff17ab49.png">

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally