### PR TITLE
[RW-4633][risk=no] Ignore more missing props & try treating warnings as errors

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/WorkspaceMapper.java
@@ -50,12 +50,13 @@ public interface WorkspaceMapper {
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   Workspace toApiWorkspace(DbWorkspace dbWorkspace, FirecloudWorkspace fcWorkspace);
 
-  @Mapping(target = "researchPurpose", source = "dbWorkspace")
+  @Mapping(target = "cdrVersionId", source = "cdrVersion")
+  @Mapping(target = "creator", source = "creator.username")
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "googleBucketName", ignore = true) // available via toApiWorkspace(DbWorkspace dbWorkspace, FirecloudWorkspace fcWorkspace)
   @Mapping(target = "id", source = "firecloudName")
   @Mapping(target = "namespace", source = "workspaceNamespace")
-  @Mapping(target = "creator", source = "creator.username")
-  @Mapping(target = "cdrVersionId", source = "cdrVersion")
+  @Mapping(target = "researchPurpose", source = "dbWorkspace")
   Workspace toApiWorkspace(DbWorkspace dbWorkspace);
 
   @Mapping(target = "workspace", source = "dbWorkspace")
@@ -73,12 +74,13 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspace", source = "dbWorkspace")
   RecentWorkspace toApiRecentWorkspace(DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel);
 
-  // I believe the following fields are ignored because they are only meant to be set once
-  // My intent was to keep the same functionality as in the original mapper so I left it in
-  // but we should be handling special business case logic like this in our controller/services
-  @Mapping(target = "approved", ignore = true)
-  @Mapping(target = "reviewRequested", ignore = true)
-  @Mapping(target = "timeRequested", ignore = true)
+  /**
+   * This method was written I think before we realized we could have multiple input arguments.
+   * @deprecated
+   * @param workspace
+   * @param researchPurpose
+   */
+  @Deprecated
   @Mapping(
       target = "specificPopulationsEnum",
       source = "populationDetails",
@@ -92,6 +94,37 @@ public interface WorkspaceMapper {
       target = "researchOutcomeEnumSet",
       source = "researchOutcomeList",
       nullValuePropertyMappingStrategy = SET_TO_DEFAULT)
+
+  // Normally using ignore should be frowned upon. In a merge method
+  // like this one, it's unavoidable; otherwise we'd just make a straight-up translation.
+  // However,
+  @Mapping(target = "approved", ignore = true)
+  @Mapping(target ="billingAccountName", ignore = true)
+  @Mapping(target ="billingAccountType", ignore = true)
+  @Mapping(target ="billingMigrationStatusEnum", ignore = true)
+  @Mapping(target ="billingStatus", ignore = true)
+  @Mapping(target ="cdrVersion", ignore = true)
+  @Mapping(target ="cohorts", ignore = true)
+  @Mapping(target ="conceptSets", ignore = true)
+  @Mapping(target ="creationTime", ignore = true)
+  @Mapping(target ="creator", ignore = true)
+  @Mapping(target ="dataAccessLevel", ignore = true)
+  @Mapping(target ="dataAccessLevelEnum", ignore = true)
+  @Mapping(target ="dataSets", ignore = true)
+  @Mapping(target ="disseminateResearchSet", ignore = true)
+  @Mapping(target ="firecloudName", ignore = true)
+  @Mapping(target ="firecloudUuid", ignore = true)
+  @Mapping(target ="lastAccessedTime", ignore = true)
+  @Mapping(target ="lastModifiedTime", ignore = true)
+  @Mapping(target ="name", ignore = true)
+  @Mapping(target ="published", ignore = true)
+  @Mapping(target ="researchOutcomeSet", ignore = true)
+  @Mapping(target = "reviewRequested", ignore = true)
+  @Mapping(target = "timeRequested", ignore = true)
+  @Mapping(target ="version", ignore = true)
+  @Mapping(target ="workspaceActiveStatusEnum", ignore = true)
+  @Mapping(target ="workspaceId", ignore = true)
+  @Mapping(target ="workspaceNamespace", ignore = true)
   void mergeResearchPurposeIntoWorkspace(
       @MappingTarget DbWorkspace workspace, ResearchPurpose researchPurpose);
 

--- a/api/src/main/java/org/pmiops/workbench/utils/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/WorkspaceMapper.java
@@ -53,7 +53,10 @@ public interface WorkspaceMapper {
   @Mapping(target = "cdrVersionId", source = "cdrVersion")
   @Mapping(target = "creator", source = "creator.username")
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
-  @Mapping(target = "googleBucketName", ignore = true) // available via toApiWorkspace(DbWorkspace dbWorkspace, FirecloudWorkspace fcWorkspace)
+  @Mapping(
+      target = "googleBucketName",
+      ignore = true) // available via toApiWorkspace(DbWorkspace dbWorkspace, FirecloudWorkspace
+  // fcWorkspace)
   @Mapping(target = "id", source = "firecloudName")
   @Mapping(target = "namespace", source = "workspaceNamespace")
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
@@ -76,6 +79,7 @@ public interface WorkspaceMapper {
 
   /**
    * This method was written I think before we realized we could have multiple input arguments.
+   *
    * @deprecated
    * @param workspace
    * @param researchPurpose
@@ -99,32 +103,32 @@ public interface WorkspaceMapper {
   // like this one, it's unavoidable; otherwise we'd just make a straight-up translation.
   // However,
   @Mapping(target = "approved", ignore = true)
-  @Mapping(target ="billingAccountName", ignore = true)
-  @Mapping(target ="billingAccountType", ignore = true)
-  @Mapping(target ="billingMigrationStatusEnum", ignore = true)
-  @Mapping(target ="billingStatus", ignore = true)
-  @Mapping(target ="cdrVersion", ignore = true)
-  @Mapping(target ="cohorts", ignore = true)
-  @Mapping(target ="conceptSets", ignore = true)
-  @Mapping(target ="creationTime", ignore = true)
-  @Mapping(target ="creator", ignore = true)
-  @Mapping(target ="dataAccessLevel", ignore = true)
-  @Mapping(target ="dataAccessLevelEnum", ignore = true)
-  @Mapping(target ="dataSets", ignore = true)
-  @Mapping(target ="disseminateResearchSet", ignore = true)
-  @Mapping(target ="firecloudName", ignore = true)
-  @Mapping(target ="firecloudUuid", ignore = true)
-  @Mapping(target ="lastAccessedTime", ignore = true)
-  @Mapping(target ="lastModifiedTime", ignore = true)
-  @Mapping(target ="name", ignore = true)
-  @Mapping(target ="published", ignore = true)
-  @Mapping(target ="researchOutcomeSet", ignore = true)
+  @Mapping(target = "billingAccountName", ignore = true)
+  @Mapping(target = "billingAccountType", ignore = true)
+  @Mapping(target = "billingMigrationStatusEnum", ignore = true)
+  @Mapping(target = "billingStatus", ignore = true)
+  @Mapping(target = "cdrVersion", ignore = true)
+  @Mapping(target = "cohorts", ignore = true)
+  @Mapping(target = "conceptSets", ignore = true)
+  @Mapping(target = "creationTime", ignore = true)
+  @Mapping(target = "creator", ignore = true)
+  @Mapping(target = "dataAccessLevel", ignore = true)
+  @Mapping(target = "dataAccessLevelEnum", ignore = true)
+  @Mapping(target = "dataSets", ignore = true)
+  @Mapping(target = "disseminateResearchSet", ignore = true)
+  @Mapping(target = "firecloudName", ignore = true)
+  @Mapping(target = "firecloudUuid", ignore = true)
+  @Mapping(target = "lastAccessedTime", ignore = true)
+  @Mapping(target = "lastModifiedTime", ignore = true)
+  @Mapping(target = "name", ignore = true)
+  @Mapping(target = "published", ignore = true)
+  @Mapping(target = "researchOutcomeSet", ignore = true)
   @Mapping(target = "reviewRequested", ignore = true)
   @Mapping(target = "timeRequested", ignore = true)
-  @Mapping(target ="version", ignore = true)
-  @Mapping(target ="workspaceActiveStatusEnum", ignore = true)
-  @Mapping(target ="workspaceId", ignore = true)
-  @Mapping(target ="workspaceNamespace", ignore = true)
+  @Mapping(target = "version", ignore = true)
+  @Mapping(target = "workspaceActiveStatusEnum", ignore = true)
+  @Mapping(target = "workspaceId", ignore = true)
+  @Mapping(target = "workspaceNamespace", ignore = true)
   void mergeResearchPurposeIntoWorkspace(
       @MappingTarget DbWorkspace workspace, ResearchPurpose researchPurpose);
 


### PR DESCRIPTION
The way research purposes and workspaces work together makes things awkward in several places. All I'm doing here is stifling a few warnings.

I'm deprecating the `mergeResearchPurposeIntoWorkspace()` mapper method as I'm about to get rid of it altogether.

Also, I looked into treating warnings as errors, and it choked on our generated files. For those interested, see the [output](https://gist.github.com/jaycarlton/d3d2bc9f134969576f1e8c362c25fe1d).
 
To enable this in the build.gradle file I did 
```
gradle.projectsEvaluated {
  tasks.withType(JavaCompile) {
    options.compilerArgs << "-Xlint:all" << "-Werror"
  }
}
```
@calbach I didn't see an obvious way to split out our generated code.  It's in its own directory, but we share packages (and a compile target) with it.
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
