### PR TITLE
[RW-4645][risk=no] CircleCI config upgrade to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,22 @@
-version: 2
+version: 2.1
 
+# -------------------------
+#   PARAMETERS
+# -------------------------
+parameters:
+  circleci_service_account:
+    type: string
+    default: "circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
+
+# -------------------------
+#   ANCHORS
+# -------------------------
 anchors:
   defaults: &defaults
     docker:
       - image: allofustest/workbench:buildimage-0.0.16
     working_directory: ~/workbench
-  ensure_branch_has_api_changes: &ensure_branch_has_api_changes
-    name: Ensure Branch has Changes to API Code
-    command: |
-      if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ] && [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep api/ | wc -l | xargs) == 0 ]; then
-        echo No relevant changes on api directory in non-master branch. Skipping
-        circleci step halt
-      fi
+
   java_defaults: &java_defaults
     <<: *defaults
     environment:
@@ -22,23 +27,209 @@ anchors:
       # In Feb 2017, this was set to 3G. But in Feb 2019 (RW-2194) we started seeing OOM errors,
       # so we bumped this down further to 2G.
       JAVA_TOOL_OPTIONS: -Xmx2g
+      # https://docs.gradle.org/6.3/userguide/gradle_daemon.html#sec:disabling_the_daemon
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       TERM: dumb
-    update_git_submodules: &update_git_submodules
-      name: Update Git Submodules
-      command: git submodule update --init --recursive
+
+  # See https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
+  # Job runs for master branch only
+  filter_only_master_branch: &filter_only_master_branch
+    tags:
+      ignore: /.*/
+    branches:
+      only: master
+
+  # Job runs for no branch and only for tags starting with ‘v’
+  filter_only_release_tags: &filter_only_release_tags
+    branches:
+      ignore: /.*/
+    tags:
+      # regex explanation:
+      # "^" asserts position at start of a line.
+      # "v" matches the character "v" literally (case sensitive).
+      # "[0-9]+" match a single numerical digit (the + quantifier, matches between one and unlimited times, as many times as possible).
+      # "-" matches the character "-" literally.
+      # "rc" matches the character "rc" literally (case sensitive).
+      # "$" asserts position at the end of a line.
+      # Workbench release tag format example: v5-3-rc1
+      only: /^v[0-9]+-[0-9]+-rc[0-9]+$/
+
+  # Job runs for all branches EXCEPT all tag and master branches
+  filter_pull_request_branch: &filter_pull_request_branch
+    tags:
+      ignore: /.*/
+    branches:
+      ignore: master
+
+# -------------------------
+#   COMMANDS
+# Refers to https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+# -------------------------
+commands:
+  activate_service_account_credential:
+    description: "Activiate CircleCI service account credential"
+    steps:
+      - run:
+          name: Activate CircleCI service account credential
+          working_directory: ~/workbench
+          # Used to call gsutil from the circle environment.
+          command: ci/activate_creds.sh api/circle-sa-key.json
+
+  checkout_init_git:
+    description: "git checkout and update submodules"
+    steps:
+      - checkout
+      - run:
+          name: Update git submodules
+          command: git submodule update --init --recursive
+
+  halt_job_noncode_changes:
+    description: "Halt job and succeed early if no code changes on master branch"
+    steps:
+      - run:
+          command: |
+            if [ ${CIRCLE_BRANCH} != "" ] &&
+              [ ${CIRCLE_BRANCH} != "master" ] &&
+              ! git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvE '(.md$)|(.pdf$)'; then
+                echo "No code changes in non-master branch. halting job."
+                circleci step halt
+            fi
+          name: Halt job and succeed early if no code changes on master branch
+
+  ensure_branch_has_changes:
+    description: "Ensure branch has changes to code in specified directory"
+    parameters:
+      dir_name:
+        type: enum
+        enum: ["api", "ui"]
+    steps:
+      - run:
+          command: |
+            if [ ${CIRCLE_BRANCH} != "" ] &&
+              [ ${CIRCLE_BRANCH} != "master" ] &&
+              [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep << parameters.dir_name >>/ | wc -l | xargs) == 0 ]; then
+                echo "No relevant changes in << parameters.dir_name >> directory in non-master branch. Skipping."
+                circleci step halt
+            fi
+          name: Ensure branch has changes to code in specified directory
+
+  install_ui_dependencies:
+    description: "workbench/ui: yarn install, save and restore cache"
+    parameters:
+      version:
+        type: string
+      key_prefix:
+        type: string
+        default: << parameters.version >>-yarn-ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
+    steps:
+      # caching: https://circleci.com/docs/2.0/caching/
+      - restore_cache:
+          keys:
+            # restore cache strategy:
+            # Check for the latest cache from your branch.
+            # If that fails, then check for the latest from master branch.
+            # If that fails, then check for the latest from any branch
+            - << parameters.key_prefix >>-{{ .Branch }}
+            - << parameters.key_prefix >>-master
+            - << parameters.key_prefix >>
+      - run:
+          name: "workbench/ui: yarn install dependencies"
+          working_directory: ~/workbench/ui
+          command: yarn install --verbose --frozen-lockfile --non-interactive
+      - save_cache:
+          paths:
+            - ~/.cache/yarn
+            - ui/node_modules
+          key: << parameters.key_prefix >>-{{ .Branch }}
+
+  install_e2e_dependencies:
+    description: "workbench/e2e: yarn install, save and restore cache"
+    parameters:
+      version:
+        type: string
+      key_prefix:
+        type: string
+        default: << parameters.version >>-yarn-e2e-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}
+    steps:
+      - restore_cache:
+          keys:
+            - << parameters.key_prefix >>-{{ .Branch }}
+            - << parameters.key_prefix >>-master
+            - << parameters.key_prefix >>
+      - run:
+          name: "workbench/e2e: yarn install dependencies"
+          working_directory: ~/workbench/e2e
+          command: yarn install --frozen-lockfile --non-interactive
+      - save_cache:
+          paths:
+            - ~/.cache/yarn
+            - e2e/node_modules
+          key: << parameters.key_prefix >>-{{ .Branch }}
+
+  manage_api_cache:
+    description: "workbench/api: save, restore or save_and_restore gradle cache"
+    parameters:
+      save:
+        type: boolean
+        default: false
+      restore:
+        type: boolean
+        default: false
+      key_prefix:
+        type: string
+        default: v1-api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+    steps:
+      - when:
+          condition: << parameters.save >>
+          steps:
+            - save_cache:
+                paths:
+                  - ~/.gradle/caches
+                  - ~/.gradle/wrapper
+                  - ~/.m2
+                  - ~/workbench/api/build/exploded-api/WEB-INF/lib/
+                key: << parameters.key_prefix >>-{{ .Branch }}
+      - when:
+          condition: << parameters.restore >>
+          steps:
+            - restore_cache:
+                keys:
+                  - << parameters.key_prefix >>-{{ .Branch }}
+                  - << parameters.key_prefix >>-master
+                  - << parameters.key_prefix >>
+
+  run_e2e_test:
+    description: "Run puppeteer e2e integration tests"
+    steps:
+      - run:
+          name: Run puppeteer e2e tests
+          working_directory: ~/workbench/e2e
+          environment:
+            USER_NAME: $PUPPETEER_TEST_USER
+            PASSWORD: $PUPPETEER_TEST_USER_PASSWORD
+            INVITATION_KEY: $PUPPETEER_TEST_REGISTRATION_KEY
+          # parallelism used to run e2e tests
+          command: yarn test:ci $(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --timings-type=classname --show-counts)
+      - store_artifacts:
+          path: e2e/logs
+          destination: logs
+      - store_test_results:
+          path: ~/workbench/e2e/logs
+
+# -------------------------
+#        JOBS
+# -------------------------
 jobs:
   api-build-test:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - run: *ensure_branch_has_api_changes
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
+      - checkout_init_git
+      - ensure_branch_has_changes:
+          dir_name: "api"
+      - manage_api_cache:
+          restore: true
       - run:
-          name: Validate swagger definitions
+          name: Validate Swagger definitions
           working_directory: ~/workbench/api
           command: ./project.rb validate-swagger --project-prop verboseTestLogging=yes
       - run:
@@ -46,7 +237,7 @@ jobs:
           working_directory: ~/workbench/api
           command: ./project.rb gradle compile__bigquerytest__Java compile__integration__Java
       - run:
-          name: Run Java Unit Tests
+          name: Run Java unit tests
           working_directory: ~/workbench/api
           command: ./project.rb test
       - run:
@@ -54,14 +245,15 @@ jobs:
           name: Java linting
           working_directory: ~/workbench/api
           command: ./gradlew spotlessCheck
-      - save_cache:
-          paths:
-            - ~/.gradle
-            - ~/.m2
-            - ~/workbench/api/build/exploded-api/WEB-INF/lib/
-          key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - manage_api_cache:
+          save: true
 
   api-local-test:
+    # The local API server starts two Java processes (the API server and the cron emulator).
+    # So we want the Java memory limit to be below half of that: other things on the
+    # machine need memory as well. The medium+ machine has 6GB.
+    # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    resource_class: medium+
     docker:
       - image: allofustest/workbench:buildimage-0.0.16
       - image: mysql:5.7
@@ -71,183 +263,137 @@ jobs:
           - MYSQL_PASSWORD=ubuntu
     working_directory: ~/workbench
     environment:
-      # Drop to ~1.5G; the local API server starts two Java processes (the API
-      # server and the cron emulator). The default machine has 4GB, so we want
-      # the Java memory limit to be below half of that: other things on the
-      # machine need memory as well. Using 2G here manifested in 137 errors.
-      # If this limit proves to be too low, an alternative would be to use a
-      # larger resource class:
-      #   https://circleci.com/docs/2.0/configuration-reference/#resource_class
-      JAVA_TOOL_OPTIONS: -Xmx1536m
+      JAVA_TOOL_OPTIONS: -Xmx2g
       TERM: dumb
       MYSQL_ROOT_PASSWORD: ubuntu
+      # https://docs.gradle.org/6.3/userguide/gradle_daemon.html#sec:disabling_the_daemon
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
-      - run: &activate_service_accont_creds
-          name: Activate Service Accont Credentials
-          working_directory: ~/workbench
-          command: ci/activate_creds.sh api/circle-sa-key.json
+      - checkout_init_git
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - run:
           # MySQL sometimes refuses connections by the time we attempt to apply
           # data migrations. Watch the port for 2m for startup.
-          name: Await MySQL startup
+          name: Await MySQL start up
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m
       - run:
-          name: Run Local Migrations
+          name: Run local migrations
           working_directory: ~/workbench/api
           command: ./project.rb run-local-migrations
       - run:
-          name: Local API Tests on Running Server
+          name: Local API tests on running server
           working_directory: ~/workbench/api
           command: ./project.rb start-local-api && ./project.rb run-local-api-tests && ./project.rb stop-local-api
-      - save_cache:
-          paths:
-            - ~/.gradle
-            - ~/.m2
-            - ~/workbench/api/build/exploded-api/WEB-INF/lib/
-          key: api-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - manage_api_cache:
+          save: true
 
   api-deploy-to-test:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
+      - checkout_init_git
       # Note: most of the time spent here appears to be in Gradle / App Engine
       # deployment. We tried more aggressively caching outputs via Circle
       # workspaces, but that seemed to have a negligible effect on speed. It's
       # also tricky to pick specific sub directories since the API deploy
       # touches several top level folders {common,}api.
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
-      - run: *activate_service_accont_creds
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - deploy:
-          name: Deploy to App Engine
+          name: Deploy API to "test" App Engine
           working_directory: ~/workbench/api
           command: |
             ./project.rb deploy \
               --project all-of-us-workbench-test \
-              --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+              --account << pipeline.parameters.circleci_service_account >> \
               --version circle-ci-test \
               --key-file circle-sa-key.json \
               --promote
 
+
   api-deps-check:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
+      - checkout_init_git
       - run:
           name: Scan dependencies for vulnerabilities
           working_directory: ~/workbench/api
-          command: |
-            ./project.rb gradle dependencyCheckAnalyze --info
+          command: ./project.rb gradle dependencyCheckAnalyze --info
 
   api-integration-test:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - run: *ensure_branch_has_api_changes
-      - restore_cache:
-          keys:
-          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
-      - run: *activate_service_accont_creds
+      - checkout_init_git
+      - ensure_branch_has_changes:
+          dir_name: "api"
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - run:
           name: Run Integration Tests
           working_directory: ~/workbench/api
           command: ./project.rb integration
       - store_test_results:
           path: ~/workbench/api/build/test-results/integrationTest/
-      - save_cache:
-          paths:
-            - ~/.gradle
-            - ~/.m2
-          key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - manage_api_cache:
+          save: true
 
   api-nightly-integration-test:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - restore_cache:
-          keys:
-          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
-      - run: *activate_service_accont_creds
+      - checkout_init_git
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - run:
-          name: Run Nightly Integration tests
+          name: Run nightly integration tests
           working_directory: ~/workbench/api
           command: ./project.rb nightly-integration
       - store_test_results:
           path: ~/workbench/api/build/test-results/integrationTest/
-      - save_cache:
-          paths:
-            - ~/.gradle
-            - ~/.m2
-          key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - manage_api_cache:
+          save: true
 
   api-bigquery-test:
     <<: *java_defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - run: *ensure_branch_has_api_changes
-      - restore_cache:
-          keys:
-          - api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-integration-cache-
+      - checkout_init_git
+      - ensure_branch_has_changes:
+          dir_name: "api"
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - run:
-          name: Activate Service Accont Credentials
-          working_directory: ~/workbench
-          # Used to call gsutil from the circle environment.
-          command: ci/activate_creds.sh api/circle-sa-key.json
-      - run:
-          name: Run BigQuery Tests
+          name: Run BigQuery tests
           working_directory: ~/workbench/api
           command: ./project.rb bigquerytest
-      - save_cache:
-          paths:
-            - ~/.gradle
-            - ~/.m2
-          key: api-integration-cache-{{ checksum "~/workbench/api/build.gradle" }}
+      - manage_api_cache:
+          save: true
 
   ui-build-test:
     <<: *defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
+      - checkout_init_git
       - run:
           name: Download Swagger CLI
           working_directory: ~/workbench
           command: |
             ruby -r ./aou-utils/swagger.rb -e Workbench::Swagger.download_swagger_codegen_cli
-      - restore_cache:
-          keys:
-          - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
-          - ui-cache-
+      - install_ui_dependencies:
+          version: "v1"
       - run:
-          name: Yarn Codegen
+          name: Yarn codegen
           working_directory: ~/workbench/ui
-          command: yarn install --verbose --frozen-lockfile && yarn codegen
-      - save_cache:
-          paths:
-            - ~/.cache/yarn
-          key: ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
+          command: yarn codegen
       - run:
-          name: Run Angular Tests
+          name: Run Angular tests
           working_directory: ~/workbench/ui
           command: |
             yarn test --no-watch --no-progress --browsers=ChromeHeadless
       - run:
-          name: Run React Jest Tests
+          name: Run React jest tests
           working_directory: ~/workbench/ui
           command: |
             yarn test-react --detectOpenHandles --forceExit --runInBand
@@ -257,7 +403,7 @@ jobs:
           command: ./project.rb build --environment test
       - run:
           # Lint last; it's more important to surface test failures early.
-          name: Lint Typescript
+          name: Lint typescript
           working_directory: ~/workbench/ui
           command: yarn run lint
       - persist_to_workspace:
@@ -265,67 +411,40 @@ jobs:
           paths:
             - ui
 
-  # Run suite of Puppeteer end-to-end QA tests, pointed at the Workbench "test" environment.
+  # Run Puppeteer e2e UI tests on Workbench deployed "test" environment.
   puppeteer-e2e-test:
     <<: *defaults
     docker:
-      - image: circleci/node:13.10.1-browsers
-        environment:
-          NODE_ENV: development
+      - image: circleci/node:12.16.2-browsers
+    environment:
+      WORKBENCH_ENV: dev
+      CI: true
+      NODE_ENV: development
     working_directory: ~/workbench
     parallelism: 3
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - restore_cache:
-          keys:
-          - v2-e2e-test-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}
-          - v2-e2e-test-cache-
-      - run:
-          name: Initialize Yarn
-          working_directory: ~/workbench/e2e
-          command: yarn cache clean && yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - ~/.cache/yarn
-          key: v2-e2e-test-cache-{{ checksum "~/workbench/e2e/yarn.lock" }}
-      - run:
-          name: Update Puppeteer Environment Variables
-          command: |
-            echo 'export USER_NAME=$PUPPETEER_TEST_USER' >> $BASH_ENV
-            echo 'export PASSWORD=$PUPPETEER_TEST_USER_PASSWORD' >> $BASH_ENV
-            echo 'export INVITATION_KEY=$PUPPETEER_TEST_REGISTRATION_KEY' >> $BASH_ENV
-            source $BASH_ENV
-      - run:
-          name: Run e2e tests (Puppeteer and Jest)
-          working_directory: ~/workbench/e2e
-          command: yarn test:ci $(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --timings-type=classname --show-counts)
-      - store_artifacts:
-          path: e2e/logs
-          destination: logs
-      - store_test_results:
-          path: ~/workbench/e2e/logs
-      
+      - checkout_init_git
+      - install_e2e_dependencies:
+          version: "v1"
+      - run_e2e_test
+
   ui-deploy-to-test:
     <<: *defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      # Use the ui-build-test workspace here to avoid redoing the setup.
+      - checkout_init_git
+      # Use "ui-build-test" job's workspace here to avoid redoing the setup.
       - attach_workspace:
           at: .
-      - restore_cache:
-          keys:
-          - ui-cache-{{ checksum "~/workbench/ui/yarn.lock" }}
-          - ui-cache-
+      - install_ui_dependencies:
+          version: "v1"
+      - activate_service_account_credential
       - deploy:
-          name: Deploy UI App to App Engine
+          name: Deploy UI to "test" App Engine
           working_directory: ~/workbench/ui
           command: |
-            ../ci/activate_creds.sh circle-sa-key.json
             ./project.rb deploy-ui \
               --project all-of-us-workbench-test \
-              --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+              --account << pipeline.parameters.circleci_service_account >> \
               --version circle-ci-test \
               --key-file circle-sa-key.json \
               --promote
@@ -337,63 +456,44 @@ jobs:
   deploy-staging:
     <<: *defaults
     steps:
-      - checkout
-      - run: *update_git_submodules
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
+      - checkout_init_git
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - deploy:
           working_directory: ~/workbench/deploy
           command: |
-            ../ci/activate_creds.sh circle-sa-key.json
             ./project.rb deploy \
               --project all-of-us-rw-staging \
-              --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+              --account << pipeline.parameters.circleci_service_account >> \
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file circle-sa-key.json \
               --promote
+          name: Deploy API and UI to "staging" App Engine
 
   deploy-perf:
     <<: *defaults
     steps:
-      - checkout
-      - run:
-          command: git submodule update --init --recursive
-      - restore_cache:
-          keys:
-          - api-cache-{{ checksum "~/workbench/api/build.gradle" }}
-          - api-cache-
+      - checkout_init_git
+      - manage_api_cache:
+          restore: true
+      - activate_service_account_credential
       - deploy:
-          name: Deploy to Perf Environment
           working_directory: ~/workbench/deploy
           command: |
-            ../ci/activate_creds.sh circle-sa-key.json
             ./project.rb deploy \
               --project all-of-us-rw-perf \
-              --account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
+              --account << pipeline.parameters.circleci_service_account >> \
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file circle-sa-key.json \
               --promote
-
-# See https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
-filter_master: &filter_master
-  filters:
-    branches:
-      only: master
-filter_releases: &filter_releases
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      only: /^v.*/
+          name: Deploy API and UI to "perf" App Engine
 
 workflows:
-  version: 2
   build-test-deploy:
     jobs:
       # Always run basic test/lint/compilation (open PRs, master merge).
@@ -405,16 +505,16 @@ workflows:
       - api-integration-test
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
-          <<: *filter_master
+          filters: *filter_only_master_branch
           requires:
             - api-build-test
       - ui-deploy-to-test:
-          <<: *filter_master
+          filters: *filter_only_master_branch
           requires:
             - ui-build-test
-      # After merge PR to master branch, run Puppeteer tests after ui and api deployed to "test" env successfully.
+      # After merge PR to master branch, run Puppeteer e2e tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
-          <<: *filter_master
+          filters: *filter_only_master_branch
           requires:
             - api-deploy-to-test
             - ui-deploy-to-test
@@ -422,20 +522,20 @@ workflows:
   deploy-staging:
     jobs:
       - api-local-test:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       - api-build-test:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       - ui-build-test:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       # Run slower integration tests and dep checks on release tags only.
       - api-bigquery-test:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       - api-deps-check:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       - api-integration-test:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
       - deploy-staging:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
           requires:
             - api-local-test
             - api-build-test
@@ -444,7 +544,7 @@ workflows:
             - api-integration-test
             - ui-build-test
       - deploy-perf:
-          <<: *filter_releases
+          filters: *filter_only_release_tags
           requires:
             - api-local-test
             - api-build-test
@@ -452,6 +552,7 @@ workflows:
             - api-deps-check
             - api-integration-test
             - ui-build-test
+
   nightly-tests:
     triggers:
       - schedule:

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     "/tsc-out/"
   ],
   "testMatch": [
-    "<rootDir>/**/tests/**/*.spec.ts"
+    "<rootDir>/tests/**/*.spec.ts"
   ],
   "transformIgnorePatterns": [
     "<rootDir>/node_modules/(?!tests)"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test": "cross-env WORKBENCH_ENV=dev jest",
     "test:debug": "cross-env WORKBENCH_ENV=dev HEADLESS=false jest --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local jest",
-    "test:ci": "cross-env NODE_ENV=development WORKBENCH_ENV=dev CI=true jest --ci --runInBand --forceExit",
+    "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --bail --runInBand --forceExit",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -21,8 +21,8 @@ const urlPath = {
 
 // localhost development server
 const local = {
-  uiBaseUrl: process.env.DEV_LOGIN_URL || 'https://localhost',
-  apiBaseUrl: process.env.DEV_API_URL || 'https://api-localhost/v1',
+  uiBaseUrl: process.env.DEV_LOGIN_URL || 'http://localhost:4200',
+  apiBaseUrl: process.env.DEV_API_URL || 'http://localhost/v1',
   userEmailDomain: '@fake-research-aou.org',
 };
 


### PR DESCRIPTION
Upgrade CircleCI yaml to version 2.1, leveraging new v2.1 features like `commands`, `parameters`, `when`. Re-organized common actions into `commands` for reuse by `jobs`.

High-level structures:
<img width="258" alt="Screen Shot 2020-04-25 at 4 54 29 PM" src="https://user-images.githubusercontent.com/35533885/80290744-8a258880-8715-11ea-9f02-5b6f8b245ccc.png">

Notes:
-  Kept all ` jobs` names unchanged to avoid adding new confusion. and number of `jobs` are not changed.
-  Use pipeline `parameters` for set/access common configs. 
-  `command` `git_checkout` combines `- checkout` and `- git submodules update`.
-  new cache `command` s. `ui_dependencies`, `e2e_dependencies` and `api_cache` with parameters.
- New anchor `filter_pr`, for running workflow jobs on non-master and non-release (tags) branches. In other words, run workflow's jobs for PR branches after pushed to origin.

I am not able test out changes in `deploy-staging`, `deploy-perf`, `api-deploy-to-test` and `ui-deploy-to-test` because these jobs are filtered by `filter_master`.
