### PR TITLE
[no ticket][risk=no] CircleCI Names and anchors for common steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,15 @@ java_defaults: &java_defaults
 jobs:
   api-build-test:
     <<: *java_defaults
+    # TODO(jaycarlton): I don't see any spport in CircleCI for reusing individual steps, but we can
+    # fake it using a Handlebars template or another simple yaml input file
     steps:
       - checkout
       - run:
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - run:
+          name: Ensure Branch is on Origin
           #Circle is bad about setting up your remotes for you, you must use origin/
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
@@ -43,7 +47,7 @@ jobs:
           working_directory: ~/workbench/api
           command: ./project.rb gradle compileBigquerytestJava compileIntegrationJava
       - run:
-          name: Unit tests
+          name: Run Java Unit Tests
           working_directory: ~/workbench/api
           command: ./project.rb test
       - run:
@@ -81,13 +85,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - restore_cache:
           keys:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-cache-
       - run:
+          name: Activate Service Accont Credentials
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
@@ -96,9 +101,11 @@ jobs:
           name: Await MySQL startup
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m
       - run:
+          name: Run Local Migrations
           working_directory: ~/workbench/api
           command: ./project.rb run-local-migrations
       - run:
+          name: Local API Tests on Running Server
           working_directory: ~/workbench/api
           command: ./project.rb start-local-api && ./project.rb run-local-api-tests && ./project.rb stop-local-api
       - save_cache:
@@ -113,6 +120,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       # Note: most of the time spent here appears to be in Gradle / App Engine
       # deployment. We tried more aggressively caching outputs via Circle
@@ -124,6 +132,7 @@ jobs:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-cache-
       - run:
+          name: Activate Service Accont Credentials
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
       - deploy:
@@ -142,6 +151,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - run:
           name: Scan dependencies for vulnerabilities
@@ -155,9 +165,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - run:
+          name: Ensure Branch is on Origin
           #Circle is bad about setting up your remotes for you, you must use origin/
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
@@ -169,10 +180,12 @@ jobs:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-integration-cache-
       - run:
+          name: Activate Service Accont Credentials
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
           command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
+          name: Run Integration Tests
           working_directory: ~/workbench/api
           command: ./project.rb integration
       - save_cache:
@@ -186,17 +199,19 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - restore_cache:
           keys:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-integration-cache-
       - run:
+          name: Activate Service Accont Credentials
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
           command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
+          name: Run Nightly Integration tests
           working_directory: ~/workbench/api
           command: ./project.rb nightly-integration
       - save_cache:
@@ -210,9 +225,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - run:
+          name: Ensure Branch is on Origin
           #Circle is bad about setting up your remotes for you, you must use origin/
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
@@ -224,10 +240,12 @@ jobs:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-integration-cache-
       - run:
+          name: Activate Service Accont Credentials
           working_directory: ~/workbench
           # Used to call gsutil from the circle environment.
           command: ci/activate_creds.sh api/circle-sa-key.json
       - run:
+          name: Run BigQuery Tests
           working_directory: ~/workbench/api
           command: ./project.rb bigquerytest
       - save_cache:
@@ -241,11 +259,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - run:
-          working_directory: ~/workbench
           name: Download Swagger CLI
+          working_directory: ~/workbench
           command: |
             ruby -r ./aou-utils/swagger.rb -e Workbench::Swagger.download_swagger_codegen_cli
       - restore_cache:
@@ -253,6 +271,7 @@ jobs:
           - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
           - ui-cache-
       - run:
+          name: Yarn Codegen
           working_directory: ~/workbench/ui
           command: yarn install --verbose --frozen-lockfile && yarn codegen
       - save_cache:
@@ -260,17 +279,17 @@ jobs:
             - ~/.cache/yarn
           key: ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
       - run:
-          name: Run Angular tests
+          name: Run Angular Tests
           working_directory: ~/workbench/ui
           command: |
             yarn test --no-watch --no-progress --browsers=ChromeHeadless
       - run:
-          name: Run React tests (Jest)
+          name: Run React Jest Tests
           working_directory: ~/workbench/ui
           command: |
             yarn test-react --detectOpenHandles --forceExit --runInBand
       - run:
-          name: Build with strict compilation
+          name: Build UI with strict compilation
           working_directory: ~/workbench/ui
           command: ./project.rb build --environment test
       - run:
@@ -295,13 +314,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Fetch Submodules
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       - restore_cache:
           keys:
           - v2-e2e-test-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}
           - v2-e2e-test-cache-
-      - run: 
+      - run:
+          name: Initialize Yarn
           working_directory: ~/workbench/e2e
           command: yarn cache clean && yarn install --frozen-lockfile
       - save_cache:
@@ -309,7 +329,7 @@ jobs:
             - ~/.cache/yarn
           key: v2-e2e-test-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}
       - run:
-          name: Update environment variables
+          name: Update Puppeteer Environment Variables
           command: |
             echo 'export USER_NAME=$PUPPETEER_TEST_USER' >> $BASH_ENV
             echo 'export PASSWORD=$PUPPETEER_TEST_USER_PASSWORD' >> $BASH_ENV
@@ -330,6 +350,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Git Submodulesz
           command: git submodule update --init --recursive
       # Use the ui-build-test workspace here to avoid redoing the setup.
       - attach_workspace:
@@ -339,7 +360,7 @@ jobs:
           - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
           - ui-cache-
       - deploy:
-          name: Deploy to App Engine
+          name: Deploy UI App to App Engine
           working_directory: ~/workbench/ui
           command: |
             ../ci/activate_creds.sh circle-sa-key.json
@@ -359,6 +380,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Git Submodulesz
           command: git submodule update --init --recursive
       - restore_cache:
           keys:
@@ -388,6 +410,7 @@ jobs:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-cache-
       - deploy:
+          name: Deploy to Perf Environment
           working_directory: ~/workbench/deploy
           command: |
             ../ci/activate_creds.sh circle-sa-key.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ anchors:
     #Circle is bad about setting up your remotes for you, you must use origin/
     command: |
       if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
-        echo No relevant changes on non-master branch, skipping
+        echo No relevant changes on api directory in non-master branch. Skipping
         circleci step halt
       fi
   java_defaults: &java_defaults
@@ -33,14 +33,7 @@ jobs:
     steps:
       - checkout
       - run: *update_git_submodules
-      - run: &ensure_branch_has_api_changes
-          name: Ensure Branch is on Origin
-          #Circle is bad about setting up your remotes for you, you must use origin/
-          command: |
-            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
-              echo No relevant changes on non-master branch, skipping
-              circleci step halt
-            fi
+      - run: *ensure_branch_has_api_changes
       - restore_cache:
           keys:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
@@ -317,9 +310,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       # Use the ui-build-test workspace here to avoid redoing the setup.
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ anchors:
     working_directory: ~/workbench
   ensure_branch_has_api_changes: &ensure_branch_has_api_changes
     name: Ensure Branch has Changes to API Code
-    #Circle is bad about setting up your remotes for you, you must use origin/
     command: |
       if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
         echo No relevant changes on api directory in non-master branch. Skipping
@@ -160,7 +159,7 @@ jobs:
       - restore_cache:
           keys:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-`
+          - api-integration-cache-
       - run: *activate_service_accont_creds
       - run:
           name: Run Integration Tests
@@ -274,9 +273,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - restore_cache:
           keys:
           - v2-e2e-test-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ anchors:
       - image: allofustest/workbench:buildimage-0.0.16
     working_directory: ~/workbench
   ensure_branch_has_api_changes: &ensure_branch_has_api_changes
-    name: Ensure Branch is on Origin
+    name: Ensure Branch has Changes to API Code
     #Circle is bad about setting up your remotes for you, you must use origin/
     command: |
       if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ java_defaults: &java_defaults
 jobs:
   api-build-test:
     <<: *java_defaults
-    # TODO(jaycarlton): I don't see any spport in CircleCI for reusing individual steps, but we can
-    # fake it using a Handlebars template or another simple yaml input file
     steps:
       - checkout
       - run:
@@ -350,7 +348,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update Git Submodulesz
+          name: Update Git Submodules
           command: git submodule update --init --recursive
       # Use the ui-build-test workspace here to avoid redoing the setup.
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,39 @@
 version: 2
 
-defaults: &defaults
-  docker:
-    - image: allofustest/workbench:buildimage-0.0.16
-  working_directory: ~/workbench
-java_defaults: &java_defaults
-  <<: *defaults
-  environment:
-    # As best I can tell (dmohs, 7 Feb '17), this is the only way to set a memory limit that Java
-    # processes executed within CircleCI's docker containers will respect. Very helpful resource:
-    # https://circleci.com/blog/how-to-handle-java-oom-errors/
-    #
-    # In Feb 2017, this was set to 3G. But in Feb 2019 (RW-2194) we started seeing OOM errors,
-    # so we bumped this down further to 2G.
-    JAVA_TOOL_OPTIONS: -Xmx2g
-    TERM: dumb
-
+anchors:
+  defaults: &defaults
+    docker:
+      - image: allofustest/workbench:buildimage-0.0.16
+    working_directory: ~/workbench
+  ensure_branch_has_api_changes: &ensure_branch_has_api_changes
+    name: Ensure Branch is on Origin
+    #Circle is bad about setting up your remotes for you, you must use origin/
+    command: |
+      if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
+        echo No relevant changes on non-master branch, skipping
+        circleci step halt
+      fi
+  java_defaults: &java_defaults
+    <<: *defaults
+    environment:
+      # As best I can tell (dmohs, 7 Feb '17), this is the only way to set a memory limit that Java
+      # processes executed within CircleCI's docker containers will respect. Very helpful resource:
+      # https://circleci.com/blog/how-to-handle-java-oom-errors/
+      #
+      # In Feb 2017, this was set to 3G. But in Feb 2019 (RW-2194) we started seeing OOM errors,
+      # so we bumped this down further to 2G.
+      JAVA_TOOL_OPTIONS: -Xmx2g
+      TERM: dumb
+    update_git_submodules: &update_git_submodules
+      name: Update Git Submodules
+      command: git submodule update --init --recursive
 jobs:
   api-build-test:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
-      - run:
+      - run: *update_git_submodules
+      - run: &ensure_branch_has_api_changes
           name: Ensure Branch is on Origin
           #Circle is bad about setting up your remotes for you, you must use origin/
           command: |
@@ -82,14 +91,12 @@ jobs:
       MYSQL_ROOT_PASSWORD: ubuntu
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - restore_cache:
           keys:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-cache-
-      - run:
+      - run: &activate_service_accont_creds
           name: Activate Service Accont Credentials
           working_directory: ~/workbench
           command: ci/activate_creds.sh api/circle-sa-key.json
@@ -117,9 +124,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       # Note: most of the time spent here appears to be in Gradle / App Engine
       # deployment. We tried more aggressively caching outputs via Circle
       # workspaces, but that seemed to have a negligible effect on speed. It's
@@ -129,10 +134,7 @@ jobs:
           keys:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-cache-
-      - run:
-          name: Activate Service Accont Credentials
-          working_directory: ~/workbench
-          command: ci/activate_creds.sh api/circle-sa-key.json
+      - run: *activate_service_accont_creds
       - deploy:
           name: Deploy to App Engine
           working_directory: ~/workbench/api
@@ -148,9 +150,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - run:
           name: Scan dependencies for vulnerabilities
           working_directory: ~/workbench/api
@@ -162,26 +162,13 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
-      - run:
-          name: Ensure Branch is on Origin
-          #Circle is bad about setting up your remotes for you, you must use origin/
-          command: |
-            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
-              echo No relevant changes on non-master branch, skipping
-              circleci step halt
-            fi
+      - run: *update_git_submodules
+      - run: *ensure_branch_has_api_changes
       - restore_cache:
           keys:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
-      - run:
-          name: Activate Service Accont Credentials
-          working_directory: ~/workbench
-          # Used to call gsutil from the circle environment.
-          command: ci/activate_creds.sh api/circle-sa-key.json
+          - api-integration-cache-`
+      - run: *activate_service_accont_creds
       - run:
           name: Run Integration Tests
           working_directory: ~/workbench/api
@@ -196,18 +183,12 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - restore_cache:
           keys:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
           - api-integration-cache-
-      - run:
-          name: Activate Service Accont Credentials
-          working_directory: ~/workbench
-          # Used to call gsutil from the circle environment.
-          command: ci/activate_creds.sh api/circle-sa-key.json
+      - run: *activate_service_accont_creds
       - run:
           name: Run Nightly Integration tests
           working_directory: ~/workbench/api
@@ -222,17 +203,8 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
-      - run:
-          name: Ensure Branch is on Origin
-          #Circle is bad about setting up your remotes for you, you must use origin/
-          command: |
-            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
-              echo No relevant changes on non-master branch, skipping
-              circleci step halt
-            fi
+      - run: *update_git_submodules
+      - run: *ensure_branch_has_api_changes
       - restore_cache:
           keys:
           - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
@@ -256,9 +228,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodules
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - run:
           name: Download Swagger CLI
           working_directory: ~/workbench
@@ -377,9 +347,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Update Git Submodulesz
-          command: git submodule update --init --recursive
+      - run: *update_git_submodules
       - restore_cache:
           keys:
           - api-cache-{{ checksum "~/workbench/api/build.gradle" }}


### PR DESCRIPTION
New CircleCI UI makes heavy use of the optional `name` attribute on job steps. I've added more, and tweaked a few existing ones for clarity. I condensed a couple of common steps into YAML anchors. There is support for more first-class reuse with parameterization in v2.1. This [ticket ](https://precisionmedicineinitiative.atlassian.net/browse/RW-4645) covers taking advantage of the new features and migrating to 2.1.

Check CircleCI run for new titles.
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
