### PR TITLE
[RW-4757][risk=no] Enable v2 Moodle API on perf/staging/stable

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -100,7 +100,7 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": true,
-    "enableMoodleV2Api": false,
+    "enableMoodleV2Api": true,
     "requireInstitutionalVerification": true,
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -97,7 +97,7 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": true,
-    "enableMoodleV2Api": false,
+    "enableMoodleV2Api": true,
     "requireInstitutionalVerification": false,
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -97,7 +97,7 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": true,
-    "enableMoodleV2Api": false,
+    "enableMoodleV2Api": true,
     "requireInstitutionalVerification": true,
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": false,


### PR DESCRIPTION
See comments on RW-4757 for more context.

This is a simple flag-flipping PR which will allow me to start testing v2 Moodle API in lower environments.

I will plan to manually push this config change to perf/staging/stable once the PR is merged; all actions will be logged in comments on the associated Jira issue.