### PR TITLE
[noTicket][RISK=NO] Fix Create workspace :two different message labels are adjacent but with no visible spacing between them.

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -309,8 +309,8 @@ describe('WorkspaceEdit', () => {
     intendedStudySection = wrapper.find('[data-test-id="intendedStudyText"]');
     const charsRemaining = 1000 - testInput.length;
 
-    expect(intendedStudySection.find('[data-test-id="characterMessage"]').get(0).props.children)
-      .toContain(charsRemaining);
+    expect(intendedStudySection.find('[data-test-id="characterMessage"]').get(0))
+        .toBeUndefined();
 
     expect(wrapper.find('[data-test-id="characterLimit"]').get(0).props.children)
       .toContain('You have reached the character limit for this question');

--- a/ui/src/app/pages/workspace/workspace-research-summary.tsx
+++ b/ui/src/app/pages/workspace/workspace-research-summary.tsx
@@ -98,12 +98,11 @@ export class WorkspaceResearchSummary extends React.Component<Props, State > {
         <div data-test-id='characterMessage'
              style={{color: textColor, marginLeft: 'auto'}}>1000
           characters remaining</div>}
-         {researchValue &&
-        <div data-test-id='characterMessage'
+         {researchValue && researchValue.length < 1000 && <div data-test-id='characterMessage'
              style={{color: textColor, marginLeft: 'auto'}}>
           {1000 - researchValue.length} characters remaining</div>}
         {researchValue && researchValue.length === 1000 &&
-        <label data-test-id='characterLimit' style={{color: colors.danger}}>
+        <label data-test-id='characterLimit' style={{color: colors.danger, marginLeft: 'auto'}}>
           You have reached the character limit for this question</label>}
 
       </FlexRow>


### PR DESCRIPTION
**Problem** : On create workspace page, if the text for question 2.1,2.2 or 2.3 has length 1000 characters then there were two warning messages (_0 characters remaining_ and _You have reached the character limit for this question_) that were  being displayed with no margin in between them 
<img width="1199" alt="Screen Shot 2020-04-22 at 9 28 18 AM" src="https://user-images.githubusercontent.com/34481816/79999405-deb4d380-8489-11ea-93b5-e143749378b9.png">

**Solution**: If the text has reached the maximum length we do not need to show "0 characters remaining  just show" just one warning message is fine : **Approved by Lou**

<img width="1197" alt="Screen Shot 2020-04-22 at 11 06 41 AM" src="https://user-images.githubusercontent.com/34481816/79999692-381d0280-848a-11ea-8a00-95f513d05a66.png">
<img width="1214" alt="Screen Shot 2020-04-22 at 11 06 49 AM" src="https://user-images.githubusercontent.com/34481816/79999696-38b59900-848a-11ea-9c48-ced425ec47ac.png">

