### PR TITLE
[RW-4620][risk=no] Update help sidebar UI

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -82,15 +82,12 @@ const styles = reactStyles({
     transition: 'background 0.2s linear',
     verticalAlign: 'middle'
   },
-  topBar: {
-    width: '14rem',
-    background: colorWithWhiteness(colors.primary, 0.4),
-    color: colors.white,
-    height: '1rem',
-    zIndex: 1
-  },
   closeIcon: {
+    color: colorWithWhiteness(colors.primary, 0.4),
     cursor: 'pointer',
+    position: 'absolute',
+    right: '0.25rem',
+    top: '0.25rem',
     verticalAlign: 'top'
   },
   sectionTitle: {
@@ -439,9 +436,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile())(
         </div>
         <div style={this.sidebarContainerStyles(activeIcon, notebookStyles)}>
           <div style={sidebarOpen ? {...styles.sidebar, ...styles.sidebarOpen} : styles.sidebar} data-test-id='sidebar-content'>
-            <div style={styles.topBar}>
-              <ClrIcon shape='caret right' size={22} style={styles.closeIcon} onClick={() => setSidebarState(false)} />
-            </div>
+            <ClrIcon shape='times' size={22} style={styles.closeIcon} onClick={() => setSidebarState(false)} />
             <div style={contentStyle('help')}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>Help Tips</h3>
               <div style={styles.textSearch}>


### PR DESCRIPTION
Replace blue bar at top of sidebar with an 'X' icon in the upper right corner to close the sidebar
<img width="529" alt="Screen Shot 2020-03-23 at 6 01 35 PM" src="https://user-images.githubusercontent.com/40036095/77562827-8391c000-6e8e-11ea-8f82-0d3654d89d80.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
