### PR TITLE
[RW-4500][RISK=MODERATE] Institution affiliation: distinguish between two institution agreement types

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -346,7 +346,7 @@ public class ProfileController implements ProfileApiDelegate {
     }
 
     if (workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
-      verifyInsitutionAffilation(request.getProfile());
+      verifyInstitutionalAffiliation(request.getProfile());
     }
 
     final Profile profile = request.getProfile();
@@ -515,7 +515,7 @@ public class ProfileController implements ProfileApiDelegate {
     }
   }
 
-  private void verifyInsitutionAffilation(Profile profile) {
+  private void verifyInstitutionalAffiliation(Profile profile) {
     String userName = profile.getUsername();
     String contactEmail = profile.getContactEmail();
     DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation =

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -30,6 +30,7 @@ import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbPageVisit;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.EmailException;
@@ -344,6 +345,10 @@ public class ProfileController implements ProfileApiDelegate {
       verifyInvitationKey(request.getInvitationKey());
     }
 
+    if (workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
+      verifyInsitutionAffilation(request.getProfile());
+    }
+
     final Profile profile = request.getProfile();
 
     // We don't include this check in validateAndCleanProfile since some existing user profiles
@@ -507,6 +512,28 @@ public class ProfileController implements ProfileApiDelegate {
       }
     } catch (org.pmiops.workbench.captcha.ApiException e) {
       throw new ServerErrorException("Exception while verifying Captcha");
+    }
+  }
+
+  private void verifyInsitutionAffilation(Profile profile) {
+    String userName = profile.getUsername();
+    String contactEmail = profile.getContactEmail();
+    DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation =
+        verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
+            profile.getVerifiedInstitutionalAffiliation(), institutionService);
+    if (!institutionService.validateAffiliation(dbVerifiedAffiliation, contactEmail)) {
+      final String msg =
+          Optional.ofNullable(dbVerifiedAffiliation)
+              .map(
+                  affiliation ->
+                      String.format(
+                          "Cannot create user %s: contact email %s is not a valid member of institution '%s'",
+                          userName, contactEmail, affiliation.getInstitution().getShortName()))
+              .orElse(
+                  String.format(
+                      "Cannot create user %s: contact email %s does not have a valid institutional affiliation",
+                      userName, contactEmail));
+      throw new BadRequestException(msg);
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -384,21 +384,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // set via the newer Verified Institutional Affiliation flow
     boolean requireInstitutionalVerification =
         configProvider.get().featureFlags.requireInstitutionalVerification;
-    if (requireInstitutionalVerification
-        && !institutionService.validateAffiliation(dbVerifiedAffiliation, contactEmail)) {
-      final String msg =
-          Optional.ofNullable(dbVerifiedAffiliation)
-              .map(
-                  affiliation ->
-                      String.format(
-                          "Cannot create user %s: contact email %s is not a valid member of institution '%s'",
-                          userName, contactEmail, affiliation.getInstitution().getShortName()))
-              .orElse(
-                  String.format(
-                      "Cannot create user %s: contact email %s does not have a valid institutional affiliation",
-                      userName, contactEmail));
-      throw new BadRequestException(msg);
-    }
 
     try {
       dbUser = userDao.save(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -44,7 +44,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.api.NihApi;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.EmailVerificationStatus;
@@ -93,7 +92,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private final FireCloudService fireCloudService;
   private final ComplianceService complianceService;
   private final DirectoryService directoryService;
-  private final InstitutionService institutionService;
 
   private static final Logger log = Logger.getLogger(UserServiceImpl.class.getName());
 
@@ -111,8 +109,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao,
       FireCloudService fireCloudService,
       ComplianceService complianceService,
-      DirectoryService directoryService,
-      InstitutionService institutionService) {
+      DirectoryService directoryService) {
     this.configProvider = configProvider;
     this.userProvider = userProvider;
     this.clock = clock;
@@ -126,7 +123,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     this.fireCloudService = fireCloudService;
     this.complianceService = complianceService;
     this.directoryService = directoryService;
-    this.institutionService = institutionService;
   }
 
   @VisibleForTesting

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -26,7 +26,6 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.google.DirectoryService;
-import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.UpdateUserDisabledRequest;
 import org.pmiops.workbench.test.FakeClock;
@@ -62,7 +61,6 @@ public class AuthDomainControllerTest {
   @Autowired private UserDao userDao;
   @Mock private UserDataUseAgreementDao userDataUseAgreementDao;
   @Mock private UserTermsOfServiceDao userTermsOfServiceDao;
-  @Mock private InstitutionService institutionService;
   @Mock private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   private AuthDomainController authDomainController;
@@ -93,8 +91,7 @@ public class AuthDomainControllerTest {
             verifiedInstitutionalAffiliationDao,
             fireCloudService,
             complianceService,
-            directoryService,
-            institutionService);
+            directoryService);
     this.authDomainController =
         new AuthDomainController(
             fireCloudService, userService, userDao, mockAuthDomainAuditAdapter);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -369,7 +369,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
-            .emailAddresses(Collections.singletonList("bob@example.com"))
+            .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
             .emailDomains(Collections.singletonList("example.com"))
             .duaTypeEnum(DuaType.RESTRICTED);
     institutionService.createInstitution(broad);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -172,7 +172,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     CommonMappers.class,
     VerifiedInstitutionalAffiliationMapperImpl.class,
     CaptchaVerificationService.class,
-    VerifiedInstitutionalAffiliationMapperImpl.class,
     UserServiceImpl.class,
     UserServiceTestConfiguration.class,
   })
@@ -289,6 +288,147 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Test(expected = BadRequestException.class)
   public void testInvitationKeyVerification_invitationKeyMismatch() {
     profileController.invitationKeyVerification(invitationVerificationRequest);
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testCreateAccount_MismatchEmailAddress() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
+            .emailDomains(Collections.singletonList("example.com"))
+            .duaTypeEnum(DuaType.RESTRICTED);
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail("notBob@example.com");
+    profileController.createAccount(createAccountRequest);
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testCreateAccount_MismatchEmailDomain() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
+            .emailDomains(Collections.singletonList("example.com"))
+            .duaTypeEnum(DuaType.MASTER);
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail("bob@broad.com");
+    profileController.createAccount(createAccountRequest);
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testCreateAccount_MismatchEmailDomainNullDUA() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
+            .emailDomains(Collections.singletonList("example.com"));
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail("bob@broadInstitute.com");
+    profileController.createAccount(createAccountRequest);
+  }
+
+  @Test
+  public void testCreateAccount_Success_RESTRICTEDDUA() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailAddresses(Collections.singletonList("bob@example.com"))
+            .emailDomains(Collections.singletonList("example.com"))
+            .duaTypeEnum(DuaType.RESTRICTED);
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail(CONTACT_EMAIL);
+    profileController.createAccount(createAccountRequest);
+  }
+
+  @Test
+  public void testCreateAccount_Success_MasterDUA() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailAddresses(Collections.singletonList("institution@example.com"))
+            .emailDomains(Collections.singletonList("example.com"))
+            .duaTypeEnum(DuaType.MASTER);
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail("bob@example.com");
+    profileController.createAccount(createAccountRequest);
+  }
+
+  @Test
+  public void testCreateAccount_Success_NULLDUA() {
+    createUser();
+    config.featureFlags.requireInstitutionalVerification = true;
+    final Institution broad =
+        new Institution()
+            .shortName("Broad")
+            .displayName("The Broad Institute")
+            .emailDomains(Collections.singletonList("example.com"));
+    institutionService.createInstitution(broad);
+
+    final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("Broad")
+            .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest
+        .getProfile()
+        .verifiedInstitutionalAffiliation(verifiedInstitutionalAffiliation)
+        .contactEmail("bob@example.com");
+    profileController.createAccount(createAccountRequest);
   }
 
   @Test


### PR DESCRIPTION
Part 2 of distinguish between two institution agreement types:


Verify institution details/validate affiliation for createAccount before directoryService.createUser to avoid creating a user which is going to throw bad request exception later resulting in an entry only in directory service and not in workbench.
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
