### PR TITLE
[RW-4843][risk=no] Only check user disabled on initial load

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -58,7 +58,7 @@ const routes: Routes = [
   }, {
     path: '',
     component: SignedInComponent,
-    canActivate: [SignInGuard, DisabledGuard],
+    canActivate: [SignInGuard],
     canActivateChild: [SignInGuard, DisabledGuard, RegistrationGuard],
     runGuardsAndResolvers: 'always',
     children: [

--- a/ui/src/app/guards/disabled-guard.service.ts
+++ b/ui/src/app/guards/disabled-guard.service.ts
@@ -1,14 +1,17 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot} from '@angular/router';
 
+import {ProfileStorageService} from 'app/services/profile-storage.service';
 import {SignInService} from 'app/services/sign-in.service';
-import {profileApi} from 'app/services/swagger-fetch-clients';
 import {convertAPIError} from 'app/utils/errors';
 import {ErrorCode} from 'generated/fetch';
 
 @Injectable()
 export class DisabledGuard implements CanActivate, CanActivateChild {
-  constructor(private router: Router, private signInService: SignInService) {}
+  constructor(
+    private router: Router,
+    private signInService: SignInService,
+    private profileStorageService: ProfileStorageService) {}
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
     try {
@@ -19,7 +22,7 @@ export class DisabledGuard implements CanActivate, CanActivateChild {
       if (!isSignedIn) {
         return false;
       }
-      await profileApi().getMe();
+      await this.profileStorageService.profile$.first().toPromise();
       return true;
     } catch (e) {
       const errorResponse = await convertAPIError(e);

--- a/ui/src/app/services/profile-storage.service.ts
+++ b/ui/src/app/services/profile-storage.service.ts
@@ -58,6 +58,7 @@ export class ProfileStorageService {
         this.nextUserProfileStore(profile);
         this.activeCall = false;
       }, (err) => {
+        this.profile.error(err);
         this.activeCall = false;
       });
   }


### PR DESCRIPTION
1. Remove the canActivate check, this was causing the rule to execute twice.
2. Change profile storage service to send errors. Previously, it would just let callers hang indefinitely on failure.
3. Switch disabled-guard to use profile storage service. This uses the cached value of the profile rather than requesting it on every page render.

This avoids sending 2 profile requests on every navigate

Minor downside: If a user happened to be disabled during active use, they would no longer immediately see their disabled status within that client session (rather, they'd see opaque errors). This doesn't seem like a case that's worth optimizing for.

Tested manually with a disabled user and a non-disabled user.