### PR TITLE
[RW-4839][RISK=NO] Change logic to 'excludeFromPublicDirectory' flag

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -79,4 +79,12 @@ public interface InstitutionService {
    * @return whether user instructions were deleted
    */
   boolean deleteInstitutionUserInstructions(final String shortName);
+
+  /**
+   * Validates if the institution is for operational User
+   *
+   * @param institution
+   * @return
+   */
+  boolean validateOperationalUser(DbInstitution institution);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -33,6 +33,7 @@ public class InstitutionServiceImpl implements InstitutionService {
   private final InstitutionMapper institutionMapper;
   private final InstitutionUserInstructionsMapper institutionUserInstructionsMapper;
   private final PublicInstitutionDetailsMapper publicInstitutionDetailsMapper;
+  private final String OPERATIONAL_USER_INSTITUTION_SHORT_NAME = "AouOps";
 
   @Autowired
   InstitutionServiceImpl(
@@ -179,5 +180,11 @@ public class InstitutionServiceImpl implements InstitutionService {
   public boolean deleteInstitutionUserInstructions(final String shortName) {
     final DbInstitution institution = getDbInstitutionOrThrow(shortName);
     return institutionUserInstructionsDao.deleteByInstitutionId(institution.getInstitutionId()) > 0;
+  }
+
+  @Override
+  public boolean validateOperationalUser(DbInstitution institution) {
+    return institution != null
+        && institution.getShortName().equals(OPERATIONAL_USER_INSTITUTION_SHORT_NAME);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -24,6 +24,7 @@ import org.pmiops.workbench.db.model.DbRdrExport;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.RdrEntityEnums;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.RdrEntity;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
@@ -52,6 +53,8 @@ public class RdrExportServiceImpl implements RdrExportService {
   private RdrExportDao rdrExportDao;
   private WorkspaceDao workspaceDao;
   private UserDao userDao;
+
+  private InstitutionService institutionService;
   private WorkspaceService workspaceService;
   private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
@@ -64,6 +67,7 @@ public class RdrExportServiceImpl implements RdrExportService {
       Provider<RdrApi> rdrApiProvider,
       RdrExportDao rdrExportDao,
       WorkspaceDao workspaceDao,
+      InstitutionService institutionService,
       WorkspaceService workspaceService,
       UserDao userDao,
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao) {
@@ -71,6 +75,7 @@ public class RdrExportServiceImpl implements RdrExportService {
     this.rdrExportDao = rdrExportDao;
     this.rdrApiProvider = rdrApiProvider;
     this.workspaceDao = workspaceDao;
+    this.institutionService = institutionService;
     this.workspaceService = workspaceService;
     this.userDao = userDao;
     this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
@@ -451,10 +456,8 @@ public class RdrExportServiceImpl implements RdrExportService {
         .ifPresent(
             verifiedInstitutionalAffiliation -> {
               rdrWorkspace.setExcludeFromPublicDirectory(
-                  verifiedInstitutionalAffiliation
-                      .getInstitution()
-                      .getShortName()
-                      .equals("AouOps"));
+                  institutionService.validateOperationalUser(
+                      verifiedInstitutionalAffiliation.getInstitution()));
             });
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -468,6 +468,26 @@ public class InstitutionServiceTest {
     service.deleteInstitutionUserInstructions("not found");
   }
 
+  @Test
+  public void validate_OperationalUser() {
+    DbInstitution institution = new DbInstitution();
+    institution.setShortName("AouOps");
+    assertThat(service.validateOperationalUser(institution)).isTrue();
+  }
+
+  @Test
+  public void validate_NonOperationalUser() {
+    DbInstitution institution = new DbInstitution();
+    institution.setShortName("MockAouOps");
+    assertThat(service.validateOperationalUser(institution)).isFalse();
+  }
+
+  @Test
+  public void validate_OperationalUser_nullInstitution() {
+    DbInstitution institution = null;
+    assertThat(service.validateOperationalUser(institution)).isFalse();
+  }
+
   // Institutions' email domains and addresses are Lists but have no inherent order,
   // so they can't be directly compared for equality
   private void assertEqualInstitutions(Institution actual, final Institution expected) {

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
@@ -61,6 +62,7 @@ public class RdrExportServiceImplTest {
   @MockBean private UserDao mockUserDao;
   @MockBean private WorkspaceDao mockWorkspaceDao;
   @MockBean private WorkspaceService mockWorkspaceService;
+  @MockBean private InstitutionService institutionService;
   @MockBean private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   private static final Instant NOW = Instant.now();
@@ -177,30 +179,6 @@ public class RdrExportServiceImplTest {
     verify(rdrExportDao, times(1)).save(anyList());
 
     RdrWorkspace rdrWorkspace = toRdrWorkspace(mockWorkspace);
-    verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
-  }
-
-  @Test
-  public void exportWorkspace_CreatorNotOperationalUser() throws ApiException {
-
-    DbVerifiedInstitutionalAffiliation mockVerifiedInstitutionalAffiliation =
-        new DbVerifiedInstitutionalAffiliation();
-    mockVerifiedInstitutionalAffiliation.setInstitution(new DbInstitution().setShortName("AouOps"));
-    mockVerifiedInstitutionalAffiliation.setInstitutionalRoleEnum(
-        InstitutionalRole.PROJECT_PERSONNEL);
-    when(verifiedInstitutionalAffiliationDao.findFirstByUser(dbUserWithEmail))
-        .thenReturn(Optional.of(mockVerifiedInstitutionalAffiliation));
-
-    List<Long> workspaceID = new ArrayList<>();
-    workspaceID.add(1l);
-    rdrExportService.exportWorkspaces(workspaceID);
-    verify(mockWorkspaceService)
-        .getFirecloudUserRoles(
-            mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
-    verify(rdrExportDao, times(1)).save(anyList());
-
-    RdrWorkspace rdrWorkspace = toRdrWorkspace(mockWorkspace);
-    rdrWorkspace.setExcludeFromPublicDirectory(true);
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -14,10 +14,16 @@ import static org.mockito.Mockito.when;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,11 +31,17 @@ import org.pmiops.workbench.db.dao.RdrExportDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.Degree;
+import org.pmiops.workbench.model.InstitutionalRole;
+import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.rdr.api.RdrApi;
+import org.pmiops.workbench.rdr.model.RdrWorkspace;
+import org.pmiops.workbench.rdr.model.RdrWorkspaceDemographic;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +61,7 @@ public class RdrExportServiceImplTest {
   @MockBean private UserDao mockUserDao;
   @MockBean private WorkspaceDao mockWorkspaceDao;
   @MockBean private WorkspaceService mockWorkspaceService;
+  @MockBean private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   private static final Instant NOW = Instant.now();
   private static final Timestamp NOW_TIMESTAMP = Timestamp.from(NOW);
@@ -84,7 +97,6 @@ public class RdrExportServiceImplTest {
     dbUserWithEmail.setDegreesEnum(Collections.singletonList(Degree.NONE));
 
     when(mockUserDao.findUserByUserId(1L)).thenReturn(dbUserWithEmail);
-
     dbUserWithoutEmail = new DbUser();
     dbUserWithoutEmail.setUserId(2L);
     dbUserWithoutEmail.setCreationTime(NOW_TIMESTAMP);
@@ -98,7 +110,17 @@ public class RdrExportServiceImplTest {
     when(rdrExportDao.findByEntityTypeAndEntityId(anyShort(), anyLong())).thenReturn(null);
     mockWorkspace =
         buildDbWorkspace(1, "workspace_name", "workspaceNS", WorkspaceActiveStatus.ACTIVE);
+    mockWorkspace.setCreator(dbUserWithEmail);
     when(mockWorkspaceDao.findDbWorkspaceByWorkspaceId(1)).thenReturn(mockWorkspace);
+
+    DbVerifiedInstitutionalAffiliation mockVerifiedInstitutionalAffiliation =
+        new DbVerifiedInstitutionalAffiliation();
+    mockVerifiedInstitutionalAffiliation.setInstitution(
+        new DbInstitution().setShortName("mockInstitution"));
+    mockVerifiedInstitutionalAffiliation.setInstitutionalRoleEnum(
+        InstitutionalRole.PROJECT_PERSONNEL);
+    when(verifiedInstitutionalAffiliationDao.findFirstByUser(dbUserWithEmail))
+        .thenReturn(Optional.of(mockVerifiedInstitutionalAffiliation));
   }
 
   private DbWorkspace buildDbWorkspace(
@@ -145,8 +167,29 @@ public class RdrExportServiceImplTest {
   }
 
   @Test
-  public void exportWorkspace_successful() throws ApiException {
-    doNothing().when(mockRdrApi).exportWorkspaces(anyList());
+  public void exportWorkspace() throws ApiException {
+    List<Long> workspaceID = new ArrayList<>();
+    workspaceID.add(1l);
+    rdrExportService.exportWorkspaces(workspaceID);
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(
+            mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
+    verify(rdrExportDao, times(1)).save(anyList());
+
+    RdrWorkspace rdrWorkspace = toRdrWorkspace(mockWorkspace);
+    verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
+  }
+
+  @Test
+  public void exportWorkspace_CreatorNotOperationalUser() throws ApiException {
+
+    DbVerifiedInstitutionalAffiliation mockVerifiedInstitutionalAffiliation =
+        new DbVerifiedInstitutionalAffiliation();
+    mockVerifiedInstitutionalAffiliation.setInstitution(new DbInstitution().setShortName("AouOps"));
+    mockVerifiedInstitutionalAffiliation.setInstitutionalRoleEnum(
+        InstitutionalRole.PROJECT_PERSONNEL);
+    when(verifiedInstitutionalAffiliationDao.findFirstByUser(dbUserWithEmail))
+        .thenReturn(Optional.of(mockVerifiedInstitutionalAffiliation));
 
     List<Long> workspaceID = new ArrayList<>();
     workspaceID.add(1l);
@@ -155,5 +198,86 @@ public class RdrExportServiceImplTest {
         .getFirecloudUserRoles(
             mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
     verify(rdrExportDao, times(1)).save(anyList());
+
+    RdrWorkspace rdrWorkspace = toRdrWorkspace(mockWorkspace);
+    rdrWorkspace.setExcludeFromPublicDirectory(true);
+    verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
+  }
+
+  /**
+   * In case workspace has any specific population FocusOnUnderrepresentedPopulations should be true
+   *
+   * @throws ApiException
+   */
+  @Test
+  public void exportWorkspace_FocusOnUnderservedPopulation() throws ApiException {
+    Set<SpecificPopulationEnum> specificPopulationEnumsSet = new HashSet<SpecificPopulationEnum>();
+    specificPopulationEnumsSet.add(SpecificPopulationEnum.RACE_AA);
+    mockWorkspace.setSpecificPopulationsEnum(specificPopulationEnumsSet);
+    when(mockWorkspaceDao.findDbWorkspaceByWorkspaceId(1)).thenReturn(mockWorkspace);
+
+    List<Long> workspaceID = new ArrayList<>();
+    workspaceID.add(1l);
+    rdrExportService.exportWorkspaces(workspaceID);
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(
+            mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
+    verify(rdrExportDao, times(1)).save(anyList());
+
+    RdrWorkspace rdrWorkspace = toRdrWorkspace(mockWorkspace);
+    rdrWorkspace
+        .getWorkspaceDemographic()
+        .setRaceEthnicity(Arrays.asList(RdrWorkspaceDemographic.RaceEthnicityEnum.AA));
+    rdrWorkspace.setFocusOnUnderrepresentedPopulations(true);
+    verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
+  }
+
+  private RdrWorkspace toRdrWorkspace(DbWorkspace dbWorkspace) {
+    ZoneOffset offset = OffsetDateTime.now().getOffset();
+    RdrWorkspace rdrWorkspace = new RdrWorkspace();
+    rdrWorkspace.setWorkspaceId(1);
+    rdrWorkspace.setName(dbWorkspace.getName());
+
+    rdrWorkspace.setCreationTime(dbWorkspace.getCreationTime().toLocalDateTime().atOffset(offset));
+    rdrWorkspace.setModifiedTime(
+        dbWorkspace.getLastModifiedTime().toLocalDateTime().atOffset(offset));
+    rdrWorkspace.setStatus(RdrWorkspace.StatusEnum.ACTIVE);
+    rdrWorkspace.setWorkspaceUsers(new ArrayList());
+    rdrWorkspace.setExcludeFromPublicDirectory(false);
+    rdrWorkspace.setDiseaseFocusedResearch(false);
+    rdrWorkspace.setDiseaseFocusedResearchName(null);
+    rdrWorkspace.setOtherPurpose(false);
+    rdrWorkspace.setOtherPurposeDetails(null);
+    rdrWorkspace.setMethodsDevelopment(false);
+    rdrWorkspace.setControlSet(false);
+    rdrWorkspace.setAncestry(false);
+    rdrWorkspace.setSocialBehavioral(false);
+    rdrWorkspace.setPopulationHealth(false);
+    rdrWorkspace.setDrugDevelopment(false);
+    rdrWorkspace.setCommercialPurpose(false);
+    rdrWorkspace.setEducational(false);
+    rdrWorkspace.setEthicalLegalSocialImplications(false);
+    rdrWorkspace.setScientificApproaches("Scientific Approach");
+    rdrWorkspace.setReviewRequested(true);
+
+    rdrWorkspace.setFocusOnUnderrepresentedPopulations(false);
+    RdrWorkspaceDemographic workspaceDemographic = new RdrWorkspaceDemographic();
+    workspaceDemographic.setRaceEthnicity(
+        Arrays.asList(RdrWorkspaceDemographic.RaceEthnicityEnum.UNSET));
+    workspaceDemographic.setAge(Arrays.asList(RdrWorkspaceDemographic.AgeEnum.UNSET));
+    workspaceDemographic.setSexAtBirth(RdrWorkspaceDemographic.SexAtBirthEnum.UNSET);
+    workspaceDemographic.setGenderIdentity(RdrWorkspaceDemographic.GenderIdentityEnum.UNSET);
+    workspaceDemographic.setSexualOrientation(RdrWorkspaceDemographic.SexualOrientationEnum.UNSET);
+    workspaceDemographic.setGeography(RdrWorkspaceDemographic.GeographyEnum.UNSET);
+    workspaceDemographic.setDisabilityStatus(RdrWorkspaceDemographic.DisabilityStatusEnum.UNSET);
+    workspaceDemographic.setAccessToCare(RdrWorkspaceDemographic.AccessToCareEnum.UNSET);
+    workspaceDemographic.setEducationLevel(RdrWorkspaceDemographic.EducationLevelEnum.UNSET);
+    workspaceDemographic.setIncomeLevel(RdrWorkspaceDemographic.IncomeLevelEnum.UNSET);
+    rdrWorkspace.setWorkspaceDemographic(workspaceDemographic);
+    if (dbWorkspace.getSpecificPopulationsEnum().contains(SpecificPopulationEnum.OTHER)) {
+      rdrWorkspace.getWorkspaceDemographic().setOthers(dbWorkspace.getOtherPopulationDetails());
+    }
+
+    return rdrWorkspace;
   }
 }


### PR DESCRIPTION
Along with workspace details, workbench send RDR attribute excludeFromPublicDirectory , that excludes the workspace to be show up in Researcher directory. 
By default we send the value false i.e show all workspace in researcher directory

As part of this PR: Workbench will send  excludeFromPublicDirectory flag as true if the creator of the workspace has institution All of Us Program operational Use

I have tested the exportToWorkspace call with:

-  Workspace with creator with no verified institution 

- Workspace with creator with verified institution other than All of Us Program operational Use
- Workspace with creator with verified institution as All of Us Program operational Use


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
