### PR TITLE
[RW-4830][RISK=NO] Export parameter focusOnUnderrepresentedPopulations to RDR

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -296,6 +296,8 @@ public class RdrExportServiceImpl implements RdrExportService {
     rdrWorkspace.setFindingsFromStudy(dbWorkspace.getAnticipatedFindings());
     rdrWorkspace.setReviewRequested(dbWorkspace.getReviewRequested());
 
+    rdrWorkspace.setFocusOnUnderrepresentedPopulations(
+        dbWorkspace.getSpecificPopulationsEnum().size() > 0);
     rdrWorkspace.setWorkspaceDemographic(
         toRdrWorkspaceDemographics(dbWorkspace.getSpecificPopulationsEnum()));
 

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -140,6 +140,8 @@ definitions:
       findingsFromStudy:
         type: string
       focusOnUnderrepresentedPopulations:
+        description: Represents if researchers has selected YES for question Will your study focus
+          on any historically underrepresented populations
         type: boolean
       reviewRequested:
         type: boolean


### PR DESCRIPTION
**Problem** : While exporting workspace data to RDR, workbench was not sending the parameter focusOnUnderrepresentedPopulations (which represents if researcher has selected the question _Will your study focus on any historically underrepresented populations_ while creating workspace). Because of which RDR was assuming this value to be false and ignoring the workspace Demographic information being sent.

**Solution**: Populate and send the value focusOnUnderrepresentedPopulations while exporting Workspace data to RDR:
 IF workspace has any Demographic information (race/age etc) send YES else NO

Confirmed with Wang Yu its working fine and RDR is able to store this value