### PR TITLE
[RW-4524][risk=no] Add in-form institution check to user creation page.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -4,6 +4,8 @@ import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.CheckEmailResponse;
+import org.pmiops.workbench.model.CheckInstitutionResponse;
 import org.pmiops.workbench.model.GetInstitutionsResponse;
 import org.pmiops.workbench.model.GetPublicInstitutionDetailsResponse;
 import org.pmiops.workbench.model.Institution;
@@ -56,14 +58,33 @@ public class InstitutionController implements InstitutionApiDelegate {
     return ResponseEntity.ok(response);
   }
 
-  // note: this endpoint is publicly accessible because it is needed for account creation
-
+  /**
+   * This API is publicly-accessible since it is called during account creation.
+   * @return
+   */
   @Override
   public ResponseEntity<GetPublicInstitutionDetailsResponse> getPublicInstitutionDetails() {
     final GetPublicInstitutionDetailsResponse response =
         new GetPublicInstitutionDetailsResponse()
             .institutions(institutionService.getPublicInstitutionDetails());
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * This API is publicly-accessible since it is called during account creation.
+   * @return
+   */
+  public ResponseEntity<CheckEmailResponse> checkEmail(String email, String institutionShortName) {
+    final Institution institution =
+        institutionService
+            .getInstitution(institutionShortName)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        String.format("Could not find Institution '%s'", institutionShortName)));
+    return ResponseEntity.ok(
+        new CheckEmailResponse()
+            .isValidMember(institutionService.validateInstitutionalEmail(institution, email)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -22,6 +22,14 @@ public class InstitutionController implements InstitutionApiDelegate {
     this.institutionService = institutionService;
   }
 
+  private Institution getInstitutionImpl(final String shortName) {
+    return institutionService
+        .getInstitution(shortName)
+        .orElseThrow(
+            () ->
+                new NotFoundException(String.format("Could not find Institution '%s'", shortName)));
+  }
+
   @Override
   @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<Institution> createInstitution(final Institution institution) {
@@ -38,15 +46,7 @@ public class InstitutionController implements InstitutionApiDelegate {
   @Override
   @AuthorityRequired({Authority.INSTITUTION_ADMIN})
   public ResponseEntity<Institution> getInstitution(final String shortName) {
-    final Institution institution =
-        institutionService
-            .getInstitution(shortName)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format("Could not find Institution '%s'", shortName)));
-
-    return ResponseEntity.ok(institution);
+    return ResponseEntity.ok(getInstitutionImpl(shortName));
   }
 
   @Override
@@ -58,9 +58,9 @@ public class InstitutionController implements InstitutionApiDelegate {
   }
 
   /**
-   * This API is publicly-accessible since it is called during account creation.
+   * Note: this API is publicly-accessible since it is called during account creation.
    *
-   * @return
+   * @return Returns publicly-accessible details about all institutions currently in the system.
    */
   @Override
   public ResponseEntity<GetPublicInstitutionDetailsResponse> getPublicInstitutionDetails() {
@@ -71,21 +71,17 @@ public class InstitutionController implements InstitutionApiDelegate {
   }
 
   /**
-   * This API is publicly-accessible since it is called during account creation.
+   * Note: this API is publicly-accessible since it is called during account creation.
    *
-   * @return
+   * @return Returns whether the email is a valid institutional member.
    */
+  @Override
   public ResponseEntity<CheckEmailResponse> checkEmail(final String shortName, final String email) {
-    final Institution institution =
-        institutionService
-            .getInstitution(shortName)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format("Could not find Institution '%s'", shortName)));
     return ResponseEntity.ok(
         new CheckEmailResponse()
-            .isValidMember(institutionService.validateInstitutionalEmail(institution, email)));
+            .isValidMember(
+                institutionService.validateInstitutionalEmail(
+                    getInstitutionImpl(shortName), email)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -5,7 +5,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CheckEmailResponse;
-import org.pmiops.workbench.model.CheckInstitutionResponse;
 import org.pmiops.workbench.model.GetInstitutionsResponse;
 import org.pmiops.workbench.model.GetPublicInstitutionDetailsResponse;
 import org.pmiops.workbench.model.Institution;
@@ -60,6 +59,7 @@ public class InstitutionController implements InstitutionApiDelegate {
 
   /**
    * This API is publicly-accessible since it is called during account creation.
+   *
    * @return
    */
   @Override
@@ -72,16 +72,17 @@ public class InstitutionController implements InstitutionApiDelegate {
 
   /**
    * This API is publicly-accessible since it is called during account creation.
+   *
    * @return
    */
-  public ResponseEntity<CheckEmailResponse> checkEmail(String email, String institutionShortName) {
+  public ResponseEntity<CheckEmailResponse> checkEmail(final String shortName, final String email) {
     final Institution institution =
         institutionService
-            .getInstitution(institutionShortName)
+            .getInstitution(shortName)
             .orElseThrow(
                 () ->
                     new NotFoundException(
-                        String.format("Could not find Institution '%s'", institutionShortName)));
+                        String.format("Could not find Institution '%s'", shortName)));
     return ResponseEntity.ok(
         new CheckEmailResponse()
             .isValidMember(institutionService.validateInstitutionalEmail(institution, email)));

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -25,12 +25,13 @@ public interface InstitutionService {
       final String shortName, final Institution institutionToUpdate);
 
   /**
-   * Validates that the user's institutional affiliation is valid, by pattern-matching the user's
-   * contact email against the institution's set of whitelisted email domains or addresses. If the
-   * user has no affiliation (null) then it will return false
+   * Checks that the user's institutional affiliation is valid by calling
+   * validateInstitutionalEmail. See Javadoc below for implementation notes.
+   *
+   * <p>If dbAffiliation is null, this method will return false.
    *
    * @param dbAffiliation the user's declared affiliation
-   * @param contactEmail the contact email to verify
+   * @param contactEmail the contact email to validate
    * @return boolean - does the affiliation pass validation?
    */
   boolean validateAffiliation(
@@ -39,8 +40,12 @@ public interface InstitutionService {
   /**
    * Checks whether a given email address is a valid member of an Institution.
    *
-   * @param institution
-   * @param contactEmail
+   * <p>Validation is done by comparing the contact email to the institution's set of whitelisted
+   * email domains and addresses. An exact match on either the domain or the email address is
+   * required.
+   *
+   * @param institution the institution to validate against
+   * @param contactEmail contact email to validate
    * @return boolean – is the contact email a valid member
    */
   boolean validateInstitutionalEmail(Institution institution, String contactEmail);

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -35,4 +35,13 @@ public interface InstitutionService {
    */
   boolean validateAffiliation(
       @Nullable DbVerifiedInstitutionalAffiliation dbAffiliation, String contactEmail);
+
+  /**
+   * Checks whether a given email address is a valid member of an Institution.
+   *
+   * @param institution
+   * @param contactEmail
+   * @return boolean – is the contact email a valid member
+   */
+  boolean validateInstitutionalEmail(Institution institution, String contactEmail);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -111,9 +111,12 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (dbAffiliation == null) {
       return false;
     }
+    return validateInstitutionalEmail(
+        institutionMapper.dbToModel(dbAffiliation.getInstitution()), contactEmail);
+  }
 
-    final Institution inst = institutionMapper.dbToModel(dbAffiliation.getInstitution());
-
+  @Override
+  public boolean validateInstitutionalEmail(Institution institution, String contactEmail) {
     try {
       // TODO RW-4489: UserService should handle initial email validation
       new InternetAddress(contactEmail).validate();
@@ -121,11 +124,11 @@ public class InstitutionServiceImpl implements InstitutionService {
       return false;
     }
 
-    if (inst.getEmailAddresses().contains(contactEmail)) {
+    if (institution.getEmailAddresses().contains(contactEmail)) {
       return true;
     }
 
     final String contactEmailDomain = contactEmail.substring(contactEmail.indexOf("@") + 1);
-    return inst.getEmailDomains().contains(contactEmailDomain);
+    return institution.getEmailDomains().contains(contactEmailDomain);
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2408,7 +2408,7 @@ paths:
           description: The updated Institution.
           schema:
             "$ref": "#/definitions/Institution"
-  "/v1/institutions/{shortName}/checkEmail/{email}":
+  "/v1/institutions/{shortName}/checkEmail/{email}/":
     parameters:
     - in: path
       name: shortName

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2324,23 +2324,17 @@ paths:
       tags:
       - institution
       description: 'Gets the list of all Institutions. Requires INSTITUTION_ADMIN
-        authority.
-
-'
+        authority.'
       operationId: getInstitutions
       responses:
         200:
-          description: 'A list of all Institutions
-
-'
+          description: 'A list of all Institutions'
           schema:
             "$ref": "#/definitions/GetInstitutionsResponse"
     post:
       tags:
       - institution
-      description: 'Create an Institution. Requires INSTITUTION_ADMIN authority.
-
-'
+      description: 'Create an Institution. Requires INSTITUTION_ADMIN authority.'
       operationId: createInstitution
       parameters:
       - in: body
@@ -2351,25 +2345,19 @@ paths:
           "$ref": "#/definitions/Institution"
       responses:
         200:
-          description: 'The Institution created by this operation.
-
-'
+          description: 'The Institution created by this operation.'
           schema:
             "$ref": "#/definitions/Institution"
   "/v1/institutions/publicDetails":
     get:
       tags:
       - institution
-      description: 'Gets the public details for the list of all Institutions.
-
-'
+      description: 'Gets the public details for the list of all Institutions.'
       operationId: getPublicInstitutionDetails
       security: []
       responses:
         200:
-          description: 'A list of all Institutions
-
-'
+          description: 'A list of all Institutions'
           schema:
             "$ref": "#/definitions/GetPublicInstitutionDetailsResponse"
   "/v1/institutions/{shortName}":
@@ -2378,45 +2366,35 @@ paths:
       name: shortName
       required: true
       type: string
-      description: A short unique name for the Institution used as an identifier,
-        such as 'VUMC'
+      description: 'A short unique name for the Institution used as an identifier,
+        such as "VUMC"'
     get:
       tags:
       - institution
       description: 'Gets the Institution corresponding to the shortName ID. Requires
-        INSTITUTION_ADMIN authority.
-
-'
+        INSTITUTION_ADMIN authority.'
       operationId: getInstitution
       responses:
         200:
-          description: 'The Institution corresponding to the shortName ID.
-
-'
+          description: 'The Institution corresponding to the shortName ID.'
           schema:
             "$ref": "#/definitions/Institution"
     delete:
       tags:
       - institution
       description: 'Deletes the Institution corresponding to the shortName ID. Requires
-        INSTITUTION_ADMIN authority.
-
-'
+        INSTITUTION_ADMIN authority.'
       operationId: deleteInstitution
       responses:
         204:
           description: 'Successful deletion of the Institution corresponding to the
-            shortName ID.
-
-'
+            shortName ID.'
         409:
           description: Could not delete the Institution because it has verified affiliations.
     patch:
       tags:
       - institution
-      description: 'Updates an Institution. Requires INSTITUTION_ADMIN authority.
-
-'
+      description: 'Updates an Institution. Requires INSTITUTION_ADMIN authority.'
       operationId: updateInstitution
       parameters:
       - in: body
@@ -2427,11 +2405,33 @@ paths:
           "$ref": "#/definitions/Institution"
       responses:
         200:
-          description: 'The updated Institution.
-
-'
+          description: The updated Institution.
           schema:
             "$ref": "#/definitions/Institution"
+  "/v1/institutions/{shortName}/checkEmail/{email}":
+    parameters:
+    - in: path
+      name: shortName
+      type: string
+      description: 'The short name / key of the institution to check, e.g. "VUMC"'
+      required: true
+    - in: path
+      name: email
+      type: string
+      description: Institutional contact email address to check.
+      required: true
+    get:
+      tags:
+        - institution
+      operationId: checkEmail
+      description: Checks whether the given email address is a verified member of an institution.
+      x-aou-note: This endpoint is publicly-accessible and called by clients during user registration.
+      security: []
+      responses:
+        200:
+          description: Whether the email is a valid member of the institution.
+          schema:
+            "$ref": "#/definitions/CheckEmailResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/getDataTableQuery":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
@@ -5269,6 +5269,14 @@ definitions:
         default: false
     example:
       isTaken: false
+
+  CheckEmailResponse:
+    type: object
+    properties:
+      isValidMember:
+        description: Whether the requested email address is a valid member of the institution.
+        type: boolean
+
   WorkspaceResponse:
     type: object
     required:
@@ -5279,6 +5287,7 @@ definitions:
         "$ref": "#/definitions/Workspace"
       accessLevel:
         "$ref": "#/definitions/WorkspaceAccessLevel"
+
   UserListResponse:
     type: object
     required:

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -257,10 +257,7 @@ public class InstitutionServiceTest {
                 .emailDomains(Lists.newArrayList("broad.org", "lab.broad.org")));
 
     final DbUser user = createUser("user@broad.org");
-    final DbVerifiedInstitutionalAffiliation affiliation =
-        createAffiliation(user, inst.getShortName());
-
-    assertThat(service.validateAffiliation(affiliation, user.getContactEmail())).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, user.getContactEmail())).isTrue();
   }
 
   @Test
@@ -275,10 +272,7 @@ public class InstitutionServiceTest {
                     Lists.newArrayList("external-researcher@sanger.uk", "science@aol.com")));
 
     final DbUser user = createUser("external-researcher@sanger.uk");
-    final DbVerifiedInstitutionalAffiliation affiliation =
-        createAffiliation(user, inst.getShortName());
-
-    assertThat(service.validateAffiliation(affiliation, user.getContactEmail())).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, user.getContactEmail())).isTrue();
   }
 
   @Test
@@ -288,10 +282,7 @@ public class InstitutionServiceTest {
             new Institution().shortName("Broad").displayName("The Broad Institute"));
 
     final DbUser user = userDao.save(new DbUser());
-    final DbVerifiedInstitutionalAffiliation affiliation =
-        createAffiliation(user, inst.getShortName());
-
-    assertThat(service.validateAffiliation(affiliation, user.getContactEmail())).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, user.getContactEmail())).isFalse();
   }
 
   @Test
@@ -303,10 +294,7 @@ public class InstitutionServiceTest {
             .emailDomains(Lists.newArrayList("broad.org", "mit.edu"));
 
     final DbUser user = createUser("external-researcher@sanger.uk");
-    final DbVerifiedInstitutionalAffiliation affiliation =
-        createAffiliation(user, inst.getShortName());
-
-    assertThat(service.validateAffiliation(affiliation, user.getContactEmail())).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, user.getContactEmail())).isFalse();
   }
 
   public void test_emailValidation_malformed() {
@@ -318,10 +306,7 @@ public class InstitutionServiceTest {
                 .emailDomains(Lists.newArrayList("broad.org", "lab.broad.org")));
 
     final DbUser user = createUser("user@hacker@broad.org");
-    final DbVerifiedInstitutionalAffiliation affiliation =
-        createAffiliation(user, inst.getShortName());
-
-    assertThat(service.validateAffiliation(affiliation, user.getContactEmail())).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, user.getContactEmail())).isFalse();
   }
 
   @Test

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -59,6 +59,9 @@ export const styles = {
     marginLeft: '-30px',
     minWidth: '30px',
     minHeight: '28px',
+    // Without explicit vertical align, this div is top-aligned when empty, which can cause some
+    // excess space above the input element and layout jitter when an icon becomes shown.
+    verticalAlign: 'middle',
   }
 };
 

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
@@ -172,6 +172,27 @@ it('should clear email validation when institution is changed', async() => {
   expect(getInstance(wrapper).validate()['checkEmailResponse']).toBeTruthy();
 });
 
+it('should trigger email check when email is filled in before choosing institution', async() => {
+  // This test ensures that a user can fill in their email address first, then choose an
+  // institution, and still be able to complete the form. This ensures that the institution change
+  // can trigger a checkEmail request.
+  const wrapper = component();
+  await waitOneTickAndUpdate(wrapper);
+
+  getEmailInput(wrapper).simulate('change', {target: {value: 'asdf@broadinstitute.org'}});
+  getEmailInput(wrapper).simulate('blur');
+  // This shouldn't strictly be needed here, since we expect the API request not to be sent due to
+  // no institution being chosen. But for consistency w/ other tests, it's included.
+  await waitOneTickAndUpdate(wrapper);
+
+  getInstitutionDropdown(wrapper).props.onChange({originalEvent: undefined, value: 'Broad'});
+  getRoleDropdown(wrapper).props.onChange({originalEvent: undefined, value: InstitutionalRole.EARLYCAREER});
+  await waitOneTickAndUpdate(wrapper);
+
+  // At this point, the form should be ready to submit.
+  expect(getInstance(wrapper).validate()).toBeUndefined();
+});
+
 
 it('should call callback with correct form data', async() => {
   let profile: Profile = null;

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
@@ -150,6 +150,29 @@ it('should validate email affiliation when inst and email are specified', async(
     .toContain('Email address is not a member of the selected institution');
 });
 
+it('should clear email validation when institution is changed', async() => {
+  const wrapper = component();
+  await waitOneTickAndUpdate(wrapper);
+
+  getInstitutionDropdown(wrapper).props.onChange({originalEvent: undefined, value: 'Broad'});
+  getEmailInput(wrapper).simulate('change', {target: {value: 'asdf@broadinstitute.org'}});
+  // Blur the email input field and wait for the API request to complete.
+  getEmailInput(wrapper).simulate('blur');
+  await waitOneTickAndUpdate(wrapper);
+  getRoleDropdown(wrapper).props.onChange({originalEvent: undefined, value: InstitutionalRole.EARLYCAREER});
+
+  // At this point, the form should be ready to submit.
+  expect(getInstance(wrapper).validate()).toBeUndefined();
+
+  // ... Mimic changing the institution & role, but leaving email as-is.
+  getInstitutionDropdown(wrapper).props.onChange({originalEvent: undefined, value: 'Verily'});
+  getRoleDropdown(wrapper).props.onChange({originalEvent: undefined, value: InstitutionalRole.PREDOCTORAL});
+
+  // The form should be blocked now due to lack of email verification.
+  expect(getInstance(wrapper).validate()['checkEmailResponse']).toBeTruthy();
+});
+
+
 it('should call callback with correct form data', async() => {
   let profile: Profile = null;
   props.onComplete = (formProfile: Profile) => {

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -110,6 +110,17 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
     }
   }
 
+  onInstitutionChange(shortName: string): void {
+    this.updateAffiliationValue('institutionShortName', shortName);
+    // Clear out any existing values for role when the institution changes.
+    this.updateAffiliationValue('institutionalRoleEnum', undefined);
+    this.updateAffiliationValue('institutionalRoleOtherText', undefined);
+
+    // Clear the email validation response, in case the email had previously been validated against
+    // the prior institution.
+    this.setState({checkEmailResponse: null});
+  }
+
   onEmailBlur() {
     this.checkEmail();
   }
@@ -152,6 +163,13 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
     }
   }
 
+  /**
+   * Indicates whether the currently-entered email is a valid member of the indicated institution.
+   * This controls the display of the "validity icon" next to the email input.
+   *
+   * Note: this does *not* check for format correctness of the indicated email. That is checked
+   * separately at the form-level via validate.js
+   */
   isEmailValid() {
     const {
       checkEmailResponse,
@@ -172,7 +190,12 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
     this.setState(fp.set(['profile', 'contactEmail'], contactEmail));
   }
 
-  // Visible for testing.
+  /**
+   * Runs client-side validation against the form inputs, and returns an object containing errors
+   * strings, if empty. If validation passes, undefined is returned.
+   *
+   * Visible for testing.
+   */
   public validate(): {[key: string]: Array<string>} {
     const validationCheck = {
       'profile.verifiedInstitutionalAffiliation.institutionShortName': {
@@ -284,12 +307,8 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
                 style={styles.wideInputSize}
                 options={institutions.map(inst => ({'value': inst.shortName, 'label': inst.displayName}))}
                 value={institutionShortName}
-                onChange={(e) => {
-                  this.updateAffiliationValue('institutionShortName', e.value);
-                  // Clear out any existing values for role when the institution changes.
-                  this.updateAffiliationValue('institutionalRoleEnum', undefined);
-                  this.updateAffiliationValue('institutionalRoleOtherText', undefined);
-                }}/>
+                onChange={(e) => this.onInstitutionChange(e.value)}
+            />
             {this.state.institutionLoadError &&
             <ErrorDiv data-test-id='data-load-error'>
               An error occurred loading the institution list. Please try again or contact

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -119,6 +119,10 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
     // Clear the email validation response, in case the email had previously been validated against
     // the prior institution.
     this.setState({checkEmailResponse: null});
+
+    // Trigger an email-verification check, in case the user has entered or changed their email and
+    // such a check hasn't yet been sent.
+    this.checkEmail();
   }
 
   onEmailBlur() {

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -118,11 +118,12 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
 
     // Clear the email validation response, in case the email had previously been validated against
     // the prior institution.
-    this.setState({checkEmailResponse: null});
+    this.setState({checkEmailResponse: null}, () => {
+      // Trigger an email-verification check, in case the user has entered or changed their email and
+      // such a check hasn't yet been sent.
+      this.checkEmail();
+    });
 
-    // Trigger an email-verification check, in case the user has entered or changed their email and
-    // such a check hasn't yet been sent.
-    this.checkEmail();
   }
 
   onEmailBlur() {

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -187,7 +187,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
-      currentStep: props.initialStep ? props.initialStep : SignInStep.INSTITUTIONAL_AFFILIATION,
+      currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
       invitationKey: null,
       termsOfServiceVersion: null,
       // This defines the profile state for a new user flow. This will get passed to each

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -187,7 +187,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
-      currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
+      currentStep: props.initialStep ? props.initialStep : SignInStep.INSTITUTIONAL_AFFILIATION,
       invitationKey: null,
       termsOfServiceVersion: null,
       // This defines the profile state for a new user flow. This will get passed to each

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -1,4 +1,5 @@
 import {
+  CheckEmailResponse,
   GetInstitutionsResponse,
   GetPublicInstitutionDetailsResponse,
   Institution,
@@ -87,4 +88,22 @@ export class InstitutionApiStub extends InstitutionApi {
     });
   }
 
+  async checkEmail(shortName: string, email: string, options?: any): Promise<CheckEmailResponse> {
+    const domain = email.substring(email.lastIndexOf('@') + 1);
+
+    const institution = this.institutions.find(x => x.shortName === shortName);
+    if (!institution) {
+      throw new Response('No institution found', {status: 404});
+    }
+
+    const response: CheckEmailResponse = {
+      isValidMember: false
+    };
+    if (institution.emailAddresses && institution.emailAddresses.includes(email)) {
+      response.isValidMember = true;
+    } else if (institution.emailDomains && institution.emailDomains.includes(domain)) {
+      response.isValidMember = true;
+    }
+    return response;
+  }
 }


### PR DESCRIPTION
This adds the last missing piece to the institution form, to check the validity of the user's email address before allowing them to progress.

From local testing, demonstrating the error icon and tooltip within the input element:

<img width="70%" alt="Screen Shot 2020-03-18 at 12 24 08 AM" src="https://user-images.githubusercontent.com/51842/76962133-04801300-68f5-11ea-9da8-acdcc0ad9485.png">

... and a validation error at the form level, which blocks form progression:

<img width="70%" alt="Screen Shot 2020-03-18 at 12 24 15 AM" src="https://user-images.githubusercontent.com/51842/76962100-f6ca8d80-68f4-11ea-8ce2-1d8c04a3b59b.png">

I also found an error in one of our existing unit tests for the form (yikes!) which was causing the test to not actually verify anything. That's fixed, and the unit tests are now exercising this entire form in what I believe is a pretty reasonable manner.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally