### PR TITLE
[RW-4573][risk=low] Delete workspace fixes

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -43,7 +43,9 @@ public class ServiceAccounts {
       throws IOException {
 
     GoogleCredentials credentials;
-    if (SystemProperty.environment.value().equals(SystemProperty.Environment.Value.Development)) {
+    if (SystemProperty.environment.value() == null
+        || SystemProperty.Environment.Value.Development.equals(
+            SystemProperty.environment.value())) {
       // When running in a local dev environment, we simply get the application default credentials.
       //
       // TODO(gjuggler): it may be possible to remove this branch point altogether, and use the

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -39,7 +39,7 @@ public class FireCloudConfig {
   public static final String SERVICE_ACCOUNT_WORKSPACE_API = "workspaceAclsApi";
   public static final String END_USER_WORKSPACE_API = "workspacesApi";
 
-  private static final List<String> BILLING_SCOPES =
+  public static final List<String> BILLING_SCOPES =
       ImmutableList.of(
           "https://www.googleapis.com/auth/userinfo.profile",
           "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
Switching to use service account creds rather than user impersonation. This is needed as there are a set of users in prod who are no longer in the registered tier, and therefore no longer have permission to delete workspaces.

Verified in the test environment by deleting one of my own workspaces.