### PR TITLE
[RW-4691][risk=no] Await authentication before checking disabled status

### DIFF
--- a/ui/src/app/guards/disabled-guard.service.ts
+++ b/ui/src/app/guards/disabled-guard.service.ts
@@ -12,7 +12,9 @@ export class DisabledGuard implements CanActivate, CanActivateChild {
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
     try {
-      // Only grab the first status, otherwise toPromise hangs forever.
+      // The user is not necessarily authenticated at this point - we have to
+      // wait for the sign-in signal before making backend requests.
+      // Only grab the first element from the observable, otherwise toPromise hangs forever.
       const isSignedIn = await this.signInService.isSignedIn$.first().toPromise();
       if (!isSignedIn) {
         return false;

--- a/ui/src/app/guards/disabled-guard.service.ts
+++ b/ui/src/app/guards/disabled-guard.service.ts
@@ -1,16 +1,22 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot} from '@angular/router';
 
+import {SignInService} from 'app/services/sign-in.service';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import {convertAPIError} from 'app/utils/errors';
 import {ErrorCode} from 'generated/fetch';
 
 @Injectable()
 export class DisabledGuard implements CanActivate, CanActivateChild {
-  constructor(private router: Router) {}
+  constructor(private router: Router, private signInService: SignInService) {}
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
     try {
+      // Only grab the first status, otherwise toPromise hangs forever.
+      const isSignedIn = await this.signInService.isSignedIn$.first().toPromise();
+      if (!isSignedIn) {
+        return false;
+      }
       await profileApi().getMe();
       return true;
     } catch (e) {


### PR DESCRIPTION
This causes the initial /getMe request to fail with a 500. There is no clear user facing issue as a result of this, but it is a confounding factor in the very least to debugging other issues.

Manually tested with a disabled and a non-disabled user.