### PR TITLE
[RW-4747][RISK=NO]  Add text for username section

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -693,7 +693,6 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         </FlexColumn>
         <FlexColumn>
           <FlexColumn style={styles.asideContainer}>
-            <div style={{marginTop: '1rem'}}></div>
             <WhyWillSomeInformationBePublic />
           </FlexColumn>
           <FlexColumn style={{...styles.asideContainer, marginTop: '21.8rem', height: '15rem'}}>

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -413,10 +413,17 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
 
     const usernameLabelText =
       <div>New Username
-        <TooltipTrigger side='top' content={<div>Usernames can contain only letters
-          (a-z), numbers (0-9), dashes (-), underscores (_), apostrophes ('), and
-          periods (.) (minimum of 3 characters and maximum of 64
-          characters).<br/>Usernames cannot begin or end with a period (.) and may not
+        <TooltipTrigger side='top' content={<div>Usernames can contain only: <ul style={{marginLeft: '0.1rem'}}>
+          <li>letters (a-z)</li>
+          <li>numbers (0-9)</li>
+          <li>dashes (-)</li>
+          <li>underscores (_)</li>
+          <li>apostrophes (')</li>
+          <li>periods (.)</li>
+          <li>minimum of 3 characters</li>
+          <li>maximum of 64 characters</li>
+        </ul>
+          <br/>Usernames cannot begin or end with a period (.) and may not
           contain more than one period (.) in a row.</div>}
                         style={{marginLeft: '0.5rem'}}>
           <InfoIcon style={{'height': '16px', 'paddingLeft': '2px'}}/>
@@ -435,10 +442,16 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           <div style={{...styles.text, fontSize: 16, marginTop: '1rem'}}>
             Please complete Step {requireInstitutionalVerification ? '2 of 3' : '1 of 2'}
           </div>
-          <div style={{...styles.text, fontSize: 12, marginTop: '0.7rem'}}>All fields required unless indicated as optional</div>
+          <div style={{...styles.text, fontSize: 12, marginTop: '0.7rem'}}>
+            All fields required unless indicated as optional</div>
           <Section header={<div>Create an <i>All of Us</i> username</div>}>
             <div>
               <FlexRow>
+                <FlexColumn>
+                  <div style={{...styles.asideText, marginBottom: '0.3rem'}}>
+                    We create a 'username'@{gsuiteDomain} Google account which you will use to
+                    login to the Workbench. This is separate account and not related to any personal
+                    or professional Google accounts you may have.</div>
                   <TextInputWithLabel value={username} inputId='username' inputName='username'
                                       placeholder='New Username' invalid={
                                         this.state.usernameConflictError || this.usernameInvalidError()}
@@ -449,6 +462,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
                   </div>
                   <i style={{...styles.asideText, marginLeft: 4}}>@{gsuiteDomain}</i>
                 </TextInputWithLabel>
+                </FlexColumn>
 
               </FlexRow>
               {this.state.usernameConflictError &&
@@ -679,9 +693,6 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         </FlexColumn>
         <FlexColumn>
           <FlexColumn style={styles.asideContainer}>
-            <div style={styles.asideHeader}>About your new username</div>
-            <div style={styles.asideText}>We create a 'username'@{gsuiteDomain} Google
-                account which you will use to login to the Workbench.</div>
             <div style={{marginTop: '1rem'}}></div>
             <WhyWillSomeInformationBePublic />
           </FlexColumn>

--- a/ui/src/app/pages/login/account-creation/common.tsx
+++ b/ui/src/app/pages/login/account-creation/common.tsx
@@ -62,7 +62,7 @@ export const commonStyles = reactStyles({
 export const WhyWillSomeInformationBePublic: React.FunctionComponent = () => {
   return <React.Fragment>
     <div style={commonStyles.asideHeader}>Why will some information be public?</div>
-    <div style={commonStyles.asideText}>The <AouTitle/> The All of Us Research Program seeks to be transparent
+    <div style={commonStyles.asideText}>The <AouTitle/> seeks to be transparent
       with participants about who can access their data and for what purpose. Therefore, we will display
       your name, institution, role, research background/interests, and a link to your professional
       profile (if available) in the the <a href='https://researchallofus.org/'>Research Projects


### PR DESCRIPTION
As part of this story: 

- Add username information above the new username lable

<img width="1100" alt="Screen Shot 2020-04-14 at 3 46 21 PM" src="https://user-images.githubusercontent.com/34481816/79272589-aac92500-7e6f-11ea-9b21-413807aef1b2.png">

- Update new username tooltip 
<img width="405" alt="Screen Shot 2020-04-14 at 3 53 46 PM" src="https://user-images.githubusercontent.com/34481816/79272669-c59b9980-7e6f-11ea-87dc-e1d7e3a7ec0c.png">

- Remove About your username section  and the extra "The All Of Us text" from the side help text
<img width="464" alt="Screen Shot 2020-04-15 at 10 56 28 AM" src="https://user-images.githubusercontent.com/34481816/79352521-f7603f00-7f07-11ea-9996-62bb9236b276.png">






---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
