### PR TITLE
[noTicket][risk=moderate]Cloud interceptor should have correct Rdr Export queue name

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -23,7 +23,7 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
   public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
   public static final Set<String> VALID_QUEUE_NAME_SET =
-      new HashSet<>(Arrays.asList("rdrQueueTest"));
+      new HashSet<>(Arrays.asList("rdrExportQueue"));
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -22,6 +22,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
   public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
+  // Keep queue name consistent with the name as in OfflineRdrExportController
   public static final Set<String> VALID_QUEUE_NAME_SET =
       new HashSet<>(Arrays.asList("rdrExportQueue"));
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -65,7 +65,7 @@ public class CloudTaskInterceptorTest {
         .thenReturn(
             CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
     when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER))
-        .thenReturn("rdrQueueTest");
+        .thenReturn("rdrExportQueue");
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 


### PR DESCRIPTION
Cloud queue( responsible for handling task to export workspace/researcher data to Rdr ) name was recently updated from rdrQueueTest to rdrExportQueue. For all the incoming request dispatched from queue, cloud task interceptor confirms that request is coming from valid queue.

This PR is to update the name of queue in CloudTaskInterceptor