### PR TITLE
[RW-4823][risk=no] Update height for completed registration cards

### DIFF
--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -325,8 +325,8 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
         {registrationTasksToRender.map((card, i) => {
           return <ResourceCardBase key={i} data-test-id={'registration-task-' + i.toString()}
             style={this.isEnabled(i) ? styles.cardStyle : {...styles.cardStyle,
-              opacity: '0.6', maxHeight: this.allTasksCompleted() ? '160px' : '305px',
-              minHeight: this.allTasksCompleted() ? '160px' : '305px'}}>
+              opacity: '0.6', maxHeight: this.allTasksCompleted() ? '190px' : '305px',
+              minHeight: this.allTasksCompleted() ? '190px' : '305px'}}>
             <FlexColumn style={{justifyContent: 'flex-start'}}>
               <div style={styles.cardHeader}>STEP {i + 1}</div>
               <div style={styles.cardHeader}>{card.title}</div>


### PR DESCRIPTION
Changes the heights of the completed cards from 160px to 190px. (min and max heights)
Before:
<img width="824" alt="Screen Shot 2020-04-23 at 2 48 45 PM" src="https://user-images.githubusercontent.com/40036095/80143439-6a099400-8572-11ea-80e0-a1c9965b15f2.png">

After:
<img width="863" alt="Screen Shot 2020-04-23 at 2 48 05 PM" src="https://user-images.githubusercontent.com/40036095/80143450-7130a200-8572-11ea-8f84-93f3daf32ec5.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
