### PR TITLE
[RW-4713][risk=moderate] Fix admin page auth and rename service methods

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -180,7 +180,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     dbUser = userDao.save(dbUser);
     currentUser = dbUser;
 
-    when(mockFireCloudService.getWorkspaceAcl(anyString(), anyString()))
+    when(mockFireCloudService.getWorkspaceAclAsService(anyString(), anyString()))
         .thenReturn(
             new FirecloudWorkspaceACL()
                 .acl(
@@ -809,7 +809,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
         ImmutableMap.of(currentUser.getUsername(), accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
-    when(mockFireCloudService.getWorkspaceAcl(NAMESPACE, NAME))
+    when(mockFireCloudService.getWorkspaceAclAsService(NAMESPACE, NAME))
         .thenReturn(workspaceAccessLevelResponse);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ClusterController.java
@@ -140,17 +140,17 @@ public class ClusterController implements ClusterApiDelegate {
     }
     List<org.pmiops.workbench.notebooks.model.ListClusterResponse> clustersToDelete =
         filterByClustersInList(
-                leonardoNotebooksClient.listClustersByProjectAsAdmin(billingProjectId).stream(),
+                leonardoNotebooksClient.listClustersByProjectAsService(billingProjectId).stream(),
                 clusterNamesToDelete.getClustersToDelete())
             .collect(Collectors.toList());
 
     clustersToDelete.forEach(
         cluster ->
-            leonardoNotebooksClient.deleteClusterAsAdmin(
+            leonardoNotebooksClient.deleteClusterAsService(
                 cluster.getGoogleProject(), cluster.getClusterName()));
     List<ListClusterResponse> clustersInProjectAffected =
         filterByClustersInList(
-                leonardoNotebooksClient.listClustersByProjectAsAdmin(billingProjectId).stream(),
+                leonardoNotebooksClient.listClustersByProjectAsService(billingProjectId).stream(),
                 clusterNamesToDelete.getClustersToDelete())
             .map(
                 leoCluster ->

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -73,10 +73,12 @@ public interface FireCloudService {
   /** Retrieves all billing project memberships for the user from FireCloud. */
   List<FirecloudBillingProjectMembership> getBillingProjectMemberships();
 
-  FirecloudWorkspaceACL getWorkspaceAcl(String projectName, String workspaceName);
+  FirecloudWorkspaceACL getWorkspaceAclAsService(String projectName, String workspaceName);
 
   FirecloudWorkspaceACLUpdateResponseList updateWorkspaceACL(
       String projectName, String workspaceName, List<FirecloudWorkspaceACLUpdate> aclUpdates);
+
+  FirecloudWorkspaceResponse getWorkspaceAsService(String projectName, String workspaceName);
 
   /**
    * Requested field options specified here:

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -59,8 +59,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<BillingApi> billingApiProvider;
   private final Provider<GroupsApi> groupsApiProvider;
   private final Provider<NihApi> nihApiProvider;
-  private final Provider<WorkspacesApi> workspacesApiProvider;
-  private final Provider<WorkspacesApi> workspaceAclsApiProvider;
+  private final Provider<WorkspacesApi> endUserWorkspacesApiProvider;
+  private final Provider<WorkspacesApi> adminServiceAccountWorkspaceApiProvider;
   private final Provider<StatusApi> statusApiProvider;
   private final Provider<StaticNotebooksApi> staticNotebooksApiProvider;
   private final FirecloudRetryHandler retryHandler;
@@ -107,9 +107,9 @@ public class FireCloudServiceImpl implements FireCloudService {
       Provider<GroupsApi> groupsApiProvider,
       Provider<NihApi> nihApiProvider,
       @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
-          Provider<WorkspacesApi> workspacesApiProvider,
+          Provider<WorkspacesApi> endUserWorkspacesApiProvider,
       @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_WORKSPACE_API)
-          Provider<WorkspacesApi> workspaceAclsApiProvider,
+          Provider<WorkspacesApi> adminServiceAccountWorkspaceApiProvider,
       Provider<StatusApi> statusApiProvider,
       Provider<StaticNotebooksApi> staticNotebooksApiProvider,
       FirecloudRetryHandler retryHandler,
@@ -122,8 +122,8 @@ public class FireCloudServiceImpl implements FireCloudService {
     this.billingApiProvider = billingApiProvider;
     this.groupsApiProvider = groupsApiProvider;
     this.nihApiProvider = nihApiProvider;
-    this.workspacesApiProvider = workspacesApiProvider;
-    this.workspaceAclsApiProvider = workspaceAclsApiProvider;
+    this.endUserWorkspacesApiProvider = endUserWorkspacesApiProvider;
+    this.adminServiceAccountWorkspaceApiProvider = adminServiceAccountWorkspaceApiProvider;
     this.statusApiProvider = statusApiProvider;
     this.retryHandler = retryHandler;
     this.fcAdminCredsProvider = fcAdminCredsProvider;
@@ -308,7 +308,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public FirecloudWorkspace createWorkspace(String projectName, String workspaceName) {
-    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     FirecloudWorkspaceIngest workspaceIngest =
         new FirecloudWorkspaceIngest()
             .namespace(projectName)
@@ -324,7 +324,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public FirecloudWorkspace cloneWorkspace(
       String fromProject, String fromName, String toProject, String toName) {
-    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     FirecloudWorkspaceRequestClone cloneRequest =
         new FirecloudWorkspaceRequestClone()
             .namespace(toProject)
@@ -349,7 +349,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public FirecloudWorkspaceACLUpdateResponseList updateWorkspaceACL(
       String projectName, String workspaceName, List<FirecloudWorkspaceACLUpdate> aclUpdates) {
-    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     // TODO: set authorization domain here
     return retryHandler.run(
         (context) ->
@@ -357,16 +357,25 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public FirecloudWorkspaceACL getWorkspaceAcl(String projectName, String workspaceName) {
-    WorkspacesApi workspaceAclsApi = workspaceAclsApiProvider.get();
+  public FirecloudWorkspaceACL getWorkspaceAclAsService(String projectName, String workspaceName) {
+    WorkspacesApi workspacesApi = adminServiceAccountWorkspaceApiProvider.get();
+    return retryHandler.run((context) -> workspacesApi.getWorkspaceAcl(projectName, workspaceName));
+  }
+
+  @Override
+  public FirecloudWorkspaceResponse getWorkspaceAsService(String projectName, String workspaceName)
+      throws WorkbenchException {
+    WorkspacesApi workspacesApi = adminServiceAccountWorkspaceApiProvider.get();
     return retryHandler.run(
-        (context) -> workspaceAclsApi.getWorkspaceAcl(projectName, workspaceName));
+        (context) ->
+            workspacesApi.getWorkspace(
+                projectName, workspaceName, FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override
   public FirecloudWorkspaceResponse getWorkspace(String projectName, String workspaceName)
       throws WorkbenchException {
-    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     return retryHandler.run(
         (context) ->
             workspacesApi.getWorkspace(
@@ -395,12 +404,12 @@ public class FireCloudServiceImpl implements FireCloudService {
   @Override
   public List<FirecloudWorkspaceResponse> getWorkspaces(List<String> fields)
       throws WorkbenchException {
-    return retryHandler.run((context) -> workspacesApiProvider.get().listWorkspaces(fields));
+    return retryHandler.run((context) -> endUserWorkspacesApiProvider.get().listWorkspaces(fields));
   }
 
   @Override
   public void deleteWorkspace(String projectName, String workspaceName) throws WorkbenchException {
-    WorkspacesApi workspacesApi = workspacesApiProvider.get();
+    WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     retryHandler.run(
         (context) -> {
           workspacesApi.deleteWorkspace(projectName, workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -60,7 +60,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<GroupsApi> groupsApiProvider;
   private final Provider<NihApi> nihApiProvider;
   private final Provider<WorkspacesApi> endUserWorkspacesApiProvider;
-  private final Provider<WorkspacesApi> adminServiceAccountWorkspaceApiProvider;
+  private final Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider;
   private final Provider<StatusApi> statusApiProvider;
   private final Provider<StaticNotebooksApi> staticNotebooksApiProvider;
   private final FirecloudRetryHandler retryHandler;
@@ -109,7 +109,7 @@ public class FireCloudServiceImpl implements FireCloudService {
       @Qualifier(FireCloudConfig.END_USER_WORKSPACE_API)
           Provider<WorkspacesApi> endUserWorkspacesApiProvider,
       @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_WORKSPACE_API)
-          Provider<WorkspacesApi> adminServiceAccountWorkspaceApiProvider,
+          Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider,
       Provider<StatusApi> statusApiProvider,
       Provider<StaticNotebooksApi> staticNotebooksApiProvider,
       FirecloudRetryHandler retryHandler,
@@ -123,7 +123,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     this.groupsApiProvider = groupsApiProvider;
     this.nihApiProvider = nihApiProvider;
     this.endUserWorkspacesApiProvider = endUserWorkspacesApiProvider;
-    this.adminServiceAccountWorkspaceApiProvider = adminServiceAccountWorkspaceApiProvider;
+    this.serviceAccountWorkspaceApiProvider = serviceAccountWorkspaceApiProvider;
     this.statusApiProvider = statusApiProvider;
     this.retryHandler = retryHandler;
     this.fcAdminCredsProvider = fcAdminCredsProvider;
@@ -358,14 +358,14 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public FirecloudWorkspaceACL getWorkspaceAclAsService(String projectName, String workspaceName) {
-    WorkspacesApi workspacesApi = adminServiceAccountWorkspaceApiProvider.get();
+    WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
     return retryHandler.run((context) -> workspacesApi.getWorkspaceAcl(projectName, workspaceName));
   }
 
   @Override
   public FirecloudWorkspaceResponse getWorkspaceAsService(String projectName, String workspaceName)
       throws WorkbenchException {
-    WorkspacesApi workspacesApi = adminServiceAccountWorkspaceApiProvider.get();
+    WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
     return retryHandler.run(
         (context) ->
             workspacesApi.getWorkspace(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -15,7 +15,7 @@ public interface LeonardoNotebooksClient {
   List<ListClusterResponse> listClustersByProject(String googleProject);
 
   /** lists all notebook clusters as the appengine SA, to be used only for admin operations */
-  List<ListClusterResponse> listClustersByProjectAsAdmin(String googleProject);
+  List<ListClusterResponse> listClustersByProjectAsService(String googleProject);
 
   /**
    * Creates a notebooks cluster owned by the current authenticated user.
@@ -32,7 +32,7 @@ public interface LeonardoNotebooksClient {
   void deleteCluster(String googleProject, String clusterName) throws WorkbenchException;
 
   /** Deletes a notebook cluster as the appengine SA, to be used only for admin operations */
-  void deleteClusterAsAdmin(String googleProject, String clusterName) throws WorkbenchException;
+  void deleteClusterAsService(String googleProject, String clusterName) throws WorkbenchException;
 
   /** Gets information about a notebook cluster */
   Cluster getCluster(String googleProject, String clusterName) throws WorkbenchException;

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -153,7 +153,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
-  public List<ListClusterResponse> listClustersByProjectAsAdmin(String googleProject) {
+  public List<ListClusterResponse> listClustersByProjectAsService(String googleProject) {
     ClusterApi clusterApi = serviceClusterApiProvider.get();
     return retryHandler.run(
         (context) -> clusterApi.listClustersByProject(googleProject, null, false));
@@ -181,7 +181,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
-  public void deleteClusterAsAdmin(String googleProject, String clusterName) {
+  public void deleteClusterAsService(String googleProject, String clusterName) {
     ClusterApi clusterApi = serviceClusterApiProvider.get();
     retryHandler.run(
         (context) -> {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -20,6 +20,12 @@ public interface NotebooksService {
 
   List<FileDetail> getNotebooks(String workspaceNamespace, String workspaceName);
 
+  /**
+   * Retrieve all notebooks in the given cloud storage bucket. This method is authenticated as the
+   * app engine service account, so authorization should be performed before calling this.
+   */
+  List<FileDetail> getNotebooksAsService(String bucketName);
+
   FileDetail copyNotebook(
       String fromWorkspaceNamespace,
       String fromWorkspaceName,

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -22,7 +22,8 @@ public interface NotebooksService {
 
   /**
    * Retrieve all notebooks in the given cloud storage bucket. This method is authenticated as the
-   * app engine service account, so authorization should be performed before calling this.
+   * app engine service account, so authorization must be performed before calling this and the
+   * input value should be trusted.
    */
   List<FileDetail> getNotebooksAsService(String bucketName);
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -99,7 +99,11 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getWorkspace(workspaceNamespace, workspaceName)
             .getWorkspace()
             .getBucketName();
+    return getNotebooksAsService(bucketName);
+  }
 
+  @Override
+  public List<FileDetail> getNotebooksAsService(String bucketName) {
     return cloudStorageService.getBlobListForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
         .stream()
         .filter(blob -> NOTEBOOK_PATTERN.matcher(blob.getName()).matches())

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -104,7 +104,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
               dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
 
       List<org.pmiops.workbench.notebooks.model.ListClusterResponse> fcClusters =
-          leonardoNotebooksClient.listClustersByProjectAsAdmin(workspaceNamespace);
+          leonardoNotebooksClient.listClustersByProjectAsService(workspaceNamespace);
       List<ListClusterResponse> clusters =
           fcClusters.stream()
               .map(

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminController.java
@@ -125,7 +125,9 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
               .clusters(clusters);
 
       FirecloudWorkspace fcWorkspace =
-          fireCloudService.getWorkspace(workspaceNamespace, workspaceFirecloudName).getWorkspace();
+          fireCloudService
+              .getWorkspaceAsService(workspaceNamespace, workspaceFirecloudName)
+              .getWorkspace();
 
       return ResponseEntity.ok(
           new AdminFederatedWorkspaceDetailsResponse()

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -65,12 +65,11 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       String workspaceNamespace, String workspaceName) {
     String bucketName =
         fireCloudService
-            .getWorkspace(workspaceNamespace, workspaceName)
+            .getWorkspaceAsService(workspaceNamespace, workspaceName)
             .getWorkspace()
             .getBucketName();
 
-    int notebookFilesCount =
-        notebooksService.getNotebooks(workspaceNamespace, workspaceName).size();
+    int notebookFilesCount = notebooksService.getNotebooksAsService(bucketName).size();
     int nonNotebookFilesCount = getNonNotebookFileCount(bucketName);
     long storageSizeBytes = getStorageSizeBytes(bucketName);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -254,7 +254,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   public Map<String, FirecloudWorkspaceAccessEntry> getFirecloudWorkspaceAcls(
       String workspaceNamespace, String firecloudName) {
     FirecloudWorkspaceACL aclResp =
-        fireCloudService.getWorkspaceAcl(workspaceNamespace, firecloudName);
+        fireCloudService.getWorkspaceAclAsService(workspaceNamespace, firecloudName);
 
     // Swagger Java codegen does not handle the WorkspaceACL model correctly; it returns a GSON map
     // instead. Run this through a typed Gson conversion process to parse into the desired type.

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -319,7 +319,7 @@ public class ClusterControllerTest {
   @Test
   public void testDeleteClustersInProject() {
     List<ListClusterResponse> listClusterResponseList = ImmutableList.of(testFcClusterListResponse);
-    when(mockLeoNotebooksClient.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
+    when(mockLeoNotebooksClient.listClustersByProjectAsService(BILLING_PROJECT_ID))
         .thenReturn(listClusterResponseList);
 
     clusterController.deleteClustersInProject(
@@ -327,7 +327,7 @@ public class ClusterControllerTest {
         new ListClusterDeleteRequest()
             .clustersToDelete(ImmutableList.of(testFcCluster.getClusterName())));
     verify(mockLeoNotebooksClient)
-        .deleteClusterAsAdmin(BILLING_PROJECT_ID, testFcCluster.getClusterName());
+        .deleteClusterAsService(BILLING_PROJECT_ID, testFcCluster.getClusterName());
     verify(mockClusterAuditor)
         .fireDeleteClustersInProject(
             BILLING_PROJECT_ID,
@@ -341,13 +341,13 @@ public class ClusterControllerTest {
     List<ListClusterResponse> listClusterResponseList =
         ImmutableList.of(testFcClusterListResponse, testFcClusterListResponse2);
     List<String> clustersToDelete = ImmutableList.of(testFcCluster.getClusterName());
-    when(mockLeoNotebooksClient.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
+    when(mockLeoNotebooksClient.listClustersByProjectAsService(BILLING_PROJECT_ID))
         .thenReturn(listClusterResponseList);
 
     clusterController.deleteClustersInProject(
         BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(clustersToDelete));
     verify(mockLeoNotebooksClient, times(clustersToDelete.size()))
-        .deleteClusterAsAdmin(BILLING_PROJECT_ID, testFcCluster.getClusterName());
+        .deleteClusterAsService(BILLING_PROJECT_ID, testFcCluster.getClusterName());
     verify(mockClusterAuditor, times(1))
         .fireDeleteClustersInProject(BILLING_PROJECT_ID, clustersToDelete);
   }
@@ -358,13 +358,13 @@ public class ClusterControllerTest {
         ImmutableList.of(testFcClusterListResponse, testFcClusterListResponse2);
     List<String> clustersToDelete =
         ImmutableList.of(testFcClusterDifferentProject.getClusterName());
-    when(mockLeoNotebooksClient.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
+    when(mockLeoNotebooksClient.listClustersByProjectAsService(BILLING_PROJECT_ID))
         .thenReturn(listClusterResponseList);
 
     clusterController.deleteClustersInProject(
         BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(clustersToDelete));
     verify(mockLeoNotebooksClient, times(0))
-        .deleteClusterAsAdmin(BILLING_PROJECT_ID, testFcCluster.getClusterName());
+        .deleteClusterAsService(BILLING_PROJECT_ID, testFcCluster.getClusterName());
     verify(mockClusterAuditor, times(0))
         .fireDeleteClustersInProject(BILLING_PROJECT_ID, clustersToDelete);
   }
@@ -372,13 +372,13 @@ public class ClusterControllerTest {
   @Test
   public void testDeleteClustersInProject_NoClusters() {
     List<ListClusterResponse> listClusterResponseList = ImmutableList.of(testFcClusterListResponse);
-    when(mockLeoNotebooksClient.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
+    when(mockLeoNotebooksClient.listClustersByProjectAsService(BILLING_PROJECT_ID))
         .thenReturn(listClusterResponseList);
 
     clusterController.deleteClustersInProject(
         BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(ImmutableList.of()));
     verify(mockLeoNotebooksClient, never())
-        .deleteClusterAsAdmin(BILLING_PROJECT_ID, testFcCluster.getClusterName());
+        .deleteClusterAsService(BILLING_PROJECT_ID, testFcCluster.getClusterName());
     verify(mockClusterAuditor, never())
         .fireDeleteClustersInProject(
             BILLING_PROJECT_ID,
@@ -390,13 +390,13 @@ public class ClusterControllerTest {
   @Test
   public void testDeleteClustersInProject_NullClustersList() {
     List<ListClusterResponse> listClusterResponseList = ImmutableList.of(testFcClusterListResponse);
-    when(mockLeoNotebooksClient.listClustersByProjectAsAdmin(BILLING_PROJECT_ID))
+    when(mockLeoNotebooksClient.listClustersByProjectAsService(BILLING_PROJECT_ID))
         .thenReturn(listClusterResponseList);
 
     clusterController.deleteClustersInProject(
         BILLING_PROJECT_ID, new ListClusterDeleteRequest().clustersToDelete(null));
     verify(mockLeoNotebooksClient)
-        .deleteClusterAsAdmin(BILLING_PROJECT_ID, testFcCluster.getClusterName());
+        .deleteClusterAsService(BILLING_PROJECT_ID, testFcCluster.getClusterName());
     verify(mockClusterAuditor)
         .fireDeleteClustersInProject(
             BILLING_PROJECT_ID,

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -339,7 +339,8 @@ public class CohortsControllerTest {
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
         ImmutableMap.of(creator, accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
-    when(fireCloudService.getWorkspaceAcl(ns, name)).thenReturn(workspaceAccessLevelResponse);
+    when(fireCloudService.getWorkspaceAclAsService(ns, name))
+        .thenReturn(workspaceAccessLevelResponse);
   }
 
   public Cohort createDefaultCohort() {

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -829,7 +829,8 @@ public class ConceptSetsControllerTest {
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
         ImmutableMap.of(creator, accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
-    when(fireCloudService.getWorkspaceAcl(ns, name)).thenReturn(workspaceAccessLevelResponse);
+    when(fireCloudService.getWorkspaceAclAsService(ns, name))
+        .thenReturn(workspaceAccessLevelResponse);
   }
 
   private void saveConcepts() {

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -344,7 +344,7 @@ public class ConceptsControllerTest {
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
         ImmutableMap.of(USER_EMAIL, accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
-    when(fireCloudService.getWorkspaceAcl(WORKSPACE_NAMESPACE, WORKSPACE_NAME))
+    when(fireCloudService.getWorkspaceAclAsService(WORKSPACE_NAMESPACE, WORKSPACE_NAME))
         .thenReturn(workspaceAccessLevelResponse);
 
     DbCriteria parentSurvey =

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -605,7 +605,8 @@ public class DataSetControllerTest {
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
         ImmutableMap.of(creator, accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
-    when(fireCloudService.getWorkspaceAcl(ns, name)).thenReturn(workspaceAccessLevelResponse);
+    when(fireCloudService.getWorkspaceAclAsService(ns, name))
+        .thenReturn(workspaceAccessLevelResponse);
   }
 
   private List<DomainValuePair> mockDomainValuePair() {

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -140,7 +140,8 @@ public class WorkspaceAdminControllerTest {
         testMockFactory.createFcWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME, "test");
     FirecloudWorkspaceResponse fcWorkspaceResponse =
         new FirecloudWorkspaceResponse().workspace(fcWorkspace);
-    when(mockFirecloudService.getWorkspace(WORKSPACE_NAMESPACE, TestMockFactory.BUCKET_NAME))
+    when(mockFirecloudService.getWorkspaceAsService(
+            WORKSPACE_NAMESPACE, TestMockFactory.BUCKET_NAME))
         .thenReturn(fcWorkspaceResponse);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminControllerTest.java
@@ -133,7 +133,7 @@ public class WorkspaceAdminControllerTest {
         testMockFactory.createFcListClusterResponse();
     List<org.pmiops.workbench.notebooks.model.ListClusterResponse> clusters = new ArrayList<>();
     clusters.add(listClusterResponse);
-    when(mockLeonardoNotebooksClient.listClustersByProjectAsAdmin(WORKSPACE_NAMESPACE))
+    when(mockLeonardoNotebooksClient.listClustersByProjectAsService(WORKSPACE_NAMESPACE))
         .thenReturn(clusters);
 
     FirecloudWorkspace fcWorkspace =

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -1,0 +1,67 @@
+package org.pmiops.workbench.workspaceadmin;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
+import org.pmiops.workbench.google.CloudStorageService;
+import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
+import org.pmiops.workbench.notebooks.NotebooksService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class WorkspaceAdminServiceTest {
+  @TestConfiguration
+  @MockBean({
+    CloudStorageService.class,
+    FireCloudService.class,
+    NotebooksService.class,
+  })
+  @Import(WorkspaceAdminServiceImpl.class)
+  static class Configuration {}
+
+  @Autowired FireCloudService mockFirecloudService;
+  @Autowired NotebooksService mockNotebooksService;
+
+  @Autowired WorkspaceAdminService workspaceAdminService;
+
+  @Before
+  public void setUp() {
+    when(mockFirecloudService.getWorkspaceAsService(any(), any()))
+        .thenReturn(
+            new FirecloudWorkspaceResponse()
+                .workspace(new FirecloudWorkspace().bucketName("bucket")));
+  }
+
+  @Test
+  public void testGetAdminWorkspaceCloudStorageCounts() {
+    AdminWorkspaceCloudStorageCounts resp =
+        workspaceAdminService.getAdminWorkspaceCloudStorageCounts("foo", "bar");
+    assertThat(resp)
+        .isEqualTo(
+            new AdminWorkspaceCloudStorageCounts()
+                .nonNotebookFileCount(0)
+                .notebookFileCount(0)
+                .storageBytesUsed(0L));
+    verify(mockNotebooksService, atLeastOnce()).getNotebooksAsService(any());
+
+    // Regression check: the admin service should never call the end-user variants of these methods.
+    verify(mockNotebooksService, never()).getNotebooks(any(), any());
+    verify(mockFirecloudService, never()).getWorkspace(any(), any());
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspacesControllerTest.java
@@ -485,7 +485,7 @@ public class WorkspacesControllerTest {
   }
 
   private void stubFcGetWorkspaceACL(FirecloudWorkspaceACL acl) {
-    when(fireCloudService.getWorkspaceAcl(anyString(), anyString())).thenReturn(acl);
+    when(fireCloudService.getWorkspaceAclAsService(anyString(), anyString())).thenReturn(acl);
   }
 
   private void stubFcGetGroup() {
@@ -2052,9 +2052,9 @@ public class WorkspacesControllerTest {
                         .put("canCompute", true)
                         .put("canShare", true)));
 
-    when(fireCloudService.getWorkspaceAcl("cloned-ns", "cloned"))
+    when(fireCloudService.getWorkspaceAclAsService("cloned-ns", "cloned"))
         .thenReturn(workspaceAclsFromCloned);
-    when(fireCloudService.getWorkspaceAcl(workspace.getNamespace(), workspace.getName()))
+    when(fireCloudService.getWorkspaceAclAsService(workspace.getNamespace(), workspace.getName()))
         .thenReturn(workspaceAclsFromOriginal);
 
     currentUser = cloner;
@@ -2204,7 +2204,7 @@ public class WorkspacesControllerTest {
     DbUser writerUser = createAndSaveUser("writerfriend@gmail.com", 124L);
     DbUser ownerUser = createAndSaveUser("ownerfriend@gmail.com", 125L);
 
-    when(fireCloudService.getWorkspaceAcl(anyString(), anyString()))
+    when(fireCloudService.getWorkspaceAclAsService(anyString(), anyString()))
         .thenReturn(
             createWorkspaceACL(
                 new JSONObject()
@@ -2320,7 +2320,7 @@ public class WorkspacesControllerTest {
                         .put("accessLevel", "READER")
                         .put("canCompute", false)
                         .put("canShare", false)));
-    when(fireCloudService.getWorkspaceAcl(any(), any())).thenReturn(workspaceACLs);
+    when(fireCloudService.getWorkspaceAclAsService(any(), any())).thenReturn(workspaceACLs);
 
     CLOCK.increment(1000);
     stubFcUpdateWorkspaceACL();


### PR DESCRIPTION
- Switch the admin endpoint to exclusively use service credentials
- Rename various methods to have the suffix `asService` to make this distinction clearer. Admin is slightly ambiguous since we also have user admins.
- Add contrived regression test. With more comprehensive fake services, it might be possible to have a better behavioral test here. With the current unit tests, the interactions between service layers are effectively change-detector tests.

Manually tested:
- Verified an admin can view the admin page for a workspace they don't have access to.
- Verified the admin can delete a cluster from this page.
- Observed notebook counts / sizes updating as expected.