### PR TITLE
[no ticket][risk=no] Puppeteer framework new component Dialog

### DIFF
--- a/e2e/app/component/dialog.ts
+++ b/e2e/app/component/dialog.ts
@@ -1,0 +1,57 @@
+import {ElementHandle, Page} from 'puppeteer';
+
+export enum ButtonLabel {
+  Confirm = 'Confirm',
+  KeepEditing = 'Keep Editing',
+}
+
+const SELECTOR = {
+  dialogRoot: '.ReactModal__Content[role="dialog"]',
+  button: '[role="button"]'
+}
+
+export default class Dialog {
+  private dialogElement: ElementHandle;
+
+  constructor(private readonly page: Page) {
+
+  }
+
+  async getContent(): Promise<string> {
+    await this.findDialog();
+    const modalText = await this.page.evaluate((selector) => {
+      const modalElement = document.querySelector(selector);
+      return modalElement.innerText;
+    }, SELECTOR.dialogRoot);
+    console.log('dialog text = ' + modalText);
+    return modalText;
+  }
+
+  async clickButton(buttonLabel: ButtonLabel): Promise<void> {
+    const selector = this.getButtonSelector();
+    await this.page.waitForSelector(selector, {visible: true});
+    const buttons = await this.page.$$(selector);
+    for (const button of buttons) {
+      const propValue = await button.getProperty('textContent');
+      if (await propValue.jsonValue() === buttonLabel) {
+        return await button.click();
+      }
+    }
+    throw new Error(`Failed to find button with label ${buttonLabel}`);
+  }
+
+  async waitUntilDialogIsClosed() {
+    await this.page.waitForSelector(SELECTOR.dialogRoot, {visible: false});
+  }
+
+  private async findDialog() {
+    if (this.dialogElement === undefined) {
+      this.dialogElement = await this.page.waitForSelector(SELECTOR.dialogRoot, {visible: true});
+    }
+  }
+
+  private getButtonSelector() {
+    return `${SELECTOR.dialogRoot} ${SELECTOR.button}`;
+  }
+
+}

--- a/e2e/app/component/dialog.ts
+++ b/e2e/app/component/dialog.ts
@@ -23,7 +23,7 @@ export default class Dialog {
       const modalElement = document.querySelector(selector);
       return modalElement.innerText;
     }, SELECTOR.dialogRoot);
-    console.log('dialog text = ' + modalText);
+    console.log('dialog: ' + modalText);
     return modalText;
   }
 
@@ -41,7 +41,7 @@ export default class Dialog {
   }
 
   async waitUntilDialogIsClosed() {
-    await this.page.waitForSelector(SELECTOR.dialogRoot, {visible: false});
+    await this.page.waitForSelector(SELECTOR.dialogRoot, {visible: false, timeout: 60000});
   }
 
   private async findDialog() {

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -51,7 +51,7 @@ export default abstract class BasePage {
    */
   async clickAndWait(clickElement: ElementHandle | BaseElement) {
     return Promise.all([
-      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 0}),
+      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
       clickElement.click(),
     ]);
   }

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -8,12 +8,9 @@ import BaseElement from 'app/element/base-element';
 export default abstract class BasePage {
 
   page: Page;
-  DEFAULT_TIMEOUT_MILLISECONDS = 30000;
-  timeout;
 
-  protected constructor(page: Page, timeout?) {
+  protected constructor(page: Page) {
     this.page = page;
-    this.timeout = timeout || this.DEFAULT_TIMEOUT_MILLISECONDS;
   }
 
   async getPageTitle() : Promise<string> {
@@ -51,7 +48,7 @@ export default abstract class BasePage {
    */
   async clickAndWait(clickElement: ElementHandle | BaseElement) {
     return Promise.all([
-      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
+      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
       clickElement.click(),
     ]);
   }
@@ -64,7 +61,7 @@ export default abstract class BasePage {
     return await this.page.waitForFunction(txt => {
       const href = window.location.href;
       return href.includes(txt);
-    }, { timeout: this.timeout}, text);
+    }, {}, text);
   }
 
   /**
@@ -75,7 +72,7 @@ export default abstract class BasePage {
     return await this.page.waitForFunction(t => {
       const actualTitle = document.title;
       return actualTitle === t;
-    }, {timeout: this.timeout}, title);
+    }, {}, title);
   }
 
   /**
@@ -86,7 +83,7 @@ export default abstract class BasePage {
     return await this.page.waitForFunction((t) => {
       const actualTitle = document.title;
       return actualTitle.includes(t);
-    }, {timeout: this.timeout}, title)
+    }, {}, title)
   }
 
   /**
@@ -98,7 +95,7 @@ export default abstract class BasePage {
       const elem = document.querySelector(selector);
       const isVisible = elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
       return !!isVisible;
-    }, {timeout: this.timeout}, cssSelector);
+    }, {}, cssSelector);
   }
 
   /**
@@ -110,7 +107,7 @@ export default abstract class BasePage {
       const elem = document.querySelector(selector);
       const isVisible = elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length;
       return !isVisible;
-    }, {timeout: this.timeout}, cssSelector);
+    }, {}, cssSelector);
   }
 
   /**
@@ -121,7 +118,7 @@ export default abstract class BasePage {
   async waitForNumberElements(cssSelector: string, expectedCount: number) {
     return await this.page.waitForFunction((selector, count) => {
       return document.querySelectorAll(selector).length === count;
-    }, {timeout: this.timeout}, cssSelector, expectedCount);
+    }, {}, cssSelector, expectedCount);
   }
 
   /**
@@ -132,7 +129,7 @@ export default abstract class BasePage {
   async waitForNumberElementsIsBiggerThan(cssSelector: string, greaterThanCount: number) {
     return await this.page.waitForFunction((selector, count) => {
       return document.querySelectorAll(selector).length > count;
-    }, {timeout: this.timeout}, cssSelector, greaterThanCount);
+    }, {}, cssSelector, greaterThanCount);
   }
 
   /**
@@ -143,7 +140,7 @@ export default abstract class BasePage {
     return await this.page.waitForFunction(matchText => {
       const bodyText = document.querySelector('body').innerText;
       return bodyText.includes(matchText)
-    }, {timeout: this.timeout}, texts);
+    }, {}, texts);
   }
 
   /**
@@ -156,7 +153,7 @@ export default abstract class BasePage {
     return await this.page.waitForFunction((selector, attributeName, attributeValue) => {
       const element = document.querySelector(selector);
       return element.attributes[attributeName] && element.attributes[attributeName].value === attributeValue;
-    }, {timeout: this.timeout}, cssSelector, attribute, value);
+    }, {}, cssSelector, attribute, value);
   }
 
   /**
@@ -171,7 +168,7 @@ export default abstract class BasePage {
       if (t !== undefined) {
         return t.innerText === expText;
       }
-    }, {timeout: 50000}, cssSelector, expectedText);
+    }, {}, cssSelector, expectedText);
 
     await this.page.waitForSelector(cssSelector, { visible: true });
   }

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -12,6 +12,9 @@ export const TAB_SELECTOR = {
   showAllTab: '//*[@role="button"][(text()="Show All")]',
 };
 
+export const PAGE = {
+  TITLE: 'Data Page',
+};
 
 export default class DataPage extends AuthenticatedPage {
 
@@ -21,8 +24,11 @@ export default class DataPage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     try {
-      await this.waitUntilTitleMatch('Data Page');
-      await this.page.waitForXPath(TAB_SELECTOR.showAllTab, {visible: true});
+      await Promise.all([
+        this.waitUntilTitleMatch(PAGE.TITLE),
+        this.page.waitForXPath(TAB_SELECTOR.showAllTab, {visible: true}),
+        this.waitUntilNoSpinner(),
+      ]);
       return true;
     } catch (e) {
       return false;

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -23,9 +23,12 @@ export default class HomePage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     try {
-      await this.waitUntilTitleMatch(PAGE.TITLE);
-      await this.waitForTextExists(PAGE.HEADER);
-      await Link.forLabel(this.page, LABEL_ALIAS.SEE_ALL_WORKSPACES);
+      await Promise.all([
+        this.waitUntilTitleMatch(PAGE.TITLE),
+        this.waitForTextExists(PAGE.HEADER),
+        Link.forLabel(this.page, LABEL_ALIAS.SEE_ALL_WORKSPACES),
+        this.waitUntilNoSpinner(),
+      ]);
       return true;
     } catch (e) {
       return false;

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -29,7 +29,10 @@ export default class ProfilePage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     try {
-      await this.waitForTextExists(PAGE.TITLE);
+      await Promise.all([
+        this.waitForTextExists(PAGE.TITLE),
+        this.waitUntilNoSpinner(),
+      ]);
       return true;
     } catch (e) {
       return false;

--- a/e2e/app/page/user-admin-page.ts
+++ b/e2e/app/page/user-admin-page.ts
@@ -13,7 +13,10 @@ export default class UserAdminPage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     try {
-      await this.waitForTextExists(PAGE.TITLE);
+      await Promise.all([
+        this.waitForTextExists(PAGE.TITLE),
+        this.waitUntilNoSpinner(),
+      ]);
       return true;
     } catch (e) {
       return false;

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -6,6 +6,7 @@ import SelectMenu from 'app/component/select-menu';
 import Textbox from 'app/element/textbox';
 import WebComponent from 'app/element/web-component';
 import AuthenticatedPage from 'app/page/authenticated-page';
+import Dialog, {ButtonLabel} from 'app/component/dialog';
 
 const faker = require('faker/locale/en_US');
 
@@ -427,7 +428,15 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
   async clickCreateFinishButton(): Promise<void> {
     const createButton = await this.getCreateWorkspaceButton();
     await createButton.focus(); // bring into viewport
-    await this.clickAndWait(createButton);
+    await createButton.click();
+
+    // confirm create in pop-up dialog
+    const dialog = new Dialog(this.page);
+    await Promise.all([
+      dialog.clickButton(ButtonLabel.Confirm),
+      dialog.waitUntilDialogIsClosed(),
+      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
+    ]);
     await this.waitUntilNoSpinner();
   }
 

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -1,4 +1,4 @@
-import {Page} from 'puppeteer';
+import {ElementHandle, Page} from 'puppeteer';
 import Button from 'app/element/button';
 import Checkbox from 'app/element/checkbox';
 import Select from 'app/element/select';
@@ -425,10 +425,9 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
   /**
    * Find and click the CREATE WORKSPACE (FINISH) button
    */
-  async clickCreateFinishButton(): Promise<void> {
-    const createButton = await this.getCreateWorkspaceButton();
-    await createButton.focus(); // bring into viewport
-    await createButton.click();
+  async clickCreateFinishButton(button: ElementHandle | Button): Promise<void> {
+    await button.focus(); // bring into viewport
+    await button.click();
 
     // confirm create in pop-up dialog
     const dialog = new Dialog(this.page);

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -425,18 +425,20 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
   /**
    * Find and click the CREATE WORKSPACE (FINISH) button
    */
-  async clickCreateFinishButton(button: ElementHandle | Button): Promise<void> {
+  async clickCreateFinishButton(button: ElementHandle | Button): Promise<string> {
     await button.focus(); // bring into viewport
     await button.click();
 
     // confirm create in pop-up dialog
     const dialog = new Dialog(this.page);
+    const dialogText = await dialog.getContent();
     await Promise.all([
       dialog.clickButton(ButtonLabel.Confirm),
       dialog.waitUntilDialogIsClosed(),
       this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
     ]);
     await this.waitUntilNoSpinner();
+    return dialogText;
   }
 
   async clickShareWithCollaboratorsCheckbox() {

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -3,7 +3,7 @@ import Button from 'app/element/button';
 import {PageUrl} from 'app/page-identifiers';
 import WorkspaceEditPage, {FIELD as EDIT_FIELD} from 'app/page/workspace-edit-page';
 import {makeWorkspaceName} from 'utils/str-utils';
-import RadioButton from '../element/radiobutton';
+import RadioButton from 'app/element/radiobutton';
 
 const faker = require('faker/locale/en_US');
 

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -31,9 +31,12 @@ export default class WorkspacesPage extends WorkspaceEditPage {
 
   async isLoaded(): Promise<boolean> {
     try {
-      await this.waitUntilTitleMatch(PAGE.TITLE);
-      await this.page.waitForXPath('//a[text()="Workspaces"]', {visible: true}); // link
-      await this.page.waitForXPath('//h3[normalize-space(text())="Workspaces"]', {visible: true}); // Texts above Filter By Select
+      await Promise.all([
+        this.waitUntilTitleMatch(PAGE.TITLE),
+        this.page.waitForXPath('//a[text()="Workspaces"]', {visible: true}),
+        this.page.waitForXPath('//h3[normalize-space(text())="Workspaces"]', {visible: true}),  // Texts above Filter By Select
+        this.waitUntilNoSpinner(),
+      ]);
       return true;
     } catch (e) {
       return false;
@@ -116,7 +119,9 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     await editPage.requestForReviewRadiobutton(reviewRequest);
 
     // click CREATE WORKSPACE button
-    await editPage.clickCreateFinishButton();
+    const createButton = await this.getCreateWorkspaceButton();
+    await createButton.waitUntilEnabled();
+    await editPage.clickCreateFinishButton(createButton);
   }
 
   /**

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -72,7 +72,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
   /**
    * Create a simple and basic new workspace end-to-end.
    */
-  async createWorkspace(workspaceName: string, billingAccount: string, reviewRequest: boolean = false) {
+  async createWorkspace(workspaceName: string, billingAccount: string, reviewRequest: boolean = false): Promise<string> {
 
     const editPage = await this.clickCreateNewWorkspace();
     // wait for Billing Account default selected value
@@ -121,7 +121,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     // click CREATE WORKSPACE button
     const createButton = await this.getCreateWorkspaceButton();
     await createButton.waitUntilEnabled();
-    await editPage.clickCreateFinishButton(createButton);
+    return await editPage.clickCreateFinishButton(createButton);
   }
 
   /**

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -5,7 +5,9 @@ const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/5
 // Runs this beforeEach() before test's beforeEach().
 beforeEach(async () => {
   await page.setUserAgent(userAgent);
+  // Refer to https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaultnavigationtimeouttimeout
   await page.setDefaultNavigationTimeout(90000);
+  await page.setDefaultTimeout(60000);
 });
 
 // Runs this afterEach() before test's afterEach().

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -18,32 +18,29 @@ describe('Clone workspace', () => {
       const workspacesPage = new WorkspacesPage(page);
       await workspacesPage.load();
 
-         // choose one workspace on "Your Workspaces" page for clone from
+      // choose one workspace on "Your Workspaces" page for clone from
       const workspaceCard = new WorkspaceCard(page);
       const retrievedWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.OWNER);
       const aWorkspaceCard: WorkspaceCard = fp.shuffle(retrievedWorkspaces)[0];
       await aWorkspaceCard.asElementHandle().hover();
-         // click on Ellipsis "Duplicate"
+      // click on Ellipsis "Duplicate"
       await (aWorkspaceCard.getEllipsis()).selectAction(WorkspaceAction.DUPLICATE);
 
-         // fill out Workspace Name should be just enough for clone successfully
+      // fill out Workspace Name should be just enough for clone successfully
       await (await workspacesPage.getWorkspaceNameTextbox()).clear();
       const cloneWorkspaceName = await workspacesPage.fillOutWorkspaceName();
 
       const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
       await finishButton.waitUntilEnabled();
+      await workspacesPage.clickCreateFinishButton(finishButton);
 
-      await finishButton.focus();
-      await workspacesPage.clickAndWait(finishButton);
-      await workspacesPage.waitUntilNoSpinner();
-
-         // wait for Data page
+      // wait for Data page
       const dataPage = new DataPage(page);
       await dataPage.waitForLoad();
-         // save Data page URL for comparison
+      // save Data page URL for comparison
       const workspaceDataUrl1 = await page.url();
 
-         // verify new workspace was created and now can be opened successfully
+      // verify new workspace was created and now can be opened successfully
       await workspacesPage.load();
       const workspaceLink = await workspaceCard.getWorkspaceNameLink(cloneWorkspaceName);
       await workspaceLink.click();
@@ -57,7 +54,7 @@ describe('Clone workspace', () => {
   describe('From "Data" page using side ellipsis menu', () => {
 
     test('As OWNER, user can clone workspace', async () => {
-         // choose one workspace on "Home" page for clone from
+       // choose one workspace on "Home" page for clone from
       const workspaceCard = new WorkspaceCard(page);
       const retrievedWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.OWNER);
       const aWorkspaceCard = fp.shuffle(retrievedWorkspaces)[0];
@@ -70,7 +67,7 @@ describe('Clone workspace', () => {
 
       const workspacesPage = new WorkspacesPage(page);
 
-         // fill out Workspace Name
+      // fill out Workspace Name
       await (await workspacesPage.getWorkspaceNameTextbox()).clear();
       const cloneWorkspaceName = await workspacesPage.fillOutWorkspaceName();
          // select "Share workspace with same set of collaborators radiobutton
@@ -78,14 +75,11 @@ describe('Clone workspace', () => {
 
       const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
       await finishButton.waitUntilEnabled();
+      await workspacesPage.clickCreateFinishButton(finishButton);
 
-      await finishButton.focus();
-      await workspacesPage.clickAndWait(finishButton);
-      await workspacesPage.waitUntilNoSpinner();
-
-         // wait for Data page
+      // wait for Data page
       await dataPage.waitForLoad();
-         // save Data page URL for comparison after sign out then sign in back
+      // save Data page URL for comparison after sign out then sign in back
       const workspaceDataUrl = await page.url();
       // strips out dash from workspace name
       expect(workspaceDataUrl).toContain(cloneWorkspaceName.replace(/-/g, ''));

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -19,7 +19,16 @@ describe('Creating new workspaces', () => {
     await workspacesPage.load();
 
     // create workspace with "No Review Requested" radiobutton selected
-    await workspacesPage.createWorkspace(newWorkspaceName, 'Use All of Us free credits',);
+    const dialogTextContent = await workspacesPage.createWorkspace(newWorkspaceName, 'Use All of Us free credits',);
+
+    console.log(dialogTextContent);
+
+    // Pick out few sentenses to verify
+    expect(dialogTextContent).toContain('Primary purpose of your project (Question 1)');
+    expect(dialogTextContent).toContain('Summary of research purpose (Question 2)');
+    expect(dialogTextContent).toContain('Will be displayed publicly to inform All of Us Research participants.');
+    expect(dialogTextContent).toContain('You can also make changes to your answers after you create your workspace.');
+
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });
 
@@ -61,7 +70,9 @@ describe('Creating new workspaces', () => {
 
     const finishButton = await workspacesPage.getCreateWorkspaceButton();
     await finishButton.waitUntilEnabled();
-    await workspacesPage.clickCreateFinishButton(finishButton);
+    const dialogTextContent = await workspacesPage.clickCreateFinishButton(finishButton);
+
+    console.log(dialogTextContent);
 
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -21,8 +21,6 @@ describe('Creating new workspaces', () => {
     // create workspace with "No Review Requested" radiobutton selected
     const dialogTextContent = await workspacesPage.createWorkspace(newWorkspaceName, 'Use All of Us free credits',);
 
-    console.log(dialogTextContent);
-
     // Pick out few sentenses to verify
     expect(dialogTextContent).toContain('Primary purpose of your project (Question 1)');
     expect(dialogTextContent).toContain('Summary of research purpose (Question 2)');
@@ -70,9 +68,7 @@ describe('Creating new workspaces', () => {
 
     const finishButton = await workspacesPage.getCreateWorkspaceButton();
     await finishButton.waitUntilEnabled();
-    const dialogTextContent = await workspacesPage.clickCreateFinishButton(finishButton);
-
-    console.log(dialogTextContent);
+    await workspacesPage.clickCreateFinishButton(finishButton);
 
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -61,13 +61,9 @@ describe('Creating new workspaces', () => {
 
     const finishButton = await workspacesPage.getCreateWorkspaceButton();
     await finishButton.waitUntilEnabled();
-
-    await finishButton.focus(); // bring button into viewport
-    await workspacesPage.clickAndWait(finishButton);
-    await workspacesPage.waitUntilNoSpinner();
+    await workspacesPage.clickCreateFinishButton(finishButton);
 
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
-
   });
 
   // helper function to check visible workspace link on Data page


### PR DESCRIPTION
This PR will address two ongoing test failures:
(1) a blank page with spinner which has seen to fail tests occasionally. I don't know why it's happening now but not before. To fix this, part 1 is refactor Page's `isLoaded` method to include `waitUntilNoSpinner` in a `Promise.all`. Part 2 is use Puppeteer global `waitFor` timeout, so I don't have to add `{timeout: 60000}` for all `waitFor`.
```
await page.setDefaultNavigationTimeout(90000);
await page.setDefaultTimeout(60000);
```

![PageIsNotLoaded](https://user-images.githubusercontent.com/35533885/80159533-3a21b700-8599-11ea-9acc-cc20beb9b464.png)


(2) UI change when creating or duplicating workspace. There is a new Confirmation Dialog now.