### PR TITLE
[RW-4583][risk=low] Switch to Rawls cloneWorkspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -330,7 +330,7 @@ public class FireCloudServiceImpl implements FireCloudService {
             .namespace(toProject)
             .name(toName)
             // We copy only the notebooks/ subdirectory as a heuristic to avoid unintentionally
-            // performing a deep copy of workspace blobs.
+            // propagating copies of large data files elswhere in the bucket.
             .copyFilesWithPrefix("notebooks/")
             .authorizationDomain(
                 ImmutableList.of(

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -42,6 +42,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACL;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdateResponseList;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceIngest;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceRequestClone;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -164,13 +165,6 @@ public class FireCloudServiceImpl implements FireCloudService {
     ApiClient apiClient = FireCloudConfig.buildApiClient(configProvider.get());
     apiClient.setAccessToken(delegatedCreds.getAccessToken().getTokenValue());
     return apiClient;
-  }
-
-  private void checkAndAddRegistered(FirecloudWorkspaceIngest workspaceIngest) {
-    // TODO: add concept of controlled auth domain.
-    FirecloudManagedGroupRef registeredDomain = new FirecloudManagedGroupRef();
-    registeredDomain.setMembersGroupName(configProvider.get().firecloud.registeredDomainName);
-    workspaceIngest.setAuthorizationDomain(ImmutableList.of(registeredDomain));
   }
 
   @Override
@@ -315,10 +309,15 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public FirecloudWorkspace createWorkspace(String projectName, String workspaceName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
-    FirecloudWorkspaceIngest workspaceIngest = new FirecloudWorkspaceIngest();
-    workspaceIngest.setName(workspaceName);
-    workspaceIngest.setNamespace(projectName);
-    checkAndAddRegistered(workspaceIngest);
+    FirecloudWorkspaceIngest workspaceIngest =
+        new FirecloudWorkspaceIngest()
+            .namespace(projectName)
+            .name(workspaceName)
+            .authorizationDomain(
+                ImmutableList.of(
+                    new FirecloudManagedGroupRef()
+                        .membersGroupName(configProvider.get().firecloud.registeredDomainName)));
+
     return retryHandler.run((context) -> workspacesApi.createWorkspace(workspaceIngest));
   }
 
@@ -326,12 +325,20 @@ public class FireCloudServiceImpl implements FireCloudService {
   public FirecloudWorkspace cloneWorkspace(
       String fromProject, String fromName, String toProject, String toName) {
     WorkspacesApi workspacesApi = workspacesApiProvider.get();
-    FirecloudWorkspaceIngest workspaceIngest = new FirecloudWorkspaceIngest();
-    workspaceIngest.setNamespace(toProject);
-    workspaceIngest.setName(toName);
-    checkAndAddRegistered(workspaceIngest);
+    FirecloudWorkspaceRequestClone cloneRequest =
+        new FirecloudWorkspaceRequestClone()
+            .namespace(toProject)
+            .name(toName)
+            // We copy only the notebooks/ subdirectory as a heuristic to avoid unintentionally
+            // performing a deep copy of workspace blobs.
+            .copyFilesWithPrefix("notebooks/")
+            .authorizationDomain(
+                ImmutableList.of(
+                    new FirecloudManagedGroupRef()
+                        .membersGroupName(configProvider.get().firecloud.registeredDomainName)));
+
     return retryHandler.run(
-        (context) -> workspacesApi.cloneWorkspace(fromProject, fromName, workspaceIngest));
+        (context) -> workspacesApi.cloneWorkspace(fromProject, fromName, cloneRequest));
   }
 
   @Override

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -499,7 +499,7 @@ paths:
           required: true
           in: body
           schema:
-            $ref: '#/definitions/WorkspaceIngest'
+            $ref: '#/definitions/WorkspaceRequestClone'
       responses:
         201:
           description: Successful Request
@@ -1092,6 +1092,30 @@ definitions:
         items:
           $ref: '#/definitions/ManagedGroupRef'
         description: The list of groups to form the Authorization Domain (empty if no Authorization Domain is set)
+
+  WorkspaceRequestClone:
+    description: ''
+    required:
+      - namespace
+      - name
+      - attributes
+    properties:
+      namespace:
+        type: string
+        description: The namespace (billing project) the workspace belongs to
+      name:
+        type: string
+        description: The name of the workspace
+      authorizationDomain:
+        type: array
+        items:
+          $ref: '#/definitions/ManagedGroupRef'
+        description: The list of groups in the Authorization Domain (empty if no AD is set)
+      attributes:
+        type: object
+      copyFilesWithPrefix:
+        type: string
+        description: Used for clone operations only; the prefix for files to copy between source and destination workspace buckets
 
   # The response object returned from Get or List workspace.
   WorkspaceResponse:


### PR DESCRIPTION
System changes:

- Drop our custom handling of file cloning on CloneWorkspace, leverage the Firecloud cloneWorkspace file copy feature instead.

Functional changes:

- We no longer copy all files in the bucket, just in the notebooks/ subdir. This is a revert to the original behavior which was intended to mitigate accidental copies of large files. It's required for this change since Rawls clone workspace doesn't support copying all files
- Drop the size limitation on cloned file size
- Files are no longer synchronously available immediately after the clone, Rawls does this in a background thread.

Based on manual local testing:
- The propagation delay was not noticeable - tested with 50 notebook files.
- Confirmed that files outside this prefix do not get copied
- Confirmed that files in "subdirectories" do get copied