### PR TITLE
[RW-4221][RISK=MODERATE]  Enable feature flag enableRdrExport for RDR Export - Prod

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -110,7 +110,7 @@
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": false
+    "excludeWorkspaceFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -109,7 +109,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -113,7 +113,7 @@
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": false
+    "excludeWorkspaceFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -112,7 +112,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -92,7 +92,7 @@
     "unsafeAllowDeleteUser": false,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableRdrExport": false,
+    "enableRdrExport": true,
     "enableBillingLockout": true,
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -110,7 +110,7 @@
     "host": "all-of-us-rdr-prod.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": true
+    "excludeWorkspaceFromPublicDirectory": true
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -109,7 +109,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-prod.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": true
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -110,7 +110,7 @@
     "host": "all-of-us-rdr-stable.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": false
+    "excludeWorkspaceFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -109,7 +109,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-stable.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -109,7 +109,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-staging.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -110,7 +110,7 @@
     "host": "all-of-us-rdr-staging.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": false
+    "excludeWorkspaceFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -110,7 +110,7 @@
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
     "exportObjectsPerTask": 10,
-    "excludeFromPublicDirectory": false
+    "excludeWorkspaceFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -109,7 +109,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "excludeFromPublicDirectory": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -255,6 +255,8 @@ public class WorkbenchConfig {
     public String queueName;
     // Number of ids per task
     public Integer exportObjectsPerTask;
+    // Should workspace details be excluded for researcher directory
+    public boolean excludeFromPublicDirectory;
   }
 
   public static class CaptchaConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -256,7 +256,7 @@ public class WorkbenchConfig {
     // Number of ids per task
     public Integer exportObjectsPerTask;
     // Should workspace details be excluded for researcher directory
-    public boolean excludeFromPublicDirectory;
+    public boolean excludeWorkspaceFromPublicDirectory;
   }
 
   public static class CaptchaConfig {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -284,11 +284,8 @@ public class RdrExportServiceImpl implements RdrExportService {
             dbWorkspace.getWorkspaceActiveStatusEnum().toString()));
     // For PROD: Confirm workspace details before showing the data on research directory.
     // As of now Workbench will always exclude workspace details from Public Directory
-    if (workbenchConfigProvider.get().server.shortName.equalsIgnoreCase(PROD_SHORTNAME)) {
-      rdrWorkspace.setExcludeFromPublicDirectory(true);
-    } else {
-      rdrWorkspace.setExcludeFromPublicDirectory(false);
-    }
+    rdrWorkspace.setExcludeFromPublicDirectory(
+        workbenchConfigProvider.get().rdrExport.excludeFromPublicDirectory);
     rdrWorkspace.setDiseaseFocusedResearch(dbWorkspace.getDiseaseFocusedResearch());
     rdrWorkspace.setDiseaseFocusedResearchName(dbWorkspace.getDiseaseOfFocus());
     rdrWorkspace.setOtherPurpose(dbWorkspace.getOtherPurpose());

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -56,7 +56,6 @@ public class RdrExportServiceImpl implements RdrExportService {
   private WorkspaceService workspaceService;
   private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
   private Provider<WorkbenchConfig> workbenchConfigProvider;
-  private final String PROD_SHORTNAME = "Prod";
 
   private static final Logger log = Logger.getLogger(RdrExportService.class.getName());
   ZoneOffset offset = OffsetDateTime.now().getOffset();
@@ -285,7 +284,7 @@ public class RdrExportServiceImpl implements RdrExportService {
     // For PROD: Confirm workspace details before showing the data on research directory.
     // As of now Workbench will always exclude workspace details from Public Directory
     rdrWorkspace.setExcludeFromPublicDirectory(
-        workbenchConfigProvider.get().rdrExport.excludeFromPublicDirectory);
+        workbenchConfigProvider.get().rdrExport.excludeWorkspaceFromPublicDirectory);
     rdrWorkspace.setDiseaseFocusedResearch(dbWorkspace.getDiseaseFocusedResearch());
     rdrWorkspace.setDiseaseFocusedResearchName(dbWorkspace.getDiseaseOfFocus());
     rdrWorkspace.setOtherPurpose(dbWorkspace.getOtherPurpose());

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -82,7 +82,7 @@ public class RdrExportServiceImplTest {
   @Before
   public void setUp() {
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
-    providedWorkbenchConfig.rdrExport.excludeFromPublicDirectory = false;
+    providedWorkbenchConfig.rdrExport.excludeWorkspaceFromPublicDirectory = false;
     rdrExportService = spy(rdrExportService);
     when(mockRdrApi.getApiClient()).thenReturn(mockApiClient);
     when(mockApiClient.setDebugging(true)).thenReturn(null);
@@ -178,7 +178,7 @@ public class RdrExportServiceImplTest {
     List<Long> workspaceID = new ArrayList<>();
     workspaceID.add(1l);
 
-    providedWorkbenchConfig.rdrExport.excludeFromPublicDirectory = true;
+    providedWorkbenchConfig.rdrExport.excludeWorkspaceFromPublicDirectory = true;
 
     rdrExportService.exportWorkspaces(workspaceID);
     verify(mockWorkspaceService)

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -82,7 +82,7 @@ public class RdrExportServiceImplTest {
   @Before
   public void setUp() {
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
-    providedWorkbenchConfig.server.shortName = "Prod";
+    providedWorkbenchConfig.rdrExport.excludeFromPublicDirectory = false;
     rdrExportService = spy(rdrExportService);
     when(mockRdrApi.getApiClient()).thenReturn(mockApiClient);
     when(mockApiClient.setDebugging(true)).thenReturn(null);
@@ -172,13 +172,13 @@ public class RdrExportServiceImplTest {
   }
 
   @Test
-  public void exportWorkspace__excludeAsFalse() throws ApiException {
+  public void exportWorkspace__excludeAsTrue() throws ApiException {
     doNothing().when(mockRdrApi).exportWorkspaces(anyList());
 
     List<Long> workspaceID = new ArrayList<>();
     workspaceID.add(1l);
 
-    providedWorkbenchConfig.server.shortName = "Stable";
+    providedWorkbenchConfig.rdrExport.excludeFromPublicDirectory = true;
 
     rdrExportService.exportWorkspaces(workspaceID);
     verify(mockWorkspaceService)


### PR DESCRIPTION
- Switch ON the flag for rdrExport  PROD

- set Parameter **ExcludeFromPublicDirectory** as True only for PROD. This is because only verified Workspace details should be visible in Research Directory. By setting excludeFromPublicDirectory to TRUE rdr will just store the details but will not not send it to ResearchDirectory.

Note: Waiting for thumbs up from RDR and research directory before merging in the changes

Feature flag clean up ticket: https://precisionmedicineinitiative.atlassian.net/browse/RW-4758

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
