### PR TITLE
[RW-3989][risk=low] Validate length on all workspace free text fields before creation

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1,7 +1,7 @@
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {cdrVersionStore, currentWorkspaceStore, navigate, routeConfigDataStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {mount} from 'enzyme';
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import {DisseminateResearchEnum, ResearchOutcomeEnum,
   SpecificPopulationEnum,UserApi, Workspace, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import * as fp from 'lodash/fp';
@@ -18,9 +18,15 @@ jest.mock('app/utils/navigation', () => ({
   navigate: jest.fn()
 }));
 
+type AnyWrapper = (ShallowWrapper|ReactWrapper);
+
 jest.mock('app/utils/workbench-gapi-client', () => ({
   getBillingAccountInfo: () => new Promise(resolve => resolve({billingAccountName: 'billing-account'}))
 }));
+
+function getSaveButtonDisableMsg(wrapper: AnyWrapper, attributeName: string) {
+  return wrapper.find('[data-test-id="workspace-save-btn"]').first().prop('disabled')[attributeName];
+}
 
 describe('WorkspaceEdit', () => {
   let workspacesApi: WorkspacesApiStub;
@@ -308,5 +314,84 @@ describe('WorkspaceEdit', () => {
 
     expect(wrapper.find('[data-test-id="characterLimit"]').get(0).props.children)
       .toContain('You have reached the character limit for this question');
+  });
+
+  it ('should show error message if Other primary purpose is more than 500 characters', async() => {
+    const wrapper = component();
+    let otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
+    expect(otherPrimaryPurposeError).toBeUndefined();
+    wrapper.find('[data-test-id="otherPurpose-checkbox"]').at(1).simulate('change', { target: { checked: true } });
+
+    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
+    expect(otherPrimaryPurposeError[0]).toBe('Other primary purpose must be true');
+
+    // Other Primary Purpose
+    const validInput = fp.repeat(500, 'a');
+    wrapper.find('[data-test-id="otherPrimaryPurposeText"]').first().simulate('change', {target: {value: validInput}});
+    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
+    expect(otherPrimaryPurposeError).toBeUndefined();
+
+    const inValidInput = fp.repeat(501, 'b');
+    wrapper.find('[data-test-id="otherPrimaryPurposeText"]').first().simulate('change', {target: {value: inValidInput}});
+    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
+    expect(otherPrimaryPurposeError[0]).toBe('Other primary purpose must be true');
+  });
+
+  it ('should show error message if Disease of focus is more than 80 characters', async() => {
+    const wrapper = component();
+    let diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
+    expect(diseaseNameError).toBeUndefined();
+
+    wrapper.find('[data-test-id="researchPurpose-checkbox"]').at(1).simulate('change', { target: { checked: true } })
+    wrapper.find('[data-test-id="diseaseFocusedResearch-checkbox"]').at(1).simulate('change', { target: { checked: true } });
+
+    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
+    expect(diseaseNameError[0]).toBe('Disease of focus must be true');
+
+    const validInput = fp.repeat(8, 'a');
+    wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: validInput}});
+
+    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
+    expect(diseaseNameError).toBeUndefined();
+    //
+    const inValidInput = fp.repeat(81, 'b');
+    wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: inValidInput}});
+    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
+    expect(diseaseNameError[0]).toBe('Disease of focus must be true');
+  });
+
+  it ('should show error message if Other text for disseminate research is more than 100 characters', async() => {
+    const wrapper = component();
+    wrapper.find('[data-test-id="OTHER-checkbox"]').at(1).simulate('change', { target: { checked: true } });
+    let otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
+    const validInput = fp.repeat(8, 'a');
+    wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: validInput}});
+
+    otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
+    expect(otherDisseminateResearchFindingsError).toBeUndefined();
+    const inValidInput = fp.repeat(101, 'b');
+    wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: inValidInput}});
+    otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
+    expect(otherDisseminateResearchFindingsError.get(0)).toBe('Other disseminate research findings must be true');
+  });
+
+  it ('should show error message if Other text for Special Population is more than 100 characters', async() => {
+    const wrapper = component();
+    expect(wrapper.find(`[data-test-id="specific-population-yes"]`)
+      .first().prop('checked')).toEqual(true);
+    wrapper.find('[data-test-id="other-specialPopulation-checkbox"]').at(1).
+    simulate('change', { target: { checked: true } });
+
+    const validInput = fp.repeat(100, 'a');
+    wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: validInput}});
+
+    let otherSpecificPopulationError = getSaveButtonDisableMsg(wrapper, 'otherSpecificPopulation');
+    expect(otherSpecificPopulationError).toBeUndefined();
+
+    const inValidInput = fp.repeat(101, 'a');
+    wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: inValidInput}});
+
+    otherSpecificPopulationError = getSaveButtonDisableMsg(wrapper, 'otherSpecificPopulation');
+    expect(otherSpecificPopulationError[0]).toBe('Other specific population must be true');
   });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -357,7 +357,7 @@ describe('WorkspaceEdit', () => {
     const inValidInput = fp.repeat(81, 'b');
     wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: inValidInput}});
     diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
-    expect(diseaseNameError[0]).toBe('Disease of focus must be true');
+    expect(fp.first(diseaseNameError)).toBe('Disease of focus must be true');
   });
 
   it ('should show error message if Other text for disseminate research is more than 100 characters', async() => {
@@ -372,7 +372,7 @@ describe('WorkspaceEdit', () => {
     const inValidInput = fp.repeat(101, 'b');
     wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: inValidInput}});
     otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
-    expect(otherDisseminateResearchFindingsError.get(0)).toBe('Other disseminate research findings must be true');
+    expect(fp.first(otherDisseminateResearchFindingsError)).toBe('Other disseminate research findings must be true');
   });
 
   it ('should show error message if Other text for Special Population is more than 100 characters', async() => {
@@ -392,6 +392,6 @@ describe('WorkspaceEdit', () => {
     wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: inValidInput}});
 
     otherSpecificPopulationError = getSaveButtonDisableMsg(wrapper, 'otherSpecificPopulation');
-    expect(otherSpecificPopulationError[0]).toBe('Other specific population must be true');
+    expect(fp.first(otherSpecificPopulationError)).toBe('Other specific population must be true');
   });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1139,7 +1139,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                   You must select a billing account</div>}
                 {errors.primaryPurpose && <div> You must choose at least one primary research
                   purpose (Question 1)</div>}
-                {errors.otherPrimaryPurpose && <div> Other primary purpose should be of atleast 500 characters</div>}
+                {errors.otherPrimaryPurpose && <div> Other primary purpose should be of at most 500 characters</div>}
                 {errors.anticipatedFindings && <div> Answer for <i>What are the anticipated findings
                   from the study? (Question # 2.1)</i> cannot be empty</div>}
                 {errors.scientificApproach && <div> Answer for <i>What are the scientific
@@ -1147,13 +1147,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                 {errors.intendedStudy && <div> Answer for<i>What are the specific scientific question(s) you intend to study
                   (Question # 2.3)</i> cannot be empty</div>}
                 {errors.specificPopulation && <div> You must specify a population of study</div>}
-                {errors.diseaseOfFocus && <div> You must specify a disease of focus and it should be atleast 80 characters</div>}
+                {errors.diseaseOfFocus && <div> You must specify a disease of focus and it should be at most 80 characters</div>}
                 {errors.researchOutcoming && <div> You must specify the outcome of the research</div>}
                 {errors.disseminate && <div> You must specific how you plan to disseminate your research findings</div>}
                 {errors.otherDisseminateResearchFindings && <div>
-                  Disseminate Research Findings Other text should be of atleast 100 characters</div>}
+                  Disseminate Research Findings Other text should be of at most 100 characters</div>}
                 {errors.otherSpecificPopulation && <div>
-                  Specific Population Other text should be of atleast 100 characters</div>}
+                  Specific Population Other text should be of at most 100 characters</div>}
               </ul>
             } disabled={!errors}>
               <Button type='primary'

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -602,9 +602,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
     get isOtherDisseminateResearchValid() {
       const researchPurpose = this.state.workspace.researchPurpose;
-      return this.isDisseminateResearchValid &&
-          (!fp.includes(DisseminateResearchEnum.OTHER, researchPurpose.disseminateResearchFindingList) ||
-              (researchPurpose.otherDisseminateResearchFindings && researchPurpose.otherDisseminateResearchFindings.length <= 100));
+      return !fp.includes(DisseminateResearchEnum.OTHER, researchPurpose.disseminateResearchFindingList) ||
+              (researchPurpose.otherDisseminateResearchFindings && researchPurpose.otherDisseminateResearchFindings.length <= 100);
     }
 
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -391,6 +391,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     makeDiseaseInput(): React.ReactNode {
       return (
         <SearchInput
+          data-test-id='diseaseOfFocus-input'
           enabled={this.state.workspace.researchPurpose.diseaseFocusedResearch}
           placeholder='Name of Disease'
           value={this.state.workspace.researchPurpose.diseaseOfFocus}
@@ -446,6 +447,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         children = <TextArea value={this.state.workspace.researchPurpose.otherPurposeDetails}
                   onChange={v => this.updateResearchPurpose('otherPurposeDetails', v)}
                   disabled={!this.state.workspace.researchPurpose.otherPurpose}
+                  data-test-id='otherPrimaryPurposeText'
                   style={{marginTop: '0.5rem'}}/>;
       }
 
@@ -484,12 +486,14 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                              placeholder='Specify the name of the forum (journal, scientific
                              conference, blog etc.) through which you will disseminate your
                              findings, if available.'
+                             data-test-id='otherDisseminateResearch-text'
                              disabled={!this.disseminateCheckboxSelected(DisseminateResearchEnum.OTHER)}
                              style={{marginTop: '0.5rem', width: '16rem'}}/>;
       }
 
       return <div key={index} style={styles.categoryRow}>
         <CheckBox style={styles.checkboxStyle}
+                  data-test-id={index + '-checkbox'}
                   checked={this.disseminateCheckboxSelected(rp.shortName)}
                   onChange={e => this.updateAttribute('disseminateResearchFindingList', rp.shortName, e)}/>
         <FlexColumn style={{marginTop: '-0.2rem'}}>
@@ -560,6 +564,12 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           rp.methodsDevelopment || rp.otherPurpose || rp.populationHealth || rp.socialBehavioral;
     }
 
+    get isOtherPrimaryPurposeValid() {
+      const rp = this.state.workspace.researchPurpose;
+      return !rp.otherPurpose ||
+          (rp.otherPurposeDetails && rp.otherPurposeDetails.length <= 500);
+    }
+
     get isSpecificPopulationValid() {
       const researchPurpose = this.state.workspace.researchPurpose;
       return (
@@ -571,10 +581,17 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       );
     }
 
+    get isOtherSpecificPopulationValid() {
+      const researchPurpose = this.state.workspace.researchPurpose;
+      return this.isSpecificPopulationValid && (
+          !fp.includes(SpecificPopulationEnum.OTHER, researchPurpose.populationDetails) ||
+          (researchPurpose.otherPopulationDetails && researchPurpose.otherPopulationDetails.length <= 100));
+    }
+
     get isDiseaseOfFocusValid() {
       const researchPurpose = this.state.workspace.researchPurpose;
       return !researchPurpose.diseaseFocusedResearch ||
-        researchPurpose.diseaseOfFocus;
+        researchPurpose.diseaseOfFocus && researchPurpose.diseaseOfFocus.length <= 80;
     }
 
     get isDisseminateResearchValid() {
@@ -582,6 +599,15 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       return researchPurpose.disseminateResearchFindingList &&
           researchPurpose.disseminateResearchFindingList.length !== 0;
     }
+
+    get isOtherDisseminateResearchValid() {
+      const researchPurpose = this.state.workspace.researchPurpose;
+      return this.isDisseminateResearchValid &&
+          (!fp.includes(DisseminateResearchEnum.OTHER, researchPurpose.disseminateResearchFindingList) ||
+              (researchPurpose.otherDisseminateResearchFindings && researchPurpose.otherDisseminateResearchFindings.length <= 100));
+    }
+
+
 
     get isResearchOutcome() {
       const researchPurpose = this.state.workspace.researchPurpose;
@@ -791,10 +817,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         intendedStudy,
         scientificApproach,
         'primaryPurpose': this.primaryPurposeIsSelected,
+        'otherPrimaryPurpose': this.isOtherPrimaryPurposeValid,
         'specificPopulation': this.isSpecificPopulationValid,
+        'otherSpecificPopulation': this.isOtherSpecificPopulationValid,
         'diseaseOfFocus': this.isDiseaseOfFocusValid,
         'researchOutcoming': this.isResearchOutcome,
-        'disseminate': this.isDisseminateResearchValid
+        'disseminate': this.isDisseminateResearchValid,
+        'otherDisseminateResearchFindings': this.isOtherDisseminateResearchValid
       }, {
         name: {
           length: { minimum: 1, maximum: 80 }
@@ -804,10 +833,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         anticipatedFindings: {length: { minimum: 1, maximum: 1000 }},
         scientificApproach: { length: { minimum: 1, maximum: 1000 } },
         primaryPurpose: { truthiness: true },
+        otherPrimaryPurpose: {truthiness: true},
         specificPopulation: { truthiness: true },
         diseaseOfFocus: { truthiness: true },
         researchOutcoming: {truthiness: true},
-        disseminate: {truthiness: true}
+        disseminate: {truthiness: true},
+        otherDisseminateResearchFindings: {truthiness: true},
+        otherSpecificPopulation: {truthiness: true}
 
       });
       return <FadeBox  style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
@@ -951,11 +983,11 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           <FlexRow>
             <FlexColumn style={styles.flexColumnBy2}>
               {disseminateFindings.slice(0, sliceByHalfLength(disseminateFindings)).map(
-                (rp, i) => this.makeDisseminateForm(rp, i))}
+                (rp, i) => this.makeDisseminateForm(rp, rp.shortName))}
             </FlexColumn>
             <FlexColumn style={styles.flexColumnBy2}>
               {disseminateFindings.slice(sliceByHalfLength(disseminateFindings)).map(
-                (rp, i) => this.makeDisseminateForm(rp, i))}
+                (rp, i) => this.makeDisseminateForm(rp, rp.shortName))}
             </FlexColumn>
           </FlexRow>
         </WorkspaceEditSection>
@@ -999,6 +1031,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                 <CheckBox
                     wrapperStyle={styles.checkboxRow}
                     style={styles.checkboxStyle}
+                    data-test-id='other-specialPopulation-checkbox'
                     label='Other'
                     labelStyle={styles.text}
                     checked={!!this.specificPopulationCheckboxSelected(SpecificPopulationEnum.OTHER)}
@@ -1009,6 +1042,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                            value={this.state.workspace.researchPurpose.otherPopulationDetails}
                            disabled={!fp.includes(SpecificPopulationEnum.OTHER,
                              this.state.workspace.researchPurpose.populationDetails)}
+                           data-test-id='other-specialPopulation-text'
                            onChange={v => this.setState(fp.set(
                              ['workspace', 'researchPurpose', 'otherPopulationDetails'], v))}/>
               </FlexColumn>
@@ -1102,19 +1136,25 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <TooltipTrigger content={
               errors && <ul>
                 {errors.name && <div>{errors.name}</div>}
-                {errors.billingAccountName && <div>You must select a billing account</div>}
-                {errors.primaryPurpose && <div>You must choose at least one primary research
+                {errors.billingAccountName && <div>
+                  You must select a billing account</div>}
+                {errors.primaryPurpose && <div> You must choose at least one primary research
                   purpose (Question 1)</div>}
-                {errors.anticipatedFindings && <div>Answer for <i>What are the anticipated findings
+                {errors.otherPrimaryPurpose && <div> Other primary purpose should be of atleast 500 characters</div>}
+                {errors.anticipatedFindings && <div> Answer for <i>What are the anticipated findings
                   from the study? (Question # 2.1)</i> cannot be empty</div>}
-                {errors.scientificApproach && <div>Answer for <i>What are the scientific
+                {errors.scientificApproach && <div> Answer for <i>What are the scientific
                   approaches you plan to use for your study (Question # 2.2)</i> cannot be empty</div>}
-                {errors.intendedStudy && <div>Answer for<i>What are the specific
-                  scientific question(s) you intend to study (Question # 2.3)</i> cannot be empty</div>}
-                {errors.specificPopulation && <div>You must specify a population of study</div>}
-                {errors.diseaseOfFocus && <div>You must specify a disease of focus</div>}
-                {errors.researchOutcoming && <div>You must specify the outcome of the research</div>}
-                {errors.disseminate && <div>You must specific how you plan to disseminate your research findings</div>}
+                {errors.intendedStudy && <div> Answer for<i>What are the specific scientific question(s) you intend to study
+                  (Question # 2.3)</i> cannot be empty</div>}
+                {errors.specificPopulation && <div> You must specify a population of study</div>}
+                {errors.diseaseOfFocus && <div> You must specify a disease of focus and it should be atleast 80 characters</div>}
+                {errors.researchOutcoming && <div> You must specify the outcome of the research</div>}
+                {errors.disseminate && <div> You must specific how you plan to disseminate your research findings</div>}
+                {errors.otherDisseminateResearchFindings && <div>
+                  Disseminate Research Findings Other text should be of atleast 100 characters</div>}
+                {errors.otherSpecificPopulation && <div>
+                  Specific Population Other text should be of atleast 100 characters</div>}
               </ul>
             } disabled={!errors}>
               <Button type='primary'


### PR DESCRIPTION
Add checks for the following attributes:

- **Name of disease (80)** : Error Message if Disease-focused research is selected and name of disease is empty or less than 80

- **Other primary Purpose(500):** Error messge if other primary purpose is selected but the text is empty or less than 500
<img width="628" alt="Screen Shot 2020-04-08 at 2 46 41 AM" src="https://user-images.githubusercontent.com/34481816/78753159-5c81c680-7943-11ea-9757-03eac8de9513.png">



- **Other disseminate research findings(100)**: If Other is selected for Question 3 and text is empty or less than 100
<img width="550" alt="Screen Shot 2020-04-08 at 2 46 13 AM" src="https://user-images.githubusercontent.com/34481816/78753249-7de2b280-7943-11ea-890a-dc5153a762a2.png">

- **Other Special Population(100)**: If special population Yes is selected and Special population Other is selected with empty or less than 100 characters 
<img width="732" alt="Screen Shot 2020-04-08 at 2 45 58 AM" src="https://user-images.githubusercontent.com/34481816/78753265-83d89380-7943-11ea-88f8-6aba18b3effc.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
