### PR TITLE
[risk=no] fix blank page bug on workspace create page

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -64,6 +64,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('displays workspaces create page', async () => {
+    currentWorkspaceStore.next(undefined);
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find(WorkspaceEditSection).first().text()).toContain('Create a new Workspace');
@@ -71,6 +72,9 @@ describe('WorkspaceEdit', () => {
     // Ensure the 'drug development' checkbox is not checked when creating.
     expect(wrapper.find('[data-test-id="researchPurpose-checkbox"]').first().prop('checked'))
       .toEqual(false);
+
+    expect(wrapper.find('[data-test-id="specific-population-no"]').first().prop('checked'))
+      .toEqual(true);
   });
 
   it('displays workspaces duplicate page', async () => {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -210,7 +210,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         showStigmatizationDetails: false,
         billingAccounts: [],
         showCreateBillingAccountModal: false,
-        populationChecked: props.workspace.researchPurpose.populationDetails.length > 0
+        populationChecked: props.workspace ? props.workspace.researchPurpose.populationDetails.length > 0 : false
       };
     }
 
@@ -1020,7 +1020,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <hr/>
           </div>
           <div style={{marginTop: '0.5rem'}}>
-            <RadioButton name='population' style={{marginRight: '0.5rem'}}
+            <RadioButton name='population'
+                         style={{marginRight: '0.5rem'}}
                          data-test-id='specific-population-no'
                          onChange={v => this.setState({populationChecked: false})}
                          checked={!this.state.populationChecked}/>


### PR DESCRIPTION
Fixing a bug found by puppeteer automation!

This should have been caught by our unit tests too but there was a bug in the test where the create test wasn't using the write test data.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
