### PR TITLE
[RW-4757][risk=no] Enable V2 Moodle API in production

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -97,7 +97,7 @@
     "enableSumoLogicEventHandling": true,
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": true,
-    "enableMoodleV2Api": false,
+    "enableMoodleV2Api": true,
     "requireInstitutionalVerification": true,
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": false,


### PR DESCRIPTION
See the context ticket for context around the change and copious notes on testing in lower environments.

This should have little risk of impacting production users, since the access module which relies on the Moodle API (enableComplianceTraining) is still set to false in production.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review