### PR TITLE
[RW-4749][risk=no] Add Google Analytics for Registration pages

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -232,6 +232,7 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
   }
 
   openVideo(videoLink: string): void {
+    AnalyticsTracker.Registration.TutorialVideo();
     this.setState({videoOpen: true, videoLink: videoLink});
   }
 

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -10,6 +10,7 @@ import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {navigate, serverConfigStore, userProfileStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {AccessModule, Profile} from 'generated/fetch';
@@ -49,6 +50,7 @@ const styles = reactStyles({
 });
 
 function redirectToGoogleSecurity(): void {
+  AnalyticsTracker.Registration.TwoFactorAuth();
   let url = 'https://myaccount.google.com/u/2/signinoptions/two-step-verification/enroll';
   const {profile} = userProfileStore.getValue();
   // The profile should always be available at this point, but avoid making an
@@ -62,6 +64,7 @@ function redirectToGoogleSecurity(): void {
 }
 
 function redirectToNiH(): void {
+  AnalyticsTracker.Registration.ERACommons();
   const url = environment.shibbolethUrl + '/link-nih-account?redirect-url=' +
           encodeURIComponent(
             window.location.origin.toString() + '/nih-callback?token={token}');
@@ -69,6 +72,7 @@ function redirectToNiH(): void {
 }
 
 async function redirectToTraining() {
+  AnalyticsTracker.Registration.EthicsTraining();
   await profileApi().updatePageVisits({page: 'moodle'});
   window.open(environment.trainingUrl + '/static/data-researcher.html?saml=on', '_blank');
 }
@@ -139,7 +143,10 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     completionTimestamp: (profile: Profile) => {
       return profile.dataUseAgreementCompletionTime || profile.dataUseAgreementBypassTime;
     },
-    onClick: () => navigate(['data-code-of-conduct'])
+    onClick: () => {
+      AnalyticsTracker.Registration.EnterDUCC();
+      navigate(['data-code-of-conduct']);
+    }
   }
 ] as RegistrationTask[]).filter(registrationTask => registrationTask.featureFlag === undefined
 || registrationTask.featureFlag) : (() => {

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -13,6 +13,7 @@ import {commonStyles, TextInputWithLabel, WhyWillSomeInformationBePublic} from '
 import {institutionApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {isBlank, reactStyles} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {isAbortError, reportError} from 'app/utils/errors';
 import {
   CheckEmailResponse,
@@ -344,7 +345,10 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
             }
             <div style={{marginTop: '.5rem'}}>
               <a href={'https://www.researchallofus.org/institutional-agreements'} target='_blank'
-                 style={{color: colors.accent}}>
+                 style={{color: colors.accent}}
+                 onClick={() => {
+                   AnalyticsTracker.Registration.InstitutionNotListed();
+                 }}>
               Don't see your institution listed?
               </a>
             </div>
@@ -419,7 +423,10 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
             </div>} disabled={!errors}>
               <Button data-test-id='submit-button'
                       disabled={loadingInstitutions || errors != null}
-                      onClick={() => this.props.onComplete(this.state.profile)}>
+                      onClick={() => {
+                        AnalyticsTracker.Registration.InstitutionPage();
+                        this.props.onComplete(this.state.profile);
+                      }}>
                 Next
               </Button>
             </TooltipTrigger>

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -37,7 +37,6 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     const {invitationKey, termsOfServiceVersion, onComplete} = this.props;
 
     try {
-      AnalyticsTracker.Registration.DemographicSurvey();
       const newProfile = await profileApi().createAccount({
         profile: profile,
         captchaVerificationToken: captchaToken,
@@ -57,7 +56,10 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     return <React.Fragment>
       <DemographicSurvey
           profile={this.props.profile}
-          onSubmit={(profile, captchaToken) => this.createAccount(profile, captchaToken)}
+          onSubmit={(profile, captchaToken) => {
+            AnalyticsTracker.Registration.DemographicSurvey();
+            return this.createAccount(profile, captchaToken);
+          }}
           onPreviousClick={(profile) => this.props.onPreviousClick(profile)}
           enableCaptcha={true}
           enablePrevious={true}

--- a/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-survey.tsx
@@ -4,6 +4,8 @@ import {Button} from 'app/components/buttons';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {DemographicSurvey} from 'app/pages/profile/demographic-survey';
 import {profileApi} from 'app/services/swagger-fetch-clients';
+
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {convertAPIError, reportError} from 'app/utils/errors';
 import {environment} from 'environments/environment';
 import {ErrorResponse, Profile} from 'generated/fetch';
@@ -35,6 +37,7 @@ export class AccountCreationSurvey extends React.Component<AccountCreationSurvey
     const {invitationKey, termsOfServiceVersion, onComplete} = this.props;
 
     try {
+      AnalyticsTracker.Registration.DemographicSurvey();
       const newProfile = await profileApi().createAccount({
         profile: profile,
         captchaVerificationToken: captchaToken,

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -38,6 +38,7 @@ import {
   WhyWillSomeInformationBePublic,
 } from 'app/pages/login/account-creation/common';
 import {isBlank, reactStyles} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/navigation';
 
 const styles = reactStyles({
@@ -685,7 +686,10 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                                 this.isUsernameValidationError() ||
                                 Boolean(errors)}
                       style={{'height': '2rem', 'width': '10rem'}}
-                      onClick={() => this.props.onComplete(this.state.profile)}>
+                      onClick={() => {
+                        AnalyticsTracker.Registration.CreateAccountPage();
+                        this.props.onComplete(this.state.profile);
+                      }}>
                 Next
               </Button>
             </TooltipTrigger>

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -18,6 +18,7 @@ import {
   withServerConfig,
   withWindowSize,
 } from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 
 import {DataAccessLevel, Degree, Profile} from 'generated/fetch';
 
@@ -284,10 +285,12 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
 
     switch (currentStep) {
       case SignInStep.LANDING:
-        return <LoginReactComponent signIn={this.props.signIn} onCreateAccount={() =>
+        return <LoginReactComponent signIn={this.props.signIn} onCreateAccount={() => {
+          AnalyticsTracker.Registration.CreateAccount();
           this.setState({
             currentStep: this.getNextStep(currentStep)
-          })}/>;
+          });
+        }}/>;
       case SignInStep.INVITATION_KEY:
         return <InvitationKey onInvitationKeyVerified={(key: string) => this.setState({
           invitationKey: key,
@@ -296,10 +299,13 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
       case SignInStep.TERMS_OF_SERVICE:
         return <AccountCreationTos
           pdfPath='/assets/documents/terms-of-service.pdf'
-          onComplete={() => this.setState({
-            termsOfServiceVersion: 1,
-            currentStep: this.getNextStep(currentStep)
-          })}/>;
+          onComplete={() => {
+            AnalyticsTracker.Registration.TOS();
+            this.setState({
+              termsOfServiceVersion: 1,
+              currentStep: this.getNextStep(currentStep)
+            });
+          }}/>;
       case SignInStep.INSTITUTIONAL_AFFILIATION:
         return <AccountCreationInstitution
           profile={this.state.profile}
@@ -362,6 +368,7 @@ export class SignInComponent extends ReactWrapperBase {
   }
 
   signIn(): void {
+    AnalyticsTracker.Registration.SignIn();
     this.signInService.signIn();
   }
 

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -232,6 +232,8 @@ export const DataUserCodeOfConduct = withUserProfile()(
                       data-test-id={'submit-ducc-button'}
                       disabled={errors || submitting}
                       onClick={() => {
+                        // This may record extra GA events if the user views & accepts the DUCC from their profile. If the additional events
+                        // are an issue, we may need further changes, possibly disable the Accept button after initial submit.
                         AnalyticsTracker.Registration.AcceptDUCC();
                         this.submitDataUserCodeOfConduct(initialMonitoring);
                       }}

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -14,6 +14,7 @@ import {
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/navigation';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
@@ -231,6 +232,7 @@ export const DataUserCodeOfConduct = withUserProfile()(
                       data-test-id={'submit-ducc-button'}
                       disabled={errors || submitting}
                       onClick={() => {
+                        AnalyticsTracker.Registration.AcceptDUCC();
                         this.submitDataUserCodeOfConduct(initialMonitoring);
                       }}
                   >

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -85,6 +85,24 @@ export const AnalyticsTracker = {
     Edit: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Edit'),
     Run: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Run (Playground Mode)')
   },
+  Registration: {
+    SignIn: () => triggerEvent('Registration', 'Click sign-in', 'Sign in'),
+    CreateAccount: () => triggerEvent('Registration', 'Click create account', 'Create account'),
+    TOS: () => triggerEvent('Registration', 'Click next', 'Accepted TOS'),
+    InstitutionNotListed: () => triggerEvent('Registration', 'Click \'don\'t see institution\' link', 'Institution not listed'),
+    InstitutionPage: () =>
+      triggerEvent('Registration', 'Clicked \'Next\' in step 1/3 in registration process', 'Institution info completed'),
+    CreateAccountPage: () =>
+      triggerEvent('Registration', 'Clicked \'Next\' in step 2/3 in registration process', 'Create Account page completed'),
+    DemographicSurvey: () =>
+      triggerEvent('Registration', 'Clicked \'Next\' in step 3/3 in registration process', 'Demographic survey completed'),
+    TwoFactorAuth: () => triggerEvent('Registration', 'Clicked on \'2FA\' button', '2FA'),
+    EthicsTraining: () => triggerEvent('Registration', 'Clicked on \'Ethics training\' button', 'Training'),
+    ERACommons: () => triggerEvent('Registration', 'Clicked on eRA commons button', 'eRA commons'),
+    EnterDUCC: () => triggerEvent('Registration', 'Clicked in DUCC button', 'Entered DUCC'),
+    AcceptDUCC: () => triggerEvent('Registration', 'Clicked in DUCC button', 'Accepted DUCC'),
+    TutorialVideo: () => triggerEvent('Home Page', 'Clicked on a tutorial video', 'Tutorial videos'),
+  },
   Sidebar: {
     OpenSidebar: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.SIDEBAR, 'Click', suffix),
     Search: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.HELP, 'Search', `Help - Search - ${suffix}`),


### PR DESCRIPTION
Add Google Analytics for events on registration pages.

Events based off the Registration tab of the [workbench analytics doc](https://docs.google.com/spreadsheets/d/1V_Zp0ZtN8f237LNcaGQA-WZzYJu9g8ECq80gJCV8njA/edit#gid=293698803)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
