### PR TITLE
[RW-4723][Risk=no] Fix eRA commons linking

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -65,27 +65,36 @@ export const styles = reactStyles({
   },
 });
 
-export const Homepage = withUserProfile()(class extends React.Component<
-  { profileState: { profile: Profile, reload: Function } },
-  { accessTasksLoaded: boolean,
-    accessTasksRemaining: boolean,
-    betaAccessGranted: boolean,
-    dataUserCodeOfConductCompleted: boolean,
-    eraCommonsError: string,
-    eraCommonsLinked: boolean,
-    firstVisit: boolean,
-    firstVisitTraining: boolean,
-    quickTour: boolean,
-    trainingCompleted: boolean,
-    twoFactorAuthCompleted: boolean,
-    videoOpen: boolean,
-    videoLink: string,
-    userHasWorkspaces: boolean | null
-  }> {
+interface Props {
+  profileState: {
+    profile: Profile,
+    reload: Function
+  };
+}
+
+interface State {
+  accessTasksLoaded: boolean;
+  accessTasksRemaining: boolean;
+  betaAccessGranted: boolean;
+  dataUserCodeOfConductCompleted: boolean;
+  eraCommonsError: string;
+  eraCommonsLinked: boolean;
+  eraCommonsLoading: boolean;
+  firstVisit: boolean;
+  firstVisitTraining: boolean;
+  quickTour: boolean;
+  trainingCompleted: boolean;
+  twoFactorAuthCompleted: boolean;
+  videoOpen: boolean;
+  videoLink: string;
+  userHasWorkspaces: boolean | null;
+}
+
+export const Homepage = withUserProfile()(class extends React.Component<Props, State> {
   private pageId = 'homepage';
   private timer: NodeJS.Timer;
 
-  constructor(props: any) {
+  constructor(props: Props) {
     super(props);
     this.state = {
       accessTasksLoaded: false,
@@ -94,6 +103,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
       dataUserCodeOfConductCompleted: undefined,
       eraCommonsError: '',
       eraCommonsLinked: undefined,
+      eraCommonsLoading: false,
       firstVisit: undefined,
       firstVisitTraining: true,
       quickTour: false,
@@ -109,6 +119,7 @@ export const Homepage = withUserProfile()(class extends React.Component<
     this.checkWorkspaces();
     this.validateNihToken();
     this.callProfile();
+    console.log('component did mount');
   }
 
   componentDidUpdate(prevProps) {
@@ -124,9 +135,14 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
   async validateNihToken() {
     const token = (new URL(window.location.href)).searchParams.get('token');
+    console.log(token);
     if (token) {
+      this.setState({eraCommonsLoading: true});
       try {
-        await profileApi().updateNihToken({ jwt: token });
+        const profileResponse = await profileApi().updateNihToken({ jwt: token });
+        if (profileResponse.eraCommonsLinkedNihUsername !== undefined) {
+          this.setState({eraCommonsLinked: true});
+        }
       } catch (e) {
         this.setState({eraCommonsError: 'Error saving NIH Authentication status.'});
       }
@@ -224,8 +240,9 @@ export const Homepage = withUserProfile()(class extends React.Component<
 
   render() {
     const {betaAccessGranted, videoOpen, accessTasksLoaded, accessTasksRemaining,
-      eraCommonsLinked, eraCommonsError, firstVisitTraining, trainingCompleted, quickTour,
-      videoLink, twoFactorAuthCompleted, dataUserCodeOfConductCompleted
+      eraCommonsError, eraCommonsLinked, eraCommonsLoading, firstVisitTraining,
+      trainingCompleted, quickTour, videoLink, twoFactorAuthCompleted,
+      dataUserCodeOfConductCompleted
     } = this.state;
 
     const quickTourResources = [
@@ -269,13 +286,14 @@ export const Homepage = withUserProfile()(class extends React.Component<
           <FlexColumn style={{justifyContent: 'flex-start'}}>
               {accessTasksLoaded ?
                 (accessTasksRemaining ?
-                    (<RegistrationDashboard eraCommonsLinked={eraCommonsLinked}
-                                            eraCommonsError={eraCommonsError}
+                    (<RegistrationDashboard eraCommonsError={eraCommonsError}
+                                            eraCommonsLinked={eraCommonsLinked}
+                                            eraCommonsLoading={eraCommonsLoading}
                                             trainingCompleted={trainingCompleted}
                                             firstVisitTraining={firstVisitTraining}
                                             betaAccessGranted={betaAccessGranted}
                                             twoFactorAuthCompleted={twoFactorAuthCompleted}
-                                          dataUserCodeOfConductCompleted={dataUserCodeOfConductCompleted}/>
+                                            dataUserCodeOfConductCompleted={dataUserCodeOfConductCompleted}/>
                     ) : (
                         <React.Fragment>
                           <FlexColumn>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -119,7 +119,6 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
     this.checkWorkspaces();
     this.validateNihToken();
     this.callProfile();
-    console.log('component did mount');
   }
 
   componentDidUpdate(prevProps) {
@@ -135,7 +134,6 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
 
   async validateNihToken() {
     const token = (new URL(window.location.href)).searchParams.get('token');
-    console.log(token);
     if (token) {
       this.setState({eraCommonsLoading: true});
       try {

--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -26,6 +26,7 @@ describe('RegistrationDashboard', () => {
     });
     props  = {
       eraCommonsLinked: false,
+      eraCommonsLoading: false,
       eraCommonsError: '',
       trainingCompleted: false,
       firstVisitTraining: true,

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -262,7 +262,6 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
     const canUnsafeSelfBypass = serverConfigStore.getValue().unsafeAllowSelfBypass;
 
     const anyBypassActionsRemaining = !(this.allTasksCompleted() && betaAccessGranted);
-    const loading = this.isLoading(0);
 
     // Assign relative positioning so the spinner's absolute positioning anchors
     // it within the registration box.

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -6,7 +6,7 @@ import {Button} from 'app/components/buttons';
 import {baseStyles, ResourceCardBase} from 'app/components/card';
 import {FlexColumn, FlexRow, FlexSpacer} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
-import {SpinnerOverlay} from 'app/components/spinners';
+import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
@@ -76,6 +76,7 @@ async function redirectToTraining() {
 interface RegistrationTask {
   key: string;
   completionPropsKey: string;
+  loadingPropsKey?: string;
   title: string;
   description: React.ReactNode;
   buttonText: string;
@@ -105,6 +106,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
   }, {
     key: 'eraCommons',
     completionPropsKey: 'eraCommonsLinked',
+    loadingPropsKey: 'eraCommonsLoading',
     title: 'Connect Your eRA Commons Account',
     description: 'Connect your account to the eRA Commons account. The application instructions will guide you through this.',
     buttonText: 'Connect',
@@ -151,8 +153,9 @@ export const getRegistrationTasksMap = () => getRegistrationTasks().reduce((acc,
 
 export interface RegistrationDashboardProps {
   betaAccessGranted: boolean;
-  eraCommonsLinked: boolean;
   eraCommonsError: string;
+  eraCommonsLinked: boolean;
+  eraCommonsLoading: boolean;
   trainingCompleted: boolean;
   firstVisitTraining: boolean;
   twoFactorAuthCompleted: boolean;
@@ -194,13 +197,23 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
 
   isEnabled(i: number): boolean {
     const taskCompletionList = this.taskCompletionList;
-
     if (i === 0) {
       return !taskCompletionList[i];
     } else {
+      // Only return the first uncompleted button.
       return !taskCompletionList[i] &&
-      fp.filter(index => this.isEnabled(index), fp.range(0, i)).length === 0;
+        fp.filter(index => this.isEnabled(index), fp.range(0, i)).length === 0;
     }
+  }
+
+  get taskLoadingList(): Array<boolean> {
+    return getRegistrationTasks().map((config) => {
+      return this.props[config.loadingPropsKey] as boolean;
+    });
+  }
+
+  isLoading(i: number): boolean {
+    return this.taskLoadingList[i];
   }
 
   showRefreshFlow(isRefreshable: boolean): boolean {
@@ -249,6 +262,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
     const canUnsafeSelfBypass = serverConfigStore.getValue().unsafeAllowSelfBypass;
 
     const anyBypassActionsRemaining = !(this.allTasksCompleted() && betaAccessGranted);
+    const loading = this.isLoading(0);
 
     // Assign relative positioning so the spinner's absolute positioning anchors
     // it within the registration box.
@@ -299,17 +313,19 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
                       style={{backgroundColor: colors.success,
                         width: 'max-content',
                         cursor: 'default'}}>
-                <ClrIcon shape='check' style={{marginRight: '0.3rem'}}/>{card.completedText}
+                {card.completedText}
+                <ClrIcon shape='check' style={{marginLeft: '0.5rem'}}/>
               </Button> :
-            <Button onClick={ () => this.onCardClick(card) }
+            <Button onClick={ () => this.isLoading(i) ? true : this.onCardClick(card) }
                     style={{width: 'max-content',
-                      cursor: this.isEnabled(i) ? 'pointer' : 'default'}}
+                      cursor: this.isEnabled(i) && !this.isLoading(i) ? 'pointer' : 'default'}}
                     disabled={!this.isEnabled(i)} data-test-id='registration-task-link'>
               {this.showRefreshFlow(card.isRefreshable) ?
                 <div>
-                  <ClrIcon shape='refresh' style={{marginRight: '0.3rem'}}/>
                   Refresh
+                  <ClrIcon shape='refresh' style={{marginLeft: '0.5rem'}}/>
                 </div> : card.buttonText}
+              {this.isLoading(i) ? <Spinner style={{marginLeft: '0.5rem', width: 20, height: 20}}/> : null}
             </Button>}
           </ResourceCardBase>;
         })}


### PR DESCRIPTION
Description:
This fixes the eRA commons redirect to follow up by setting the task to completed. In doing this, I realized there was a loading step, so I added a loading spinner to the button. I talked to Lou about the styling on that, and we decided to move all the icons to the right of the button, because if the spinner was on the left, it would push the text when it appeared. The button is disabled but still primary while loading per Lou's request. This has been confirmed with Karthik
Here is a screenshot while loading:
<img width="1101" alt="Screen Shot 2020-04-13 at 4 31 41 PM" src="https://user-images.githubusercontent.com/15351021/79159719-953bf880-7da6-11ea-8e3e-ce207c1bd12e.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
