### PR TITLE
[no ticket][risk=no] Puppeteer Remove a Workspace automated test

### DIFF
--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -22,16 +22,6 @@ describe('Creating new workspaces', () => {
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });
 
-  test('Create workspace - YES request for review', async () => {
-    const newWorkspaceName = `aoutest-${Math.floor(Math.random() * 1000)}-${Math.floor(Date.now() / 1000)}`;
-    const workspacesPage = new WorkspacesPage(page);
-    await workspacesPage.load();
-
-    // create workspace with "Yes, Review Requested" radiobutton selected
-    await workspacesPage.createWorkspace(newWorkspaceName, 'Use All of Us free credits', true);
-    await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
-  });
-
   test('User can create a workspace using all inputs', async () => {
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();


### PR DESCRIPTION
Reason: Selecting YES for the "request a workspace review" option would generates some Zendesk tickets which can't be deleted. Testing of this feature was already covered by other automated tests.