### PR TITLE
[RW-4667][risk=no] Allow Incapsula's unsafe-eval in our content security policy

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -21,14 +21,16 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
-    # unsafe-inline is unfortunately required as the Incapsula WAF injects a
-    # script onto the page when we're serving in production, for which we'd be
-    # unable to precompute a hash.
+    # unsafe-inline and unsafe-eval are unfortunately required as the Incapsula
+    # WAF injects a script onto the page when we're serving in production, for
+    # which we'd be unable to precompute a hash. This script also apparently
+    # uses an unsafe eval.
     Content-Security-Policy-Report-Only: "
       default-src 'none';
       script-src
         'self'
         'unsafe-inline'
+        'unsafe-eval'
         https://apis.google.com
         https://*.googleapis.com
         https://static.zdassets.com


### PR DESCRIPTION
I've started a thread with security to start a thread with Incapsula about why their script needs to be performing an unsafe eval.

I'm hopeful that we can observe this in prod, then QA the enforced policy in a non-prod WAF environment (e.g. preprod, or stable if we can finally switch stable to use the WAF endpoint), and then finally enable it prod after the next few releases.