### PR TITLE
[RW-4768][risk=no] Add check for green checkmark back to e2e tests.

### DIFF
--- a/e2e/app/create-account-page.ts
+++ b/e2e/app/create-account-page.ts
@@ -154,6 +154,8 @@ export default class CreateAccountPage extends BasePage {
     const emailAddressTextbox = await Textbox.forLabel(this.page, {textContains: FIELD_LABEL.INSTITUTION_EMAIL, ancestorNodeLevel: 2});
     await emailAddressTextbox.type(config.broadInstitutionEmail);
     await emailAddressTextbox.tabKey(); // tab out to start email validation
+    // Wait for the validation success checkbox to be present.
+    await ClrIconLink.forLabel(this.page, FIELD_LABEL.INSTITUTION_EMAIL, 'success-standard');
     const roleSelect = new SelectComponent(this.page, 'describes your role');
     await roleSelect.select(INSTITUTION_ROLE_VALUE.UNDERGRADUATE_STUDENT);
   }


### PR DESCRIPTION
This reverts a small change that Alex had made to the e2e tests when the green checkmarks accidentally were removed from the inst. affiliation email field.