### PR TITLE
[RW-4808][risk=no] Enable compliance training in stable & prod

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": false,
+    "enableComplianceTraining": true,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": false,
+    "enableComplianceTraining": true,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": true,


### PR DESCRIPTION
This config change will turn on enforcement of compliance training in our stable and prod environments. Due to time constraints for this release, I am opting not to flip the flag on stable, since we don't know how that will impact Rainforest QA tests and we don't want to delay release if we have to add or alter tests in order to make Rainforest tests pass.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review