### PR TITLE
[RW-4817][Risk=no] Hardcode width on dropdown

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -29,6 +29,9 @@ import {Dropdown} from 'primereact/dropdown';
 const styles = reactStyles({
   ...commonStyles,
   wideInputSize: {
+    // We have a fixed width here because the text for dropdown options sometimes
+    // expands beyond the width of the dropdown, which leads to display bugs.
+    // For example, https://precisionmedicineinitiative.atlassian.net/browse/RW-4817
     width: 600
   },
   institutionalDuaTextBox: {

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -29,8 +29,7 @@ import {Dropdown} from 'primereact/dropdown';
 const styles = reactStyles({
   ...commonStyles,
   wideInputSize: {
-    width: '50%',
-    minWidth: '600px'
+    width: 600
   },
   institutionalDuaTextBox: {
     ...commonStyles.text,


### PR DESCRIPTION
Description:
So, this one is interesting. It looks like the PrimeReact dropdown text has a bug where it will expand out to fill the space. I am attaching a screenshot of what that does to the actual bounding boxes. 
Problem:
<img width="849" alt="Screen Shot 2020-04-23 at 3 00 20 PM" src="https://user-images.githubusercontent.com/15351021/80138683-2c593b00-8573-11ea-8b48-bbffd224261c.png">
Solution:
<img width="812" alt="Screen Shot 2020-04-23 at 3 06 53 PM" src="https://user-images.githubusercontent.com/15351021/80139244-257ef800-8574-11ea-94d7-d727047b2615.png">

 
We tried fixing it with `text-overflow` and with `overflow` but neither worked. The best thing we could find was pinning the width, which we do a lot on these pages anyway, so that should be okay.

Note: This solution doesn't fix the underlying issues, but does cap out the width such that the aside moves back in, so that the page doesn't get wider.


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
