### PR TITLE
[RW-4724][RISK=NO] Link support articles to billing section of create workspace

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit-section.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit-section.tsx
@@ -34,6 +34,7 @@ export const styles = reactStyles({
 interface Props {
   children?: string | React.ReactNode;
   description?: string | React.ReactNode;
+  descriptionStyle?: React.CSSProperties;
   header: any;
   index?: string;
   indent?: boolean;
@@ -75,7 +76,7 @@ export const WorkspaceEditSection = (props: Props) => {
       {props.subHeader}
     </div>
     }
-    <div style={{...styles.text, marginLeft: '0.9rem'}}>
+    <div style={{...styles.text, marginLeft: '0.9rem', ...props.descriptionStyle}}>
       {props.description}
     </div>
     <div style={{marginTop: '0.5rem', marginLeft: (props.indent ? '0.9rem' : '0rem')}}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -428,10 +428,14 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
     renderBillingDescription() {
       return <div>
-        The <i>All of Us</i> Program provides free credits for each registered user. If you use up your free credits,
-        you can request additional credits or use your own <StyledAnchorTag href={'https://aousupporthelp.zendesk.' +
-        'com/hc/en-us/articles/360039539411-How-to-Create-a-Billing-Account>'} target='_blank'>Google Cloud Platform
-        billing account</StyledAnchorTag>
+        The <i>All of Us</i> Program provides $300 in free credits per user. Please refer to
+        <StyledAnchorTag href={'https://aousupporthelp.zendesk.com/hc/en-us/sections' +
+        '/360008099991-Questions-About-Billing'} target='_blank'> &nbsp;this article
+        </StyledAnchorTag> to learn more about the free credit
+        program and how it can be used. Once you have used up your free credits, you can request
+        additional credits by <StyledAnchorTag href={'https://aousupporthelp.zendesk.' +
+      'com/hc/en-us/articles/360039539411-How-to-Create-a-Billing-Account>'} target='_blank'>
+        &nbsp;contacting support</StyledAnchorTag>.
       </div>;
     }
 
@@ -912,7 +916,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         {serverConfigStore.getValue().enableBillingUpgrade &&
           (!this.isMode(WorkspaceEditMode.Edit) || this.props.workspace.accessLevel === WorkspaceAccessLevel.OWNER) &&
           <WorkspaceEditSection header={<div><i>All of Us</i> Billing account</div>}
-                                description={this.renderBillingDescription()}>
+                                description={this.renderBillingDescription()} descriptionStyle={{marginLeft: '0rem'}}>
             <div style={{...styles.header, color: colors.primary, fontSize: 14, marginBottom: '0.2rem'}}>
               Select account
             </div>


### PR DESCRIPTION
Updated the billing section description the link 
<img width="1494" alt="Screen Shot 2020-04-22 at 1 40 00 PM" src="https://user-images.githubusercontent.com/34481816/80015382-a4563100-849f-11ea-81d2-a29e0fd56fc1.png">

For width reference. 
<img width="1458" alt="Screen Shot 2020-04-22 at 1 52 06 PM" src="https://user-images.githubusercontent.com/34481816/80015965-7b826b80-84a0-11ea-9f77-3a57d61438fd.png">



**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
