### PR TITLE
[RW-4445][risk=low] Add OpsGenieService to create alerts on inbound high-egress events.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -457,6 +457,8 @@ dependencies {
   compile "io.opencensus:opencensus-exporter-trace-stackdriver:${OPENCENSUS_VERSION}"
   compile "io.opencensus:opencensus-impl:${OPENCENSUS_VERSION}"
 
+  compile "com.opsgenie.integration:sdk:2+"
+
   // Force these dependencies to safe versions, Zendesk client depends on this.
   compile 'io.netty:netty-codec-http:4.1.44.Final'
   compile 'com.typesafe.netty:netty-reactive-streams:2.0.4'
@@ -481,7 +483,7 @@ dependencies {
 
   // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1502
   compile 'org.json:json:20160810'
-  
+
   compile 'com.github.fge:json-patch:1.9'
   toolsCompile 'commons-cli:commons-cli:1.4'
   toolsCompile 'com.opencsv:opencsv:4.6'

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -46,8 +46,8 @@
     "gSuiteDomain": "fake-research-aou.org"
   },
   "server": {
-    "clientBaseUrl": "http:\/\/localhost:4200",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
+    "uiBaseUrl": "http:\/\/localhost:4200",
     "publicApiKeyForErrorReports": "",
     "projectId": "all-of-us-workbench-test",
     "shortName": "Local",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -46,6 +46,7 @@
     "gSuiteDomain": "fake-research-aou.org"
   },
   "server": {
+    "clientBaseUrl": "http:\/\/localhost:4200",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
     "publicApiKeyForErrorReports": "",
     "projectId": "all-of-us-workbench-test",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -49,6 +49,7 @@
     "gSuiteDomain": "perf.fake-research-aou.org"
   },
   "server": {
+    "clientBaseUrl": "https:\/\/all-of-us-rw-perf.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-perf.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyB44pugxPbfevF_fb7GichIv9D9ee5-nNk",
     "projectId": "all-of-us-rw-perf",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -49,8 +49,8 @@
     "gSuiteDomain": "perf.fake-research-aou.org"
   },
   "server": {
-    "clientBaseUrl": "https:\/\/all-of-us-rw-perf.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-perf.appspot.com",
+    "uiBaseUrl": "https:\/\/all-of-us-rw-perf.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyB44pugxPbfevF_fb7GichIv9D9ee5-nNk",
     "projectId": "all-of-us-rw-perf",
     "shortName": "Perf",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -46,6 +46,7 @@
     "gSuiteDomain": "researchallofus.org"
   },
   "server": {
+    "clientBaseUrl": "https:\/\/workbench.researchallofus.org",
     "apiBaseUrl": "https:\/\/api.workbench.researchallofus.org",
     "publicApiKeyForErrorReports": "AIzaSyBSPcQ0FcR99GLXaqX4Ujpoj3JUDSP689g",
     "projectId": "all-of-us-rw-prod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -46,8 +46,8 @@
     "gSuiteDomain": "researchallofus.org"
   },
   "server": {
-    "clientBaseUrl": "https:\/\/workbench.researchallofus.org",
     "apiBaseUrl": "https:\/\/api.workbench.researchallofus.org",
+    "uiBaseUrl": "https:\/\/workbench.researchallofus.org",
     "publicApiKeyForErrorReports": "AIzaSyBSPcQ0FcR99GLXaqX4Ujpoj3JUDSP689g",
     "projectId": "all-of-us-rw-prod",
     "shortName": "Prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -46,6 +46,7 @@
     "gSuiteDomain": "stable.fake-research-aou.org"
   },
   "server": {
+    "clientBaseUrl": "https:\/\/all-of-us-rw-stable.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-stable.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyA4gOEvyJRkhIbW0x0Y7PkIowOSIK_Tous",
     "projectId": "all-of-us-rw-stable",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -46,8 +46,8 @@
     "gSuiteDomain": "stable.fake-research-aou.org"
   },
   "server": {
-    "clientBaseUrl": "https:\/\/all-of-us-rw-stable.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-stable.appspot.com",
+    "uiBaseUrl": "https:\/\/all-of-us-rw-stable.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyA4gOEvyJRkhIbW0x0Y7PkIowOSIK_Tous",
     "projectId": "all-of-us-rw-stable",
     "shortName": "Stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -46,6 +46,7 @@
     "gSuiteDomain": "staging.fake-research-aou.org"
   },
   "server": {
+    "clientBaseUrl": "https:\/\/all-of-us-rw-staging.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-staging.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyAkMIMIzUwv02RBK-A7cE1PbPpDJ2MTNtk",
     "projectId": "all-of-us-rw-staging",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -46,8 +46,8 @@
     "gSuiteDomain": "staging.fake-research-aou.org"
   },
   "server": {
-    "clientBaseUrl": "https:\/\/all-of-us-rw-staging.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-staging.appspot.com",
+    "uiBaseUrl": "https:\/\/all-of-us-rw-staging.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyAkMIMIzUwv02RBK-A7cE1PbPpDJ2MTNtk",
     "projectId": "all-of-us-rw-staging",
     "shortName": "Staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -46,6 +46,7 @@
     "gSuiteDomain": "fake-research-aou.org"
   },
   "server": {
+    "clientBaseUrl": "https:\/\/all-of-us-workbench-test.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyDPoX4Eg7-_FVKi7JFzEKaJpZ4IMRLaER4",
     "projectId": "all-of-us-workbench-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -46,8 +46,8 @@
     "gSuiteDomain": "fake-research-aou.org"
   },
   "server": {
-    "clientBaseUrl": "https:\/\/all-of-us-workbench-test.appspot.com",
     "apiBaseUrl": "https:\/\/api-dot-all-of-us-workbench-test.appspot.com",
+    "uiBaseUrl": "https:\/\/all-of-us-workbench-test.appspot.com",
     "publicApiKeyForErrorReports": "AIzaSyDPoX4Eg7-_FVKi7JFzEKaJpZ4IMRLaER4",
     "projectId": "all-of-us-workbench-test",
     "shortName": "Test",

--- a/api/src/main/java/org/pmiops/workbench/api/SumoLogicController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/SumoLogicController.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.exceptions.UnauthorizedException;
 import org.pmiops.workbench.google.CloudStorageService;
 import org.pmiops.workbench.model.EgressEvent;
 import org.pmiops.workbench.model.EgressEventRequest;
+import org.pmiops.workbench.opsgenie.OpsGenieService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,15 +27,18 @@ public class SumoLogicController implements SumoLogicApiDelegate {
   private static final Logger log = Logger.getLogger(SumoLogicController.class.getName());
   private final EgressEventAuditor egressEventAuditor;
   private final CloudStorageService cloudStorageService;
+  private final OpsGenieService opsGenieService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired
   SumoLogicController(
       EgressEventAuditor egressEventAuditor,
       CloudStorageService cloudStorageService,
+      OpsGenieService opsGenieService,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.egressEventAuditor = egressEventAuditor;
     this.cloudStorageService = cloudStorageService;
+    this.opsGenieService = opsGenieService;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
@@ -107,5 +111,6 @@ public class SumoLogicController implements SumoLogicApiDelegate {
             "Received an egress event from project %s (%.2fMib, VM %s)",
             event.getProjectName(), event.getEgressMib(), event.getVmName()));
     this.egressEventAuditor.fireEgressEvent(event);
+    this.opsGenieService.createEgressEventAlert(event);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/SumoLogicController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/SumoLogicController.java
@@ -19,6 +19,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Implements an inbound API that is called by the Broad Institute's SumoLogic installation to
+ * report high-egress events detected by SumoLogic. See http://broad.io/vpc-egress-alerting for more
+ * details on the end-to-end data flow.
+ */
 @RestController
 public class SumoLogicController implements SumoLogicApiDelegate {
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -141,10 +141,10 @@ public class WorkbenchConfig {
   }
 
   public static class ServerConfig {
-    // Base URL for the webapp (e.g. client / ui service).
-    public String clientBaseUrl;
     // Base URL for the App Engine API service (e.g. backend server).
     public String apiBaseUrl;
+    // Base URL for the App Engine UI service (e.g. webapp / client).
+    public String uiBaseUrl;
     public String publicApiKeyForErrorReports;
     public String projectId;
     public String shortName;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -141,6 +141,9 @@ public class WorkbenchConfig {
   }
 
   public static class ServerConfig {
+    // Base URL for the webapp (e.g. client / ui service).
+    public String clientBaseUrl;
+    // Base URL for the App Engine API service (e.g. backend server).
     public String apiBaseUrl;
     public String publicApiKeyForErrorReports;
     public String projectId;

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieConfig.java
@@ -1,0 +1,29 @@
+package org.pmiops.workbench.opsgenie;
+
+import com.ifountain.opsgenie.client.OpsGenieClient;
+import com.ifountain.opsgenie.client.swagger.api.AlertApi;
+import org.pmiops.workbench.google.CloudStorageService;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class OpsGenieConfig {
+
+  static final String OPSGENIE_API_KEY_FILENAME = "opsgenie-key.txt";
+
+  // This bean is prototype-scoped, so a Cloud Storage API call will be made every time a new
+  // instance is injected. This is okay since we expect alert API requests to be rare; the benefit
+  // is that API key changes will be reflected immediately rather than requiring a restart of all
+  // App Engine tasks.
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  public AlertApi getAlertApi(CloudStorageService cloudStorageService) {
+    AlertApi client = new OpsGenieClient().alertV2();
+    client
+        .getApiClient()
+        .setApiKey(cloudStorageService.getCredentialsBucketString(OPSGENIE_API_KEY_FILENAME));
+    return client;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieService.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieService.java
@@ -1,0 +1,9 @@
+package org.pmiops.workbench.opsgenie;
+
+import org.pmiops.workbench.model.EgressEvent;
+
+public interface OpsGenieService {
+
+  // Creates an Opsgenie alert for a high-egress event detected in the Workbench system.
+  public void createEgressEventAlert(EgressEvent egressEvent);
+}

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieServiceImpl.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.opsgenie;
 
+import com.google.common.collect.ImmutableList;
 import com.ifountain.opsgenie.client.swagger.ApiException;
 import com.ifountain.opsgenie.client.swagger.api.AlertApi;
 import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
@@ -53,6 +54,8 @@ public class OpsGenieServiceImpl implements OpsGenieService {
             egressEvent.getTimeWindowDuration(),
             egressEvent.getEgressMibThreshold(),
             egressEvent.getEgressMib()));
+    request.setTags(ImmutableList.of("high-egress-event"));
+
     // Set the alias, which is Opsgenie's string key for alert de-duplication. See
     // https://docs.opsgenie.com/docs/alert-deduplication
     request.setAlias(egressEvent.getProjectName() + " | " + egressEvent.getVmName());

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/OpsGenieServiceImpl.java
@@ -1,0 +1,72 @@
+package org.pmiops.workbench.opsgenie;
+
+import com.ifountain.opsgenie.client.swagger.ApiException;
+import com.ifountain.opsgenie.client.swagger.api.AlertApi;
+import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
+import java.util.logging.Logger;
+import javax.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.EgressEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpsGenieServiceImpl implements OpsGenieService {
+  private static final Logger logger = Logger.getLogger(OpsGenieServiceImpl.class.getName());
+
+  private Provider<AlertApi> alertApiProvider;
+  private Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  @Autowired
+  public OpsGenieServiceImpl(
+      Provider<AlertApi> alertApiProvider, Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.alertApiProvider = alertApiProvider;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  private CreateAlertRequest egressEventToOpsGenieAlert(
+      EgressEvent egressEvent, WorkbenchConfig workbenchConfig) {
+    CreateAlertRequest request = new CreateAlertRequest();
+    request.setMessage(String.format("High-egress event (%s)", egressEvent.getProjectName()));
+    request.setDescription(
+        new StringBuilder()
+            .append(String.format("Workspace project: %s\n", egressEvent.getProjectName()))
+            .append(String.format("VM name: %s\n", egressEvent.getVmName()))
+            .append(String.format("Egress amount: %.2f Mib\n\n", egressEvent.getEgressMib()))
+            .append(
+                String.format(
+                    "Admin link (PMI-Ops): %s/admin/workspaces/%s/\n",
+                    workbenchConfig.server.clientBaseUrl, egressEvent.getProjectName()))
+            .append("Playbook: https://broad.io/aou-high-egress-event")
+            .toString());
+    // Add a note with some more specific details about the alerting criteria and threshold. Notes
+    // are appended to an existing Opsgenie ticket if this request is de-duplicated against an
+    // existing ticket, so they're a helpful way to summarize temporal updates to the status of
+    // an incident.
+    request.setNote(
+        String.format(
+            "Time window: %d secs, threshold: %.2f Mib, observed: %.2f Mib",
+            egressEvent.getTimeWindowDuration(),
+            egressEvent.getEgressMibThreshold(),
+            egressEvent.getEgressMib()));
+    // Set the alias, which is Opsgenie's string key for alert de-duplication. See
+    // https://docs.opsgenie.com/docs/alert-deduplication
+    request.setAlias(egressEvent.getProjectName() + " - " + egressEvent.getVmName());
+    return request;
+  }
+
+  @Override
+  public void createEgressEventAlert(EgressEvent egressEvent) {
+    try {
+      this.alertApiProvider
+          .get()
+          .createAlert(egressEventToOpsGenieAlert(egressEvent, workbenchConfigProvider.get()));
+    } catch (ApiException e) {
+      logger.severe(
+          String.format(
+              "Error creating OpsGenie alert for egress event on project %s: %s",
+              egressEvent.getProjectName(), e.getMessage()));
+      e.printStackTrace();
+    }
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/opsgenie/OpsGenieServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/opsgenie/OpsGenieServiceTest.java
@@ -1,0 +1,69 @@
+package org.pmiops.workbench.opsgenie;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.ifountain.opsgenie.client.swagger.ApiException;
+import com.ifountain.opsgenie.client.swagger.api.AlertApi;
+import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.EgressEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class OpsGenieServiceTest {
+  private static WorkbenchConfig workbenchConfig;
+  private EgressEvent egressEvent;
+
+  @MockBean private AlertApi mockAlertApi;
+  @Captor private ArgumentCaptor<CreateAlertRequest> alertRequestCaptor;
+  @Autowired private OpsGenieService opsGenieService;
+
+  @TestConfiguration
+  @Import({OpsGenieServiceImpl.class})
+  static class Configuration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    WorkbenchConfig getWorkbenchConfig() {
+      return workbenchConfig;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    workbenchConfig = WorkbenchConfig.createEmptyConfig();
+    workbenchConfig.server.clientBaseUrl = "https://workbench.researchallofus.org";
+
+    egressEvent =
+        new EgressEvent()
+            .projectName("aou-rw-test-c7dec260")
+            .vmName("aou-rw-1")
+            .egressMib(120.7)
+            .egressMibThreshold(100.0)
+            .timeWindowDuration(600L);
+  }
+
+  @Test
+  public void createEgressEventAlert() throws ApiException {
+    opsGenieService.createEgressEventAlert(egressEvent);
+    verify(mockAlertApi).createAlert(alertRequestCaptor.capture());
+
+    CreateAlertRequest request = alertRequestCaptor.getValue();
+    assertThat(request.getDescription()).contains("Workspace project: aou-rw-test-c7dec260");
+    assertThat(request.getDescription())
+        .contains("https://workbench.researchallofus.org/admin/workspaces/aou-rw-test-c7dec260/");
+    assertThat(request.getAlias()).isEqualTo("aou-rw-test-c7dec260 - aou-rw-1");
+  }
+}


### PR DESCRIPTION
To tighten up our egress alerting story, it makes more sense to directly fire OpsGenie alerts from the Workbench rather than going through the more circuitous path of Stackdriver logs-based metrics (see attached ticket for a more detailed description).

This PR adds a simple Opsgenie API client and hooks it into the SumoLogicController to create an Opsgenie alert for each high-egress event detected.

**Testing**
I tested this locally by manually firing an API request to the local backend:

```
curl -H "X-API-KEY: [redacted]" -H "Content-Type: application/json" -d @test.json http://localhost:8081/v1/admin/sumo/egressEvent
```

where API-KEY is our GCS-stored inbound-sumologic API key, and test.json is a temporary file replicating the JSON structure sent from SumoLogic to Workbench (see [this gist](https://gist.github.com/gjuggler/e15d94e610bbacb9744b2a604319a17a) for example).

The resulting Opsgenie alert looked like this:

<img width="70%" alt="opsgenie-alert" src="https://user-images.githubusercontent.com/51842/77433249-88367580-6db5-11ea-9bdb-f775c98db5ef.png">

**Alert deduplication**

Another nice thing about directly connecting to Opsgenie here is that events can be de-duplicated in a meaningful way. This is important, because our SumoLogic queries are set up to detect alerts with different time windows, meaning a single underlying event may result in 3+ distinct highEgressEvent calls from SumoLogic to the Workbench.

With this PR, when that happens subsequent alerts will be bundled into any existing open alerts (this is the "alias" key that Opsgenie uses for deduplicatdion). Each alert will add a timestamped note to the Opsgenie sidepanel with some more details:

<img width="50%" alt="opsgenie-alert-note" src="https://user-images.githubusercontent.com/51842/77433263-8e2c5680-6db5-11ea-84d1-8cc7e370e7bd.png">

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally