### PR TITLE
[risk=no][RW-4678]Followup: don't spam logs and make proper float comparisons

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -47,9 +47,9 @@ public class FreeTierBillingService {
 
   private static final Logger logger = Logger.getLogger(FreeTierBillingService.class.getName());
 
-  // somewhat arbitrary
-  private static final double COST_COMPARISON_TOLERANCE = 0.0001;
-  private static final double COST_FRACTION_TOLERANCE = 0.0001;
+  // somewhat arbitrary - 1 per million
+  private static final double COST_COMPARISON_TOLERANCE = 0.000001;
+  private static final double COST_FRACTION_TOLERANCE = 0.000001;
 
   @Autowired
   public FreeTierBillingService(

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -176,9 +176,10 @@ public class FreeTierBillingService {
 
     // this shouldn't happen, but it did (RW-4678)
     // alert if it happens again
-    if (currentCost < previousCost &&
-            // was logging many false positives
-            !withinCostTolerance(currentCost, previousCost) ) {
+    if (currentCost < previousCost
+        &&
+        // was logging many false positives
+        !withinCostTolerance(currentCost, previousCost)) {
       String msg =
           String.format(
               "User %s (%s) has %f in total free tier spending in BigQuery, "

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.billing;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.Sets;
+import com.google.common.math.DoubleMath;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,10 @@ public class FreeTierBillingService {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
   private static final Logger logger = Logger.getLogger(FreeTierBillingService.class.getName());
+
+  // somewhat arbitrary
+  private static final double COST_COMPARISON_TOLERANCE = 0.0001;
+  private static final double COST_FRACTION_TOLERANCE = 0.0001;
 
   @Autowired
   public FreeTierBillingService(
@@ -123,8 +128,16 @@ public class FreeTierBillingService {
     sendAlertsForCostThresholds(usersToThresholdCheck, previousUserCosts, userCosts);
   }
 
+  private int compareCosts(final double a, final double b) {
+    return DoubleMath.fuzzyCompare(a, b, COST_COMPARISON_TOLERANCE);
+  }
+
+  private int compareCostFractions(final double a, final double b) {
+    return DoubleMath.fuzzyCompare(a, b, COST_FRACTION_TOLERANCE);
+  }
+
   private boolean expiredByCost(final DbUser user, final double currentCost) {
-    return currentCost > getUserFreeTierDollarLimit(user);
+    return compareCosts(currentCost, getUserFreeTierDollarLimit(user)) > 0;
   }
 
   private void deactivateUserWorkspaces(final DbUser user) {
@@ -151,12 +164,6 @@ public class FreeTierBillingService {
         });
   }
 
-  // are these two cost values approximately equal?
-  // used to determine whether we should log anomalies
-  private boolean withinCostTolerance(double currentCost, double previousCost) {
-    return Math.abs(currentCost - previousCost) < 0.000001;
-  }
-
   /**
    * Has this user passed a cost threshold between this check and the previous run?
    *
@@ -176,10 +183,7 @@ public class FreeTierBillingService {
 
     // this shouldn't happen, but it did (RW-4678)
     // alert if it happens again
-    if (currentCost < previousCost
-        &&
-        // was logging many false positives
-        !withinCostTolerance(currentCost, previousCost)) {
+    if (compareCosts(currentCost, previousCost) < 0) {
       String msg =
           String.format(
               "User %s (%s) has %f in total free tier spending in BigQuery, "
@@ -195,9 +199,9 @@ public class FreeTierBillingService {
     final double previousFraction = previousCost / limit;
 
     for (final double threshold : thresholdsInDescOrder) {
-      if (currentFraction > threshold) {
+      if (compareCostFractions(currentFraction, threshold) > 0) {
         // only alert if we have not done so previously
-        if (previousFraction <= threshold) {
+        if (compareCostFractions(previousFraction, threshold) <= 0) {
           try {
             mailService.alertUserFreeTierDollarThreshold(
                 user, threshold, currentCost, remainingBalance);
@@ -269,7 +273,7 @@ public class FreeTierBillingService {
    */
   public boolean userHasRemainingFreeTierCredits(DbUser user) {
     return Optional.ofNullable(getCachedFreeTierUsage(user))
-        .map(usage -> getUserFreeTierDollarLimit(user) > usage)
+        .map(usage -> compareCosts(getUserFreeTierDollarLimit(user), usage) > 0)
         .orElse(true);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -151,6 +151,12 @@ public class FreeTierBillingService {
         });
   }
 
+  // are these two cost values approximately equal?
+  // used to determine whether we should log anomalies
+  private boolean withinCostTolerance(double currentCost, double previousCost) {
+    return Math.abs(currentCost - previousCost) < 0.000001;
+  }
+
   /**
    * Has this user passed a cost threshold between this check and the previous run?
    *
@@ -170,7 +176,9 @@ public class FreeTierBillingService {
 
     // this shouldn't happen, but it did (RW-4678)
     // alert if it happens again
-    if (currentCost < previousCost) {
+    if (currentCost < previousCost &&
+            // was logging many false positives
+            !withinCostTolerance(currentCost, previousCost) ) {
       String msg =
           String.format(
               "User %s (%s) has %f in total free tier spending in BigQuery, "

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -60,7 +60,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @DataJpaTest
 public class FreeTierBillingServiceTest {
 
-  private static final double DEFAULT_PERCENTAGE_TOLERANCE = 0.001;
+  private static final double DEFAULT_PERCENTAGE_TOLERANCE = 0.000001;
 
   @Autowired BigQueryService bigQueryService;
   @Autowired FreeTierBillingService freeTierBillingService;
@@ -241,7 +241,7 @@ public class FreeTierBillingServiceTest {
         .alertUserFreeTierDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
 
-    // check that we do not alert twice for the 75% threshold
+    // check that we do not alert twice for the 65% threshold
 
     doReturn(mockBQTableSingleResult(costOverThreshold)).when(bigQueryService).executeQuery(any());
     freeTierBillingService.checkFreeTierBillingUsage();

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -555,14 +555,14 @@ public class FreeTierBillingServiceTest {
     createWorkspace(user1, "another project");
 
     final Map<String, Double> costs =
-        ImmutableMap.of(SINGLE_WORKSPACE_TEST_PROJECT, 1000.0, "another project", 100.0);
+        ImmutableMap.of(SINGLE_WORKSPACE_TEST_PROJECT, 1000.0, "another project", 200.0);
     doReturn(mockBQTableResult(costs)).when(bigQueryService).executeQuery(any());
 
     // we have not yet cached the new workspace costs
     assertWithinBillingTolerance(freeTierBillingService.getCachedFreeTierUsage(user1), 100.01);
 
     freeTierBillingService.checkFreeTierBillingUsage();
-    final double expectedTotalCachedFreeTierUsage = 1000.0 + 100.01;
+    final double expectedTotalCachedFreeTierUsage = 1000.0 + 200.0;
     assertWithinBillingTolerance(
         freeTierBillingService.getCachedFreeTierUsage(user1), expectedTotalCachedFreeTierUsage);
 


### PR DESCRIPTION
Description:

The motivation for this change was seeing a large number of logs like this:

```User [redacted] has 4.041393 in total free tier spending in BigQuery, which is less than the 4.041393 previous spending we have recorded in the DB (FreeTierBillingService.java:182)```

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
