### PR TITLE
[risk=no]UserServiceTestConfiguration: transitive imports for UserServiceImpl

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -46,9 +45,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.model.Cluster;
 import org.pmiops.workbench.model.ClusterConfig;
 import org.pmiops.workbench.model.ClusterLocalizeRequest;
@@ -62,6 +58,7 @@ import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.pmiops.workbench.notebooks.model.ListClusterResponse;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.WorkspaceMapper;
 import org.pmiops.workbench.utils.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -113,13 +110,9 @@ public class ClusterControllerTest {
   @TestConfiguration
   @Import({
     ClusterController.class,
-    UserServiceImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
     WorkspaceMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
 
     @Bean
     @Scope("prototype")

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -111,8 +111,9 @@ public class ClusterControllerTest {
   @Import({
     ClusterController.class,
     WorkspaceMapperImpl.class,
+    UserServiceTestConfiguration.class,
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
 
     @Bean
     @Scope("prototype")

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -47,7 +47,6 @@ import org.pmiops.workbench.db.dao.DataSetService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohortReview;
 import org.pmiops.workbench.db.model.DbUser;
@@ -61,9 +60,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.Concept;
@@ -88,6 +84,7 @@ import org.pmiops.workbench.notebooks.NotebooksServiceImpl;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.test.SearchRequests;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.ManualWorkspaceMapper;
@@ -189,16 +186,12 @@ public class CohortsControllerTest {
     ConceptSetService.class,
     ConceptService.class,
     NotebooksServiceImpl.class,
-    UserServiceImpl.class,
     WorkspacesController.class,
     CohortsController.class,
     ConceptSetsController.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
     LogsBasedMetricServiceFakeImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -217,7 +210,7 @@ public class CohortsControllerTest {
     UserServiceAuditor.class,
     FreeTierBillingService.class
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
 
     @Bean
     Cloudbilling cloudbilling() {

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -131,7 +131,7 @@ public class CohortsControllerTest {
           .domainId("Condition")
           .countValue(123L)
           .prevalence(0.2F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final Concept CLIENT_CONCEPT_2 =
       new Concept()
@@ -144,7 +144,7 @@ public class CohortsControllerTest {
           .domainId("Condition")
           .countValue(789L)
           .prevalence(0.4F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final DbConcept CONCEPT_1 = makeConcept(CLIENT_CONCEPT_1);
   private static final DbConcept CONCEPT_2 = makeConcept(CLIENT_CONCEPT_2);
@@ -192,6 +192,7 @@ public class CohortsControllerTest {
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
     LogsBasedMetricServiceFakeImpl.class,
+    UserServiceTestConfiguration.class,
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -210,7 +211,7 @@ public class CohortsControllerTest {
     UserServiceAuditor.class,
     FreeTierBillingService.class
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
 
     @Bean
     Cloudbilling cloudbilling() {

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -40,7 +40,6 @@ import org.pmiops.workbench.db.dao.DataSetService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
@@ -54,9 +53,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.CreateConceptSetRequest;
@@ -72,6 +68,7 @@ import org.pmiops.workbench.monitoring.LogsBasedMetricServiceFakeImpl;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.ManualWorkspaceMapper;
@@ -224,17 +221,13 @@ public class ConceptSetsControllerTest {
     CohortCloningService.class,
     CohortFactoryImpl.class,
     ConceptSetMapperImpl.class,
-    UserServiceImpl.class,
     ConceptSetsController.class,
     ConceptService.class,
     WorkspacesController.class,
     ConceptSetService.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
-    LogsBasedMetricServiceFakeImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
+    LogsBasedMetricServiceFakeImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -250,7 +243,7 @@ public class ConceptSetsControllerTest {
     UserServiceAuditor.class,
     FreeTierBillingService.class
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
 
     @Bean
     Cloudbilling cloudbilling() {

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -104,7 +104,7 @@ public class ConceptSetsControllerTest {
           .domainId("Condition")
           .countValue(123L)
           .prevalence(0.2F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final Concept CLIENT_CONCEPT_2 =
       new Concept()
@@ -117,7 +117,7 @@ public class ConceptSetsControllerTest {
           .domainId("Measurement")
           .countValue(456L)
           .prevalence(0.3F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final Concept CLIENT_CONCEPT_3 =
       new Concept()
@@ -130,7 +130,7 @@ public class ConceptSetsControllerTest {
           .domainId("Condition")
           .countValue(789L)
           .prevalence(0.4F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final Concept CLIENT_CONCEPT_4 =
       new Concept()
@@ -144,7 +144,7 @@ public class ConceptSetsControllerTest {
           .domainId("Condition")
           .countValue(7890L)
           .prevalence(0.9F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final Concept CLIENT_SURVEY_CONCEPT_1 =
       new Concept()
@@ -157,7 +157,7 @@ public class ConceptSetsControllerTest {
           .domainId("Observation")
           .countValue(123L)
           .prevalence(0.2F)
-          .conceptSynonyms(new ArrayList<String>());
+          .conceptSynonyms(new ArrayList<>());
 
   private static final DbConcept CONCEPT_1 = makeConcept(CLIENT_CONCEPT_1);
   private static final DbConcept CONCEPT_2 = makeConcept(CLIENT_CONCEPT_2);
@@ -227,7 +227,8 @@ public class ConceptSetsControllerTest {
     ConceptSetService.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
-    LogsBasedMetricServiceFakeImpl.class
+    LogsBasedMetricServiceFakeImpl.class,
+    UserServiceTestConfiguration.class,
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -243,7 +244,7 @@ public class ConceptSetsControllerTest {
     UserServiceAuditor.class,
     FreeTierBillingService.class
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
 
     @Bean
     Cloudbilling cloudbilling() {

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -276,6 +276,7 @@ public class DataSetControllerTest {
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
     LogsBasedMetricServiceFakeImpl.class,
+    UserServiceTestConfiguration.class,
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -300,7 +301,7 @@ public class DataSetControllerTest {
     Zendesk.class,
     FreeTierBillingService.class
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
 
     @Bean(END_USER_CLOUD_BILLING)
     Cloudbilling endUserCloudbilling() {
@@ -523,7 +524,7 @@ public class DataSetControllerTest {
             .domainId("Observation")
             .countValue(123L)
             .prevalence(0.2F)
-            .conceptSynonyms(new ArrayList<String>()));
+            .conceptSynonyms(new ArrayList<>()));
 
     ConceptSet conceptSurveySet =
         new ConceptSet()

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -81,7 +81,6 @@ import org.pmiops.workbench.db.dao.DataSetServiceImpl;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbBillingProjectBufferEntry;
 import org.pmiops.workbench.db.model.DbCdrVersion;
@@ -97,9 +96,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.Concept;
@@ -129,6 +125,7 @@ import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.test.SearchRequests;
 import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.WorkspaceMapper;
 import org.pmiops.workbench.utils.WorkspaceMapperImpl;
@@ -274,15 +271,11 @@ public class DataSetControllerTest {
     ConceptSetService.class,
     DataSetServiceImpl.class,
     TestBigQueryCdrSchemaConfig.class,
-    UserServiceImpl.class,
     WorkspacesController.class,
     WorkspaceServiceImpl.class,
     WorkspaceMapperImpl.class,
     ManualWorkspaceMapper.class,
     LogsBasedMetricServiceFakeImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
   })
   @MockBean({
     BillingProjectBufferService.class,
@@ -307,7 +300,7 @@ public class DataSetControllerTest {
     Zendesk.class,
     FreeTierBillingService.class
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
 
     @Bean(END_USER_CLOUD_BILLING)
     Cloudbilling endUserCloudbilling() {

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -159,8 +159,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     ProfileMapperImpl.class,
     CaptchaVerificationService.class,
     VerifiedInstitutionalAffiliationMapperImpl.class,
+    UserServiceTestConfiguration.class,
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
     @Bean
     @Primary
     Clock clock() {
@@ -389,7 +390,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createUser();
 
     Profile profile = profileController.getMe().getBody();
-    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<InstitutionalAffiliation>();
+    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<>();
     InstitutionalAffiliation first = new InstitutionalAffiliation();
     first.setRole("test");
     first.setInstitution("Institution");
@@ -412,7 +413,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createUser();
 
     Profile profile = profileController.getMe().getBody();
-    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<InstitutionalAffiliation>();
+    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<>();
     InstitutionalAffiliation first = new InstitutionalAffiliation();
     first.setRole("zeta");
     first.setInstitution("Zeta");
@@ -435,7 +436,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createUser();
 
     Profile profile = profileController.getMe().getBody();
-    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<InstitutionalAffiliation>();
+    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<>();
     InstitutionalAffiliation first = new InstitutionalAffiliation();
     first.setRole("test");
     first.setInstitution("Institution");
@@ -446,7 +447,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     affiliations.add(second);
     profile.setInstitutionalAffiliations(affiliations);
     profileController.updateProfile(profile);
-    affiliations = new ArrayList<InstitutionalAffiliation>();
+    affiliations = new ArrayList<>();
     affiliations.add(first);
     profile.setInstitutionalAffiliations(affiliations);
     profileController.updateProfile(profile);
@@ -460,7 +461,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createUser();
 
     Profile profile = profileController.getMe().getBody();
-    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<InstitutionalAffiliation>();
+    ArrayList<InstitutionalAffiliation> affiliations = new ArrayList<>();
     InstitutionalAffiliation first = new InstitutionalAffiliation();
     first.setRole("test");
     first.setInstitution("Institution");

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.captcha.CaptchaVerificationService;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserDataUseAgreement;
@@ -48,11 +47,8 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
 import org.pmiops.workbench.institution.InstitutionService;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.institution.InstitutionalAffiliationMapperImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperImpl;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AccessBypassRequest;
@@ -83,6 +79,7 @@ import org.pmiops.workbench.profile.ProfileMapperImpl;
 import org.pmiops.workbench.profile.ProfileService;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -157,18 +154,13 @@ public class ProfileControllerTest extends BaseControllerTest {
     DemographicSurveyMapperImpl.class,
     InstitutionalAffiliationMapperImpl.class,
     PageVisitMapperImpl.class,
-    UserServiceImpl.class,
     ProfileService.class,
     ProfileController.class,
     ProfileMapperImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    VerifiedInstitutionalAffiliationMapperImpl.class,
     CaptchaVerificationService.class,
-    PublicInstitutionDetailsMapperImpl.class,
-    VerifiedInstitutionalAffiliationMapperImpl.class
+    VerifiedInstitutionalAffiliationMapperImpl.class,
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
     @Bean
     @Primary
     Clock clock() {

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -64,9 +64,10 @@ public class UserControllerTest {
     ComplianceService.class,
     DirectoryService.class,
     AdminActionHistoryDao.class,
-    UserServiceAuditor.class
+    UserServiceAuditor.class,
+    UserServiceTestConfiguration.class,
   })
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
 
     @Bean
     @Scope("prototype")

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -21,20 +21,17 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.FeatureFlagsConfig;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.User;
 import org.pmiops.workbench.model.UserResponse;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.PaginationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -61,10 +58,6 @@ public class UserControllerTest {
   @TestConfiguration
   @Import({
     UserController.class,
-    UserServiceImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
   })
   @MockBean({
     FireCloudService.class,
@@ -73,7 +66,7 @@ public class UserControllerTest {
     AdminActionHistoryDao.class,
     UserServiceAuditor.class
   })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
 
     @Bean
     @Scope("prototype")

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -58,14 +58,14 @@ public class UserControllerTest {
   @TestConfiguration
   @Import({
     UserController.class,
+    UserServiceTestConfiguration.class,
   })
   @MockBean({
     FireCloudService.class,
     ComplianceService.class,
     DirectoryService.class,
     AdminActionHistoryDao.class,
-    UserServiceAuditor.class,
-    UserServiceTestConfiguration.class,
+    UserServiceAuditor.class
   })
   static class Configuration {
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -30,20 +30,17 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionMapperImpl;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
-import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV1;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -77,13 +74,7 @@ public class UserServiceTest {
   @Autowired private UserDao userDao;
 
   @TestConfiguration
-  @Import({
-    UserServiceImpl.class,
-    InstitutionServiceImpl.class,
-    InstitutionMapperImpl.class,
-    PublicInstitutionDetailsMapperImpl.class
-  })
-  static class Configuration {
+  static class Configuration extends UserServiceTestConfiguration {
     @Bean
     Clock clock() {
       return PROVIDED_CLOCK;

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -41,6 +41,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -73,8 +74,9 @@ public class UserServiceTest {
   @Autowired private UserService userService;
   @Autowired private UserDao userDao;
 
+  @Import(UserServiceTestConfiguration.class)
   @TestConfiguration
-  static class Configuration extends UserServiceTestConfiguration {
+  static class Configuration {
     @Bean
     Clock clock() {
       return PROVIDED_CLOCK;

--- a/api/src/test/java/org/pmiops/workbench/testconfig/UserServiceTestConfiguration.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/UserServiceTestConfiguration.java
@@ -7,7 +7,7 @@ import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 
-// Collect the imports necessary for tests which refer to UserService in one place
+// Collect the imports necessary for tests to access UserServiceImpl in one place
 
 @TestConfiguration
 @Import({

--- a/api/src/test/java/org/pmiops/workbench/testconfig/UserServiceTestConfiguration.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/UserServiceTestConfiguration.java
@@ -1,0 +1,21 @@
+package org.pmiops.workbench.testconfig;
+
+import org.pmiops.workbench.db.dao.UserServiceImpl;
+import org.pmiops.workbench.institution.InstitutionMapperImpl;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
+import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+// Collect the imports necessary for tests which refer to UserService in one place
+
+@TestConfiguration
+@Import({
+  UserServiceImpl.class,
+  // UserServiceImpl depends on InstitutionServiceImpl
+  InstitutionServiceImpl.class,
+  // InstitutionServiceImpl depends on InstitutionMapperImpl and PublicInstitutionDetailsMapperImpl
+  InstitutionMapperImpl.class,
+  PublicInstitutionDetailsMapperImpl.class
+})
+public class UserServiceTestConfiguration {}


### PR DESCRIPTION
Description:

I ran into this again and I'm now annoyed enough to solve the problem: https://github.com/all-of-us/workbench/commit/4da7c082ebc5fb94f89f914557f2703c5c8bad88

After this change, tests of controllers/services/etc which depend on UserService will not need to be individually updated after UserService's dependencies change.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
