### PR TITLE
[RW-4618][risk=no] Adding EHR/PM data filters to Elastic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticDocument.java
@@ -92,6 +92,8 @@ public class ElasticDocument {
           .put("measurement_source_concept_ids", esType(ElasticType.KEYWORD))
           .put("visit_concept_ids", esType(ElasticType.KEYWORD))
           .put("is_deceased", esType(ElasticType.BOOLEAN))
+          .put("has_ehr_data", esType(ElasticType.BOOLEAN))
+          .put("has_physical_measurement_data", esType(ElasticType.BOOLEAN))
           .put("events", NESTED_FOREIGN_SCHEMA)
           .build();
 

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -77,8 +77,12 @@ public final class ElasticFilters {
         filter.mustNot(searchGroupToFilter(sg));
       }
     }
+    BoolQueryBuilder b = QueryBuilders.boolQuery();
+    for (String dataFilter : req.getDataFilters()) {
+      b.filter(QueryBuilders.termQuery(dataFilter, true));
+    }
     processed = true;
-    return filter;
+    return req.getDataFilters().isEmpty() ? filter : filter.filter(b);
   }
 
   /**

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -5,6 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -219,23 +220,31 @@ public class ElasticFiltersTest {
     jdbcTemplate.execute("drop table cb_criteria_ancestor");
   }
 
-  private static final QueryBuilder singleNestedQuery(QueryBuilder... inners) {
-    return singleNestedQueryOccurrences(1, inners);
+  private static final QueryBuilder singleNestedQuery(
+      List<String> dataFilters, QueryBuilder... inners) {
+    return singleNestedQueryOccurrences(dataFilters, 1, inners);
   }
 
-  private static final QueryBuilder singleNestedQueryOccurrences(int n, QueryBuilder... inners) {
+  private static final QueryBuilder singleNestedQueryOccurrences(
+      List<String> dataFilters, int n, QueryBuilder... inners) {
     BoolQueryBuilder b = QueryBuilders.boolQuery();
     for (QueryBuilder in : inners) {
       b.filter(in);
     }
-    return QueryBuilders.boolQuery()
-        .filter(
-            QueryBuilders.boolQuery()
-                .should(
-                    QueryBuilders.functionScoreQuery(
-                            QueryBuilders.nestedQuery(
-                                "events", QueryBuilders.constantScoreQuery(b), ScoreMode.Total))
-                        .setMinScore(n)));
+    BoolQueryBuilder b2 =
+        QueryBuilders.boolQuery()
+            .filter(
+                QueryBuilders.boolQuery()
+                    .should(
+                        QueryBuilders.functionScoreQuery(
+                                QueryBuilders.nestedQuery(
+                                    "events", QueryBuilders.constantScoreQuery(b), ScoreMode.Total))
+                            .setMinScore(n)));
+    BoolQueryBuilder b3 = QueryBuilders.boolQuery();
+    for (String dataFilter : dataFilters) {
+      b3.filter(QueryBuilders.termQuery(dataFilter, true));
+    }
+    return dataFilters.isEmpty() ? b2 : b2.filter(b3);
   }
 
   private static final QueryBuilder nonNestedQuery(QueryBuilder... inners) {
@@ -270,10 +279,13 @@ public class ElasticFiltersTest {
             new SearchRequest()
                 .addIncludesItem(
                     new SearchGroup()
-                        .addItemsItem(new SearchGroupItem().addSearchParametersItem(leafParam2))));
+                        .addItemsItem(new SearchGroupItem().addSearchParametersItem(leafParam2)))
+                .addDataFiltersItem("has_ehr_data")
+                .addDataFiltersItem("has_physical_measurement_data"));
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of("has_ehr_data", "has_physical_measurement_data"),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
   }
 
@@ -298,6 +310,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery(
                     "events.concept_id", ImmutableList.of("21600002", "21600009"))));
   }
@@ -324,6 +337,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("771", "772", "773"))));
   }
@@ -403,6 +417,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("77", "7771", "777"))));
   }
@@ -429,6 +444,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("7771", "777"))));
   }
@@ -458,6 +474,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("7771")),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(1.0F).lte(1.0F)));
   }
@@ -486,6 +503,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("777")),
                 QueryBuilders.termsQuery(
                     "events.value_as_source_concept_id", ImmutableList.of("1"))));
@@ -510,6 +528,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.rangeQuery("events.age_at_start").gte(18)));
   }
@@ -534,6 +553,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.rangeQuery("events.start_date").gte("12/25/1988").lte("12/27/1988")));
   }
@@ -557,6 +577,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.termsQuery("events.visit_concept_id", ImmutableList.of("123"))));
   }
@@ -580,7 +601,9 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQueryOccurrences(
-                13, QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
+                ImmutableList.of(),
+                13,
+                QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
   }
 
   @Test
@@ -605,6 +628,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId))));
   }
 
@@ -634,6 +658,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(left).lte(right)));
   }
@@ -667,6 +692,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(left).lte(right)));
   }
@@ -842,6 +868,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.termsQuery("events.value_as_concept_id", ImmutableList.of(operand))));
   }
@@ -875,6 +902,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.termsQuery(
                     "events.value_as_concept_id", ImmutableList.of(operand1, operand2))));
@@ -901,6 +929,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
+                ImmutableList.of(),
                 QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId))));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -43,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class ElasticFiltersTest {
 
+  private static final ImmutableList<String> NO_DATA_FILTERS = ImmutableList.of();
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
 
@@ -310,7 +311,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery(
                     "events.concept_id", ImmutableList.of("21600002", "21600009"))));
   }
@@ -337,7 +338,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("771", "772", "773"))));
   }
@@ -417,7 +418,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("77", "7771", "777"))));
   }
@@ -444,7 +445,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery(
                     "events.source_concept_id", ImmutableList.of("7771", "777"))));
   }
@@ -474,7 +475,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("7771")),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(1.0F).lte(1.0F)));
   }
@@ -503,7 +504,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("777")),
                 QueryBuilders.termsQuery(
                     "events.value_as_source_concept_id", ImmutableList.of("1"))));
@@ -528,7 +529,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.rangeQuery("events.age_at_start").gte(18)));
   }
@@ -553,7 +554,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.rangeQuery("events.start_date").gte("12/25/1988").lte("12/27/1988")));
   }
@@ -577,7 +578,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772")),
                 QueryBuilders.termsQuery("events.visit_concept_id", ImmutableList.of("123"))));
   }
@@ -601,7 +602,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQueryOccurrences(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 13,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of("772"))));
   }
@@ -628,7 +629,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId))));
   }
 
@@ -658,7 +659,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(left).lte(right)));
   }
@@ -692,7 +693,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.rangeQuery("events.value_as_number").gte(left).lte(right)));
   }
@@ -868,7 +869,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.source_concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.termsQuery("events.value_as_concept_id", ImmutableList.of(operand))));
   }
@@ -902,7 +903,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId)),
                 QueryBuilders.termsQuery(
                     "events.value_as_concept_id", ImmutableList.of(operand1, operand2))));
@@ -929,7 +930,7 @@ public class ElasticFiltersTest {
     assertThat(resp)
         .isEqualTo(
             singleNestedQuery(
-                ImmutableList.of(),
+                NO_DATA_FILTERS,
                 QueryBuilders.termsQuery("events.concept_id", ImmutableList.of(conceptId))));
   }
 

--- a/api/tools/src/main/resources/bigquery/es_person.sql
+++ b/api/tools/src/main/resources/bigquery/es_person.sql
@@ -5,19 +5,19 @@ SELECT p.person_id                                             _id,
        p.gender_concept_id,
        case
            when gc.concept_name is null then 'Unknown'
-           else gc.concept_name end as                         gender_concept_name,
+           else gc.concept_name end                    as      gender_concept_name,
        p.race_concept_id,
        case
            when rc.concept_name is null then 'Unknown'
-           else rc.concept_name end as                         race_concept_name,
+           else rc.concept_name end                    as      race_concept_name,
        p.ethnicity_concept_id,
        case
            when ec.concept_name is null then 'Unknown'
-           else ec.concept_name end as                         ethnicity_concept_name,
+           else ec.concept_name end                    as      ethnicity_concept_name,
        p.sex_at_birth_concept_id,
        case
            when sc.concept_name is null then 'Unknown'
-           else sc.concept_name end as                         sex_at_birth_concept_name,
+           else sc.concept_name end                    as      sex_at_birth_concept_name,
        condition_concept_ids,
        condition_source_concept_ids,
        observation_concept_ids,
@@ -29,9 +29,11 @@ SELECT p.person_id                                             _id,
        measurement_concept_ids,
        measurement_source_concept_ids,
        visit_concept_ids,
-       death.person_id is not null  as                         is_deceased,
+       death.person_id is not null                     as      is_deceased,
+       CAST(cbp.has_ehr_data as BOOL)                  as      has_ehr_data,
+       CAST(cbp.has_physical_measurement_data as BOOL) as      has_physical_measurement_data,
        ARRAY_CONCAT(observations, conditions, drugs, procedures,
-                    measurements)   AS                         events
+                    measurements)                      AS      events
 FROM `{BQ_DATASET}.person` p
          LEFT JOIN (
     SELECT ob.person_id                                                             person_id,


### PR DESCRIPTION
CB will allow users to filter cohort results based on if they have EHR or Physical Measurement data. Pretty simple... adding boolean flags to the person index for each.
<img width="404" alt="Screen Shot 2020-03-17 at 4 42 33 PM" src="https://user-images.githubusercontent.com/3904919/77573950-70d3b700-6e9f-11ea-96c6-678a05c454d3.png">
