### PR TITLE
[RW-4671][risk=no] Puppeteer: Fix Home Page flaky test

### DIFF
--- a/e2e/app/authenticated-page.ts
+++ b/e2e/app/authenticated-page.ts
@@ -48,16 +48,6 @@ export default abstract class AuthenticatedPage extends BasePage {
     super(page);
   }
 
-  /**
-   * Take a full-page screenshot, save file in .png format in logs/screenshots directory.
-   * @param fileName
-   */
-  async takeScreenshot(fileName: string) {
-    const timestamp = new Date().getTime();
-    const screenshotFile = `screenshots/${fileName}_${timestamp}.png`;
-    await this.page.screenshot({path: screenshotFile, fullPage: true});
-  }
-
   protected async isSignedIn(): Promise<boolean> {
     await this.page.waitForSelector(selectors.signedInIndicator);
     await this.page.waitForSelector(selectors.logo, {visible: true});

--- a/e2e/app/base-page.ts
+++ b/e2e/app/base-page.ts
@@ -1,5 +1,5 @@
 import {ElementHandle, Page, Response} from 'puppeteer';
-const fse = require('fs-extra');
+import { ensureDir } from 'fs-extra';
 
 /**
  * All Page Object classes will extends the BasePage.
@@ -228,7 +228,7 @@ export default abstract class BasePage {
    */
   async takeScreenshot(fileName: string) {
     const SCREENSHOT_DIR = 'logs/screenshot';
-    await fse.ensureDir(SCREENSHOT_DIR);
+    await ensureDir(SCREENSHOT_DIR);
     const timestamp = new Date().getTime();
     const screenshotFile = `${SCREENSHOT_DIR}/${fileName}_${timestamp}.png`;
     await this.page.screenshot({path: screenshotFile, fullPage: true});

--- a/e2e/app/workspace-card.ts
+++ b/e2e/app/workspace-card.ts
@@ -42,9 +42,10 @@ export default class WorkspaceCard extends BaseElement {
   }
 
   static async findCard(page: Page, workspaceName: string): Promise<WorkspaceCard | null> {
+    const selector = `.//*[@data-test-id="workspace-card-name" and text()="${workspaceName}"]`;
     const allCards = await this.getAllCards(page);
     for (const card of allCards) {
-      const children = await card.asElementHandle().$x(`.//*[@data-test-id="workspace-card-name" and text()="${workspaceName}"]`);
+      const children = await card.asElementHandle().$x(selector);
       if (children.length > 0) {
         return card; // matched workspace name, found the Workspace card.
       }
@@ -60,8 +61,8 @@ export default class WorkspaceCard extends BaseElement {
 
   async getWorkspaceName(): Promise<unknown> {
     const selector = './/*[@data-test-id="workspace-card-name"]';
-    const cardNameElem = await this.element.$x(selector);
-    const jHandle = await cardNameElem[0].getProperty('innerText');
+    const workspaceNameElemt = await this.element.$x(selector);
+    const jHandle = await workspaceNameElemt[0].getProperty('innerText');
     const name = await jHandle.jsonValue();
     await jHandle.dispose();
     return name;

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -50,7 +50,7 @@ describe('Home page ui tests', () => {
       }
 
       // check workspace name has characters
-      const cardName = await card.getResourceCardName();
+      const cardName = await card.getWorkspaceName();
       expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
 
       // check ellipsis icon existed

--- a/e2e/tests/workspace/workspace-ui.spec.ts
+++ b/e2e/tests/workspace/workspace-ui.spec.ts
@@ -22,7 +22,7 @@ describe('Workspace ui tests', () => {
   });
 
 
-  test('Workspace cards all have same ui size', async () => {
+  test.skip('Workspace cards all have same ui size', async () => {
     const cards = await WorkspaceCard.getAllCards(page);
     let width;
     let height;
@@ -41,7 +41,7 @@ describe('Workspace ui tests', () => {
   });
 
   // Click CreateNewWorkspace link on My Workpsaces page => Open Create Workspace page
-  test('Click Create New Workspace link on My Workspaces page', async () => {
+  test.skip('Click Create New Workspace link on My Workspaces page', async () => {
     const workspaces = new WorkspacesPage(page);
     await workspaces.load();
     const workspaceEdit = await workspaces.clickCreateNewWorkspace();
@@ -56,11 +56,12 @@ describe('Workspace ui tests', () => {
     await new WorkspacesPage(page).waitForLoad();
 
     await WorkspaceCard.getAllCards(page);
-    const anyCard = await WorkspaceCard.getAnyCard(page);
-    const cardName = await anyCard.getWorkspaceName();
-    expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
-    expect(await anyCard.getEllipsisIcon()).toBeTruthy();
-    const links = await anyCard.getPopupLinkTextsArray();
+    const card = await WorkspaceCard.getAnyCard(page);
+    const workspaceName = await card.getWorkspaceName();
+    expect(workspaceName).toMatch(new RegExp(/^[a-zA-Z]+/));
+
+    expect(await card.getEllipsisIcon()).toBeTruthy();
+    const links = await card.getPopupLinkTextsArray();
     expect(links).toEqual(expect.arrayContaining(['Share', 'Edit', 'Duplicate', 'Delete']));
   });
 

--- a/e2e/tests/workspace/workspace-ui.spec.ts
+++ b/e2e/tests/workspace/workspace-ui.spec.ts
@@ -57,7 +57,7 @@ describe('Workspace ui tests', () => {
 
     await WorkspaceCard.getAllCards(page);
     const anyCard = await WorkspaceCard.getAnyCard(page);
-    const cardName = await anyCard.getResourceCardName();
+    const cardName = await anyCard.getWorkspaceName();
     expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
     expect(await anyCard.getEllipsisIcon()).toBeTruthy();
     const links = await anyCard.getPopupLinkTextsArray();

--- a/e2e/tests/workspace/workspace-ui.spec.ts
+++ b/e2e/tests/workspace/workspace-ui.spec.ts
@@ -22,7 +22,7 @@ describe('Workspace ui tests', () => {
   });
 
 
-  test.skip('Workspace cards all have same ui size', async () => {
+  test('Workspace cards all have same ui size', async () => {
     const cards = await WorkspaceCard.getAllCards(page);
     let width;
     let height;
@@ -41,7 +41,7 @@ describe('Workspace ui tests', () => {
   });
 
   // Click CreateNewWorkspace link on My Workpsaces page => Open Create Workspace page
-  test.skip('Click Create New Workspace link on My Workspaces page', async () => {
+  test('Click Create New Workspace link on My Workspaces page', async () => {
     const workspaces = new WorkspacesPage(page);
     await workspaces.load();
     const workspaceEdit = await workspaces.clickCreateNewWorkspace();


### PR DESCRIPTION
This failure happens on CircleCI runs but not running on localhost.
Root cause: Not waiting for Workspace Cards become visible.

```
FAIL  tests/home/home-page.spec.ts (188.854s)
  Home page ui tests
    ✕ Workspace cards have same ui size (117910ms)
    ✓ Click on See All Workspace link (23277ms)
    ✓ Click on Create New Workspace link (19764ms)
    ✓ Check Create New Workspace link on Home page (13836ms)
    ✓ Check Workspace card on Home page (13752ms)

  ● Home page ui tests › Workspace cards have same ui size

    expect(received).toBeGreaterThan(expected)

    Matcher error: received value must be a number or bigint

    Received has value: undefined

      47 |       }
      48 |     }
    > 49 |     expect(height).toBeGreaterThan(1);
         |                    ^
      50 |     expect(width).toBeGreaterThan(1);
      51 |   });
      52 | 

      at tests/home/home-page.spec.ts:49:20
      at fulfilled (node_modules/tslib/tslib.js:110:62)
```
