### PR TITLE
[risk=no][RW-3211]Don't include free tier billing account if the user is out of credits

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -138,6 +138,14 @@ public class UserController implements UserApiDelegate {
     return ResponseEntity.ok(response);
   }
 
+  private BillingAccount freeTierBillingAccount() {
+    return new BillingAccount()
+        .isFreeTier(true)
+        .displayName("Use All of Us free credits")
+        .name(configProvider.get().billing.freeTierBillingAccountName())
+        .isOpen(true);
+  }
+
   @Override
   public ResponseEntity<WorkbenchListBillingAccountsResponse> listBillingAccounts() {
     final List<BillingAccount> billingAccounts = Lists.newArrayList();
@@ -145,12 +153,7 @@ public class UserController implements UserApiDelegate {
     // if we show the free credits account, it goes first
 
     if (freeTierBillingService.userHasRemainingFreeTierCredits(userProvider.get())) {
-      billingAccounts.add(
-          new BillingAccount()
-              .isFreeTier(true)
-              .displayName("Use All of Us free credits")
-              .name(configProvider.get().billing.freeTierBillingAccountName())
-              .isOpen(true));
+      billingAccounts.add(freeTierBillingAccount());
     }
 
     billingAccounts.addAll(getCloudbillingAccounts());


### PR DESCRIPTION
Description:

API portion of RW-3211: don't return free tier billing account in the account options for Create Workspace if the user is expired.

This API is only called by the UI when enableBillingLockout is enabled, so we can assume this.

If I had a normal-powered computer I would prefer to combine this with the UI, but running both UI and API servers locally is moderately painful right now.  Merging this first will let me run UI only, speeding up my dev cycle. :)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
