### PR TITLE
[RW-4570][RISK=NO]Workspace creation bug when selecting population of interest

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -111,6 +111,39 @@ describe('WorkspaceEdit', () => {
       .first().prop('checked')).toEqual(true);
   });
 
+  it('should clear all selected specific populations if NO underrepresented populations study is selected', async () => {
+    // Set the workspace state to represent a workspace which is studying a
+    // specific population group.
+    workspace.researchPurpose.population = true;
+    workspace.researchPurpose.populationDetails = [SpecificPopulationEnum.AGECHILDREN,
+      SpecificPopulationEnum.RACEMENA, SpecificPopulationEnum.DISABILITYSTATUS];
+
+    routeConfigDataStore.next({mode: WorkspaceEditMode.Edit});
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(`[data-test-id="specific-population-yes"]`)
+      .first().prop('checked')).toEqual(true);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.AGECHILDREN}-checkbox"]`)
+      .first().prop('checked')).toEqual(true);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.RACEMENA}-checkbox"]`)
+      .first().prop('checked')).toEqual(true);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.DISABILITYSTATUS}-checkbox"]`)
+      .first().prop('checked')).toEqual(true);
+
+    wrapper.find('[data-test-id="specific-population-no"]').first().simulate('click');
+
+    // Selecting no for specific population should clear/un select all checkboxes under YES
+    expect(wrapper.find(`[data-test-id="specific-population-yes"]`)
+      .first().prop('checked')).toEqual(false);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.AGECHILDREN}-checkbox"]`)
+      .first().prop('checked')).toEqual(false);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.RACEMENA}-checkbox"]`)
+      .first().prop('checked')).toEqual(false);
+    expect(wrapper.find(`[data-test-id="${SpecificPopulationEnum.DISABILITYSTATUS}-checkbox"]`)
+      .first().prop('checked')).toEqual(false);
+  });
+
   it('supports disable save button if Research Outcome is not answered', async () => {
     routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
     workspace.researchPurpose.researchOutcomeList = []

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -533,6 +533,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       return <div><strong>{item.label} *</strong>
         {item.subCategory.map((sub, index) => <FlexRow>
           <CheckBox
+              manageOwnState={false}
               wrapperStyle={styles.checkboxRow}
               data-test-id={sub.shortName + '-checkbox'}
               style={styles.checkboxStyle}


### PR DESCRIPTION
Selecting No for underrepresented population did not uncheck previously selected Specific population, causing error when selecting Update.
This was because the Checkbox props manageOwnState was not set to false because of which even after setting populationDetails to empty the checkbox state did not change.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
