### PR TITLE
[noTicket][risk=low]Add parameter 'target' to queue.yaml

### DIFF
--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -1,6 +1,7 @@
 queue:
 - name: rdrExportQueue
   rate: 1/m
+  target: api
   bucket_size: 500
   retry_parameters:
     task_retry_limit: 1


### PR DESCRIPTION
Queue.yaml was missing target parameter for rdrExportQueue, because of which the request generated from queue was not hitting API.

https://cloud.google.com/appengine/docs/standard/python/config/queueref