### PR TITLE
[noTicket][RISK=MEDIUM] Should display error message only after email verification

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.spec.tsx
@@ -189,6 +189,30 @@ it('should validate email affiliation when inst and email domain are specified',
   expect(getEmailErrorMessage(wrapper).getDOMNode().textContent).toBe(
     'Your email does not match your institution'
   );
+
+});
+
+it('should display validation icon only after email verification', async() => {
+  const wrapper = component();
+  await waitOneTickAndUpdate(wrapper);
+
+  // Choose 'VUMC' and enter an email address.
+  getInstitutionDropdown(wrapper).props.onChange({originalEvent: undefined, value: 'VUMC'});
+  getEmailInput(wrapper).simulate('change', {target: {value: 'asdf@wrongDomain.com'}});
+
+  // Email address is entered, but the input hasn't been blurred. The form should know that a
+  // response is required, but the API request hasn't been sent and returned yet.
+  expect(getInstance(wrapper).validate()['checkEmailResponse'])
+    .toContain('Institutional membership check has not completed');
+
+  // At this point, the validation icon should not be displayed as email has not been verified
+  await waitOneTickAndUpdate(wrapper);
+  expect(wrapper.find('[data-test-id="email-validation-icon"]').children().length).toBe(0);
+  getEmailInput(wrapper).simulate('blur');
+
+  // Email has beeb verified, the validation icon should now be displayed
+  await waitOneTickAndUpdate(wrapper);
+  expect(wrapper.find('[data-test-id="email-validation-icon"]').children().length).toBe(1);
 });
 
 it('should clear email validation when institution is changed', async() => {

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -216,6 +216,10 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
       return '';
     }
 
+    // Institution email Address is either being verified or researcher has just enter it and not change focus
+    if (!checkEmailResponse && !checkEmailError) {
+      return '';
+    }
     // No error if the institution check was successful.
     if (checkEmailResponse && checkEmailResponse.isValidMember) {
       return '';
@@ -396,7 +400,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
                                 onBlur={() => this.onEmailBlur()}
                                 onChange={email => this.updateContactEmail(email)}>
               <div style={{...inputStyles.iconArea}}>
-                <ValidationIcon validSuccess={this.isEmailValid()}/>
+                <ValidationIcon data-test-id='email-validation-icon' validSuccess={this.isEmailValid()}/>
               </div>
             </TextInputWithLabel>
             {this.displayEmailErrorMessageIfNeeded()}


### PR DESCRIPTION
**Bug**: Institution error message was being displayed as soon as user starts typing  in email. Therefore even valid email ids were being shown some error message unless they looses email textbox focus and email verification is done, correcting the email message and the icon

**Solution**: add a check to show the validation icon or error message once email verification has been done i.e verification API has returned with some kind of response before 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
