### PR TITLE
[risk=no] Bump UI local docker to node 12

### DIFF
--- a/ui/src/dev/server/Dockerfile
+++ b/ui/src/dev/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12-alpine
 
 # We set the UID to the host's UID to ensure written files get proper permissions. The default UID
 # for node is 1000, which conflicts with some of our host machines.


### PR DESCRIPTION
Without this, eslint package fails to install, since current Dockerfile uses Node 11.2. This breaks the dev-up workflow for those that use the docker-based wrapper instead of direct `yarn`.

```
./project.rb dev-up                                                                                                                                                                  
+ docker-compose run --rm ui yarn install                                                                                                                                                                            
WARNING: The ENV_FLAG variable is not set. Defaulting to a blank string.                                                                                                                                             
yarn install v1.12.3                                                                                                                                                                                                 
[1/4] Resolving packages...                                                                                                                                                                                          
[2/4] Fetching packages...                                                                                                                                                                                           
info fsevents@1.2.9: The platform "linux" is incompatible with this module.                                                                                                                                          
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.                                                                                                      
error @typescript-eslint/eslint-plugin@2.28.0: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1". Got "11.2.0"                                                 
error Found incompatible module                                                                                                                                                                                      
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.     
```

To pickup this change locally, run:

```
ui$ docker-compose build ui
```