### PR TITLE
[no ticket][risk=no] Refactoring Home page tests

### DIFF
--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -8,8 +8,8 @@ import WorkspaceEditPage from '../../app/workspace-edit-page';
 import WorkspacesPage from '../../app/workspaces-page';
 import launchBrowser from '../../driver/puppeteer-launch';
 
-// set timeout globally per suite, not per test.
-jest.setTimeout(2 * 60 * 1000);
+// set timeout per suite, not per test.
+jest.setTimeout(4 * 60 * 1000);
 
 const configs = require('../../resources/workbench-config');
 
@@ -26,9 +26,8 @@ describe('Home page ui tests', () => {
   afterEach(async () => {
     await browser.close();
   });
-
-
-  test('Workspace cards have same ui size', async () => {
+   
+  test('Check visibility of Workspace cards', async () => {
     await GoogleLoginPage.logIn(page);
 
     const cards = await WorkspaceCard.getAllCards(page);
@@ -38,19 +37,34 @@ describe('Home page ui tests', () => {
       const cardElem = new BaseElement(page, card.asElementHandle());
       expect(await cardElem.isVisible()).toBe(true);
       const size = await cardElem.getSize();
-      if (width === undefined) {
+      expect(size).toBeTruthy();
+      expect(size.height).toBeGreaterThan(1);
+      expect(size.width).toBeGreaterThan(1);
+
+      if (width === undefined || height === undefined) {
         width = size.width; // Initialize width and height with first card element's size, compare with rest cards
         height = size.height;
       } else {
         expect(size.height).toEqual(height);
         expect(size.width).toEqual(width);
       }
+
+      // check workspace name has characters
+      const cardName = await card.getResourceCardName();
+      expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
+
+      // check ellipsis icon existed
+      expect(await card.getEllipsisIcon()).toBeTruthy();
+
+      // Assumption: test user is workspace Owner.
+      // Check ellipsis popup has right option values
+      const links = await card.getPopupLinkTextsArray();
+      expect(links).toEqual(expect.arrayContaining(['Share', 'Edit', 'Duplicate', 'Delete']));
     }
-    expect(height).toBeGreaterThan(1);
-    expect(width).toBeGreaterThan(1);
+
   });
 
-  // Click See All Workspaces link => Opens Your Workspaces page
+   // Click See All Workspaces link => Opens Your Workspaces page
   test('Click on See All Workspace link', async () => {
     await GoogleLoginPage.logIn(page);
 
@@ -62,7 +76,7 @@ describe('Home page ui tests', () => {
     await seeAllWorkspacesLink.dispose();
   });
 
-  // Click Create New Workspace link => Opens Create Workspace page
+   // Click Create New Workspace link => Opens Create Workspace page
   test('Click on Create New Workspace link', async () => {
     const home = await GoogleLoginPage.logIn(page);
     await home.getCreateNewWorkspaceLink().then((link) => link.click());
@@ -95,16 +109,5 @@ describe('Home page ui tests', () => {
     expect(await anyLink.isVisible()).toBe(false);
   });
 
-  test('Check Workspace card on Home page', async () => {
-    await GoogleLoginPage.logIn(page);
-
-    await WorkspaceCard.getAllCards(page);
-    const anyCard = await WorkspaceCard.getAnyCard(page);
-    const cardName = await anyCard.getResourceCardName();
-    expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
-    expect(await anyCard.getEllipsisIcon()).toBeTruthy();
-    const links = await anyCard.getPopupLinkTextsArray();
-    expect(links).toEqual(expect.arrayContaining(['Share', 'Edit', 'Duplicate', 'Delete']));
-  });
 
 });


### PR DESCRIPTION
Combine steps from `Workspace cards have same ui size` and `Check Workspace card on Home page` into one test.
Reworked code logic.

```
FAIL  tests/home/home-page.spec.ts (188.854s)
  Home page ui tests
    ✕ Workspace cards have same ui size (117910ms)
    ✓ Click on See All Workspace link (23277ms)
    ✓ Click on Create New Workspace link (19764ms)
    ✓ Check Create New Workspace link on Home page (13836ms)
    ✓ Check Workspace card on Home page (13752ms)

  ● Home page ui tests › Workspace cards have same ui size

    expect(received).toBeGreaterThan(expected)

    Matcher error: received value must be a number or bigint

    Received has value: undefined

      47 |       }
      48 |     }
    > 49 |     expect(height).toBeGreaterThan(1);
         |                    ^
      50 |     expect(width).toBeGreaterThan(1);
      51 |   });
      52 | 

      at tests/home/home-page.spec.ts:49:20
      at fulfilled (node_modules/tslib/tslib.js:110:62)
```
