### PR TITLE
[risk=low]Update a few more vulnerable packages

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -481,7 +481,7 @@ dependencies {
   compile "com.google.code.gson:gson:$project.ext.GSON_VERSION"
   compile "com.google.guava:guava:26.0-jre"
   compile "com.google.http-client:google-http-client-apache:2.0.0"
-  compile "com.google.oauth-client:google-oauth-client-jetty:1.30.3"
+  compile "com.google.oauth-client:google-oauth-client-jetty:1.30.6"
   compile "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1"
   compile "com.opsgenie.integration:sdk:2+"
   compile "com.squareup.okhttp:logging-interceptor:$project.ext.OKHTTP_VERSION"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -528,7 +528,7 @@ dependencies {
   }
 
   compile "org.springframework.retry:spring-retry:1.1.5.RELEASE"
-  compile "org.springframework.security:spring-security-web:4.2.13.RELEASE"
+  compile "org.springframework.security:spring-security-web:4.2.15.RELEASE"
 
   implementation "org.mapstruct:mapstruct:$project.ext.MAPSTRUCT_VERSION"
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"


### PR DESCRIPTION
Description:

From Snyk:
```
Vulnerable module: org.springframework:spring-web
Introduced through: org.springframework.security:spring-security-web@4.2.13.RELEASE
Exploit maturity: No known exploit
Fixed in: 5.2.3, 5.1.13, 5.0.16
Detailed paths
Introduced through: project@0.0.0 › org.springframework.security:spring-security-web@4.2.13.RELEASE › org.springframework:spring-web@5.2.2.RELEASE
```

```
Vulnerable module: org.mortbay.jetty:jetty
Introduced through: com.google.oauth-client:google-oauth-client-jetty@1.30.3
Exploit maturity: No known exploit
Detailed paths
Introduced through: project@0.0.0 › com.google.oauth-client:google-oauth-client-jetty@1.30.3 › org.mortbay.jetty:jetty@6.1.26
```

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
