### PR TITLE
[noTicket][RISK=NO] Fix broken data code of conduct flow

### DIFF
--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -21,7 +21,7 @@ export class RegistrationGuard implements CanActivate, CanActivateChild {
     if (route.routeConfig.path === 'nih-callback' ||
         route.routeConfig.path === '' ||
         route.routeConfig.path.startsWith('admin/') ||
-        route.routeConfig.path.startsWith('data-use-agreement')) {
+        route.routeConfig.path.startsWith('data-code-of-conduct')) {
       // Leave /admin unguarded in order to allow bootstrapping of verified users.
       return Observable.from([true]);
     }

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -137,7 +137,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     completionTimestamp: (profile: Profile) => {
       return profile.dataUseAgreementCompletionTime || profile.dataUseAgreementBypassTime;
     },
-    onClick: () => navigate(['data-use-agreement'])
+    onClick: () => navigate(['data-code-of-conduct'])
   }
 ] as RegistrationTask[]).filter(registrationTask => registrationTask.featureFlag === undefined
 || registrationTask.featureFlag) : (() => {


### PR DESCRIPTION
This PR will fix the broken button @ user registration -> STEP 4 Data User Code of Conduct
the Bug: 
Click the button 'View and Sign' on Data User Code Of Conduct does nothing
Fix: 1) the new route was not change in guard service neither was the navigate url updated to use the new url data-code-of-conduct rather than new one.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
