### PR TITLE
[no ticket][risk=no] jest-junit flag to support circleci split by timings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,6 @@ workflows:
       - ui-build-test
       - api-bigquery-test
       - api-integration-test
-      - puppeteer-e2e-test
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
           <<: *filter_master
@@ -434,11 +433,11 @@ workflows:
           requires:
             - ui-build-test
       # After merge PR to master branch, run Puppeteer tests after ui and api deployed to "test" env successfully.
-      #- puppeteer-e2e-test:
-          #<<: *filter_master
-          #requires:
-            #- api-deploy-to-test
-            #- ui-deploy-to-test
+      - puppeteer-e2e-test:
+          <<: *filter_master
+          requires:
+            - api-deploy-to-test
+            - ui-deploy-to-test
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,7 @@ workflows:
       - ui-build-test
       - api-bigquery-test
       - api-integration-test
+      - puppeteer-e2e-test
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
           <<: *filter_master
@@ -433,11 +434,11 @@ workflows:
           requires:
             - ui-build-test
       # After merge PR to master branch, run Puppeteer tests after ui and api deployed to "test" env successfully.
-      - puppeteer-e2e-test:
-          <<: *filter_master
-          requires:
-            - api-deploy-to-test
-            - ui-deploy-to-test
+      #- puppeteer-e2e-test:
+          #<<: *filter_master
+          #requires:
+            #- api-deploy-to-test
+            #- ui-deploy-to-test
 
   deploy-staging:
     jobs:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,7 +27,9 @@
   },
   "jest-junit": {
     "outputDirectory": "./logs",
-    "outputName": "test-results.xml"
+    "outputName": "test-results.xml",
+    "classNameTemplate": "{filename}",
+    "suiteNameTemplate": "{filename}"
   },
   "dependencies": {},
   "devDependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -28,8 +28,7 @@
   "jest-junit": {
     "outputDirectory": "./logs",
     "outputName": "test-results.xml",
-    "classNameTemplate": "{filename}",
-    "suiteNameTemplate": "{filename}"
+    "suiteNameTemplate": "{filepath}"
   },
   "dependencies": {},
   "devDependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -28,6 +28,7 @@
   "jest-junit": {
     "outputDirectory": "./logs",
     "outputName": "test-results.xml",
+    "classNameTemplate": "{filepath}",
     "suiteNameTemplate": "{filepath}"
   },
   "dependencies": {},


### PR DESCRIPTION
Update junit XML format to fix `No timing found` error.
Before
<img width="640" alt="Screen Shot 2020-04-10 at 12 54 37 PM" src="https://user-images.githubusercontent.com/35533885/79008163-c9a38080-7b2a-11ea-90b6-d95a3e692255.png">
After
<img width="603" alt="Screen Shot 2020-04-10 at 12 54 20 PM" src="https://user-images.githubusercontent.com/35533885/79008182-cdcf9e00-7b2a-11ea-9f31-0ab2a5cde9da.png">
