### PR TITLE
[risk=no] Upgrade from junit 4 -> junit 5

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -486,7 +486,7 @@ dependencies {
   toolsCompile 'commons-cli:commons-cli:1.4'
   toolsCompile 'com.opencsv:opencsv:4.6'
 
-  testCompile 'junit:junit:4.13'
+  testCompile 'org.junit.jupiter:junit-jupiter:5.6.1'
   testCompile 'org.mockito:mockito-core:2.18.3'
   testCompile "com.google.appengine:appengine-api-stubs:${GAE_VERSION}"
   testCompile "com.google.appengine:appengine-tools-sdk:${GAE_VERSION}"

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/api/src/test/java/org/pmiops/workbench/api/SumoLogicControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/SumoLogicControllerTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.api;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;


### PR DESCRIPTION
There are some more advanced framework libraries we could choose to depend on with Junit 5. I haven't imported those yet. The library I've imported is mostly backwards compatible with Junit 4.

~~I'm upgrading because I want to use `@Tag` for test filtering, which is only available in Junit 5.~~ I couldn't get tags working. Still going to continue with this PR anyways since I already did the work and I don't see a downside.