### PR TITLE
[RW-4621][risk=no] Fix nightly command

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -432,7 +432,7 @@ end
 Common.register_command({
   :invocation => "nightly-integration",
   :description => "Runs nightly tests, including integration tests.",
-  :fn => ->(*args) { run_nightly_tests("nightly", *args) }
+  :fn => ->(*args) { run_nightly_integration_tests("nightly", *args) }
 })
 
 def run_integration_tests(cmd_name, *args)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -432,7 +432,7 @@ end
 Common.register_command({
   :invocation => "nightly-integration",
   :description => "Runs nightly tests, including integration tests.",
-  :fn => ->(*args) { run_nightly_integration_tests("nightly", *args) }
+  :fn => ->(*args) { run_nightly_integration_tests("nightly-integration", *args) }
 })
 
 def run_integration_tests(cmd_name, *args)


### PR DESCRIPTION
Fixed some late-breaking regressions on the last PR which I apparently neglected to run afterwards. Verified locally that `./project.rb nightly-integration` now passes.