### PR TITLE
[RW-4793][risk=no] Clean up flags to delete-cluster

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageClusters.java
@@ -236,6 +236,11 @@ public class ManageClusters {
           // Note: IDs are optional, this set may be empty.
           Set<String> ids = commaDelimitedStringToSet(args[2]);
           boolean dryRun = Boolean.valueOf(args[3]);
+
+          if (oldest == null && ids.isEmpty()) {
+            throw new IllegalArgumentException(
+                "must provide either a maximum age, or a list of ids for filtering of clusters");
+          }
           deleteClusters(apiUrl, oldest, ids, dryRun);
           return;
 


### PR DESCRIPTION
- Disallow running this tool without any criteria
- Clarify documentation / dry run mode

Still TODO, possibly not in this PR:
- This tool should be switched to the standard flag library (we have a ticket for this)
- The pattern of defaulting into a dry run is not consistent with other commands, but this command is dangerous enough that I don't want to change that behavior without adding a confirmation step.