### PR TITLE
[risk=low]Enforce DUCC version for registered tier

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -242,7 +242,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         || !configProvider.get().access.enableDataUseAgreement) {
       // Data use agreement version may be ignored, since it's bypassed on the user or env level.
       dataUseAgreementCompliant = true;
-    } else if (user.getDataUseAgreementSignedVersion() == getCurrentDuccVersion()) {
+    } else if (user.getDataUseAgreementSignedVersion() != null
+        && user.getDataUseAgreementSignedVersion() == getCurrentDuccVersion()) {
       // User has signed the most-recent DUCC version.
       dataUseAgreementCompliant = true;
     }
@@ -370,7 +371,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     if (dbAddress != null) {
       dbAddress.setUser(dbUser);
     }
-    if (dbDemographicSurvey != null) dbDemographicSurvey.setUser(dbUser);
+    if (dbDemographicSurvey != null) {
+      dbDemographicSurvey.setUser(dbUser);
+    }
     // set via the older Institutional Affiliation flow, from the Demographic Survey
     if (dbAffiliations != null) {
       // We need an "effectively final" variable to be captured in the lambda
@@ -700,6 +703,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   /** Syncs the current user's training status from Moodle. */
+  @Override
   public DbUser syncComplianceTrainingStatusV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     DbUser user = userProvider.get();
@@ -717,6 +721,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
    * we clear the completion/expiration dates from the database as the user will need to complete a
    * new training.
    */
+  @Override
   public DbUser syncComplianceTrainingStatusV2(DbUser dbUser, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     // Skip sync for service account user rows.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -237,10 +237,15 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   private boolean shouldUserBeRegistered(DbUser user) {
-    boolean dataUseAgreementCompliant =
-        user.getDataUseAgreementCompletionTime() != null
-            || user.getDataUseAgreementBypassTime() != null
-            || !configProvider.get().access.enableDataUseAgreement;
+    boolean dataUseAgreementCompliant = false;
+    if (user.getDataUseAgreementBypassTime() != null
+        || !configProvider.get().access.enableDataUseAgreement) {
+      // Data use agreement version may be ignored, since it's bypassed on the user or env level.
+      dataUseAgreementCompliant = true;
+    } else if (user.getDataUseAgreementSignedVersion() == getCurrentDuccVersion()) {
+      // User has signed the most-recent DUCC version.
+      dataUseAgreementCompliant = true;
+    }
     boolean eraCommonsCompliant =
         user.getEraCommonsBypassTime() != null
             || !configProvider.get().access.enableEraCommons

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -492,6 +492,45 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(dbUserDataUseAgreement.getDataUseAgreementSignedVersion()).isEqualTo(DUA_VERSION);
   }
 
+  @Test(expected = BadRequestException.class)
+  public void testSubmitDataUseAgreement_wrongVersion() {
+    createUser();
+    String duaInitials = "NIH";
+    profileController.submitDataUseAgreement(DUA_VERSION - 1, duaInitials);
+  }
+
+  @Test
+  public void test_outdatedDataUseAgreement() {
+    // force version number to 2 instead of 3
+    config.featureFlags.enableV3DataUserCodeOfConduct = false;
+    final int outdatedDuaVersion = 2;
+
+    final long userId = createUser().getUserId();
+
+    // bypass the other access requirements
+    final DbUser dbUser = userDao.findUserByUserId(userId);
+    dbUser.setBetaAccessBypassTime(TIMESTAMP);
+    dbUser.setComplianceTrainingBypassTime(TIMESTAMP);
+    dbUser.setEraCommonsBypassTime(TIMESTAMP);
+    dbUser.setTwoFactorAuthBypassTime(TIMESTAMP);
+    userDao.save(dbUser);
+
+    // sign the outdated version
+
+    String duaInitials = "NIH";
+    assertThat(profileController.submitDataUseAgreement(outdatedDuaVersion, duaInitials).getStatusCode())
+            .isEqualTo(HttpStatus.OK);
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.REGISTERED);
+
+    // update and enforce the required version
+
+    config.featureFlags.enableV3DataUserCodeOfConduct = true;
+    profile = profileController.getMe().getBody();
+    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.UNREGISTERED);
+  }
+
   @Test
   public void testMe_success() {
     config.featureFlags.requireInstitutionalVerification = false;


### PR DESCRIPTION
Description:

When we check the user's access level (on every 2FA sync cron run, as well as triggered by certain events) enforce that the user has signed the current version of the Data User Code of Conduct (DUCC)

Not renaming any "DUA" code to DUCC here.  Filed https://precisionmedicineinitiative.atlassian.net/browse/RW-4838

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
