### PR TITLE
[RW-4722][Risk=no] Remove default selections from workspace-edit page

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -78,9 +78,6 @@ describe('WorkspaceEdit', () => {
     // Ensure the 'drug development' checkbox is not checked when creating.
     expect(wrapper.find('[data-test-id="researchPurpose-checkbox"]').first().prop('checked'))
       .toEqual(false);
-
-    expect(wrapper.find('[data-test-id="specific-population-no"]').first().prop('checked'))
-      .toEqual(true);
   });
 
   it('displays workspaces duplicate page', async () => {

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -78,6 +78,9 @@ describe('WorkspaceEdit', () => {
     // Ensure the 'drug development' checkbox is not checked when creating.
     expect(wrapper.find('[data-test-id="researchPurpose-checkbox"]').first().prop('checked'))
       .toEqual(false);
+
+    expect(wrapper.find('[data-test-id="specific-population-no"]').first().prop('checked'))
+      .toEqual(false);
   });
 
   it('displays workspaces duplicate page', async () => {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1054,7 +1054,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <RadioButton name='population' style={{marginRight: '0.5rem'}}
                          data-test-id='specific-population-yes'
                          onChange={v => this.setState({populationChecked: true})}
-                         checked={this.state.populationChecked}/>
+                         checked={populationChecked}/>
             <label style={styles.text}>Yes, my study will focus on one or more specific
               underrepresented populations, either on their own or in comparison to other groups.</label>
           </div>
@@ -1077,7 +1077,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                     labelStyle={styles.text}
                     checked={!!this.specificPopulationCheckboxSelected(SpecificPopulationEnum.OTHER)}
                     onChange={v => this.updateSpecificPopulation(SpecificPopulationEnum.OTHER, v)}
-                    disabled={!this.state.populationChecked}
+                    disabled={!populationChecked}
                 />
                 <TextInput type='text' autoFocus placeholder='Please specify'
                            value={this.state.workspace.researchPurpose.otherPopulationDetails}
@@ -1099,7 +1099,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                          style={{marginRight: '0.5rem'}}
                          data-test-id='specific-population-no'
                          onChange={v => this.setState({populationChecked: false})}
-                         checked={this.state.populationChecked === false}/>
+                         checked={populationChecked === false}/>
             <label style={styles.text}>No, my study will not center on underrepresented populations.
               I am interested in a diverse sample in general, or I am focused on populations that
               have been well represented in prior research.</label>
@@ -1149,7 +1149,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                              onChange={() => {
                                this.updateResearchPurpose('reviewRequested', true);
                              }}
-                             checked={this.state.workspace.researchPurpose.reviewRequested}/>
+                             checked={reviewRequested}/>
                 <label style={{...styles.text, marginLeft: '0.5rem'}}>Yes, I would like to request
                   a review of my research purpose.</label>
                 </FlexRow>
@@ -1159,7 +1159,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                              onChange={() => {
                                this.updateResearchPurpose('reviewRequested', false);
                              }}
-                             checked={this.state.workspace.researchPurpose.reviewRequested === false}/>
+                             checked={
+                               reviewRequested === false}/>
                 <label style={{...styles.text, marginLeft: '0.5rem', marginRight: '3rem'}}>No, I
                   have no concerns at this time about potential stigmatization based on my study.</label>
                 </FlexRow>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1192,12 +1192,12 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                   (Question 2.3)</i> cannot be empty</div>}
                 {errors.disseminate && <div> You must specific how you plan to disseminate your research findings (Question 3)</div>}
                 {errors.otherDisseminateResearchFindings && <div>
-                    Disseminate Research Findings Other text should be of at most 100 characters</div>}
+                    Disseminate Research Findings Other text should not be blank and should be at most 100 characters</div>}
                 {errors.researchOutcoming && <div> You must specify the outcome of the research (Question 4)</div>}
                 {errors.populationChecked && <div>You must pick an answer Population of interest question (Question 5)</div>}
                 {errors.specificPopulation && <div> You must specify a population of study (Question 5)</div>}
                 {errors.otherSpecificPopulation && <div>
-                    Specific Population Other text should be of at most 100 characters</div>}
+                    Specific Population Other text should not be blank and should be at most 100 characters</div>}
                 {errors.reviewRequested && <div>You must pick an answer for review of stigmatizing research (Question 6)</div>}
               </ul>
             } disabled={!errors}>


### PR DESCRIPTION
Description:
This changes the default selection of review requested and specific populations from `no` to nothing. It also adds error messaging when those aren't selected. From there, I cleaned up a bunch of stuff on the page. (screenshots where applicable)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
