### PR TITLE
[No Ticket][Risk=no] Make minimum width 1300px for site

### DIFF
--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -136,7 +136,7 @@ const WorkbenchFooter = withUserProfile()(
               </FlexColumn>
             </FlexRow>
           </FooterSection>
-          <div style={{...styles.workbenchFooterItem, ...styles.footerAside}}>
+          <div style={{...styles.workbenchFooterItem, ...styles.footerAside, marginRight: 0}}>
             The <i>All of Us</i> logo is a service mark of the
             U.S. Department of Health and Human Services.
             The <i>All of Us</i> platform is for research only and does

--- a/ui/src/app/pages/profile/data-user-code-of-conduct-styles.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct-styles.tsx
@@ -15,7 +15,7 @@ export const dataUserCodeOfConductStyles = reactStyles({
     paddingTop: '2rem',
     paddingLeft: '3rem',
     paddingBottom: '2rem',
-    maxWidth: '50rem',
+    maxWidth: '48rem',
     height: '100%',
     color: colors.primary,
   },

--- a/ui/src/app/pages/signed-in/component.css
+++ b/ui/src/app/pages/signed-in/component.css
@@ -6,8 +6,8 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  /*Footer minimum width*/
-  min-width: 68.5rem
+  /*minimum supported width is 1300, this allows 20px for the scrollbar*/
+  min-width: 1280px;
 }
 
 .content-container {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -989,7 +989,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
         <WorkspaceEditSection
           header={researchPurposeQuestions[1].header} indent
-          description={researchPurposeQuestions[1].description} style={{width: '50rem'}} index='2.'>
+          description={researchPurposeQuestions[1].description} style={{width: '48rem'}} index='2.'>
           <FlexColumn>
             {/* TextBox: scientific question(s) researcher intend to study Section*/}
             <WorkspaceResearchSummary researchPurpose={researchPurposeQuestions[2]}
@@ -1012,7 +1012,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
           {/*disseminate  research Section */}
         <WorkspaceEditSection header={researchPurposeQuestions[5].header}
-                              description={researchPurposeQuestions[5].description} style={{width: '50rem'}} index='3.'>
+                              description={researchPurposeQuestions[5].description} style={{width: '48rem'}} index='3.'>
           <FlexRow>
             <FlexColumn style={styles.flexColumnBy2}>
               {disseminateFindings.slice(0, sliceByHalfLength(disseminateFindings)).map(
@@ -1028,7 +1028,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           {/*Research outcome section*/}
           <WorkspaceEditSection header={researchPurposeQuestions[6].header} index='4.'
                                 description={researchPurposeQuestions[6].description}
-                                style={{width: '50rem'}}>
+                                style={{width: '48rem'}}>
             <FlexRow style={{marginLeft: '1rem'}}>
               <FlexColumn style={{flex: '1 1 0'}}>
                 {researchOutcomes.map(
@@ -1040,7 +1040,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           {/*Underrespresented population section*/}
         <WorkspaceEditSection header={researchPurposeQuestions[7].header} index='5.' indent
                               description={researchPurposeQuestions[7].description}
-                              style={{width: '50rem'}}>
+                              style={{width: '48rem'}}>
           <div style={styles.header}>Will your study focus on any historically underrepresented populations?</div>
           <div>
             <RadioButton name='population' style={{marginRight: '0.5rem'}}

--- a/ui/src/app/pages/workspace/workspace-research-summary.tsx
+++ b/ui/src/app/pages/workspace/workspace-research-summary.tsx
@@ -11,13 +11,13 @@ const styles = reactStyles({
   textArea: {
     height: '15rem',
     resize: 'none',
-    width: '50rem',
+    width: '48rem',
     borderRadius: '3px 3px 0 0',
     boderColor: colorWithWhiteness(colors.dark, 0.5)
   },
   textBoxCharRemaining: {
     justifyContent: 'space-between',
-    width: '50rem',
+    width: '48rem',
     backgroundColor: colorWithWhiteness(colors.primary, 0.95),
     fontSize: 12,
     colors: colors.primary,

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -25,5 +25,5 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: true,
-  enableSignedInFooter: true
+  enableSignedInFooter: false
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,5 +23,5 @@ export const testEnvironmentBase = {
   enablePublishedWorkspaces: false,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: false,
-  enableSignedInFooter: true
+  enableSignedInFooter: false
 };


### PR DESCRIPTION
Description:
This is to address the desire to audit the site for horizontal scroll bars. This disables the footer on all environments (for now), and drops the width of some workspace edit components to fit within 1280px of screen width. This makes the lowest supported web-browser width of the site 1300px. Lou has confirmed that all screens he has designed are 1280px wide. (And then we add 20px for the scroll bar)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
