### PR TITLE
[RW-4583][risk=no] Fix invocation of Rawls clone API

### DIFF
--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -1113,6 +1113,8 @@ definitions:
         description: The list of groups in the Authorization Domain (empty if no AD is set)
       attributes:
         type: object
+        additionalProperties:
+          type: string
       copyFilesWithPrefix:
         type: string
         description: Used for clone operations only; the prefix for files to copy between source and destination workspace buckets


### PR DESCRIPTION
Missed this follow-up commit in my previous PR which I was using for local manual testing. Without this, the call to Firecloud clone will fail. May be worth adding a nightly integration test for this, since it will generate spam workspaces.

Without this, fails with:

```
api_1_84f0e5a17331       |   "message": "Object is missing required member 'attributes'",                                                                             
```