### PR TITLE
[RW-4621][risk=no] Add Zendesk integration test which runs nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
           command: |
             ./project.rb gradle dependencyCheckAnalyze --info
 
+  # TODO(RW-4645): Upgrade to Circle 2.1 and leverage shared commands to reduce duplication.
   api-integration-test:
     <<: *java_defaults
     steps:
@@ -174,6 +175,30 @@ jobs:
       - run:
           working_directory: ~/workbench/api
           command: ./project.rb integration
+      - save_cache:
+          paths:
+            - ~/.gradle
+            - ~/.m2
+          key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+
+  api-nightly-integration-test:
+    <<: *java_defaults
+    steps:
+      - checkout
+      - run:
+          name: Fetch Submodules
+          command: git submodule update --init --recursive
+      - restore_cache:
+          keys:
+          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+          - api-integration-cache-
+      - run:
+          working_directory: ~/workbench
+          # Used to call gsutil from the circle environment.
+          command: ci/activate_creds.sh api/circle-sa-key.json
+      - run:
+          working_directory: ~/workbench/api
+          command: ./project.rb nightly-integration
       - save_cache:
           paths:
             - ~/.gradle
@@ -442,8 +467,7 @@ workflows:
             - api-deps-check
             - api-integration-test
             - ui-build-test
-
-  integration-test:
+  nightly-tests:
     triggers:
       - schedule:
           # Run this command once every day at 4:00AM UTC
@@ -453,17 +477,7 @@ workflows:
               only:
                 - master
     jobs:
-      - api-integration-test
-  bigquery-test:
-    triggers:
-      - schedule:
-          # Run this command once every day at 4:00AM UTC
-          cron: "0 4 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
+      - api-nightly-integration-test
       - api-bigquery-test
 
 experimental:

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -496,6 +496,10 @@ dependencies {
   testCompile 'com.h2database:h2:1.4.194'
   testCompile 'org.liquibase:liquibase-core:3.5.3'
   testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
+  testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
+  testRuntime 'org.junit.vintage:junit-vintage-engine:5.4.0'
+  testCompile "org.jetbrains.kotlin:kotlin-test:1.3.21"
+
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${MOCKITO_KOTLIN_VERSION}"
 
   // Dependencies for Swagger codegen. This should include all dependencies required by Swagger's
@@ -526,8 +530,8 @@ task integrationTest(type: Test) {
   group = LifecycleBasePlugin.VERIFICATION_GROUP
   testClassesDirs = sourceSets.integration.output.classesDirs
   classpath = sourceSets.integration.runtimeClasspath
-  useJUnitPlatform{
-		excludeTags 'nightly'
+  useJUnit {
+		excludeCategories 'org.pmiops.workbench.NightlyTests'
 	}
   // Option to control size of stack trace:
   // jvmArgs '-XX:MaxJavaStackTraceDepth=10'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -563,7 +563,7 @@ tasks.withType(Test) {
   }
 }
 
-integration {
+integrationTest {
   // These tests should always run when requested since they consume and produce side-effects.
   outputs.upToDateWhen { false }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -531,8 +531,8 @@ task integrationTest(type: Test) {
   testClassesDirs = sourceSets.integration.output.classesDirs
   classpath = sourceSets.integration.runtimeClasspath
   useJUnit {
-		excludeCategories 'org.pmiops.workbench.NightlyTests'
-	}
+    excludeCategories 'org.pmiops.workbench.NightlyTests'
+  }
   // Option to control size of stack trace:
   // jvmArgs '-XX:MaxJavaStackTraceDepth=10'
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -291,8 +291,8 @@ spotless {
 configurations {
   integrationCompile.extendsFrom testCompile
   integrationRuntime.extendsFrom testRuntime
-  bigquerytestCompile.extendsFrom testCompile
-  bigquerytestRuntime.extendsFrom testRuntime
+  bigQueryTestCompile.extendsFrom testCompile
+  bigQueryTestRuntime.extendsFrom testRuntime
 
   toolsImplementation.extendsFrom implementation
   toolsRuntimeOnly.extendsFrom runtimeOnly
@@ -337,7 +337,7 @@ sourceSets {
       srcDirs = ['tools/src/main/java']
     }
   }
-  bigquerytest {
+  bigQueryTest {
     resources {
       srcDir "bigquerytest/resources"
       srcDir "config/"
@@ -522,18 +522,28 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-task integration(type: Test) {
+task integrationTest(type: Test) {
   group = LifecycleBasePlugin.VERIFICATION_GROUP
   testClassesDirs = sourceSets.integration.output.classesDirs
   classpath = sourceSets.integration.runtimeClasspath
+  useJUnitPlatform{
+		excludeTags 'nightly'
+	}
   // Option to control size of stack trace:
   // jvmArgs '-XX:MaxJavaStackTraceDepth=10'
 }
 
-task bigquerytest(type: Test) {
+task nightlyIntegrationTest(type: Test) {
   group = LifecycleBasePlugin.VERIFICATION_GROUP
-  testClassesDirs = sourceSets.bigquerytest.output.classesDirs
-  classpath = sourceSets.bigquerytest.runtimeClasspath
+  testClassesDirs = sourceSets.integration.output.classesDirs
+  classpath = sourceSets.integration.runtimeClasspath
+  // Leave "nightly" tag, but run everything else as well.
+}
+
+task bigQueryTest(type: Test) {
+  group = LifecycleBasePlugin.VERIFICATION_GROUP
+  testClassesDirs = sourceSets.bigQueryTest.output.classesDirs
+  classpath = sourceSets.bigQueryTest.runtimeClasspath
 }
 
 tasks.withType(Test) {

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -420,18 +420,33 @@ Common.register_command({
 })
 
 
+def run_nightly_integration_tests(cmd_name, *args)
+  ensure_docker cmd_name, args
+  common = Common.new
+  ServiceAccountContext.new(TEST_PROJECT).run do
+    get_gsuite_admin_key(TEST_PROJECT)
+    common.run_inline %W{gradle nightlyIntegrationTest} + args
+  end
+end
+
+Common.register_command({
+  :invocation => "nightly-integration",
+  :description => "Runs nightly tests, including integration tests.",
+  :fn => ->(*args) { run_nightly_tests("nightly", *args) }
+})
+
 def run_integration_tests(cmd_name, *args)
   ensure_docker cmd_name, args
   common = Common.new
   ServiceAccountContext.new(TEST_PROJECT).run do
     get_gsuite_admin_key(TEST_PROJECT)
-    common.run_inline %W{gradle integration} + args
+    common.run_inline %W{gradle integrationTest} + args
   end
 end
 
 Common.register_command({
   :invocation => "integration",
-  :description => "Runs integration tests.",
+  :description => "Runs integration tests. Excludes nightly-only tests.",
   :fn => ->(*args) { run_integration_tests("integration", *args) }
 })
 
@@ -439,7 +454,7 @@ def run_bigquery_tests(cmd_name, *args)
   ensure_docker cmd_name, args
   common = Common.new
   ServiceAccountContext.new(TEST_PROJECT).run do
-    common.run_inline %W{gradle bigquerytest} + args
+    common.run_inline %W{gradle bigQueryTest} + args
   end
 end
 

--- a/api/src/integration/java/org/pmiops/workbench/NightlyTests.java
+++ b/api/src/integration/java/org/pmiops/workbench/NightlyTests.java
@@ -1,0 +1,4 @@
+package org.pmiops.workbench;
+
+/** JUnit category marker which indicates a test should only run nightly. */
+public interface NightlyTests {}

--- a/api/src/integration/java/org/pmiops/workbench/ZendeskIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/ZendeskIntegrationTest.java
@@ -5,7 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import javax.inject.Provider;
 import org.junit.Test;
-import org.junit.jupiter.api.Tag;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -22,7 +22,7 @@ import org.zendesk.client.v2.Zendesk;
 import org.zendesk.client.v2.model.Request;
 
 // Run nightly only, as it creates a Zendesk request on every run without cleanup (spammy).
-@Tag("nightly")
+@Category(NightlyTests.class)
 @RunWith(SpringRunner.class)
 public class ZendeskIntegrationTest extends BaseIntegrationTest {
 

--- a/api/src/integration/java/org/pmiops/workbench/ZendeskIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/ZendeskIntegrationTest.java
@@ -1,0 +1,84 @@
+package org.pmiops.workbench;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import javax.inject.Provider;
+import org.junit.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.SpecificPopulationEnum;
+import org.pmiops.workbench.model.Workspace;
+import org.pmiops.workbench.zendesk.ZendeskConfig;
+import org.pmiops.workbench.zendesk.ZendeskRequests;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.zendesk.client.v2.Zendesk;
+import org.zendesk.client.v2.model.Request;
+
+// Run nightly only, as it creates a Zendesk request on every run without cleanup (spammy).
+@Tag("nightly")
+@RunWith(SpringRunner.class)
+public class ZendeskIntegrationTest extends BaseIntegrationTest {
+
+  @TestConfiguration
+  @Import(ZendeskConfig.class)
+  static class Configuration {
+    @Bean
+    DbUser user() {
+      DbUser user = new DbUser();
+      user.setUsername("testing@fake-resarch-aou.org");
+      user.setGivenName("Integration");
+      user.setFamilyName("Testerson");
+      return user;
+    }
+  }
+
+  // This must be created in the request scope as it requires the active username, hence the
+  // provider.
+  @Autowired private Provider<Zendesk> zendeskProvider;
+  @Autowired private DbUser user;
+
+  @Test
+  public void testCreateRequest() throws Exception {
+    Request req =
+        zendeskProvider
+            .get()
+            .createRequest(
+                ZendeskRequests.workspaceToReviewRequest(
+                    user,
+                    new Workspace()
+                        .name("nightly integration test (feel free to delete)")
+                        .namespace("fc-123")
+                        .id("wsid")
+                        .researchPurpose(
+                            new ResearchPurpose()
+                                .diseaseFocusedResearch(true)
+                                .diseaseOfFocus("cancer")
+                                .methodsDevelopment(true)
+                                .controlSet(true)
+                                .ancestry(true)
+                                .commercialPurpose(true)
+                                .socialBehavioral(true)
+                                .populationHealth(true)
+                                .educational(true)
+                                .drugDevelopment(true)
+                                .population(true)
+                                .populationDetails(
+                                    ImmutableList.copyOf(SpecificPopulationEnum.values()))
+                                .additionalNotes("additional notes")
+                                .reasonForAllOfUs("reason for aou")
+                                .intendedStudy("intended study")
+                                .anticipatedFindings("anticipated findings")
+                                .timeRequested(1000L)
+                                .timeReviewed(1500L)
+                                .reviewRequested(true)
+                                .approved(false))));
+    assertThat(req.getId()).isNotNull();
+  }
+}


### PR DESCRIPTION
This only runs nightly on account of the test generating ZD sandbox requests which aren't cleaned up. Leverages Junit "Categories" for filtering on tests. I couldn't get `@Tag` filtering to work with gradle; on further review this may only be possible if you're using the new JUnit5 platform engine, so upgrading to the JUnit5 lib may not have been sufficient:

```
> Could not find method useJUnitPlatform() for arguments [build_7rmii44aljl4a99qxkq0ucme2$_run_closure20$_closure70@31450fc0] on task ':integrationTest' of type org.gradle.api.tasks.testing.Test.
```