### PR TITLE
[risk=no][RW-3211] Show free credits balance on Workspace Create

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -91,11 +91,11 @@ export const styles = reactStyles({
     padding: '0.25rem 0 0 1rem'
   },
   freeCreditsBalanceOverlay: {
-    height: '44px',
-    width: '150px',
-    color: '#262262',
+    height: 44,
+    width: 150,
+    color: colors.primary,
     fontFamily: 'Montserrat',
-    fontSize: '12px',
+    fontSize: 12,
     letterSpacing: '0',
     lineHeight: '22px',
   },

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -930,7 +930,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                           }
                         }}
               />
-              <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true}>
+              <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true} appendTo={document.body}>
                 <div style={styles.freeCreditsBalanceOverlay}>
                   FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
                 </div>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -88,14 +88,14 @@ export const styles = reactStyles({
   freeCreditsBalanceClickable: {
     display: 'inline-block',
     color: colors.accent,
-    padding: '0.5rem 0.5rem 0.5rem 0.75rem'
+    padding: '0.25rem 0 0 1rem'
   },
   freeCreditsBalanceOverlay: {
     height: '44px',
-    width: '189.45px',
+    width: '150px',
     color: '#262262',
     fontFamily: 'Montserrat',
-    fontSize: '14px',
+    fontSize: '12px',
     letterSpacing: '0',
     lineHeight: '22px',
   },
@@ -916,6 +916,11 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <div style={{...styles.header, color: colors.primary, fontSize: 14, marginBottom: '0.2rem'}}>
               Select account
             </div>
+            <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true} appendTo={document.body}>
+              <div style={styles.freeCreditsBalanceOverlay}>
+                FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
+              </div>
+            </OverlayPanel>
             <FlexRow>
               <Dropdown style={{width: '14rem'}}
                         value={this.state.workspace.billingAccountName}
@@ -930,16 +935,9 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                           }
                         }}
               />
-              <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true} appendTo={document.body}>
-                <div style={styles.freeCreditsBalanceOverlay}>
-                  FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
-                </div>
-              </OverlayPanel>
-              {freeTierCreditsBalance > 0.0 && <Clickable onClick={(e) => freeTierBalancePanel.toggle(e)}>
-                <div style={styles.freeCreditsBalanceClickable}>
-                  View FREE credits balance
-                </div>
-              </Clickable>}
+              {freeTierCreditsBalance > 0.0 && <div style={styles.freeCreditsBalanceClickable}>
+                <Clickable onClick={(e) => freeTierBalancePanel.toggle(e)}>View FREE credits balance</Clickable>
+              </div>}
             </FlexRow>
           </WorkspaceEditSection>}
         <hr style={{marginTop: '1rem'}}/>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -85,7 +85,12 @@ export const styles = reactStyles({
     flex: '1 1 0',
     marginLeft: '1rem'
   },
-  freeCreditBalance: {
+  freeCreditsBalanceClickable: {
+    display: 'inline-block',
+    color: colors.accent,
+    padding: '0.5rem 0.5rem 0.5rem 0.75rem'
+  },
+  freeCreditsBalanceOverlay: {
     height: '44px',
     width: '189.45px',
     color: '#262262',
@@ -925,21 +930,16 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                           }
                         }}
               />
-              <FlexColumn>
-                {freeTierCreditsBalance > 0.0 && <Clickable onClick={(e) => freeTierBalancePanel.toggle(e)}>
-                  <div style={{
-                    display: 'inline-block',
-                    color: colors.accent,
-                    padding: '0.5rem 0.5rem 0.5rem 0.75rem'}}>
-                    View FREE credits balance
-                  </div>
-                </Clickable>}
-                <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true}>
-                  <div style={styles.freeCreditBalance}>
-                      FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
-                  </div>
-                </OverlayPanel>
-              </FlexColumn>
+              <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true}>
+                <div style={styles.freeCreditsBalanceOverlay}>
+                  FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
+                </div>
+              </OverlayPanel>
+              {freeTierCreditsBalance > 0.0 && <Clickable onClick={(e) => freeTierBalancePanel.toggle(e)}>
+                <div style={styles.freeCreditsBalanceClickable}>
+                  View FREE credits balance
+                </div>
+              </Clickable>}
             </FlexRow>
           </WorkspaceEditSection>}
         <hr style={{marginTop: '1rem'}}/>


### PR DESCRIPTION
Description:

Pop up an OverlayPanel to display free credits, if the user has any remaining.

Mocks: https://projects.invisionapp.com/d/#/console/12820961/373893999/preview

<img width="590" alt="Screen Shot 2020-04-10 at 10 50 21 AM" src="https://user-images.githubusercontent.com/2701406/78999680-25650e00-7b19-11ea-9039-bc9dd3d19bee.png">

TODO: Remove the pointer?  Have not figured out how to do so yet

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
