### PR TITLE
[RW-4436][risk=no] Make deceased its own menu item

### DIFF
--- a/ui/src/app/cohort-search/demographics/demographics.component.css
+++ b/ui/src/app/cohort-search/demographics/demographics.component.css
@@ -22,7 +22,7 @@ h3 {
   position: relative;
 }
 .ng2-nouislider {
-  margin-top: 0;
+  margin: 0;
 }
 .number-display {
   margin-top: 0.25rem;
@@ -70,23 +70,15 @@ h3 {
   font-size: 14px;
   font-weight: 500;
 }
-.disabled {
-  opacity: 0.4;
-  pointer-events: none;
-}
 .form-container {
   padding-left: 1rem;
   max-height: 15rem;
 }
 .form-container.age {
   margin: 0.5rem 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 1.5rem;
   border: 1px solid #cccccc;
   border-radius: 5px;
-}
-.form-container.age clr-checkbox {
-  margin-top: 1rem;
-  padding-left: 1rem;
 }
 .form-container .radio-inline {
   margin-right: 0.75rem;

--- a/ui/src/app/cohort-search/demographics/demographics.component.html
+++ b/ui/src/app/cohort-search/demographics/demographics.component.html
@@ -5,7 +5,7 @@
       <div class="age-label">
         Age Range
       </div>
-      <div class="control-wrapper slider-wrapper" [class.disabled]="deceased.value">
+      <div class="control-wrapper slider-wrapper">
         <input type="number"
           id="min-age"
           [min]="minAge" [max]="maxAge"
@@ -34,19 +34,12 @@
           class="number-display"
           (blur)="checkMax()">
       </div>
-      <div *ngIf="enableCBAgeTypeOptions" style="margin-left: 1rem" [class.disabled]="deceased.value">
+      <div *ngIf="enableCBAgeTypeOptions" style="margin-left: 1rem">
         <div *ngFor="let ageType of ageTypes; let i = index;" class="radio-inline">
           <input type="radio" [id]="'age_' + i" [value]="ageType.type" formControlName="ageType">
           <label [for]="'age_' + i">{{ageType.label}}</label>
         </div>
       </div>
-
-      <clr-checkbox formControlName="deceased" [clrDisabled]="!ageNode || !deceasedNode">
-        Is Deceased
-        <span *ngIf="enableCBAgeTypeOptions && deceasedNode" class="badge badge-info">
-          {{deceasedNode.count | number}}
-        </span>
-      </clr-checkbox>
     </ng-container>
     <div *ngIf="loading" class="spinner" style="left: 45%"></div>
   </div>

--- a/ui/src/app/cohort-search/modal/modal.component.ts
+++ b/ui/src/app/cohort-search/modal/modal.component.ts
@@ -3,7 +3,7 @@ import {searchRequestStore, wizardStore} from 'app/cohort-search/search-state.se
 import {domainToTitle, generateId, stripHtml, typeToTitle} from 'app/cohort-search/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {environment} from 'environments/environment';
-import {CriteriaType, DomainType, TemporalMention, TemporalTime} from 'generated/fetch';
+import {CriteriaType, DomainType, SearchParameter, TemporalMention, TemporalTime} from 'generated/fetch';
 import {Subscription} from 'rxjs/Subscription';
 
 
@@ -45,23 +45,27 @@ export class ModalComponent implements OnInit, OnDestroy {
         // reset to default each time the modal is opened
         this.wizard = wizard;
         if (!this.open) {
-          this.title = wizard.domain === DomainType.PERSON ? typeToTitle(wizard.type) : domainToTitle(wizard.domain);
           this.selections = wizard.item.searchParameters;
           this.selectedIds = this.selections.map(s => s.parameterId);
-          if (this.initTree) {
-            this.hierarchyNode = {
-              domainId: wizard.domain,
-              type: wizard.type,
-              isStandard: wizard.standard,
-              id: 0,
-            };
-            this.backMode = 'tree';
-            this.mode = 'tree';
+          if (wizard.type === CriteriaType.DECEASED) {
+            this.selectDeceased();
           } else {
-            this.backMode = 'list';
-            this.mode = 'list';
+            this.title = wizard.domain === DomainType.PERSON ? typeToTitle(wizard.type) : domainToTitle(wizard.domain);
+            if (this.initTree) {
+              this.hierarchyNode = {
+                domainId: wizard.domain,
+                type: wizard.type,
+                isStandard: wizard.standard,
+                id: 0,
+              };
+              this.backMode = 'tree';
+              this.mode = 'tree';
+            } else {
+              this.backMode = 'list';
+              this.mode = 'list';
+            }
+            this.open = true;
           }
-          this.open = true;
         }
       });
   }
@@ -266,5 +270,21 @@ export class ModalComponent implements OnInit, OnDestroy {
     if (param.group) {
       this.groupSelections = this.groupSelections.filter(id => id !== param.id);
     }
+  }
+
+  selectDeceased() {
+    const param = {
+      parameterId: '',
+      type: CriteriaType.DECEASED.toString(),
+      name: 'Deceased',
+      group: false,
+      domain: DomainType.PERSON.toString(),
+      hasHierarchy: false,
+      ancestorData: false,
+      standard: true,
+      attributes: []
+    } as SearchParameter;
+    this.addSelection(param);
+    this.finish();
   }
 }

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -94,11 +94,15 @@ const css = `
     padding: 0 1rem;
   }
   body .p-menuitem.menuitem-header > .p-menuitem-link {
+    cursor: default;
     font-size: 12px;
     font-weight: 600;
     height: auto;
     line-height: 0.75rem;
     padding-left: 0.5rem;
+  }
+  body .p-menuitem.menuitem-header > .p-menuitem-link:hover {
+    background: ${colors.white};
   }
   body .p-tieredmenu .p-menu-separator {
     margin: 0.25rem 0;
@@ -119,6 +123,7 @@ interface Props {
 interface State {
   criteriaMenuOptions: any;
   index: number;
+  loadingMenuOptions: boolean;
 }
 
 export class SearchGroupList extends React.Component<Props, State> {
@@ -129,6 +134,7 @@ export class SearchGroupList extends React.Component<Props, State> {
     this.state = {
       criteriaMenuOptions: {programTypes: [], domainTypes: []},
       index: 0,
+      loadingMenuOptions: false
     };
   }
 
@@ -152,6 +158,7 @@ export class SearchGroupList extends React.Component<Props, State> {
   }
 
   getMenuOptions() {
+    this.setState({loadingMenuOptions: true});
     const {cdrVersionId} = currentWorkspaceStore.getValue();
     const criteriaMenuOptions = criteriaMenuOptionsStore.getValue();
     cohortBuilderApi().findCriteriaMenuOptions(+cdrVersionId).then(res => {
@@ -183,6 +190,7 @@ export class SearchGroupList extends React.Component<Props, State> {
       criteriaMenuOptions[cdrVersionId].programTypes.sort((a, b) => a.order - b.order);
       criteriaMenuOptions[cdrVersionId].domainTypes.sort((a, b) => a.order - b.order);
       criteriaMenuOptionsStore.next(criteriaMenuOptions);
+      this.setState({loadingMenuOptions: false});
     });
   }
 
@@ -194,14 +202,16 @@ export class SearchGroupList extends React.Component<Props, State> {
   }
 
   get criteriaMenuItems() {
-    const {criteriaMenuOptions: {domainTypes, programTypes}} = this.state;
-    return [
-      {label: 'Program Data', className: 'menuitem-header'},
-      ...programTypes.map((dt) => this.mapCriteriaMenuItem(dt, 0)),
-      {separator: true},
-      {label: 'Domains', className: 'menuitem-header'},
-      ...domainTypes.map((dt) => this.mapCriteriaMenuItem(dt, 0))
-    ];
+    const {criteriaMenuOptions: {domainTypes, programTypes}, loadingMenuOptions} = this.state;
+    return loadingMenuOptions
+      ? [{icon: 'pi pi-spin pi-spinner'}]
+      : [
+        {label: 'Program Data', className: 'menuitem-header'},
+        ...programTypes.map((dt) => this.mapCriteriaMenuItem(dt, 0)),
+        {separator: true},
+        {label: 'Domains', className: 'menuitem-header'},
+        ...domainTypes.map((dt) => this.mapCriteriaMenuItem(dt, 0))
+      ];
   }
 
   launchWizard(criteria: any) {

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -13,7 +13,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {CriteriaType, DomainType, SearchRequest} from 'generated/fetch';
+import {DomainType, SearchRequest} from 'generated/fetch';
 
 function initItem(id: string, type: string) {
   return {
@@ -166,7 +166,6 @@ export class SearchGroupList extends React.Component<Props, State> {
             order: PROGRAM_TYPES.indexOf(DomainType[domain])};
           if (domain === DomainType[DomainType.PERSON]) {
             option['children'] = types
-            .filter(subopt => subopt.type !== CriteriaType[CriteriaType.DECEASED])
             .map(subopt => ({name: typeToTitle(subopt.type), domain, type: subopt.type}));
           }
           acc.programTypes.push(option);

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -98,10 +98,10 @@ export function domainToTitle(domain: any): string {
 export function typeToTitle(_type: string): string {
   switch (_type) {
     case CriteriaType[CriteriaType.AGE]:
-      _type = 'Age/Deceased';
+      _type = 'Age';
       break;
     case CriteriaType[CriteriaType.DECEASED]:
-      _type = 'Age/Deceased';
+      _type = 'Deceased';
       break;
     case CriteriaType[CriteriaType.ETHNICITY]:
       _type = 'Ethnicity';


### PR DESCRIPTION
- Separate Age and Deceased items in criteria menu dropdown
- Remove deceased checkbox from age wizard
<img width="591" alt="Screen Shot 2020-04-10 at 3 27 38 PM" src="https://user-images.githubusercontent.com/40036095/79021195-805e2b80-7b40-11ea-9324-8ac1bc60439b.png">
<img width="961" alt="Screen Shot 2020-04-10 at 3 27 55 PM" src="https://user-images.githubusercontent.com/40036095/79021207-86540c80-7b40-11ea-9ee7-7b09178babd0.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
