### PR TITLE
[RW-4563][RISK=NO] Minor changes to registration steps screen

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import {SignInGuard} from './guards/sign-in-guard.service';
 
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
-import {DataUseAgreementComponent} from 'app/pages/profile/data-use-agreement';
+import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import {UserDisabledComponent} from 'app/pages/user-disabled';
 import {AdminBannerComponent} from './pages/admin/admin-banner';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
@@ -72,8 +72,8 @@ const routes: Routes = [
         data: {title: 'Homepage'},
       }, {
         path: 'data-code-of-conduct',
-        component: DataUseAgreementComponent,
-        data: {title: 'Data Code of Conduct'}
+        component: DataUserCodeOfConduct,
+        data: {title: 'Data User Code of Conduct'}
       }, {
         path: 'library',
         component: WorkspaceLibraryComponent,

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import {SignInGuard} from './guards/sign-in-guard.service';
 
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
-import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
+import {DataUserCodeOfConductComponent} from 'app/pages/profile/data-user-code-of-conduct';
 import {UserDisabledComponent} from 'app/pages/user-disabled';
 import {AdminBannerComponent} from './pages/admin/admin-banner';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
@@ -72,7 +72,7 @@ const routes: Routes = [
         data: {title: 'Homepage'},
       }, {
         path: 'data-code-of-conduct',
-        component: DataUserCodeOfConduct,
+        component: DataUserCodeOfConductComponent,
         data: {title: 'Data User Code of Conduct'}
       }, {
         path: 'library',

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -71,9 +71,9 @@ const routes: Routes = [
         component: HomepageComponent,
         data: {title: 'Homepage'},
       }, {
-        path: 'data-use-agreement',
+        path: 'data-code-of-conduct',
         component: DataUseAgreementComponent,
-        data: {title: 'Data Use Agreement'}
+        data: {title: 'Data Code of Conduct'}
       }, {
         path: 'library',
         component: WorkspaceLibraryComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -42,7 +42,7 @@ import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-detai
 import {HomepageComponent} from './pages/homepage/homepage';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignInComponent} from './pages/login/sign-in';
-import {DataUserCodeOfConduct} from './pages/profile/data-user-code-of-conduct';
+import {DataUserCodeOfConductComponent} from './pages/profile/data-user-code-of-conduct';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
@@ -145,7 +145,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     CreateReviewModalComponent,
     DataPageComponent,
     DataSetPageComponent,
-    DataUserCodeOfConduct,
+    DataUserCodeOfConductComponent,
     DetailPageComponent,
     HelpSidebarComponent,
     InitialErrorComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -42,7 +42,7 @@ import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-detai
 import {HomepageComponent} from './pages/homepage/homepage';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignInComponent} from './pages/login/sign-in';
-import {DataUseAgreementComponent} from './pages/profile/data-use-agreement';
+import {DataUserCodeOfConduct} from './pages/profile/data-user-code-of-conduct';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
@@ -145,7 +145,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     CreateReviewModalComponent,
     DataPageComponent,
     DataSetPageComponent,
-    DataUseAgreementComponent,
+    DataUserCodeOfConduct,
     DetailPageComponent,
     HelpSidebarComponent,
     InitialErrorComponent,

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -185,7 +185,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
       this.setState({
         eraCommonsLinked: !!(getRegistrationTasksMap()['eraCommons'].completionTimestamp(profile)),
         dataUseAgreementCompleted: (serverConfigStore.getValue().enableDataUseAgreement ?
-          (() => !!(getRegistrationTasksMap()['dataUseAgreement']
+          (() => !!(getRegistrationTasksMap()['dataUserCodeOfConduct']
             .completionTimestamp(profile)))() : true)
       });
       this.setState({betaAccessGranted: !!profile.betaAccessBypassTime});

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -70,7 +70,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
   { accessTasksLoaded: boolean,
     accessTasksRemaining: boolean,
     betaAccessGranted: boolean,
-    dataUseAgreementCompleted: boolean,
+    dataUserCodeOfConductCompleted: boolean,
     eraCommonsError: string,
     eraCommonsLinked: boolean,
     firstVisit: boolean,
@@ -91,7 +91,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
       accessTasksLoaded: false,
       accessTasksRemaining: undefined,
       betaAccessGranted: undefined,
-      dataUseAgreementCompleted: undefined,
+      dataUserCodeOfConductCompleted: undefined,
       eraCommonsError: '',
       eraCommonsLinked: undefined,
       firstVisit: undefined,
@@ -184,7 +184,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
       this.setState({
         eraCommonsLinked: !!(getRegistrationTasksMap()['eraCommons'].completionTimestamp(profile)),
-        dataUseAgreementCompleted: (serverConfigStore.getValue().enableDataUseAgreement ?
+        dataUserCodeOfConductCompleted: (serverConfigStore.getValue().enableDataUseAgreement ?
           (() => !!(getRegistrationTasksMap()['dataUserCodeOfConduct']
             .completionTimestamp(profile)))() : true)
       });
@@ -225,7 +225,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
   render() {
     const {betaAccessGranted, videoOpen, accessTasksLoaded, accessTasksRemaining,
       eraCommonsLinked, eraCommonsError, firstVisitTraining, trainingCompleted, quickTour,
-      videoLink, twoFactorAuthCompleted, dataUseAgreementCompleted
+      videoLink, twoFactorAuthCompleted, dataUserCodeOfConductCompleted
     } = this.state;
 
     const quickTourResources = [
@@ -275,7 +275,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
                                             firstVisitTraining={firstVisitTraining}
                                             betaAccessGranted={betaAccessGranted}
                                             twoFactorAuthCompleted={twoFactorAuthCompleted}
-                                          dataUseAgreementCompleted={dataUseAgreementCompleted}/>
+                                          dataUserCodeOfConductCompleted={dataUserCodeOfConductCompleted}/>
                     ) : (
                         <React.Fragment>
                           <FlexColumn>

--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -31,7 +31,7 @@ describe('RegistrationDashboard', () => {
       firstVisitTraining: true,
       betaAccessGranted: true,
       twoFactorAuthCompleted: false,
-      dataUseAgreementCompleted: false
+      dataUserCodeOfConductCompleted: false
     };
   });
 
@@ -77,7 +77,7 @@ describe('RegistrationDashboard', () => {
     props.eraCommonsLinked = true;
     props.trainingCompleted = true;
     props.twoFactorAuthCompleted = true;
-    props.dataUseAgreementCompleted = true;
+    props.dataUserCodeOfConductCompleted = true;
     const wrapper = component();
     expect(wrapper.find('[data-test-id="success-message"]').length).toBe(1);
   });

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -130,7 +130,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     key: 'dataUseAgreement',
     completionPropsKey: 'dataUseAgreementCompleted',
     title: 'Data User Code of Conduct',
-    description: <span>Sign the data user code of conduct consenting to the <i> All of Us data </i> use policy.</span>,
+    description: <span>Sign the data user code of conduct consenting to the <i>All of Us</i> data use policy.</span>,
     buttonText: 'View & Sign',
     featureFlag: serverConfigStore.getValue().enableDataUseAgreement,
     completedText: 'Signed',

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -107,7 +107,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     completionPropsKey: 'eraCommonsLinked',
     title: 'Connect Your eRA Commons Account',
     description: 'Connect your account to the eRA Commons account. The application instructions will guide you through this.',
-    buttonText: 'Login',
+    buttonText: 'Connect',
     completedText: 'Linked',
     completionTimestamp: (profile: Profile) => {
       return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
@@ -127,7 +127,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     },
     onClick: redirectToTraining
   }, {
-    key: 'dataUseAgreement',
+    key: 'dataUserCodeOfConduct',
     completionPropsKey: 'dataUseAgreementCompleted',
     title: 'Data User Code of Conduct',
     description: <span>Sign the data user code of conduct consenting to the <i>All of Us</i> data use policy.</span>,

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -128,7 +128,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     onClick: redirectToTraining
   }, {
     key: 'dataUserCodeOfConduct',
-    completionPropsKey: 'dataUseAgreementCompleted',
+    completionPropsKey: 'dataUserCodeOfConductCompleted',
     title: 'Data User Code of Conduct',
     description: <span>Sign the data user code of conduct consenting to the <i>All of Us</i> data use policy.</span>,
     buttonText: 'View & Sign',
@@ -156,7 +156,7 @@ export interface RegistrationDashboardProps {
   trainingCompleted: boolean;
   firstVisitTraining: boolean;
   twoFactorAuthCompleted: boolean;
-  dataUseAgreementCompleted: boolean;
+  dataUserCodeOfConductCompleted: boolean;
 }
 
 interface State {

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -65,12 +65,12 @@ function redirectToNiH(): void {
   const url = environment.shibbolethUrl + '/link-nih-account?redirect-url=' +
           encodeURIComponent(
             window.location.origin.toString() + '/nih-callback?token={token}');
-  window.location.assign(url);
+  window.open(url, '_blank');
 }
 
 async function redirectToTraining() {
   await profileApi().updatePageVisits({page: 'moodle'});
-  window.location.assign(environment.trainingUrl + '/static/data-researcher.html?saml=on');
+  window.open(environment.trainingUrl + '/static/data-researcher.html?saml=on', '_blank');
 }
 
 interface RegistrationTask {
@@ -103,10 +103,22 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     },
     onClick: redirectToGoogleSecurity
   }, {
+    key: 'eraCommons',
+    completionPropsKey: 'eraCommonsLinked',
+    title: 'Connect Your eRA Commons Account',
+    description: 'Connect your account to the eRA Commons account. The application instructions will guide you through this.',
+    buttonText: 'Login',
+    completedText: 'Linked',
+    completionTimestamp: (profile: Profile) => {
+      return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
+    },
+    onClick: redirectToNiH
+  }, {
     key: 'complianceTraining',
     completionPropsKey: 'trainingCompleted',
-    title: 'Complete Online Training',
-    description: 'Complete mandatory compliance training courses on how data should be used and handled.',
+    title: 'Complete Ethics training',
+    description: <div>Complete ethics training courses to understand the privacy safeguards and the
+      compliance requirements for using the <i>All of Us</i> Dataset.</div>,
     buttonText: 'Complete training',
     featureFlag: serverConfigStore.getValue().enableComplianceTraining,
     completedText: 'Completed',
@@ -115,21 +127,10 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     },
     onClick: redirectToTraining
   }, {
-    key: 'eraCommons',
-    completionPropsKey: 'eraCommonsLinked',
-    title: 'Login to eRA Commons',
-    description: 'Link to your eRA Commons account to the workbench to gain full access to data and tools.',
-    buttonText: 'Login',
-    completedText: 'Linked',
-    completionTimestamp: (profile: Profile) => {
-      return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
-    },
-    onClick: redirectToNiH
-  }, {
     key: 'dataUseAgreement',
     completionPropsKey: 'dataUseAgreementCompleted',
-    title: 'Data Use Agreement',
-    description: <span>Sign our data use agreement consenting to the <i>All of Us</i> data use policy.</span>,
+    title: 'Data User Code of Conduct',
+    description: <span>Sign the data user code of conduct consenting to the <i> All of Us data </i> use policy.</span>,
     buttonText: 'View & Sign',
     featureFlag: serverConfigStore.getValue().enableDataUseAgreement,
     completedText: 'Signed',
@@ -253,7 +254,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
     // it within the registration box.
     return <FlexColumn style={{position: 'relative'}} data-test-id='registration-dashboard'>
       {bypassInProgress && <SpinnerOverlay />}
-      <div style={styles.mainHeader}>Getting Started</div>
+      <div style={styles.mainHeader}>Complete Registration</div>
       {canUnsafeSelfBypass &&
         <div data-test-id='self-bypass'
              style={{...baseStyles.card, ...styles.warningModal, margin: '0.85rem 0 0'}}>

--- a/ui/src/app/pages/profile/data-use-agreement.spec.tsx
+++ b/ui/src/app/pages/profile/data-use-agreement.spec.tsx
@@ -1,7 +1,7 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 
-import {DataUseAgreement} from 'app/pages/profile/data-use-agreement';
+import {DataUseAgreement} from 'app/pages/profile/data-user-code-of-conduct';
 import {profileApi, registerApiClient} from 'app/services/swagger-fetch-clients';
 import {userProfileStore} from 'app/utils/navigation';
 import {Profile, ProfileApi} from 'generated/fetch';

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -83,7 +83,7 @@ export const DataUseAgreement = withUserProfile()(
 @Component({
   template: '<div #root></div>'
 })
-export class DataUseAgreementComponent extends ReactWrapperBase {
+export class DataUserCodeOfConduct extends ReactWrapperBase {
   constructor() {
     super(DataUseAgreement, []);
   }

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -83,7 +83,7 @@ export const DataUseAgreement = withUserProfile()(
 @Component({
   template: '<div #root></div>'
 })
-export class DataUserCodeOfConduct extends ReactWrapperBase {
+export class DataUserCodeOfConductComponent extends ReactWrapperBase {
   constructor() {
     super(DataUseAgreement, []);
   }

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -398,13 +398,13 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
           </ProfileRegistrationStepStatus>}
 
           {enableDataUseAgreement && <ProfileRegistrationStepStatus
-            title='Data Use Agreement'
+            title='Data User Code Of Conduct'
             wasBypassed={!!profile.dataUseAgreementBypassTime}
             incompleteButtonText='Sign'
-            completedButtonText={getRegistrationTasksMap()['dataUseAgreement'].completedText}
-            completionTimestamp={getRegistrationTasksMap()['dataUseAgreement'].completionTimestamp(profile)}
-            isComplete={!!(getRegistrationTasksMap()['dataUseAgreement'].completionTimestamp(profile))}
-            completeStep={getRegistrationTasksMap()['dataUseAgreement'].onClick} >
+            completedButtonText={getRegistrationTasksMap()['dataUserCodeOfConduct'].completedText}
+            completionTimestamp={getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile)}
+            isComplete={!!(getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile))}
+            completeStep={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick} >
             {profile.dataUseAgreementCompletionTime != null && <React.Fragment>
               <div> Agreement Renewal: </div>
               <div>
@@ -414,7 +414,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
               </div>
             </React.Fragment>}
             <a
-              onClick={getRegistrationTasksMap()['dataUseAgreement'].onClick}>
+              onClick={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}>
               View current agreement
             </a>
           </ProfileRegistrationStepStatus>}


### PR DESCRIPTION
Following changes were done 

- Data user Agreement is changed “Data User Code of Conduct” ( Just the title and url assumption the file name etc changes will be done by 4561 if not i can change it here)

- the order for registration is now Two factor -> ERA Commons -> Compliance Training ->  Data Code of Conduct

- All external links (NIH, Ethics etc) from registration will open in a new tab 

- Some text and description changes

<img width="1240" alt="Screen Shot 2020-03-16 at 6 21 17 PM" src="https://user-images.githubusercontent.com/34481816/76805258-be239a80-67b4-11ea-9a22-3c72edf44349.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
