### PR TITLE
[RW-4720][risk=no] Show confirmation modal when saving a workspace

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -147,6 +147,9 @@ describe('WorkspaceEdit', () => {
     wrapper.find('[data-test-id="workspace-save-btn"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
 
+    wrapper.find('[data-test-id="workspace-confirm-save-btn"]').first().simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
     expect(workspacesApi.workspaces[0].researchPurpose.populationDetails.length).toBe(0);
   });
 
@@ -206,6 +209,9 @@ describe('WorkspaceEdit', () => {
     const numBefore = workspacesApi.workspaces.length;
     wrapper.find('[data-test-id="workspace-save-btn"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
+
+    wrapper.find('[data-test-id="workspace-confirm-save-btn"]').first().simulate('click');
+    await waitOneTickAndUpdate(wrapper);
     expect(workspacesApi.workspaces.length).toEqual(numBefore + 1);
     expect(navigate).toHaveBeenCalledTimes(1);
   });
@@ -221,6 +227,8 @@ describe('WorkspaceEdit', () => {
 
     jest.useFakeTimers();
     wrapper.find('[data-test-id="workspace-save-btn"]').first().simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    wrapper.find('[data-test-id="workspace-confirm-save-btn"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
     expect(navigate).not.toHaveBeenCalled();
 
@@ -249,6 +257,8 @@ describe('WorkspaceEdit', () => {
 
     jest.useFakeTimers();
     wrapper.find('[data-test-id="workspace-save-btn"]').first().simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    wrapper.find('[data-test-id="workspace-confirm-save-btn"]').first().simulate('click');
     let aclDelayBtn;
     for (let i = 0; i < 10; i++) {
       jest.advanceTimersByTime(20e3);

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1293,7 +1293,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                 onClick={() => this.setState({showConfirmationModal: false})}>
                 Keep Editing
               </Button>
-              <Button type='primary' onClick={() => this.onSaveClick()}>
+              <Button type='primary' onClick={() => this.onSaveClick()}
+                data-test-id='workspace-confirm-save-btn'>
                 Confirm
               </Button>
             </ModalFooter>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -208,6 +208,7 @@ export interface WorkspaceEditState {
   showResearchPurpose: boolean;
   billingAccounts: Array<BillingAccount>;
   showCreateBillingAccountModal: boolean;
+  showConfirmationModal: boolean;
   populationChecked: boolean;
 }
 
@@ -231,6 +232,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         showStigmatizationDetails: false,
         billingAccounts: [],
         showCreateBillingAccountModal: false,
+        showConfirmationModal: false,
         populationChecked: props.workspace ? props.workspace.researchPurpose.populationDetails.length > 0 : undefined,
       };
     }
@@ -832,7 +834,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             scientificApproach,
             reviewRequested
           }
-        }
+        },
+        showConfirmationModal
       } = this.state;
       const {freeTierDollarQuota, freeTierUsage} = this.props.profileState.profile;
       const freeTierCreditsBalance = freeTierDollarQuota - freeTierUsage;
@@ -1202,7 +1205,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
               </ul>
             } disabled={!errors}>
               <Button type='primary'
-                      onClick={() => this.onSaveClick()}
+                      onClick={() => this.setState({showConfirmationModal: true})}
                       disabled={errors || this.state.loading}
                       data-test-id='workspace-save-btn'>
                 {this.renderButtonText()}
@@ -1262,6 +1265,39 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             </Button>
           </ModalFooter>
         </Modal>
+        }
+        {showConfirmationModal &&
+          <Modal width={500}>
+            <ModalTitle style={{fontSize: '16px', marginBottom: 0}}>
+              {this.renderButtonText()}
+            </ModalTitle>
+            <ModalBody style={{color: colors.primary, lineHeight: '1rem', marginTop: '0.25rem'}}>
+              <div>Your responses to these questions:</div>
+              <div style={{margin: '0.25rem 0 0.25rem 1rem'}}>
+                <span style={{fontWeight: 600}}>Primary purpose of your project</span> (Question 1)<br/>
+                <span style={{fontWeight: 600}}>Summary of research purpose</span> (Question 2)<br/>
+                <span style={{fontWeight: 600}}>Population of interest</span> (Question 5)<br/>
+              </div>
+              <div style={{marginBottom: '1rem'}}>
+                Will be
+                <a style={{color: colors.accent}}
+                  href='https://www.researchallofus.org/research-projects-directory/'
+                  target='_blank'> displayed publicly </a>
+                 to inform <i>All of Us</i> Research participants. Therefore, please verify that you have provided sufficiently detailed
+                 responses in plain language.
+              </div>
+              <div>You can also make changes to your answers after you create your workspace.</div>
+            </ModalBody>
+            <ModalFooter>
+              <Button type='secondary' style={{marginRight: '1rem'}}
+                onClick={() => this.setState({showConfirmationModal: false})}>
+                Keep Editing
+              </Button>
+              <Button type='primary' onClick={() => this.onSaveClick()}>
+                Confirm
+              </Button>
+            </ModalFooter>
+          </Modal>
         }
         </div>
       </FadeBox> ;


### PR DESCRIPTION
Shows the user a confirmation modal before saving when creating, editing or duplicating a workspace.
<img width="741" alt="Screen Shot 2020-04-16 at 11 30 54 AM" src="https://user-images.githubusercontent.com/40036095/79529352-12c76900-8032-11ea-9aef-5f2222ee7b85.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
