### PR TITLE
[RW-4812][risk=no] Reduce spacing on cookie policy page

### DIFF
--- a/ui/src/app/pages/cookie-policy.tsx
+++ b/ui/src/app/pages/cookie-policy.tsx
@@ -37,9 +37,10 @@ const styles = {
   smallHeader: {
     fontSize: 16,
     fontWeight: 600,
+    marginTop: '.5rem'
   },
   textSection: {
-    marginTop: '.75rem'
+    marginTop: '.25rem'
   }
 };
 


### PR DESCRIPTION
Reduced space between headers and text by .5rem.
<img width="1294" alt="Screen Shot 2020-04-24 at 9 22 56 AM" src="https://user-images.githubusercontent.com/40036095/80224899-f9b15000-860f-11ea-957c-940f394d85ee.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
