### PR TITLE
[RW-4737][risk=no] Enable Google Private IP Adddress flag on new project creation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -246,7 +246,8 @@ public class FireCloudServiceImpl implements FireCloudService {
             .billingAccount(configProvider.get().billing.freeTierBillingAccountName())
             .projectName(projectName)
             .highSecurityNetwork(enableVpcFlowLogs)
-            .enableFlowLogs(enableVpcFlowLogs);
+            .enableFlowLogs(enableVpcFlowLogs)
+            .privateIpGoogleAccess(true);
 
     boolean enableVpcServicePerimeter = configProvider.get().featureFlags.enableVpcServicePerimeter;
     if (enableVpcServicePerimeter) {

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -171,7 +171,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
             new UserAuthentication(user, OAuth2Userinfo, token, UserType.RESEARCHER));
 
     // TODO: setup this in the context, get rid of log statement
-    log.log(Level.INFO, "{0} logged in", OAuth2Userinfo.getEmail());
+    log.log(Level.FINE, "{0} logged in", OAuth2Userinfo.getEmail());
 
     if (!hasRequiredAuthority(method, user)) {
       response.sendError(HttpServletResponse.SC_FORBIDDEN);

--- a/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
+++ b/api/src/main/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterService.java
@@ -126,7 +126,7 @@ public class StackdriverStatsExporterService {
     } catch (ModulesException e) {
       final String newNodeId = getSpoofedNodeId();
       if (workbenchConfigProvider.get().server.shortName.equals("Local")) {
-        logger.log(Level.INFO, String.format("Spoofed nodeID for local process is %s.", newNodeId));
+        logger.log(Level.FINE, String.format("Spoofed nodeID for local process is %s.", newNodeId));
       } else {
         logger.warning(
             String.format(

--- a/api/src/main/resources/fireCloud.yaml
+++ b/api/src/main/resources/fireCloud.yaml
@@ -828,6 +828,9 @@ definitions:
       enableFlowLogs:
         type: boolean
         description: Optional, false if not specified. If true, enable flow logs within the high security network. Requires highSecurityNetwork = true.
+      privateIpGoogleAccess:
+        type: boolean
+        description: Optional, false if not specified. If true, it configures the VPC network to only allow access to GCP APIs that are protected by the project's service perimeter and routes all allowed API traffic through a narrow IP range. Requires highSecurityNetwork = true.
       servicePerimeter:
         type: string
         description: The fully qualified name of the GCP service perimeter to put this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME]. Caller must have the add_project action for this service perimeter in Sam.


### PR DESCRIPTION
Incorporate new RAWLS option into our version of the FireCloud Swagger, and set the new option to true.

I did see a couple of attempts fail before this one succeeded, so I'm not sure what happened. After restarting everything, it worked.

![Screen Shot 2020-04-18 at 2 00 20 PM](https://user-images.githubusercontent.com/53479492/79645432-524e9c00-817d-11ea-9a91-4bd295b56862.png)
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
