### PR TITLE
[RW-4774][risk=no]Update denormalized scripts to allow args for databrowser

### DIFF
--- a/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
@@ -12,7 +12,7 @@ set -ex
 
 export BQ_PROJECT=$1        # project
 export BQ_DATASET=$2        # dataset
-export DATA_BROWSER_FLAG=$3 # data browser flag
+export DATA_BROWSER=$3      # data browser flag
 export DRY_RUN=$4           # dry run
 
 if [ "$DRY_RUN" == false ]
@@ -1083,7 +1083,7 @@ then
   SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
       0,'PERSON',1,'SEX','Sex',1,0,0,0"
 
-  if [ "$DATA_BROWSER_FLAG" == false ]
+  if [ "$DATA_BROWSER" == false ]
   then
   echo "DEMO - Sex at birth children"
   bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \

--- a/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
@@ -1104,22 +1104,22 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
     0,'PERSON',1,'SEX','Sex',1,0,0,0"
 
-echo "DEMO - Sex at birth children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
-    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
-    'PERSON',1,'SEX',concept_id,
-    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
-    a.cnt,0,1,0,0
-FROM
-    (
-        SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-        GROUP BY 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
+#echo "DEMO - Sex at birth children"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+#    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+#SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
+#    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
+#    'PERSON',1,'SEX',concept_id,
+#    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
+#    a.cnt,0,1,0,0
+#FROM
+#    (
+#        SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
+#        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+#        GROUP BY 1
+#    ) a
+#LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
 
 echo "DEMO - Race parent"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \

--- a/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
@@ -15,3811 +15,3810 @@ export BQ_DATASET=$2        # dataset
 export DATA_BROWSER=$3      # data browser flag
 export DRY_RUN=$4           # dry run
 
-if [ "$DRY_RUN" == false ]
+if [ "$DRY_RUN" == true ]
 then
-  # Check that bq_project exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
-  then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-
-  # Check that bq_dataset exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
-  then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-  re=\\b$BQ_DATASET\\b
-  if [[ $datasets =~ $re ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-
-
-  ################################################
-  # CREATE TABLES
-  ################################################
-  # table that holds temp data to get ancestor information for parent counts
-  echo "CREATE TABLES - prep_concept_ancestor_temp"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  (
-      ancestor_concept_id     INT64,
-      domain_id               STRING,
-      type                    STRING,
-      is_standard             INT64,
-      concept_id_1            INT64,
-      concept_id_2            INT64,
-      concept_id_3            INT64,
-      concept_id_4            INT64,
-      concept_id_5            INT64,
-      concept_id_6            INT64,
-      concept_id_7            INT64,
-      concept_id_8            INT64,
-      concept_id_9            INT64,
-      concept_id_10           INT64,
-      concept_id_11           INT64,
-      concept_id_12           INT64,
-      concept_id_13           INT64,
-      concept_id_14           INT64,
-      concept_id_15           INT64,
-      concept_id_16           INT64,
-      concept_id_17           INT64,
-      concept_id_18           INT64,
-      concept_id_19           INT64,
-      concept_id_20           INT64
-  )"
-
-  # table that holds ancestor information for parent counts
-  echo "CREATE TABLES - prep_concept_ancestor"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-  (
-      ancestor_concept_id     INT64,
-      descendant_concept_id   INT64,
-      is_standard             INT64
-  )"
-
-  echo "CREATE TABLES - cb_criteria"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  (
-      id                  INT64,
-      parent_id           INT64,
-      domain_id           STRING,
-      is_standard         INT64,
-      type                STRING,
-      subtype             STRING,
-      concept_id          INT64,
-      code                STRING,
-      name                STRING,
-      value               STRING,
-      est_count           INT64,
-      is_group            INT64,
-      is_selectable       INT64,
-      has_attribute       INT64,
-      has_hierarchy       INT64,
-      has_ancestor_data   INT64,
-      path                STRING,
-      synonyms            STRING
-  )"
-
-  # table that holds the ingredient --> coded drugs mapping
-  echo "CREATE TABLES - cb_criteria_ancestor"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-  (
-      ancestor_id INT64,
-      descendant_id INT64
-  )"
-
-  # table that holds categorical results and min/max information about individual labs
-  echo "CREATE TABLES - cb_criteria_attribute"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-  (
-      id                    INT64,
-      concept_id            INT64,
-      value_as_concept_id	  INT64,
-      concept_name          STRING,
-      type                  STRING,
-      est_count             STRING
-  )"
-
-  # table that holds the drug brands to ingredients relationship mapping
-  echo "CREATE TABLES - cb_criteria_relationship"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-  (
-      concept_id_1 INT64,
-      concept_id_2 INT64
-  )"
-
-  echo "CREATE TABLES - atc_rel_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - loinc_rel_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - snomed_rel_cm_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - snomed_rel_cm_src_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - snomed_rel_meas_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - snomed_rel_pcs_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-  echo "CREATE TABLES - snomed_rel_pcs_src_in_data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-  (
-      p_concept_id    INT64,
-      p_concept_code  STRING,
-      p_concept_name  STRING,
-      p_domain_id     STRING,
-      concept_id      INT64,
-      concept_code    STRING,
-      concept_name    STRING,
-      domain_id       STRING
-  )"
-
-
-  ################################################
-  # CREATE VIEWS
-  ################################################
-  echo "CREATE VIEWS - v_loinc_rel"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE,
-      C1.CONCEPT_NAME AS P_CONCEPT_NAME, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND CR.RELATIONSHIP_ID = 'Subsumes'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.VOCABULARY_ID = 'LOINC'
-      AND C2.VOCABULARY_ID = 'LOINC'
-      AND C1.STANDARD_CONCEPT IN ('S','C')
-      AND C2.STANDARD_CONCEPT IN ('S','C')
-      AND C1.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')
-      AND C2.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')"
-
-  echo "CREATE VIEWS - v_snomed_rel_cm"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND C1.VOCABULARY_ID = 'SNOMED'
-      AND C2.VOCABULARY_ID = 'SNOMED'
-      AND C1.STANDARD_CONCEPT = 'S'
-      AND C2.STANDARD_CONCEPT = 'S'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.DOMAIN_ID = 'Condition'
-      AND C2.DOMAIN_ID = 'Condition'
-      AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-  echo "CREATE VIEWS - v_snomed_rel_cm_src"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND C1.VOCABULARY_ID = 'SNOMED'
-      AND C2.VOCABULARY_ID = 'SNOMED'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.DOMAIN_ID = 'Condition'
-      AND C2.DOMAIN_ID = 'Condition'
-      AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-  echo "CREATE VIEWS - v_snomed_rel_meas"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND C1.VOCABULARY_ID = 'SNOMED'
-      AND C2.VOCABULARY_ID = 'SNOMED'
-      AND C1.STANDARD_CONCEPT = 'S'
-      AND C2.STANDARD_CONCEPT = 'S'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.DOMAIN_ID = 'Measurement'
-      AND C2.DOMAIN_ID = 'Measurement'
-      AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-  echo "CREATE VIEWS - v_snomed_rel_pcs"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND C1.VOCABULARY_ID = 'SNOMED'
-      AND C2.VOCABULARY_ID = 'SNOMED'
-      AND C1.STANDARD_CONCEPT = 'S'
-      AND C2.STANDARD_CONCEPT = 'S'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.DOMAIN_ID = 'Procedure'
-      AND C2.DOMAIN_ID = 'Procedure'
-      AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-  echo "CREATE VIEWS - v_snomed_rel_pcs_src"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` AS
-  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-      AND C1.VOCABULARY_ID = 'SNOMED'
-      AND C2.VOCABULARY_ID = 'SNOMED'
-      AND R.IS_HIERARCHICAL = '1'
-      AND R.DEFINES_ANCESTRY = '1'
-      AND C1.DOMAIN_ID = 'Procedure'
-      AND C2.DOMAIN_ID = 'Procedure'
-      AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-
-  ################################################
-  # SOURCE ICD9
-  ################################################
-  echo "ICD9 - add data (do not insert zero count children)"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-      case when b.concept_id is not null then b.concept_name else a.name end as name,
-      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-  LEFT JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          WHERE (vocabulary_id in ('ICD9CM', 'ICD9Proc') and concept_code != '92')
-              or (vocabulary_id = 'ICD9Proc' and concept_code = '92')
-      ) b on a.concept_id = b.concept_id
-  LEFT JOIN
-      (
-          SELECT concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          WHERE is_standard = 0
-              and concept_id in
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                      WHERE type in ('ICD9CM', 'ICD9Proc')
-                          and is_group = 0
-                          and is_selectable = 1
-                  )
-          group by 1
-      ) c on b.concept_id = c.concept_id
-  WHERE type in ('ICD9CM', 'ICD9Proc')
-      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-  ORDER BY 1"
-
-  echo "ICD9 - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT e.id, COUNT(distinct f.person_id) cnt
-          FROM
-              (
-                  SELECT *
-                  FROM
-                      (
-                          SELECT id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE type in ('ICD9CM', 'ICD9Proc')
-                              and is_group = 1
-                              and is_selectable = 1
-                      ) a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) e
-          LEFT JOIN
-              (
-                  SELECT c.id, d.*
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                  JOIN
-                      (
-                          SELECT a.person_id, a.concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                          JOIN
-                              (
-                                  SELECT concept_id, path
-                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                  WHERE type in ('ICD9CM', 'ICD9Proc')
-                                      and is_selectable = 1
-                              ) b on a.concept_id = b.concept_id
-                          WHERE is_standard = 0
-                      ) d on c.concept_id = d.concept_id
-              ) f on e.descendant_id = f.id
-          GROUP BY 1
-      ) y
-  WHERE x.id = y.id"
-
-  echo "ICD9 - delete zero count parents"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "DELETE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  WHERE type in ('ICD9CM', 'ICD9Proc')
-      and is_selectable = 1
-      and (est_count is null or est_count = 0)"
-
-  ################################################
-  # SOURCE ICD10
-  ################################################
-  echo "ICD10CM - insert data (do not insert zero count children)"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-      case when b.concept_id is not null then b.concept_name else a.name end as name,
-      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-  LEFT JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          WHERE vocabulary_id in ('ICD10CM')
-      ) b on a.concept_id = b.concept_id
-  LEFT JOIN
-      (
-          SELECT concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          WHERE is_standard = 0
-              and concept_id in
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                      WHERE type = 'ICD10CM'
-                          and is_group = 0
-                          and is_selectable = 1
-                  )
-          GROUP BY 1
-      ) c on b.concept_id = c.concept_id
-  WHERE type = 'ICD10CM'
-      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-  ORDER BY 1"
-
-  echo "ICD10CM - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT e.id, count(distinct f.person_id) cnt
-          FROM
-              (
-                  SELECT *
-                  FROM
-                      (
-                          SELECT id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE type = 'ICD10CM'
-                              and parent_id != 0
-                              and is_group = 1
-                      ) a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) e
-          LEFT JOIN
-              (
-                  SELECT c.id, d.*
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                  JOIN
-                      (
-                          SELECT a.person_id, a.concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                          JOIN
-                              (
-                                  SELECT concept_id, path
-                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                  WHERE type = 'ICD10CM'
-                                      and is_selectable = 1
-                              ) b on a.concept_id = b.concept_id
-                          WHERE is_standard = 0
-                      ) d on c.concept_id = d.concept_id
-              ) f on e.descendant_id = f.id
-          group by 1
-      ) y
-  WHERE x.id = y.id"
-
-  echo "ICD10PCS - insert data (do not insert zero count children)"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-      case when b.concept_id is not null then b.concept_name else a.name end as name,
-      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-  LEFT JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          WHERE vocabulary_id in ('ICD10PCS')
-      ) b on a.concept_id = b.concept_id
-  LEFT JOIN
-      (
-          SELECT concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          WHERE is_standard = 0
-              and concept_id in
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                      WHERE type = 'ICD10PCS'
-                          and is_group = 0
-                          and is_selectable = 1
-                  )
-          GROUP BY 1
-      ) c on b.concept_id = c.concept_id
-  WHERE type = 'ICD10PCS'
-      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-  ORDER BY 1"
-
-  echo "ICD10PCS - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT e.id, count(distinct f.person_id) cnt
-          FROM
-              (
-                  SELECT *
-                  FROM
-                      (
-                          SELECT id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE type = 'ICD10PCS'
-                              and parent_id != 0
-                              and is_group = 1
-                      ) a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) e
-          LEFT JOIN
-              (
-                  SELECT c.id, d.*
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                  JOIN
-                      (
-                          SELECT a.person_id, a.concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                          JOIN
-                              (
-                                  SELECT concept_id, path
-                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                  WHERE type = 'ICD10PCS'
-                                      and is_selectable = 1
-                              ) b on a.concept_id = b.concept_id
-                          WHERE is_standard = 0
-                      ) d on c.concept_id = d.concept_id
-              ) f on e.descendant_id = f.id
-          group by 1
-      ) y
-  WHERE x.id = y.id"
-
-  echo "ICD10 - delete zero count parents"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "DELETE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  WHERE type in ('ICD10CM', 'ICD10PCS')
-      and is_group = 1
-      and is_selectable = 1
-      and (est_count is null or est_count = 0)"
-
-
-  ################################################
-  # SOURCE CPT
-  ################################################
-  echo "CPT - insert data (do not insert zero count children)"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-      case when b.concept_id is not null then b.concept_name else a.name end as name,
-      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-  LEFT JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          WHERE vocabulary_id = 'CPT4'
-      ) b on a.concept_id = b.concept_id
-  LEFT JOIN
-      (
-          SELECT concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          WHERE is_standard = 0
-              and concept_id in
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                      WHERE type = 'CPT4'
-                          and is_group = 0
-                          and is_selectable = 1
-                  )
-          group by 1
-      ) c on b.concept_id = c.concept_id
-  WHERE type = 'CPT4'
-      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-  ORDER BY 1"
-
-  echo "CPT - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT e.id, count(distinct f.person_id) cnt
-          FROM
-              (
-                  SELECT *
-                  FROM
-                      (
-                          SELECT id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE type = 'CPT4'
-                              and parent_id != 0
-                              and is_group = 1
-                      ) a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) e
-          LEFT JOIN
-              (
-                  SELECT c.id, d.*
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                  JOIN
-                      (
-                          SELECT a.person_id, a.concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                          JOIN
-                              (
-                                  SELECT concept_id, path
-                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                  WHERE type = 'CPT4'
-                                      and is_selectable = 1
-                              ) b on a.concept_id = b.concept_id
-                          WHERE is_standard = 0
-                      ) d on c.concept_id = d.concept_id
-              ) f on e.descendant_id = f.id
-          group by 1
-      ) y
-  WHERE x.id = y.id"
-
-  echo "CPT - delete zero count parents"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "DELETE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  WHERE type = 'CPT4'
-      and
-      (
-          (parent_id != 0 and (est_count is null or est_count = 0))
-          or
-              (
-                is_group = 1
-                and id not in
-                  (
-                      SELECT parent_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      WHERE type = 'CPT4'
-                          and est_count is not null
-                  )
-              )
-      )"
-
-
-  ################################################
-  # PPI PHYSICAL MEASUREMENTS (PM)
-  ################################################
-  echo "PM - insert data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  select id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
-      case when is_selectable = 1 then 0 else null end as est_count,
-      is_group,is_selectable,has_attribute,has_hierarchy
-  from \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-  order by 1"
-
-  echo "PM - counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select measurement_source_concept_id as concept_id, count(distinct person_id) as cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-          where measurement_source_concept_id in (903126,903133,903121,903124,903135,903136)
-          group by 1
-      ) y
-  where x.domain_id = 'PHYSICAL_MEASUREMENT'
-      and x.concept_id = y.concept_id"
-
-  echo "PM - counts for heart rhythm, pregnancy, and wheelchair use"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select concept_id, CAST(value_as_concept_id as STRING) as value, count(distinct person_id) as cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id IN (1586218, 903120, 903111)
-          group by 1,2
-      ) y
-  where x.domain_id = 'PHYSICAL_MEASUREMENT'
-      and x.concept_id = y.concept_id
-      and x.value = y.value"
-
-  #----- BLOOD PRESSURE -----
-  echo "PM - blood pressure  - hypotensive"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count =
-      (
-          select count(distinct person_id)
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id in (903115, 903118)
-              and systolic <= 90
-              and diastolic <= 60
-      )
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-      and subtype = 'BP'
-      and name LIKE 'Hypotensive%'"
-
-  echo "PM - blood pressure  - normal"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count =
-      (
-          select count(distinct person_id)
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id in (903115, 903118)
-              and systolic <= 120
-              and diastolic <= 80
-      )
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-      and subtype = 'BP'
-      and name LIKE 'Normal%'"
-
-  echo "PM - blood pressure  - pre-hypertensive"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count =
-      (
-          select count(distinct person_id)
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id in (903115, 903118)
-              and systolic BETWEEN 120 AND 139
-              and diastolic BETWEEN 81 AND 89
-      )
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-      and subtype = 'BP'
-      and name LIKE 'Pre-Hypertensive%'"
-
-  echo "PM - blood pressure  - hypertensive"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count =
-      (
-          select count(distinct person_id)
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id in (903115, 903118)
-              and systolic >= 140
-              and diastolic >= 90
-      )
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-      and subtype = 'BP'
-      and name LIKE 'Hypertensive%'"
-
-  echo "PM - blood pressure  - detail"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count =
-      (
-          select count(distinct person_id)
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where concept_id in (903115, 903118)
-      )
-  where domain_id = 'PHYSICAL_MEASUREMENT'
-      and subtype = 'BP'
-      and name = 'Blood Pressure'
-      and is_selectable = 1"
-
-
-  ################################################
-  # PPI SURVEYS
-  ################################################
-  echo "PPI SURVEYS - insert data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
-      case when (is_selectable = 1 and name != 'Select a value') then 0 else null end as est_count,
-      is_group,is_selectable,has_attribute,has_hierarchy,path
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-  WHERE domain_id = 'SURVEY'
-      and type = 'PPI'
-  ORDER BY 1"
-
-  echo "PPI SURVEYS - insert extra answers"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-  e.id as parent_id, e.domain_id, e.is_standard, e.type, 'ANSWER', e.concept_id, d.answer as name, CAST(d.value_source_concept_id as STRING), 0, 1, 0, 1,
-  CONCAT(e.path, '.',
-          CAST(ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  FROM
-  (
-  SELECT DISTINCT a.observation_source_concept_id, a.value_source_concept_id, regexp_replace(b.concept_name, r'^.+:\s', '') as answer
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_source_concept_id = b.concept_id
-  LEFT JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-          WHERE domain_id = 'SURVEY'
-      ) c on (a.observation_source_concept_id = c.concept_id and CAST(a.value_source_concept_id as STRING) = c.value)
-  WHERE a.value_source_concept_id in (903096, 903079, 903087)
-      and a.observation_source_concept_id in
-          (
-              SELECT concept_id
-              FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-              WHERE domain_id = 'SURVEY'
-                  and concept_id is not null
-          )
-      and c.id is null
-  ) d
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` e on
-      (d.observation_source_concept_id = e.concept_id and e.domain_id = 'SURVEY' and e.is_group = 1)"
-
-  echo "PPI SURVEYS - add items into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-      (ancestor_concept_id, descendant_concept_id, is_standard)
-  SELECT DISTINCT b.concept_id as ancestor_concept_id, a.concept_id as descendant_concept_id, a.is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` b on CAST(regexp_extract(a.path, r'^\d+') AS INT64) = b.id
-  WHERE a.domain_id = 'SURVEY'
-      and a.subtype = 'ANSWER'"
-
-  echo "PPI SURVEYS - generate answer counts for all questions EXCEPT where question concept_id = 1585747"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          SELECT concept_id, CAST(value_source_concept_id as STRING) as value, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          WHERE is_standard = 0
-              and concept_id in
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      WHERE domain_id = 'SURVEY'
-                          and type = 'PPI'
-                          and subtype = 'ANSWER'
-                          and concept_id != 1585747
-                  )
-          GROUP BY 1,2
-          ORDER BY 1,2
-      ) y
-  where x.domain_id = 'SURVEY'
-      and x.type = 'PPI'
-      and x.subtype = 'ANSWER'
-      and x.concept_id = y.concept_id
-      and x.value = y.value"
-
-  echo "PPI SURVEYS - generate answer counts for question (concept_id = 1585747)"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select concept_id, CAST(value_as_number as STRING) as value, count(distinct person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where is_standard = 0
-              and concept_id = 1585747
-          group by 1,2
-      ) y
-  where x.domain_id = 'SURVEY'
-      and x.type = 'PPI'
-      and x.subtype = 'ANSWER'
-      and x.concept_id = y.concept_id
-      and x.value = y.value"
-
-  echo "PPI SURVEYS - generate question counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          SELECT concept_id, count(distinct person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-          where is_standard = 0
-              and concept_id in
-                  (
-                      select concept_id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where domain_id = 'SURVEY'
-                          and type = 'PPI'
-                          and is_group = 1
-                          and is_selectable = 1
-                          and parent_id != 0
-                  )
-          group by 1
-      ) y
-  where x.domain_id = 'SURVEY'
-      and x.type = 'PPI'
-      and x.is_group = 1
-      and x.concept_id = y.concept_id"
-
-  echo "PPI SURVEYS - generate survey counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT b.ancestor_concept_id, count(DISTINCT a.person_id) as cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-          JOIN
-              (
-                  SELECT *
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                  WHERE ancestor_concept_id in
-                      (
-                          SELECT concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE domain_id = 'SURVEY'
-                              and parent_id = 0
-                      )
-              ) b on a.concept_id = b.descendant_concept_id
-          WHERE a.is_standard = 0
-          GROUP BY 1
-      ) y
-  WHERE x.domain_id = 'SURVEY'
-      and x.concept_id = y.ancestor_concept_id"
-
-
-  ################################################
-  # DEMOGRAPHICS
-  ################################################
-  echo "DEMO - Age parent"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PERSON',1,'AGE','Age',1,0,0,0"
-
-  echo "DEMO - Age Children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  select row_num + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'AGE' and parent_id = 0) as parent_id,
-      'PERSON',1,'AGE', CAST(row_num AS STRING) as name, CAST(row_num as STRING) as value,
-      case when b.cnt is null then 0 else b.cnt end as est_count,
-      0,1,0,0
-  from
-      (
-          select ROW_NUMBER() OVER(ORDER BY person_id) as row_num
-          from \`$BQ_PROJECT.$BQ_DATASET.person\`
-          order by person_id limit 120
-      ) a
-  left join
-      (
-          select CAST(FLOOR(DATE_DIFF(CURRENT_DATE(), DATE(birth_datetime), MONTH)/12) as INT64) as age, count(*) as cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.person\`
-          where person_id not in
-              (
-                  select person_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.death\`
-              )
-          group by 1
-      ) b on a.row_num = b.age
-  order by 1"
-
-  echo "DEMO - Deceased"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PERSON',1,'DECEASED','Deceased',
-      (select count(distinct person_id) from \`$BQ_PROJECT.$BQ_DATASET.death\`),
-      0,1,0,0"
-
-  echo "DEMO - Gender parent"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PERSON',1,'GENDER','Gender',1,0,0,0"
-
-  echo "DEMO - Gender children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
-      (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'GENDER' and parent_id = 0) as parent_id,
-      'PERSON',1,'GENDER',concept_id,
-      CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
-      a.cnt,0,1,0,0
-  FROM
-      (
-          SELECT gender_concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-          GROUP BY 1
-      ) a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.gender_concept_id = b.concept_id"
-
-  echo "DEMO - Sex at birth parent"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
-      0,'PERSON',1,'SEX','Sex',1,0,0,0"
-
-  if [ "$DATA_BROWSER" == false ]
-  then
-  echo "DEMO - Sex at birth children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
-      (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
-      'PERSON',1,'SEX',concept_id,
-      CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
-      a.cnt,0,1,0,0
-  FROM
-      (
-          SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-          GROUP BY 1
-      ) a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
-  fi
-
-  echo "DEMO - Race parent"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PERSON',1,'RACE','Race',1,0,0,0"
-
-  echo "DEMO - Race children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'RACE' and parent_id = 0) as parent_id,
-      'PERSON',1,'RACE',concept_id,
-      CASE
-          WHEN a.race_concept_id = 0 THEN 'Unknown'
-          ELSE regexp_replace(b.concept_name, r'^.+:\s', '')
-      END as name,
-      a.cnt,0,1,0,0
-  FROM
-      (
-          SELECT race_concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-          GROUP BY 1
-      ) a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.race_concept_id = b.concept_id
-  WHERE b.concept_id is not null"
-
-  echo "DEMO - Ethnicity parent"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PERSON',1,'ETHNICITY','Ethnicity',1,0,0,0"
-
-  echo "DEMO - Ethnicity children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'ETHNICITY' and parent_id = 0) as parent_id,
-      'PERSON',1,'ETHNICITY',concept_id,
-      regexp_replace(b.concept_name, r'^.+:\s', ''),
-      a.cnt,0,1,0,0
-  FROM
-      (
-          SELECT ethnicity_concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-          GROUP BY 1
-      ) a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ethnicity_concept_id = b.concept_id
-  WHERE b.concept_id is not null"
-
-
-  ################################################
-  # VISITS
-  ################################################
-  echo "VISITS - add items with counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-  SELECT ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-      0,'VISIT',1,'VISIT',concept_id,concept_name,a.cnt,0,1,0,0
-  FROM
-      (
-          select visit_concept_id, count(distinct person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\`
-          group by 1
-      ) a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b ON a.visit_concept_id = b.concept_id
-  where b.domain_id = 'Visit'
-      and b.standard_concept = 'S'"
-
-
-  ################################################
-  # CONDITIONS
-  ################################################
-  # ----- SOURCE SNOMED -----
-  echo "CONDITIONS - SOURCE SNOMED - temp table level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
-  where concept_id in
-      (
-          select distinct condition_source_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
-          where condition_source_concept_id != 0
-              and b.domain_id = 'Condition'
-              and b.vocabulary_id = 'SNOMED'
-      )"
-
-  # currently, there are only 5 levels, but we run it 6 times to be safe
-  for i in {1..6};
-  do
-      echo "CONDITIONS - SOURCE SNOMED - temp table level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
-      where concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-          )
-          and concept_id not in
-              (
-                  select CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-              )"
-  done
-
-  echo "CONDITIONS - SOURCE SNOMED - add root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'CONDITION',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-  where concept_id = 441840"
-
-  echo "CONDITIONS - SOURCE SNOMED - add level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'CONDITION'
-      and p.type = 'SNOMED'
-      and p.is_standard = 0
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          )
-      and c.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-          )"
-
-  # currently, there are only 16 levels, but we run it 18 times to be safe (if changed, change number of joins in next query)
-  for i in {1..18};
-  do
-      echo "CONDITIONS - SOURCE SNOMED - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-          case when l.concept_code is null then 1 else 0 end,
-          1,0,1,
-          CONCAT(p.path, '.',
-              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
-      left join
-          (
-              select distinct a.concept_code
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` b on a.concept_id = b.p_concept_id
-              where b.concept_id is null
-          ) l on c.concept_code = l.concept_code
-      where p.domain_id = 'CONDITION'
-          and p.type = 'SNOMED'
-          and p.is_standard = 0
-          and p.id not in
-              (
-                  select parent_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )"
-  done
-
-  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-  echo "CONDITIONS - SOURCE SNOMED - add items into temp ancestor table for use in next query"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
-      concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
-  SELECT DISTINCT a.concept_id as ancestor_concept_id
-      , a.domain_id
-      , a.type
-      , a.is_standard
-      , b.concept_id c1
-      , c.concept_id c2
-      , d.concept_id c3
-      , e.concept_id c4
-      , f.concept_id c5
-      , g.concept_id c6
-      , h.concept_id c7
-      , i.concept_id c8
-      , j.concept_id c9
-      , k.concept_id c10
-      , m.concept_id c11
-      , n.concept_id as c12
-      , o.concept_id as c13
-      , p.concept_id as c14
-      , q.concept_id as c15
-      , r.concept_id as c16
-      , s.concept_id as c17
-      , t.concept_id as c18
-  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
-      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) o on n.id = o.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) p on o.id = p.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) q on p.id = q.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) r on q.id = r.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) s on r.id = s.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) t on s.id = t.parent_id"
-
-  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-  # the last UNION statement is to add the ancestor item to itself
-  echo "CONDITIONS - SOURCE SNOMED - add items into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-      (ancestor_concept_id, descendant_concept_id, is_standard)
-  SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_18 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_17 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_16 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_15 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_14 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_13 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_12 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_11 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_10 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_9 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_8 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_7 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_6 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_5 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_4 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_3 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_2 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_1 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 0"
-
-  echo "CONDITIONS - SOURCE SNOMED - child counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT condition_source_concept_id as concept_id, COUNT(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
-          GROUP BY 1
-      ) y
-  WHERE x.concept_id = y.concept_id
-      and x.domain_id = 'CONDITION'
-      and x.type = 'SNOMED'
-      and x.is_standard = 0
-      and x.is_group = 0
-      and x.is_selectable = 1"
-
-  echo "CONDITIONS - SOURCE SNOMED - parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  FROM
-      (
-          SELECT ancestor_concept_id as concept_id, COUNT(distinct person_id) cnt
-          FROM
-              (
-                  SELECT *
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                  WHERE ancestor_concept_id in
-                      (
-                          SELECT distinct concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          WHERE domain_id = 'CONDITION'
-                              and type = 'SNOMED'
-                              and is_standard = 0
-                              and parent_id != 0
-                              and is_group = 1
-                      )
-                      and is_standard = 0
-              ) a
-          JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_source_concept_id
-          GROUP BY 1
-      ) y
-  WHERE x.concept_id = y.concept_id
-      and x.domain_id = 'CONDITION'
-      and x.type = 'SNOMED'
-      and x.is_standard = 0
-      and x.is_group = 1"
-
-  # ----- STANDARD SNOMED -----
-  echo "CONDITIONS - STANDARD SNOMED - temp table level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
-  where concept_id in
-      (
-          select distinct condition_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
-          where condition_concept_id != 0
-              and b.domain_id = 'Condition'
-              and b.standard_concept = 'S'
-              and b.vocabulary_id = 'SNOMED'
-      )"
-
-  # currently, there are only 5 levels, but we run it 6 times to be safe
-  for i in {1..6};
-  do
-      echo "CONDITIONS - STANDARD SNOMED - temp table level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
-      where concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-          )
-        and concept_id not in
-          (
-              select CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-          )"
-  done
-
-  echo "CONDITIONS - STANDARD SNOMED - add root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'CONDITION',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-  where concept_id = 441840"
-
-  echo "CONDITIONS - STANDARD SNOMED - add level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'CONDITION'
-      and p.type = 'SNOMED'
-      and p.is_standard = 1
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          )
-      and c.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-          )"
-
-  # currently, there are only 17 levels, but we run it 18 times to be safe. If this changes, change the next query
-  for i in {1..18};
-  do
-      echo "CONDITIONS - STANDARD SNOMED - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-          case when l.concept_code is null then 1 else 0 end,
-          1,0,1,
-          CONCAT(p.path, '.',
-              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
-      left join
-          (
-              select distinct a.CONCEPT_CODE
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` b on a.concept_id = b.p_concept_id
-              where b.concept_id is null
-          ) l on c.concept_code = l.concept_code
-      where p.domain_id = 'CONDITION'
-          and p.type = 'SNOMED'
-          and p.is_standard = 1
-          and p.id not in
-              (
-                  select PARENT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )"
-  done
-
-  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-  echo "CONDITIONS - STANDARD SNOMED - add items into temp ancestor table for use in next query"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
-      concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
-  SELECT DISTINCT a.concept_id as ancestor_concept_id
-      , a.domain_id
-      , a.type
-      , a.is_standard
-      , b.concept_id c1
-      , c.concept_id c2
-      , d.concept_id c3
-      , e.concept_id c4
-      , f.concept_id c5
-      , g.concept_id c6
-      , h.concept_id c7
-      , i.concept_id c8
-      , j.concept_id c9
-      , k.concept_id c10
-      , m.concept_id c11
-      , n.concept_id as c12
-      , o.concept_id as c13
-      , p.concept_id as c14
-      , q.concept_id as c15
-      , r.concept_id as c16
-      , s.concept_id as c17
-      , t.concept_id as c18
-  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
-      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) o on n.id = o.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) p on o.id = p.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) q on p.id = q.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) r on q.id = r.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) s on r.id = s.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) t on s.id = t.parent_id"
-
-  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-  # there last UNION statement is to add the ancestor item to itself
-  echo "CONDITIONS - STANDARD SNOMED - add items into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-      (ancestor_concept_id, descendant_concept_id, is_standard)
-  SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_18 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_17 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_16 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_15 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_14 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_13 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_12 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_11 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_10 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_9 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_8 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_7 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_6 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_5 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_4 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_3 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_2 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_1 is not null
-      and domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE domain_id = 'CONDITION'
-      and type = 'SNOMED'
-      and is_standard = 1"
-
-  echo "CONDITIONS - STANDARD SNOMED - child counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select condition_concept_id as concept_id, count(distinct person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'CONDITION'
-      and x.type = 'SNOMED'
-      and x.is_standard = 1
-      and x.is_group = 0
-      and x.is_selectable = 1"
-
-  echo "CONDITIONS - STANDARD SNOMED - parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-          from
-              (
-                  select *
-                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                  where ancestor_concept_id in
-                      (
-                          select distinct concept_id
-                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where domain_id = 'CONDITION'
-                              and type = 'SNOMED'
-                              and is_standard = 1
-                              and parent_id != 0
-                              and is_group = 1
-                      )
-                      and is_standard = 1
-              ) a
-          join \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_concept_id
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'CONDITION'
-      and x.type = 'SNOMED'
-      and x.is_standard = 1
-      and x.is_group = 1"
-
-
-  ################################################
-  # MEASUREMENTS
-  ################################################
-  echo "MEASUREMENTS - add clinical root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-      0,'MEASUREMENT',1,'LOINC','CLIN',36207527,'LP248771-0','Clinical',1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
-
-  echo "MEASUREMENTS - add lab root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-      0,'MEASUREMENT',1,'LOINC','LAB',36206173,'LP29693-6','Lab',1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
-
-  # ----- LOINC CLINICAL -----
-  echo "MEASUREMENTS - clinical - add parents"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN') as parent_id,
-      'MEASUREMENT',1,'LOINC','CLIN',name,1,0,0,1,
-      CONCAT( (SELECT PATH FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN'), '.',
-          CAST(ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-  from
-      (
-          select distinct parent as name
-          from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b using (concept_id)
-          where b.concept_id in
-              (
-                  select distinct measurement_concept_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-              )
-      ) x"
-
-  # add items with vocabulary_id = 'LOINC' and concept_class_id = 'Clinical Observation' where we have categorized them
-  echo "MEASUREMENTS - clinical - add children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      parent_id,'MEASUREMENT',1,'LOINC','CLIN',concept_id,concept_code,concept_name,est_count,0,1,0,1,
-      CONCAT(parent_path, '.',
-          CAST(ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from
-      (
-          select z.*, y.id as parent_id, y.path as parent_path
-          from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` x
-          join
-              (
-                  select id,name,path
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  where type = 'LOINC'
-                      and subtype = 'CLIN'
-                      and is_group = 1
-              ) y on x.parent = y.name
-          join
-              (
-                  select concept_name, concept_id, concept_code, count(distinct person_id) est_count
-                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-                  where standard_concept = 'S'
-                      and domain_id = 'Measurement'
-                      and vocabulary_id = 'LOINC'
-                  group by 1,2,3
-              ) z on x.concept_id = z.concept_id
-      ) g"
-
-  #----- LOINC LABS -----
-  echo "MEASUREMENTS - labs - load temp table 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
-  where concept_id in
-      (
-          select distinct MEASUREMENT_CONCEPT_ID
-          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.MEASUREMENT_CONCEPT_ID = b.concept_id
-          where MEASUREMENT_CONCEPT_ID != 0
-              and b.vocabulary_id = 'LOINC'
-              and b.STANDARD_CONCEPT = 'S'
-              and b.domain_id = 'Measurement'
-      )"
-
-  # currently, there are only 4 levels, but we run it 5 times to be safe
-  for i in {1..5};
-  do
-      echo "MEASUREMENTS - labs - load temp table $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
-      where concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-          )
-          and concept_id not in
-              (
-                  select CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-              )"
-  done
-
-  echo "MEASUREMENTS - labs - add roots - level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      t.ID,'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE,b.CONCEPT_NAME,1,0,0,1,
-      CONCAT( t.path, '.',
-          CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
-  join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
-  where (t.id) not in (select PARENT_ID from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)
-      and t.type = 'LOINC'
-      and t.subtype = 'LAB'
-      and b.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-          )"
-
-  # for each loop, add all items (children/parents) directly under the items that were previously added
-  # currently, there are only 11 levels, but we run it 12 times to be safe
-  # if this number is changed, you will need to change the number of JOINS in the query below adding data to the ancestor table
-  for i in {1..12};
-  do
-      echo "MEASUREMENTS - labs - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          t.ID, 'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE, b.CONCEPT_NAME,
-          case when l.CONCEPT_CODE is null then null else m.cnt end as est_count,
-          case when l.CONCEPT_CODE is null then 1 else 0 end as is_group,
-          case when l.CONCEPT_CODE is null then 0 else 1 end as is_selectable,
-          0,1,
-          CONCAT(t.path, '.',
-              CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
-      join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
-      left join
-          (
-              select distinct a.CONCEPT_CODE
-              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on a.CONCEPT_ID = b.P_CONCEPT_ID
-              where b.CONCEPT_ID is null
-          ) l on b.CONCEPT_CODE = l.CONCEPT_CODE
-      left join
-          (
-              select measurement_concept_id, count(distinct person_id) cnt
-              from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-              group by 1
-          ) m on b.concept_id = m.measurement_concept_id
-      where
-          t.id not in
-              (
-                  select parent_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  where type = 'LOINC'
-                      and subtype = 'LAB'
-              )
-          and parent_id != 0"
-  done
-
-  echo "MEASUREMENTS - labs - add parent for uncategorized labs"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-      a.id as parent_id,'MEASUREMENT',1,'LOINC','LAB','Uncategorized',1,0,0,1,
-      CONCAT(a.path, '.', CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING))
-  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-  WHERE type = 'LOINC' and subtype = 'LAB' and parent_id = 0"
-
-  echo "MEASUREMENTS - labs - add uncategorized labs"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as parent_id,
-      'MEASUREMENT',1,'LOINC','LAB',concept_id,concept_code,concept_name,est_count,0,1,0,1,
-      CONCAT( (select path from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` where type = 'LOINC' and subtype = 'LAB' and name = 'Uncategorized'), '.',
-          CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-  from
-      (
-          select concept_id, concept_code, concept_name, count(distinct person_id) est_count
-          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-          where standard_concept = 'S'
-              and domain_id = 'Measurement'
-              and vocabulary_id = 'LOINC'
-              and measurement_concept_id not in
-                  (
-                      select concept_id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where type = 'LOINC'
-                      and concept_id is not null
-                  )
-          group by 1,2,3
-      ) x"
-
-  # if loop count above is changed, the number of JOINS below must be updated
-  echo "MEASUREMENTS - labs - add data into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-      (ancestor_id, descendant_id)
-  SELECT DISTINCT a.id as ancestor_id,
-      COALESCE(n.id, m.id, k.id, j.id, i.id, h.id, g.id, f.id, e.id, d.id, c.id, b.id) as descendant_id
-  FROM
-      (SELECT id, parent_id, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB' and parent_id != 0 and is_group = 1) a
-      JOIN (SELECT id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') b on a.id = b.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') c on b.id = c.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') d on c.id = d.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') e on d.id = e.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') f on e.id = f.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') g on f.id = g.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') h on g.id = h.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') i on h.id = i.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') j on i.id = j.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') k on j.id = k.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') m on k.id = m.parent_id
-      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') n on m.id = n.parent_id"
-
-  echo "MEASUREMENTS - labs - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select e.id, count(distinct person_id) cnt
-          from
-              (
-                  select * from
-                  (
-                      select id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where type = 'LOINC'
-                          and subtype = 'LAB'
-                          and is_group = 1
-                          and parent_id != 0
-                  ) a
-                  left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) e
-          left join
-              (
-                  select c.id, d.*
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                  join
-                    (
-                      SELECT person_id, concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-              join
-                        (
-                  select concept_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where type = 'LOINC'
-                    and subtype = 'LAB'
-                    and is_selectable = 1
-                        ) b on a.measurement_concept_id = b.concept_id
-                    ) d on c.concept_id = d.concept_id
-              ) f on e.descendant_id = f.id
-          group by 1
-      ) y
-  where x.id = y.id"
-
-
-  #----- SNOMED -----
-  echo "MEASUREMENTS - SNOMED - temp table level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
-  where concept_id in
-      (
-          select distinct measurement_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-          where measurement_concept_id != 0
-              and b.vocabulary_id = 'SNOMED'
-              and b.STANDARD_CONCEPT = 'S'
-              and b.domain_id = 'Measurement'
-      )"
-
-  # for each loop, add all items (children/parents) directly under the items that were previously added
-  # currently, there are only 3 levels, but we run it 4 times to be safe
-  for i in {1..4};
-  do
-      echo "MEASUREMENTS - SNOMED - temp table level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
-      where concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-          )
-          and concept_id not in
-              (
-                  select CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-              )"
-  done
-
-  echo "MEASUREMENTS - SNOMED - add roots"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      0, 'MEASUREMENT',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-      CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  from
-      (
-          select distinct concept_id, concept_name, concept_code
-          from
-              (
-                  select *, rank() over (partition by descendant_concept_id order by MAX_LEVELS_OF_SEPARATION desc) rnk
-                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
-                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.concept_id
-                  where b.domain_id = 'Measurement'
-                      and b.vocabulary_id = 'SNOMED'
-                      and a.descendant_concept_id in
-                          (
-                              select distinct concept_id
-                              from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-                              left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-                              where standard_concept = 'S'
-                                  and domain_id = 'Measurement'
-                                  and vocabulary_id = 'SNOMED'
-                          )
-              ) a
-          where rnk = 1
-      ) x"
-
-  echo "MEASUREMENTS - SNOMED - add level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,0,0,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'MEASUREMENT'
-      and p.type = 'SNOMED'
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          )
-      and c.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-          )"
-
-  # for each loop, add all items (children/parents) directly under the items that were previously added
-  # currently, there are only 6 levels, but we run it 7 times to be safe
-  for i in {1..7};
-  do
-      echo "MEASUREMENTS - SNOMED - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-          case when l.concept_code is null then 1 else 0 end,
-          case when l.concept_code is null then 0 else 1 end,
-          0,1,
-          CONCAT(p.path, '.',
-              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
-      left join
-          (
-              select distinct a.concept_code
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` b on a.concept_id = b.p_concept_id
-              where b.concept_id is null
-          ) l on c.concept_code = l.concept_code
-      where p.domain_id = 'MEASUREMENT'
-          and p.type = 'SNOMED'
-          and p.id not in
-              (
-                  select parent_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )
-          and c.concept_id not in
-              (
-                  select parent_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )"
-  done
-
-  echo "MEASUREMENTS - SNOMED - generate counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-          from
-              (
-                  select *
-                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                  where ancestor_concept_id in
-                      (
-                          select distinct concept_id
-                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where domain_id = 'MEASUREMENT'
-                              and type = 'SNOMED'
-                      )
-              ) a
-          join \`$BQ_PROJECT.$BQ_DATASET.measurement\` b on a.descendant_concept_id = b.measurement_concept_id
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'MEASUREMENT'
-      and x.type = 'SNOMED'"
-
-  echo "MEASUREMENTS - SNOMED - add parents as children"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select (row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)) as ID,
-      id as parent_id,domain_id,is_standard,type,concept_id,code,name,cnt,0,1,0,1,CONCAT(path, '.',
-      CAST(row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-  from
-      (
-          select *
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-          join
-              (
-                  select measurement_concept_id, count(distinct person_id) cnt
-                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-                  group by 1
-              ) b on a.concept_id = b.measurement_concept_id
-          where domain_id = 'MEASUREMENT'
-              and type = 'SNOMED'
-              and is_group = 1
-      ) x"
-
-
-  ################################################
-  # DRUG EXPOSURE
-  ################################################
-  #----- RXNORM / RXNORM EXTENSION -----
-  # ATC4 - ATC5 --> RXNORM/RXNORM Extension ingredient
-  # ATC4 - ATC5 --> RXNORM/RXNORM Extension precise ingedient --> RXNORM ingredient
-  echo "DRUGS - temp table - ATC4 to RXNORM"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  SELECT distinct e.p_concept_id, e.p_concept_code, e.p_concept_name, e.p_DOMAIN_ID,
-      d.CONCEPT_ID, d.CONCEPT_CODE, d.CONCEPT_NAME, d.DOMAIN_ID
-  from
-      (
-          SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c2.CONCEPT_ID atc_5
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, atc, atc_5th
-          WHERE a.RELATIONSHIP_ID IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
-              and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
-              and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 5th' and c2.STANDARD_CONCEPT = 'C'
-              and c1.concept_id in
-                  (
-                      SELECT ANCESTOR_CONCEPT_ID
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                      WHERE DESCENDANT_CONCEPT_ID in
-                          (
-                              SELECT distinct DRUG_CONCEPT_ID
-                              FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                          )
-                  )
-          UNION ALL
-          SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c3.CONCEPT_ID atc_5
-          FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, rxnorm, precise ingredient
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` b on a.CONCEPT_ID_2 = b.CONCEPT_ID_1
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on b.CONCEPT_ID_2 = c3.CONCEPT_ID--child, atc, atc_5th
-          WHERE a.RELATIONSHIP_ID = 'Has form' and b.RELATIONSHIP_ID = 'RxNorm - ATC'
-              and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
-              and c2.VOCABULARY_ID = 'RxNorm' and c2.CONCEPT_CLASS_ID = 'Precise Ingredient'
-              and c3.VOCABULARY_ID = 'ATC' and c3.CONCEPT_CLASS_ID = 'ATC 5th' and c3.STANDARD_CONCEPT = 'C'
-              and c1.concept_id in
-                  (
-                      SELECT ANCESTOR_CONCEPT_ID
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                      WHERE DESCENDANT_CONCEPT_ID in
-                          (
-                              SELECT distinct DRUG_CONCEPT_ID
-                              FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                          )
-                  )
-      ) d
-  left join
-      (
-          select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-              c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID as atc_5, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-          from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID --parent, atc, atc_4
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID --child, atc, atc_5
-          where RELATIONSHIP_ID = 'Subsumes'
-              and c1.VOCABULARY_ID = 'ATC'
-              and c1.CONCEPT_CLASS_ID = 'ATC 4th'
-              and c1.STANDARD_CONCEPT = 'C'
-              and c2.VOCABULARY_ID = 'ATC'
-              and c2.CONCEPT_CLASS_ID = 'ATC 5th'
-              and c2.STANDARD_CONCEPT = 'C'
-      ) e on d.atc_5 = e.atc_5"
-
-  echo "DRUGS - temp table - ATC3 to ATC4"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-      left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-      left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-  where RELATIONSHIP_ID = 'Subsumes'
-      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 3rd' and c1.STANDARD_CONCEPT = 'C'
-      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 4th' and c2.STANDARD_CONCEPT = 'C'
-      and c2.concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )
-      and c2.concept_id not in
-          (
-              select CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )"
-
-  echo "DRUGS - temp table - ATC2 TO ATC3"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-  where RELATIONSHIP_ID = 'Subsumes'
-      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 2nd' and c1.STANDARD_CONCEPT = 'C'
-      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 3rd' and c2.STANDARD_CONCEPT = 'C'
-      and c2.concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )
-      and c2.concept_id not in
-          (
-              select CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )"
-
-  echo "DRUGS - temp table - ATC1 TO ATC2"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-  where RELATIONSHIP_ID = 'Subsumes'
-      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 1st' and c1.STANDARD_CONCEPT = 'C'
-      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 2nd' and c2.STANDARD_CONCEPT = 'C'
-      and c2.concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )
-      and c2.concept_id not in
-          (
-              select CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-          )"
-
-  echo "DRUGS - add roots"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      0, 'DRUG', 1, 'ATC', concept_id, concept_code, CONCAT( UPPER(SUBSTR(concept_name, 1, 1)), LOWER(SUBSTR(concept_name, 2)) ),
-      1,0,0,1,1,
-      CAST(ROW_NUMBER() OVER(order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-  where VOCABULARY_ID = 'ATC'
-      and CONCEPT_CLASS_ID = 'ATC 1st'
-      and STANDARD_CONCEPT = 'C'"
-
-  echo "DRUGS - add root for unmapped ingredients"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'DRUG',1,'ATC','Unmapped ingredients',1,0,0,1,1,
-      CAST( (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING ) as path"
-
-  echo "DRUGS - level 2"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'DRUG'
-      and p.type = 'ATC'
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              where domain_id = 'DRUG'
-                  and type = 'ATC'
-          )"
-
-  echo "DRUGS - level 3"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'DRUG'
-      and p.type = 'ATC'
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              where domain_id = 'DRUG'
-                  and type = 'ATC'
-          )"
-
-  echo "DRUGS - level 4"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'DRUG'
-      and p.type = 'ATC'
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              where domain_id = 'DRUG'
-                  and type = 'ATC'
-          )"
-
-  echo "DRUGS - level 5 - ingredients"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'DRUG',1,'RXNORM',c.concept_id,c.concept_code,
-      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),0,1,0,1,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'DRUG'
-      and p.type = 'ATC'
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              where domain_id = 'DRUG'
-                  and type = 'ATC'
-          )"
-
-  echo "DRUGS - add parents for unmapped ingredients"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      (select id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients') as parent_id,
-      'DRUG',1,'ATC',name as code, name,1,0,0,1,1,
-      CONCAT( (select CAST(id as STRING) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients'),
-          '.', CAST(ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-  from
-      (
-          select distinct UPPER(SUBSTR(concept_name, 1, 1)) name
-          from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-              and CONCEPT_CLASS_ID = 'Ingredient'
-              and STANDARD_CONCEPT = 'S'
-              and concept_id in
-                  (
-                      select ANCESTOR_CONCEPT_ID
-                      from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                      where DESCENDANT_CONCEPT_ID in
-                          (
-                              select distinct DRUG_CONCEPT_ID
-                              from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                          )
-                  )
-              and concept_id not in
-                  (
-                      select concept_id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where domain_id = 'DRUG'
-                          and concept_id is not null
-                  )
-
-      ) x"
-
-  echo "DRUGS - add unmapped ingredients"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-  select row_number() over (order by z.id, upper(x.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      z.id,'DRUG',1,'RXNORM',x.concept_id,x.concept_code,CONCAT( UPPER(SUBSTR(x.concept_name, 1, 1)), LOWER(SUBSTR(x.concept_name, 2)) ),
-      0,1,0,1,1,
-      CONCAT(z.path, '.',
-          CAST(ROW_NUMBER() OVER(order by z.id, upper(x.concept_name)) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from
-      (
-          select *
-          from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-          where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-              and CONCEPT_CLASS_ID = 'Ingredient'
-              and STANDARD_CONCEPT = 'S'
-              and concept_id in
-                  (
-                      select ANCESTOR_CONCEPT_ID
-                      from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                      where DESCENDANT_CONCEPT_ID in
-                          (
-                              select distinct DRUG_CONCEPT_ID
-                              from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                          )
-                  )
-              and concept_id not in
-                  (
-                      select concept_id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where domain_id = 'DRUG'
-                          and concept_id is not null
-                  )
-      ) x
-  join
-      (
-          select *
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          where domain_id = 'DRUG'
-              and type = 'ATC'
-              and length(name) = 1
-      ) z on UPPER(SUBSTR(x.concept_name, 1, 1)) = z.name"
-
-  echo "DRUGS - generate child counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select b.ANCESTOR_CONCEPT_ID as concept_id, count(distinct a.person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-          join
-              (
-                  select *
-                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` x
-                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` y on x.ANCESTOR_CONCEPT_ID = y.CONCEPT_ID
-                  where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-                      and CONCEPT_CLASS_ID = 'Ingredient'
-              ) b on a.DRUG_CONCEPT_ID = b.DESCENDANT_CONCEPT_ID
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'DRUG'
-      and x.type = 'RXNORM'"
-
-  echo "DRUGS - add brand names"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy)
-  select ROW_NUMBER() OVER(ORDER BY upper(concept_name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-      0,'DRUG',1,'BRAND',concept_id,concept_code,concept_name,0,1,0,0
-  FROM
-      (
-          select distinct b.concept_id, b.concept_name, b.concept_code
-          from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.CONCEPT_ID_1 = b.CONCEPT_ID --brands
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.CONCEPT_ID_2 = c.CONCEPT_ID --ingredients
-          where b.vocabulary_id in ('RxNorm','RxNorm Extension')
-              and b.concept_class_id = 'Brand Name'
-              and b.invalid_reason is null
-              and c.concept_id in
-                  (
-                      select concept_id
-                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      where domain_id = 'DRUG'
-                          and type = 'RXNORM'
-                          and is_group = 0
-                          and is_selectable = 1
-                  )
-      ) x"
-
-  echo "DRUGS - add data into prep_criteria_ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-      (ancestor_id, descendant_id)
-  SELECT DISTINCT a.id as ancestor_id,
-      COALESCE(e.id, d.id, c.id, b.id) as descendant_id
-  FROM (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM') and is_group = 1 and is_selectable = 1) a
-  JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) b on a.id = b.parent_id
-  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) c on b.id = c.parent_id
-  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) d on c.id = d.parent_id
-  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) e on d.id = e.parent_id"
-
-  echo "DRUGS - generate parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select g.id, count(distinct person_id) cnt
-          from
-              (
-                  select *
-                  from
-                      (
-                          select id
-                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where domain_id = 'DRUG'
-                              and type = 'ATC'
-                              and is_group = 1
-                              and is_selectable = 1
-                      ) a
-                      left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-              ) g
-          left join
-              (
-                  select e.id, f.*
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` e
-                  join
-                      (
-                          select d.ANCESTOR_CONCEPT_ID as concept_id, c.person_id
-                          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` c
-                          join
-                              (
-                                  select *
-                                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
-                                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.CONCEPT_ID
-                                  where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-                                      and CONCEPT_CLASS_ID = 'Ingredient'
-                              ) d on c.DRUG_CONCEPT_ID = d.DESCENDANT_CONCEPT_ID
-                      ) f on e.concept_id = f.concept_id
-              ) h on g.descendant_id = h.id
-          group by 1
-      ) y
-  where x.id = y.id"
-
-
-  ################################################
-  # PROCEDURES
-  ################################################
-  #----- STANDARD SNOMED -----
-  echo "PROCEDURES - STANDARD SNOMED - temp table level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
-  where concept_id in
-      (
-          select distinct procedure_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
-          where procedure_concept_id != 0
-              and b.domain_id = 'Procedure'
-              and b.vocabulary_id = 'SNOMED'
-              and b.standard_concept = 'S'
-      )"
-
-  # currently, there are only 8 levels, but we run it 9 times to be safe
-  for i in {1..9};
-  do
-      echo "PROCEDURES - STANDARD SNOMED - temp table level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
-      where
-          concept_id in
-              (
-                  select P_CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-              )
-          and concept_id not in
-              (
-                  select CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-              )"
-  done
-
-  echo "PROCEDURES - STANDARD SNOMED - add root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select (select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1,
-      0,'PROCEDURE',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-  where concept_id = 4322976"
-
-  echo "PROCEDURES - STANDARD SNOMED - add level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'PROCEDURE'
-      and p.type = 'SNOMED'
-      and p.is_standard = 1
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          )
-      and c.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-          )"
-
-  # currently, there are only 11 levels, but we run it 12 times to be safe, If this count changes, change the query below
-  for i in {1..12};
-  do
-      echo "PROCEDURES - STANDARD SNOMED - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-          case when l.concept_code is null then 1 else 0 end,
-          1,0,1,
-          CONCAT(p.path, '.',
-              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
-      left join
-          (
-              select distinct a.CONCEPT_CODE
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` b on a.concept_id = b.p_concept_id
-              where b.concept_id is null
-          ) l on c.concept_code = l.concept_code
-      where p.domain_id = 'PROCEDURE'
-          and p.type = 'SNOMED'
-          and p.is_standard = 1
-          and p.id not in
-              (
-                  select PARENT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )"
-  done
-
-  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-  echo "PROCEDURES - STANDARD SNOMED - add items into temp ancestor table for use in next query"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
-  SELECT DISTINCT a.concept_id as ancestor_concept_id
-      , a.domain_id
-      , a.type
-      , a.is_standard
-      , b.concept_id c1
-      , c.concept_id c2
-      , d.concept_id c3
-      , e.concept_id c4
-      , f.concept_id c5
-      , g.concept_id c6
-      , h.concept_id c7
-      , i.concept_id c8
-      , j.concept_id c9
-      , k.concept_id c10
-      , m.concept_id c11
-      , n.concept_id as c12
-  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
-      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id"
-
-  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-  # there last UNION statement is to add the ancestor item to itself
-  echo "PROCEDURES - STANDARD SNOMED - add items into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-      (ancestor_concept_id, descendant_concept_id, is_standard)
-  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_12 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_11 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_10 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_9 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_8 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_7 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_6 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_5 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_4 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_3 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_2 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_1 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 1"
-
-  echo "PROCEDURES - STANDARD SNOMED - generate child counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          SELECT procedure_concept_id as concept_id, count(distinct person_id) cnt
-          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
-          GROUP BY 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'PROCEDURE'
-      and x.type = 'SNOMED'
-      and x.is_standard = 1
-      and x.is_group = 0
-      and x.is_selectable = 1"
-
-  echo "PROCEDURES - STANDARD SNOMED - parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-          from
-              (
-                  select *
-                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                  where ancestor_concept_id in
-                      (
-                          select distinct concept_id
-                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where domain_id = 'PROCEDURE'
-                              and type = 'SNOMED'
-                              and is_standard = 1
-                              and parent_id != 0
-                              and is_group = 1
-                      )
-                      and is_standard = 1
-              ) a
-          join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_concept_id
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'PROCEDURE'
-      and x.type = 'SNOMED'
-      and x.is_standard = 1
-      and x.is_group = 1"
-
-  # ----- SOURCE SNOMED -----
-  echo "PROCEDURES - SOURCE SNOMED - temp table level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-  select *
-  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
-  where concept_id in
-      (
-          select distinct procedure_source_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
-          where procedure_source_concept_id != 0
-              and b.domain_id = 'Procedure'
-              and b.vocabulary_id = 'SNOMED'
-      )"
-
-  # currently, there are only 8 levels, but we run it 9 times to be safe
-  for i in {1..9};
-  do
-      echo "PROCEDURES - SOURCE SNOMED - temp table level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-      select *
-      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
-      where concept_id in
-          (
-              select P_CONCEPT_ID
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-          )
-          and concept_id not in
-              (
-                  select CONCEPT_ID
-                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-              )"
-  done
-
-  echo "PROCEDURES - SOURCE SNOMED - add root"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-      0,'PROCEDURE',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-  where concept_id = 4322976"
-
-  echo "PROCEDURES - SOURCE SNOMED - add level 0"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-      p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-      CONCAT(p.path, '.',
-          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
-  where p.domain_id = 'PROCEDURE'
-      and p.type = 'SNOMED'
-      and p.is_standard = 0
-      and p.id not in
-          (
-              select parent_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          )
-      and c.concept_id in
-          (
-              select p_concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-          )"
-
-  # currently, there are only 11 levels, but we run it 12 times to be safe (if changed, change number of joins in next query)
-  for i in {1..12};
-  do
-      echo "PROCEDURES - SOURCE SNOMED - add level $i"
-      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-          p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-          case when l.concept_code is null then 1 else 0 end,
-          1,0,1,
-          CONCAT(p.path, '.',
-              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
-      left join
-          (
-              select distinct a.concept_code
-              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` a
-              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` b on a.concept_id = b.p_concept_id
-              where b.concept_id is null
-          ) l on c.concept_code = l.concept_code
-      where p.domain_id = 'PROCEDURE'
-          and p.type = 'SNOMED'
-          and p.is_standard = 0
-          and p.id not in
-              (
-                  select parent_id
-                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              )"
-  done
-
-  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-  echo "PROCEDURES - SOURCE SNOMED - add items into temp ancestor table for use in next query"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
-  SELECT DISTINCT a.concept_id as ancestor_concept_id
-      , a.domain_id
-      , a.type
-      , a.is_standard
-      , b.concept_id c1
-      , c.concept_id c2
-      , d.concept_id c3
-      , e.concept_id c4
-      , f.concept_id c5
-      , g.concept_id c6
-      , h.concept_id c7
-      , i.concept_id c8
-      , j.concept_id c9
-      , k.concept_id c10
-      , m.concept_id c11
-      , n.concept_id as c12
-  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
-      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
-      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id"
-
-  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-  # there last UNION statement is to add the ancestor item to itself
-  echo "PROCEDURES - SOURCE SNOMED - add items into ancestor table"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-      (ancestor_concept_id, descendant_concept_id, is_standard)
-  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_12 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_11 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_10 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_9 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_8 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_7 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_6 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_5 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_4 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_3 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_2 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE concept_id_1 is not null
-      and domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0
-  UNION DISTINCT
-  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-  WHERE domain_id = 'PROCEDURE'
-      and type = 'SNOMED'
-      and is_standard = 0"
-
-  echo "PROCEDURES - SOURCE SNOMED - child counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.est_count = y.cnt
-  from
-      (
-          select procedure_source_concept_id as concept_id, count(distinct person_id) cnt
-          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'PROCEDURE'
-      and x.type = 'SNOMED'
-      and x.is_standard = 0
-      and x.is_group = 0
-      and x.is_selectable = 1"
-
-  echo "PROCEDURES - SOURCE SNOMED - parent counts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  SET x.est_count = y.cnt
-  from
-      (
-          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-          from
-              (
-                  select *
-                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                  where ancestor_concept_id in
-                      (
-                          select distinct concept_id
-                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                          where domain_id = 'PROCEDURE'
-                              and type = 'SNOMED'
-                              and is_standard = 0
-                              and parent_id != 0
-                              and is_group = 1
-                      )
-                      and is_standard = 0
-              ) a
-          join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_source_concept_id
-          group by 1
-      ) y
-  where x.concept_id = y.concept_id
-      and x.domain_id = 'PROCEDURE'
-      and x.type = 'SNOMED'
-      and x.is_standard = 0
-      and x.is_group = 1"
-
-
-  ################################################
-  # CB_CRITERIA_ANCESTOR
-  ################################################
-  echo "CB_CRITERIA_ANCESTOR - Drugs - add ingredients to drugs mapping"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-      (ancestor_id, descendant_id)
-  select ancestor_concept_id, descendant_concept_id
-  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-  where ancestor_concept_id in
-      (
-          select distinct concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          where domain_id = 'DRUG'
-              and type = 'RXNORM'
-              and is_group = 0
-              and is_selectable = 1
-      )
-  and descendant_concept_id in
-      (
-          select distinct drug_concept_id
-          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-      )"
-
-
-  ################################################
-  # ADD IN OTHER CODES NOT ALREADY CAPTURED
-  ################################################
-  echo "CONDITIONS - add other source concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-      -1, 'CONDITION', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.condition_concept_id = c.concept_id
-          WHERE a.condition_source_concept_id NOT IN
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE is_standard = 0
-                      and concept_id is not null
-              )
-              and a.condition_source_concept_id != 0
-              and a.condition_source_concept_id is not null
-              and b.concept_id is not null
-              and b.vocabulary_id != 'PPI'
-              and (b.domain_id LIKE 'Condition%' OR c.domain_id = 'Condition')
-          GROUP BY 1,2,3,4
-      ) x"
-
-  echo "CONDITIONS - add other standard concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      -1, 'CONDITION',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
-          WHERE standard_concept = 'S'
-              and domain_id = 'Condition'
-              and condition_concept_id NOT IN
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      WHERE domain_id = 'CONDITION'
-                          and is_standard = 1
-                          and concept_id is not null
-                  )
-          GROUP BY 1,2,3,4
-      ) x"
-
-  echo "PROCEDURES - add other source concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-      -1, 'PROCEDURE', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.procedure_concept_id = c.concept_id
-          WHERE a.procedure_source_concept_id NOT IN
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE is_standard = 0
-                      and concept_id is not null
-              )
-              and a.procedure_source_concept_id != 0
-              and a.procedure_source_concept_id is not null
-              and b.concept_id is not null
-              and b.vocabulary_id != 'PPI'
-              and (b.domain_id = 'Procedure' OR c.domain_id = 'Procedure')
-          GROUP BY 1,2,3,4
-      ) x"
-
-  echo "PROCEDURES - add other standard concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      -1, 'PROCEDURE',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
-          WHERE standard_concept = 'S'
-              and domain_id = 'Procedure'
-              and procedure_concept_id NOT IN
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      WHERE domain_id = 'PROCEDURE'
-                          and is_standard = 1
-                          and concept_id is not null
-                  )
-          GROUP BY 1,2,3,4
-      ) x"
-
-  echo "MEASUREMENTS - add other standard concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      -1, 'MEASUREMENT',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-          WHERE standard_concept = 'S'
-              and domain_id = 'Measurement'
-              and vocabulary_id not in ('PPI')
-              and measurement_concept_id NOT IN
-                  (
-                      SELECT concept_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                      WHERE domain_id = 'MEASUREMENT'
-                          and is_standard = 1
-                          and concept_id is not null
-                  )
-          GROUP BY 1,2,3,4
-      ) x"
-
-  echo "DRUGS - add other standard concepts"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-      -1, 'DRUG',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-  FROM
-      (
-          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-          FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.drug_concept_id = b.concept_id
-          WHERE standard_concept = 'S'
-              and domain_id = 'Drug'
-              and drug_concept_id NOT IN
-                  (
-                      SELECT descendant_id
-                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-                      WHERE ancestor_id in
-                          (
-                              SELECT concept_id
-                              FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                              WHERE domain_id = 'DRUG'
-                                  and is_standard = 1
-                          )
-                  )
-          GROUP BY 1,2,3,4
-      ) x"
-
-
-  ################################################
-  # CB_CRITERIA_ATTRIBUTE
-  ################################################
-  echo "CB_CRITERIA_ATTRIBUTE - PPI SURVEY - add values for certain questions"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-      (id, concept_id, value_as_concept_id, concept_name, type, est_count)
-  VALUES
-      (1, 1585889, 0, 'MIN', 'NUM', '0'),
-      (2, 1585889, 0, 'MAX', 'NUM', '20'),
-      (3, 1585890, 0, 'MIN', 'NUM', '0'),
-      (4, 1585890, 0, 'MAX', 'NUM', '20'),
-      (5, 1585864, 0, 'MIN', 'NUM', '0'),
-      (6, 1585864, 0, 'MAX', 'NUM', '99'),
-      (7, 1585870, 0, 'MIN', 'NUM', '0'),
-      (8, 1585870, 0, 'MAX', 'NUM', '99'),
-      (9, 1585873, 0, 'MIN', 'NUM', '0'),
-      (10, 1585873, 0, 'MAX', 'NUM', '99'),
-      (11, 1586159, 0, 'MIN', 'NUM', '0'),
-      (12, 1586159, 0, 'MAX', 'NUM', '99'),
-      (13, 1586162, 0, 'MIN', 'NUM', '0'),
-      (14, 1586162, 0, 'MAX', 'NUM', '99'),
-      (15, 1585795, 0, 'MIN', 'NUM', '0'),
-      (16, 1585795, 0, 'MAX', 'NUM', '99'),
-      (17, 1585802, 0, 'MIN', 'NUM', '0'),
-      (18, 1585802, 0, 'MAX', 'NUM', '99'),
-      (19, 1585820, 0, 'MIN', 'NUM', '0'),
-      (20, 1585820, 0, 'MAX', 'NUM', '255')
-  "
-
-  # this code filters out any labs where all results = 0
-  echo "CB_CRITERIA_ATTRIBUTE - Measurements - add numeric results"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-      (id, concept_id, value_as_concept_id, concept_name, type, est_count)
-  SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
-  FROM
-      (
-          SELECT measurement_concept_id, 0, 'MIN', 'NUM', CAST(min(value_as_number) as STRING)
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-          WHERE measurement_concept_id in
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE domain_id = 'MEASUREMENT'
-              )
-              and value_as_number is not null
-          GROUP BY 1
-          HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
-
-          UNION ALL
-
-          SELECT measurement_concept_id, 0, 'MAX', 'NUM', CAST(max(value_as_number) as STRING)
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-          WHERE measurement_concept_id in
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE domain_id = 'MEASUREMENT'
-              )
-              and value_as_number is not null
-          GROUP BY 1
-          HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
-      ) a"
-
-  echo "CB_CRITERIA_ATTRIBUTE - Measurements - add categorical results"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-      (id, concept_id, value_as_concept_Id, concept_name, type, est_count)
-  SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
-  FROM
-      (
-          SELECT measurement_concept_id, value_as_concept_id, b.concept_name, 'CAT' as type, CAST(count(distinct person_id) as STRING)
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_as_concept_Id = b.concept_id
-          WHERE measurement_concept_id in
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE domain_id = 'MEASUREMENT'
-              )
-              and value_as_concept_id != 0
-              and value_as_concept_id is not null
-          GROUP BY 1,2,3
-      ) a"
-
-
-  # set has_attributes=1 for any criteria that has data in cb_criteria_attribute
-  echo "CB_CRITERIA_ATTRIBUTE - update has_attributes column for measurement criteria"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  SET has_attribute = 1
-  WHERE concept_id in
-      (
-          SELECT distinct concept_id
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-      )
-      and domain_id = 'MEASUREMENT'
-      and is_selectable = 1"
-
-
-  ################################################
-  # CB_CRITERIA_RELATIONSHIP
-  ################################################
-  echo "CB_CRITERIA_RELATIONSHIP - Drugs - add drug/ingredient relationships"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-      (concept_id_1, concept_id_2)
-  select a.concept_id_1, a.concept_id_2
-  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-  join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
-  where b.concept_class_id = 'Ingredient'
-      and a.concept_id_1 in
-          (
-              select concept_id
-              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              where domain_id = 'DRUG'
-                  and type = 'BRAND'
-          )"
-
-  echo "CB_CRITERIA_RELATIONSHIP - Source Concept -> Standard Concept Mapping"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-      (concept_id_1, concept_id_2)
-  SELECT a.concept_id_1 as source_concept_id, a.concept_id_2 as standard_concept_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
-  WHERE b.standard_concept = 'S'
-      AND a.relationship_id = 'Maps to'
-      AND a.concept_id_1 in
-          (
-              SELECT DISTINCT concept_id
-              FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-              WHERE concept_id is not null
-                  and is_standard = 0
-          )"
-
-
-  ################################################
-  # DATA CLEAN UP
-  ################################################
-  echo "CLEAN UP - set est_count = -1 where the count is NULL"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set est_count = -1
-  where est_count is null"
-
-  echo "CLEAN UP - set has_ancestor_data = 0 for all items where it is currently NULL"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  set has_ancestor_data = 0
-  where has_ancestor_data is null"
-
-  echo "CLEAN UP - remove all double quotes from criteria names"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-  SET name = REGEXP_REPLACE(name, r'[\"]', '')
-  WHERE REGEXP_CONTAINS(name, r'[\"]')"
-
-  echo "remove lab items from prep_criteria_ancestor that were added during the run"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "DELETE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-  WHERE ancestor_id IN
-      (
-          SELECT id
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          WHERE domain_id = 'MEASUREMENT'
-              and type = 'LOINC'
-              and subtype = 'LAB'
-              and parent_id != 0
-              and is_group = 1
-      )"
-
-  echo "remove drug items from prep_criteria_ancestor that were added during the run"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "DELETE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-  WHERE ancestor_id IN
-      (
-          SELECT id
-          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          WHERE domain_id = 'DRUG'
-              and type = 'ATC'
-              and is_group = 1
-              and is_selectable = 1
-      )"
-
-
-  ################################################
-  # SYNONYMS
-  ################################################
-  echo "SYNONYMS - add synonym data to criteria"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.synonyms = y.synonyms
-  from
-      (
-          select c.id,
-          case
-              when c.name is not null and string_agg(replace(cs.concept_synonym_name,'|','||'),'|') is null then c.name
-              else concat(c.name,'|',string_agg(replace(cs.concept_synonym_name,'|','||'),'|'))
-          end as synonyms
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-          left join \`$BQ_PROJECT.$BQ_DATASET.concept_synonym\` cs on c.concept_id = cs.concept_id
-          where domain_id not in ('SURVEY', 'PERSON')
-          group by c.id, c.name, c.code
-      ) y
-  where x.id = y.id"
-
-  echo "SYNONYMS - add demographics synonym data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.synonyms = y.synonyms
-  from
-      (
-          select id,
-          case
-              when type = 'AGE' and parent_id = 0 then 'Age'
-              when type = 'DECEASED' and parent_id = 0 then 'Deceased'
-              when type = 'GENDER' and parent_id = 0 then 'Gender'
-              when type = 'RACE' and parent_id = 0 then 'Race'
-              when type = 'ETHNICITY' and parent_id = 0 then 'Ethnicity'
-              when type = 'AGE' and parent_id != 0 then null
-          else name
-          end as synonyms
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          where domain_id = 'PERSON'
-      ) y
-  where x.id = y.id"
-
-  echo "SYNONYMS - add PPI synonym data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.synonyms = x.name
-  where domain_id in ('SURVEY')"
-
-  # add [rank1] for all items. this is to deal with the poly-hierarchical issue in many trees
-  echo "SYNONYMS - add [rank1]"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-  set x.synonyms = CONCAT(x.synonyms, '|', y.rnk)
-  from
-      (
-          select min(id) as id, CONCAT('[', LOWER(domain_id), '_rank1]') as rnk
-          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-          where synonyms is not null
-              and (est_count != -1 OR (est_count = -1 AND type = 'BRAND'))
-          group by domain_id, is_standard, type, subtype, concept_id, name
-      ) y
-  where x.id = y.id"
-
-
-  ################################################
-  # DATABASE CLEAN UP - drop tables/views
-  ################################################
-  #echo "DROP - prep_criteria"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`"
-  #
-  #echo "DROP - prep_criteria_ancestor"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`"
-  #
-  #echo "DROP - prep_clinical_terms_nc"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\`"
-  #
-  #echo "DROP - atc_rel_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`"
-  #
-  #echo "DROP - loinc_rel_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`"
-  #
-  #echo "DROP - snomed_rel_cm_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`"
-  #
-  #echo "DROP - snomed_rel_cm_src_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`"
-  #
-  #echo "DROP - snomed_rel_pcs_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`"
-  #
-  #echo "DROP - snomed_rel_meas_in_data"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`"
-  #
-  #echo "DROP - v_loinc_rel"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\`"
-  #
-  #echo "DROP - v_snomed_rel_cm"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\`"
-  #
-  #echo "DROP - v_snomed_rel_cm_src"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\`"
-  #
-  #echo "DROP - v_snomed_rel_pcs"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\`"
-  #
-  #echo "DROP - v_snomed_rel_meas"
-  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\`"
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_search_all_events")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_criteria")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_criteria_ancestor")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.death")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_relationship")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_ancestor")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_synonym")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
+  exit 0
 fi
+
+# Check that bq_project exists and exit if not
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+if [ -z "$datasets" ]
+then
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+else
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+
+
+################################################
+# CREATE TABLES
+################################################
+# table that holds temp data to get ancestor information for parent counts
+echo "CREATE TABLES - prep_concept_ancestor_temp"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+(
+    ancestor_concept_id     INT64,
+    domain_id               STRING,
+    type                    STRING,
+    is_standard             INT64,
+    concept_id_1            INT64,
+    concept_id_2            INT64,
+    concept_id_3            INT64,
+    concept_id_4            INT64,
+    concept_id_5            INT64,
+    concept_id_6            INT64,
+    concept_id_7            INT64,
+    concept_id_8            INT64,
+    concept_id_9            INT64,
+    concept_id_10           INT64,
+    concept_id_11           INT64,
+    concept_id_12           INT64,
+    concept_id_13           INT64,
+    concept_id_14           INT64,
+    concept_id_15           INT64,
+    concept_id_16           INT64,
+    concept_id_17           INT64,
+    concept_id_18           INT64,
+    concept_id_19           INT64,
+    concept_id_20           INT64
+)"
+
+# table that holds ancestor information for parent counts
+echo "CREATE TABLES - prep_concept_ancestor"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+(
+    ancestor_concept_id     INT64,
+    descendant_concept_id   INT64,
+    is_standard             INT64
+)"
+
+echo "CREATE TABLES - cb_criteria"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+(
+    id                  INT64,
+    parent_id           INT64,
+    domain_id           STRING,
+    is_standard         INT64,
+    type                STRING,
+    subtype             STRING,
+    concept_id          INT64,
+    code                STRING,
+    name                STRING,
+    value               STRING,
+    est_count           INT64,
+    is_group            INT64,
+    is_selectable       INT64,
+    has_attribute       INT64,
+    has_hierarchy       INT64,
+    has_ancestor_data   INT64,
+    path                STRING,
+    synonyms            STRING
+)"
+
+# table that holds the ingredient --> coded drugs mapping
+echo "CREATE TABLES - cb_criteria_ancestor"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+(
+    ancestor_id INT64,
+    descendant_id INT64
+)"
+
+# table that holds categorical results and min/max information about individual labs
+echo "CREATE TABLES - cb_criteria_attribute"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+(
+    id                    INT64,
+    concept_id            INT64,
+    value_as_concept_id	  INT64,
+    concept_name          STRING,
+    type                  STRING,
+    est_count             STRING
+)"
+
+# table that holds the drug brands to ingredients relationship mapping
+echo "CREATE TABLES - cb_criteria_relationship"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+(
+    concept_id_1 INT64,
+    concept_id_2 INT64
+)"
+
+echo "CREATE TABLES - atc_rel_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - loinc_rel_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - snomed_rel_cm_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - snomed_rel_cm_src_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - snomed_rel_meas_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - snomed_rel_pcs_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+echo "CREATE TABLES - snomed_rel_pcs_src_in_data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+(
+    p_concept_id    INT64,
+    p_concept_code  STRING,
+    p_concept_name  STRING,
+    p_domain_id     STRING,
+    concept_id      INT64,
+    concept_code    STRING,
+    concept_name    STRING,
+    domain_id       STRING
+)"
+
+
+################################################
+# CREATE VIEWS
+################################################
+echo "CREATE VIEWS - v_loinc_rel"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE,
+    C1.CONCEPT_NAME AS P_CONCEPT_NAME, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND CR.RELATIONSHIP_ID = 'Subsumes'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.VOCABULARY_ID = 'LOINC'
+    AND C2.VOCABULARY_ID = 'LOINC'
+    AND C1.STANDARD_CONCEPT IN ('S','C')
+    AND C2.STANDARD_CONCEPT IN ('S','C')
+    AND C1.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')
+    AND C2.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')"
+
+echo "CREATE VIEWS - v_snomed_rel_cm"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND C1.VOCABULARY_ID = 'SNOMED'
+    AND C2.VOCABULARY_ID = 'SNOMED'
+    AND C1.STANDARD_CONCEPT = 'S'
+    AND C2.STANDARD_CONCEPT = 'S'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.DOMAIN_ID = 'Condition'
+    AND C2.DOMAIN_ID = 'Condition'
+    AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+echo "CREATE VIEWS - v_snomed_rel_cm_src"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND C1.VOCABULARY_ID = 'SNOMED'
+    AND C2.VOCABULARY_ID = 'SNOMED'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.DOMAIN_ID = 'Condition'
+    AND C2.DOMAIN_ID = 'Condition'
+    AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+echo "CREATE VIEWS - v_snomed_rel_meas"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND C1.VOCABULARY_ID = 'SNOMED'
+    AND C2.VOCABULARY_ID = 'SNOMED'
+    AND C1.STANDARD_CONCEPT = 'S'
+    AND C2.STANDARD_CONCEPT = 'S'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.DOMAIN_ID = 'Measurement'
+    AND C2.DOMAIN_ID = 'Measurement'
+    AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+echo "CREATE VIEWS - v_snomed_rel_pcs"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND C1.VOCABULARY_ID = 'SNOMED'
+    AND C2.VOCABULARY_ID = 'SNOMED'
+    AND C1.STANDARD_CONCEPT = 'S'
+    AND C2.STANDARD_CONCEPT = 'S'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.DOMAIN_ID = 'Procedure'
+    AND C2.DOMAIN_ID = 'Procedure'
+    AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+echo "CREATE VIEWS - v_snomed_rel_pcs_src"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` AS
+SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+    AND C1.VOCABULARY_ID = 'SNOMED'
+    AND C2.VOCABULARY_ID = 'SNOMED'
+    AND R.IS_HIERARCHICAL = '1'
+    AND R.DEFINES_ANCESTRY = '1'
+    AND C1.DOMAIN_ID = 'Procedure'
+    AND C2.DOMAIN_ID = 'Procedure'
+    AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+
+################################################
+# SOURCE ICD9
+################################################
+echo "ICD9 - add data (do not insert zero count children)"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+    case when b.concept_id is not null then b.concept_name else a.name end as name,
+    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+LEFT JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        WHERE (vocabulary_id in ('ICD9CM', 'ICD9Proc') and concept_code != '92')
+            or (vocabulary_id = 'ICD9Proc' and concept_code = '92')
+    ) b on a.concept_id = b.concept_id
+LEFT JOIN
+    (
+        SELECT concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        WHERE is_standard = 0
+            and concept_id in
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                    WHERE type in ('ICD9CM', 'ICD9Proc')
+                        and is_group = 0
+                        and is_selectable = 1
+                )
+        group by 1
+    ) c on b.concept_id = c.concept_id
+WHERE type in ('ICD9CM', 'ICD9Proc')
+    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+ORDER BY 1"
+
+echo "ICD9 - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT e.id, COUNT(distinct f.person_id) cnt
+        FROM
+            (
+                SELECT *
+                FROM
+                    (
+                        SELECT id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE type in ('ICD9CM', 'ICD9Proc')
+                            and is_group = 1
+                            and is_selectable = 1
+                    ) a
+                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) e
+        LEFT JOIN
+            (
+                SELECT c.id, d.*
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                JOIN
+                    (
+                        SELECT a.person_id, a.concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                        JOIN
+                            (
+                                SELECT concept_id, path
+                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                WHERE type in ('ICD9CM', 'ICD9Proc')
+                                    and is_selectable = 1
+                            ) b on a.concept_id = b.concept_id
+                        WHERE is_standard = 0
+                    ) d on c.concept_id = d.concept_id
+            ) f on e.descendant_id = f.id
+        GROUP BY 1
+    ) y
+WHERE x.id = y.id"
+
+echo "ICD9 - delete zero count parents"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"DELETE
+FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+WHERE type in ('ICD9CM', 'ICD9Proc')
+    and is_selectable = 1
+    and (est_count is null or est_count = 0)"
+
+################################################
+# SOURCE ICD10
+################################################
+echo "ICD10CM - insert data (do not insert zero count children)"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+    case when b.concept_id is not null then b.concept_name else a.name end as name,
+    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+LEFT JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        WHERE vocabulary_id in ('ICD10CM')
+    ) b on a.concept_id = b.concept_id
+LEFT JOIN
+    (
+        SELECT concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        WHERE is_standard = 0
+            and concept_id in
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                    WHERE type = 'ICD10CM'
+                        and is_group = 0
+                        and is_selectable = 1
+                )
+        GROUP BY 1
+    ) c on b.concept_id = c.concept_id
+WHERE type = 'ICD10CM'
+    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+ORDER BY 1"
+
+echo "ICD10CM - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT e.id, count(distinct f.person_id) cnt
+        FROM
+            (
+                SELECT *
+                FROM
+                    (
+                        SELECT id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE type = 'ICD10CM'
+                            and parent_id != 0
+                            and is_group = 1
+                    ) a
+                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) e
+        LEFT JOIN
+            (
+                SELECT c.id, d.*
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                JOIN
+                    (
+                        SELECT a.person_id, a.concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                        JOIN
+                            (
+                                SELECT concept_id, path
+                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                WHERE type = 'ICD10CM'
+                                    and is_selectable = 1
+                            ) b on a.concept_id = b.concept_id
+                        WHERE is_standard = 0
+                    ) d on c.concept_id = d.concept_id
+            ) f on e.descendant_id = f.id
+        group by 1
+    ) y
+WHERE x.id = y.id"
+
+echo "ICD10PCS - insert data (do not insert zero count children)"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+    case when b.concept_id is not null then b.concept_name else a.name end as name,
+    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+LEFT JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        WHERE vocabulary_id in ('ICD10PCS')
+    ) b on a.concept_id = b.concept_id
+LEFT JOIN
+    (
+        SELECT concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        WHERE is_standard = 0
+            and concept_id in
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                    WHERE type = 'ICD10PCS'
+                        and is_group = 0
+                        and is_selectable = 1
+                )
+        GROUP BY 1
+    ) c on b.concept_id = c.concept_id
+WHERE type = 'ICD10PCS'
+    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+ORDER BY 1"
+
+echo "ICD10PCS - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT e.id, count(distinct f.person_id) cnt
+        FROM
+            (
+                SELECT *
+                FROM
+                    (
+                        SELECT id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE type = 'ICD10PCS'
+                            and parent_id != 0
+                            and is_group = 1
+                    ) a
+                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) e
+        LEFT JOIN
+            (
+                SELECT c.id, d.*
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                JOIN
+                    (
+                        SELECT a.person_id, a.concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                        JOIN
+                            (
+                                SELECT concept_id, path
+                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                WHERE type = 'ICD10PCS'
+                                    and is_selectable = 1
+                            ) b on a.concept_id = b.concept_id
+                        WHERE is_standard = 0
+                    ) d on c.concept_id = d.concept_id
+            ) f on e.descendant_id = f.id
+        group by 1
+    ) y
+WHERE x.id = y.id"
+
+echo "ICD10 - delete zero count parents"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"DELETE
+FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+WHERE type in ('ICD10CM', 'ICD10PCS')
+    and is_group = 1
+    and is_selectable = 1
+    and (est_count is null or est_count = 0)"
+
+
+################################################
+# SOURCE CPT
+################################################
+echo "CPT - insert data (do not insert zero count children)"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+    case when b.concept_id is not null then b.concept_name else a.name end as name,
+    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+LEFT JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        WHERE vocabulary_id = 'CPT4'
+    ) b on a.concept_id = b.concept_id
+LEFT JOIN
+    (
+        SELECT concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        WHERE is_standard = 0
+            and concept_id in
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                    WHERE type = 'CPT4'
+                        and is_group = 0
+                        and is_selectable = 1
+                )
+        group by 1
+    ) c on b.concept_id = c.concept_id
+WHERE type = 'CPT4'
+    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+ORDER BY 1"
+
+echo "CPT - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT e.id, count(distinct f.person_id) cnt
+        FROM
+            (
+                SELECT *
+                FROM
+                    (
+                        SELECT id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE type = 'CPT4'
+                            and parent_id != 0
+                            and is_group = 1
+                    ) a
+                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) e
+        LEFT JOIN
+            (
+                SELECT c.id, d.*
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                JOIN
+                    (
+                        SELECT a.person_id, a.concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                        JOIN
+                            (
+                                SELECT concept_id, path
+                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                WHERE type = 'CPT4'
+                                    and is_selectable = 1
+                            ) b on a.concept_id = b.concept_id
+                        WHERE is_standard = 0
+                    ) d on c.concept_id = d.concept_id
+            ) f on e.descendant_id = f.id
+        group by 1
+    ) y
+WHERE x.id = y.id"
+
+echo "CPT - delete zero count parents"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"DELETE
+FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+WHERE type = 'CPT4'
+    and
+    (
+        (parent_id != 0 and (est_count is null or est_count = 0))
+        or
+            (
+              is_group = 1
+              and id not in
+                (
+                    SELECT parent_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE type = 'CPT4'
+                        and est_count is not null
+                )
+            )
+		)"
+
+
+################################################
+# PPI PHYSICAL MEASUREMENTS (PM)
+################################################
+echo "PM - insert data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+select id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
+    case when is_selectable = 1 then 0 else null end as est_count,
+    is_group,is_selectable,has_attribute,has_hierarchy
+from \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+where domain_id = 'PHYSICAL_MEASUREMENT'
+order by 1"
+
+echo "PM - counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select measurement_source_concept_id as concept_id, count(distinct person_id) as cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+        where measurement_source_concept_id in (903126,903133,903121,903124,903135,903136)
+        group by 1
+    ) y
+where x.domain_id = 'PHYSICAL_MEASUREMENT'
+    and x.concept_id = y.concept_id"
+
+echo "PM - counts for heart rhythm, pregnancy, and wheelchair use"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select concept_id, CAST(value_as_concept_id as STRING) as value, count(distinct person_id) as cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id IN (1586218, 903120, 903111)
+        group by 1,2
+    ) y
+where x.domain_id = 'PHYSICAL_MEASUREMENT'
+    and x.concept_id = y.concept_id
+    and x.value = y.value"
+
+#----- BLOOD PRESSURE -----
+echo "PM - blood pressure  - hypotensive"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count =
+    (
+        select count(distinct person_id)
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id in (903115, 903118)
+            and systolic <= 90
+            and diastolic <= 60
+    )
+where domain_id = 'PHYSICAL_MEASUREMENT'
+    and subtype = 'BP'
+    and name LIKE 'Hypotensive%'"
+
+echo "PM - blood pressure  - normal"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count =
+    (
+        select count(distinct person_id)
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id in (903115, 903118)
+            and systolic <= 120
+            and diastolic <= 80
+    )
+where domain_id = 'PHYSICAL_MEASUREMENT'
+    and subtype = 'BP'
+    and name LIKE 'Normal%'"
+
+echo "PM - blood pressure  - pre-hypertensive"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count =
+    (
+        select count(distinct person_id)
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id in (903115, 903118)
+            and systolic BETWEEN 120 AND 139
+            and diastolic BETWEEN 81 AND 89
+    )
+where domain_id = 'PHYSICAL_MEASUREMENT'
+    and subtype = 'BP'
+    and name LIKE 'Pre-Hypertensive%'"
+
+echo "PM - blood pressure  - hypertensive"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count =
+    (
+        select count(distinct person_id)
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id in (903115, 903118)
+            and systolic >= 140
+            and diastolic >= 90
+    )
+where domain_id = 'PHYSICAL_MEASUREMENT'
+    and subtype = 'BP'
+    and name LIKE 'Hypertensive%'"
+
+echo "PM - blood pressure  - detail"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count =
+    (
+        select count(distinct person_id)
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where concept_id in (903115, 903118)
+    )
+where domain_id = 'PHYSICAL_MEASUREMENT'
+    and subtype = 'BP'
+    and name = 'Blood Pressure'
+    and is_selectable = 1"
+
+
+################################################
+# PPI SURVEYS
+################################################
+echo "PPI SURVEYS - insert data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
+    case when (is_selectable = 1 and name != 'Select a value') then 0 else null end as est_count,
+    is_group,is_selectable,has_attribute,has_hierarchy,path
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+WHERE domain_id = 'SURVEY'
+    and type = 'PPI'
+ORDER BY 1"
+
+echo "PPI SURVEYS - insert extra answers"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+e.id as parent_id, e.domain_id, e.is_standard, e.type, 'ANSWER', e.concept_id, d.answer as name, CAST(d.value_source_concept_id as STRING), 0, 1, 0, 1,
+CONCAT(e.path, '.',
+        CAST(ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+FROM
+(
+SELECT DISTINCT a.observation_source_concept_id, a.value_source_concept_id, regexp_replace(b.concept_name, r'^.+:\s', '') as answer
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_source_concept_id = b.concept_id
+LEFT JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+        WHERE domain_id = 'SURVEY'
+    ) c on (a.observation_source_concept_id = c.concept_id and CAST(a.value_source_concept_id as STRING) = c.value)
+WHERE a.value_source_concept_id in (903096, 903079, 903087)
+    and a.observation_source_concept_id in
+        (
+            SELECT concept_id
+            FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+            WHERE domain_id = 'SURVEY'
+                and concept_id is not null
+        )
+    and c.id is null
+) d
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` e on
+    (d.observation_source_concept_id = e.concept_id and e.domain_id = 'SURVEY' and e.is_group = 1)"
+
+echo "PPI SURVEYS - add items into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+    (ancestor_concept_id, descendant_concept_id, is_standard)
+SELECT DISTINCT b.concept_id as ancestor_concept_id, a.concept_id as descendant_concept_id, a.is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` b on CAST(regexp_extract(a.path, r'^\d+') AS INT64) = b.id
+WHERE a.domain_id = 'SURVEY'
+    and a.subtype = 'ANSWER'"
+
+echo "PPI SURVEYS - generate answer counts for all questions EXCEPT where question concept_id = 1585747"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        SELECT concept_id, CAST(value_source_concept_id as STRING) as value, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        WHERE is_standard = 0
+            and concept_id in
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'SURVEY'
+                        and type = 'PPI'
+                        and subtype = 'ANSWER'
+                        and concept_id != 1585747
+                )
+        GROUP BY 1,2
+        ORDER BY 1,2
+    ) y
+where x.domain_id = 'SURVEY'
+    and x.type = 'PPI'
+    and x.subtype = 'ANSWER'
+    and x.concept_id = y.concept_id
+    and x.value = y.value"
+
+echo "PPI SURVEYS - generate answer counts for question (concept_id = 1585747)"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select concept_id, CAST(value_as_number as STRING) as value, count(distinct person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where is_standard = 0
+            and concept_id = 1585747
+        group by 1,2
+    ) y
+where x.domain_id = 'SURVEY'
+    and x.type = 'PPI'
+    and x.subtype = 'ANSWER'
+    and x.concept_id = y.concept_id
+    and x.value = y.value"
+
+echo "PPI SURVEYS - generate question counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        SELECT concept_id, count(distinct person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+        where is_standard = 0
+            and concept_id in
+                (
+                    select concept_id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where domain_id = 'SURVEY'
+                        and type = 'PPI'
+                        and is_group = 1
+                        and is_selectable = 1
+                        and parent_id != 0
+                )
+        group by 1
+    ) y
+where x.domain_id = 'SURVEY'
+    and x.type = 'PPI'
+    and x.is_group = 1
+    and x.concept_id = y.concept_id"
+
+echo "PPI SURVEYS - generate survey counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT b.ancestor_concept_id, count(DISTINCT a.person_id) as cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+        JOIN
+            (
+                SELECT *
+                FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                WHERE ancestor_concept_id in
+                    (
+                        SELECT concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE domain_id = 'SURVEY'
+                            and parent_id = 0
+                    )
+            ) b on a.concept_id = b.descendant_concept_id
+        WHERE a.is_standard = 0
+        GROUP BY 1
+    ) y
+WHERE x.domain_id = 'SURVEY'
+    and x.concept_id = y.ancestor_concept_id"
+
+
+################################################
+# DEMOGRAPHICS
+################################################
+echo "DEMO - Age parent"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PERSON',1,'AGE','Age',1,0,0,0"
+
+echo "DEMO - Age Children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+select row_num + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'AGE' and parent_id = 0) as parent_id,
+    'PERSON',1,'AGE', CAST(row_num AS STRING) as name, CAST(row_num as STRING) as value,
+    case when b.cnt is null then 0 else b.cnt end as est_count,
+    0,1,0,0
+from
+    (
+        select ROW_NUMBER() OVER(ORDER BY person_id) as row_num
+        from \`$BQ_PROJECT.$BQ_DATASET.person\`
+        order by person_id limit 120
+    ) a
+left join
+    (
+        select CAST(FLOOR(DATE_DIFF(CURRENT_DATE(), DATE(birth_datetime), MONTH)/12) as INT64) as age, count(*) as cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.person\`
+        where person_id not in
+            (
+                select person_id
+                from \`$BQ_PROJECT.$BQ_DATASET.death\`
+            )
+        group by 1
+    ) b on a.row_num = b.age
+order by 1"
+
+echo "DEMO - Deceased"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PERSON',1,'DECEASED','Deceased',
+    (select count(distinct person_id) from \`$BQ_PROJECT.$BQ_DATASET.death\`),
+    0,1,0,0"
+
+echo "DEMO - Gender parent"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PERSON',1,'GENDER','Gender',1,0,0,0"
+
+echo "DEMO - Gender children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
+    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'GENDER' and parent_id = 0) as parent_id,
+    'PERSON',1,'GENDER',concept_id,
+    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
+    a.cnt,0,1,0,0
+FROM
+    (
+        SELECT gender_concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+        GROUP BY 1
+    ) a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.gender_concept_id = b.concept_id"
+
+echo "DEMO - Sex at birth parent"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
+    0,'PERSON',1,'SEX','Sex',1,0,0,0"
+
+echo "DEMO - Sex at birth children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
+    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
+    'PERSON',1,'SEX',concept_id,
+    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
+    a.cnt,0,1,0,0
+FROM
+    (
+        SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+        GROUP BY 1
+    ) a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
+
+echo "DEMO - Race parent"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PERSON',1,'RACE','Race',1,0,0,0"
+
+echo "DEMO - Race children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'RACE' and parent_id = 0) as parent_id,
+    'PERSON',1,'RACE',concept_id,
+    CASE
+        WHEN a.race_concept_id = 0 THEN 'Unknown'
+        ELSE regexp_replace(b.concept_name, r'^.+:\s', '')
+    END as name,
+    a.cnt,0,1,0,0
+FROM
+    (
+        SELECT race_concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+        GROUP BY 1
+    ) a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.race_concept_id = b.concept_id
+WHERE b.concept_id is not null"
+
+echo "DEMO - Ethnicity parent"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PERSON',1,'ETHNICITY','Ethnicity',1,0,0,0"
+
+echo "DEMO - Ethnicity children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'ETHNICITY' and parent_id = 0) as parent_id,
+    'PERSON',1,'ETHNICITY',concept_id,
+    regexp_replace(b.concept_name, r'^.+:\s', ''),
+    a.cnt,0,1,0,0
+FROM
+    (
+        SELECT ethnicity_concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+        GROUP BY 1
+    ) a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ethnicity_concept_id = b.concept_id
+WHERE b.concept_id is not null"
+
+
+################################################
+# VISITS
+################################################
+echo "VISITS - add items with counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+SELECT ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+    0,'VISIT',1,'VISIT',concept_id,concept_name,a.cnt,0,1,0,0
+FROM
+    (
+        select visit_concept_id, count(distinct person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\`
+        group by 1
+    ) a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b ON a.visit_concept_id = b.concept_id
+where b.domain_id = 'Visit'
+    and b.standard_concept = 'S'"
+
+
+################################################
+# CONDITIONS
+################################################
+# ----- SOURCE SNOMED -----
+echo "CONDITIONS - SOURCE SNOMED - temp table level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
+where concept_id in
+    (
+        select distinct condition_source_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
+        where condition_source_concept_id != 0
+            and b.domain_id = 'Condition'
+            and b.vocabulary_id = 'SNOMED'
+    )"
+
+# currently, there are only 5 levels, but we run it 6 times to be safe
+for i in {1..6};
+do
+    echo "CONDITIONS - SOURCE SNOMED - temp table level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
+    where concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+        )
+        and concept_id not in
+            (
+                select CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+            )"
+done
+
+echo "CONDITIONS - SOURCE SNOMED - add root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'CONDITION',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+where concept_id = 441840"
+
+echo "CONDITIONS - SOURCE SNOMED - add level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'CONDITION'
+    and p.type = 'SNOMED'
+    and p.is_standard = 0
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        )
+    and c.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+        )"
+
+# currently, there are only 16 levels, but we run it 18 times to be safe (if changed, change number of joins in next query)
+for i in {1..18};
+do
+    echo "CONDITIONS - SOURCE SNOMED - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+        case when l.concept_code is null then 1 else 0 end,
+        1,0,1,
+        CONCAT(p.path, '.',
+            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
+    left join
+        (
+            select distinct a.concept_code
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` b on a.concept_id = b.p_concept_id
+            where b.concept_id is null
+        ) l on c.concept_code = l.concept_code
+    where p.domain_id = 'CONDITION'
+        and p.type = 'SNOMED'
+        and p.is_standard = 0
+        and p.id not in
+            (
+                select parent_id
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )"
+done
+
+# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+echo "CONDITIONS - SOURCE SNOMED - add items into temp ancestor table for use in next query"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
+    concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
+SELECT DISTINCT a.concept_id as ancestor_concept_id
+    , a.domain_id
+    , a.type
+    , a.is_standard
+    , b.concept_id c1
+    , c.concept_id c2
+    , d.concept_id c3
+    , e.concept_id c4
+    , f.concept_id c5
+    , g.concept_id c6
+    , h.concept_id c7
+    , i.concept_id c8
+    , j.concept_id c9
+    , k.concept_id c10
+    , m.concept_id c11
+    , n.concept_id as c12
+    , o.concept_id as c13
+    , p.concept_id as c14
+    , q.concept_id as c15
+    , r.concept_id as c16
+    , s.concept_id as c17
+    , t.concept_id as c18
+FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
+    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) o on n.id = o.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) p on o.id = p.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) q on p.id = q.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) r on q.id = r.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) s on r.id = s.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) t on s.id = t.parent_id"
+
+# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+# the last UNION statement is to add the ancestor item to itself
+echo "CONDITIONS - SOURCE SNOMED - add items into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+    (ancestor_concept_id, descendant_concept_id, is_standard)
+SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_18 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_17 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_16 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_15 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_14 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_13 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_12 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_11 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_10 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_9 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_8 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_7 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_6 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_5 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_4 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_3 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_2 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_1 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 0"
+
+echo "CONDITIONS - SOURCE SNOMED - child counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT condition_source_concept_id as concept_id, COUNT(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
+        GROUP BY 1
+    ) y
+WHERE x.concept_id = y.concept_id
+    and x.domain_id = 'CONDITION'
+    and x.type = 'SNOMED'
+    and x.is_standard = 0
+    and x.is_group = 0
+    and x.is_selectable = 1"
+
+echo "CONDITIONS - SOURCE SNOMED - parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+FROM
+    (
+        SELECT ancestor_concept_id as concept_id, COUNT(distinct person_id) cnt
+        FROM
+            (
+                SELECT *
+                FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                WHERE ancestor_concept_id in
+                    (
+                        SELECT distinct concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        WHERE domain_id = 'CONDITION'
+                            and type = 'SNOMED'
+                            and is_standard = 0
+                            and parent_id != 0
+                            and is_group = 1
+                    )
+                    and is_standard = 0
+            ) a
+        JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_source_concept_id
+        GROUP BY 1
+    ) y
+WHERE x.concept_id = y.concept_id
+    and x.domain_id = 'CONDITION'
+    and x.type = 'SNOMED'
+    and x.is_standard = 0
+    and x.is_group = 1"
+
+# ----- STANDARD SNOMED -----
+echo "CONDITIONS - STANDARD SNOMED - temp table level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
+where concept_id in
+    (
+        select distinct condition_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
+        where condition_concept_id != 0
+            and b.domain_id = 'Condition'
+            and b.standard_concept = 'S'
+            and b.vocabulary_id = 'SNOMED'
+    )"
+
+# currently, there are only 5 levels, but we run it 6 times to be safe
+for i in {1..6};
+do
+    echo "CONDITIONS - STANDARD SNOMED - temp table level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
+    where concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+        )
+      and concept_id not in
+        (
+            select CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+        )"
+done
+
+echo "CONDITIONS - STANDARD SNOMED - add root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'CONDITION',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+where concept_id = 441840"
+
+echo "CONDITIONS - STANDARD SNOMED - add level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'CONDITION'
+    and p.type = 'SNOMED'
+    and p.is_standard = 1
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        )
+    and c.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+        )"
+
+# currently, there are only 17 levels, but we run it 18 times to be safe. If this changes, change the next query
+for i in {1..18};
+do
+    echo "CONDITIONS - STANDARD SNOMED - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+        case when l.concept_code is null then 1 else 0 end,
+        1,0,1,
+        CONCAT(p.path, '.',
+            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
+    left join
+        (
+            select distinct a.CONCEPT_CODE
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` b on a.concept_id = b.p_concept_id
+            where b.concept_id is null
+        ) l on c.concept_code = l.concept_code
+    where p.domain_id = 'CONDITION'
+        and p.type = 'SNOMED'
+        and p.is_standard = 1
+        and p.id not in
+            (
+                select PARENT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )"
+done
+
+# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+echo "CONDITIONS - STANDARD SNOMED - add items into temp ancestor table for use in next query"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
+    concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
+SELECT DISTINCT a.concept_id as ancestor_concept_id
+    , a.domain_id
+    , a.type
+    , a.is_standard
+    , b.concept_id c1
+    , c.concept_id c2
+    , d.concept_id c3
+    , e.concept_id c4
+    , f.concept_id c5
+    , g.concept_id c6
+    , h.concept_id c7
+    , i.concept_id c8
+    , j.concept_id c9
+    , k.concept_id c10
+    , m.concept_id c11
+    , n.concept_id as c12
+    , o.concept_id as c13
+    , p.concept_id as c14
+    , q.concept_id as c15
+    , r.concept_id as c16
+    , s.concept_id as c17
+    , t.concept_id as c18
+FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
+    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) o on n.id = o.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) p on o.id = p.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) q on p.id = q.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) r on q.id = r.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) s on r.id = s.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) t on s.id = t.parent_id"
+
+# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+# there last UNION statement is to add the ancestor item to itself
+echo "CONDITIONS - STANDARD SNOMED - add items into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+    (ancestor_concept_id, descendant_concept_id, is_standard)
+SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_18 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_17 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_16 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_15 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_14 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_13 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_12 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_11 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_10 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_9 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_8 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_7 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_6 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_5 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_4 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_3 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_2 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_1 is not null
+    and domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE domain_id = 'CONDITION'
+    and type = 'SNOMED'
+    and is_standard = 1"
+
+echo "CONDITIONS - STANDARD SNOMED - child counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select condition_concept_id as concept_id, count(distinct person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'CONDITION'
+    and x.type = 'SNOMED'
+    and x.is_standard = 1
+    and x.is_group = 0
+    and x.is_selectable = 1"
+
+echo "CONDITIONS - STANDARD SNOMED - parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+        from
+            (
+                select *
+                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                where ancestor_concept_id in
+                    (
+                        select distinct concept_id
+                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        where domain_id = 'CONDITION'
+                            and type = 'SNOMED'
+                            and is_standard = 1
+                            and parent_id != 0
+                            and is_group = 1
+                    )
+                    and is_standard = 1
+            ) a
+        join \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_concept_id
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'CONDITION'
+    and x.type = 'SNOMED'
+    and x.is_standard = 1
+    and x.is_group = 1"
+
+
+################################################
+# MEASUREMENTS
+################################################
+echo "MEASUREMENTS - add clinical root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+    0,'MEASUREMENT',1,'LOINC','CLIN',36207527,'LP248771-0','Clinical',1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
+
+echo "MEASUREMENTS - add lab root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+    0,'MEASUREMENT',1,'LOINC','LAB',36206173,'LP29693-6','Lab',1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
+
+# ----- LOINC CLINICAL -----
+echo "MEASUREMENTS - clinical - add parents"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN') as parent_id,
+    'MEASUREMENT',1,'LOINC','CLIN',name,1,0,0,1,
+    CONCAT( (SELECT PATH FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN'), '.',
+        CAST(ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+from
+    (
+        select distinct parent as name
+        from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b using (concept_id)
+        where b.concept_id in
+            (
+                select distinct measurement_concept_id
+                from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+            )
+    ) x"
+
+# add items with vocabulary_id = 'LOINC' and concept_class_id = 'Clinical Observation' where we have categorized them
+echo "MEASUREMENTS - clinical - add children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    parent_id,'MEASUREMENT',1,'LOINC','CLIN',concept_id,concept_code,concept_name,est_count,0,1,0,1,
+    CONCAT(parent_path, '.',
+        CAST(ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from
+    (
+        select z.*, y.id as parent_id, y.path as parent_path
+        from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` x
+        join
+            (
+                select id,name,path
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                where type = 'LOINC'
+                    and subtype = 'CLIN'
+                    and is_group = 1
+            ) y on x.parent = y.name
+        join
+            (
+                select concept_name, concept_id, concept_code, count(distinct person_id) est_count
+                from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+                where standard_concept = 'S'
+                    and domain_id = 'Measurement'
+                    and vocabulary_id = 'LOINC'
+                group by 1,2,3
+            ) z on x.concept_id = z.concept_id
+    ) g"
+
+#----- LOINC LABS -----
+echo "MEASUREMENTS - labs - load temp table 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
+where concept_id in
+    (
+        select distinct MEASUREMENT_CONCEPT_ID
+        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.MEASUREMENT_CONCEPT_ID = b.concept_id
+        where MEASUREMENT_CONCEPT_ID != 0
+            and b.vocabulary_id = 'LOINC'
+            and b.STANDARD_CONCEPT = 'S'
+            and b.domain_id = 'Measurement'
+    )"
+
+# currently, there are only 4 levels, but we run it 5 times to be safe
+for i in {1..5};
+do
+    echo "MEASUREMENTS - labs - load temp table $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
+    where concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+        )
+        and concept_id not in
+            (
+                select CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+            )"
+done
+
+echo "MEASUREMENTS - labs - add roots - level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    t.ID,'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE,b.CONCEPT_NAME,1,0,0,1,
+    CONCAT( t.path, '.',
+        CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
+join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
+where (t.id) not in (select PARENT_ID from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)
+    and t.type = 'LOINC'
+    and t.subtype = 'LAB'
+    and b.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+        )"
+
+# for each loop, add all items (children/parents) directly under the items that were previously added
+# currently, there are only 11 levels, but we run it 12 times to be safe
+# if this number is changed, you will need to change the number of JOINS in the query below adding data to the ancestor table
+for i in {1..12};
+do
+    echo "MEASUREMENTS - labs - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        t.ID, 'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE, b.CONCEPT_NAME,
+        case when l.CONCEPT_CODE is null then null else m.cnt end as est_count,
+        case when l.CONCEPT_CODE is null then 1 else 0 end as is_group,
+        case when l.CONCEPT_CODE is null then 0 else 1 end as is_selectable,
+        0,1,
+        CONCAT(t.path, '.',
+            CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
+    join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
+    left join
+        (
+            select distinct a.CONCEPT_CODE
+            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on a.CONCEPT_ID = b.P_CONCEPT_ID
+            where b.CONCEPT_ID is null
+        ) l on b.CONCEPT_CODE = l.CONCEPT_CODE
+    left join
+        (
+            select measurement_concept_id, count(distinct person_id) cnt
+            from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+            group by 1
+        ) m on b.concept_id = m.measurement_concept_id
+    where
+        t.id not in
+            (
+                select parent_id
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                where type = 'LOINC'
+                    and subtype = 'LAB'
+            )
+        and parent_id != 0"
+done
+
+echo "MEASUREMENTS - labs - add parent for uncategorized labs"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+    a.id as parent_id,'MEASUREMENT',1,'LOINC','LAB','Uncategorized',1,0,0,1,
+    CONCAT(a.path, '.', CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING))
+FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+WHERE type = 'LOINC' and subtype = 'LAB' and parent_id = 0"
+
+echo "MEASUREMENTS - labs - add uncategorized labs"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as parent_id,
+    'MEASUREMENT',1,'LOINC','LAB',concept_id,concept_code,concept_name,est_count,0,1,0,1,
+    CONCAT( (select path from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` where type = 'LOINC' and subtype = 'LAB' and name = 'Uncategorized'), '.',
+        CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+from
+    (
+        select concept_id, concept_code, concept_name, count(distinct person_id) est_count
+        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+        where standard_concept = 'S'
+            and domain_id = 'Measurement'
+            and vocabulary_id = 'LOINC'
+            and measurement_concept_id not in
+                (
+                    select concept_id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where type = 'LOINC'
+                    and concept_id is not null
+                )
+        group by 1,2,3
+    ) x"
+
+# if loop count above is changed, the number of JOINS below must be updated
+echo "MEASUREMENTS - labs - add data into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+    (ancestor_id, descendant_id)
+SELECT DISTINCT a.id as ancestor_id,
+    COALESCE(n.id, m.id, k.id, j.id, i.id, h.id, g.id, f.id, e.id, d.id, c.id, b.id) as descendant_id
+FROM
+    (SELECT id, parent_id, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB' and parent_id != 0 and is_group = 1) a
+    JOIN (SELECT id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') b on a.id = b.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') c on b.id = c.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') d on c.id = d.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') e on d.id = e.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') f on e.id = f.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') g on f.id = g.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') h on g.id = h.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') i on h.id = i.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') j on i.id = j.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') k on j.id = k.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') m on k.id = m.parent_id
+    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') n on m.id = n.parent_id"
+
+echo "MEASUREMENTS - labs - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select e.id, count(distinct person_id) cnt
+        from
+            (
+                select * from
+                (
+                    select id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where type = 'LOINC'
+                        and subtype = 'LAB'
+                        and is_group = 1
+                        and parent_id != 0
+                ) a
+                left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) e
+        left join
+            (
+                select c.id, d.*
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                join
+	                (
+		                SELECT person_id, concept_id
+		                FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+						join
+			                (
+								select concept_id
+								from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+			                	where type = 'LOINC'
+									and subtype = 'LAB'
+									and is_selectable = 1
+			                ) b on a.measurement_concept_id = b.concept_id
+	                ) d on c.concept_id = d.concept_id
+            ) f on e.descendant_id = f.id
+        group by 1
+    ) y
+where x.id = y.id"
+
+
+#----- SNOMED -----
+echo "MEASUREMENTS - SNOMED - temp table level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
+where concept_id in
+    (
+        select distinct measurement_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+        where measurement_concept_id != 0
+            and b.vocabulary_id = 'SNOMED'
+            and b.STANDARD_CONCEPT = 'S'
+            and b.domain_id = 'Measurement'
+    )"
+
+# for each loop, add all items (children/parents) directly under the items that were previously added
+# currently, there are only 3 levels, but we run it 4 times to be safe
+for i in {1..4};
+do
+    echo "MEASUREMENTS - SNOMED - temp table level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
+    where concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+        )
+        and concept_id not in
+            (
+                select CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+            )"
+done
+
+echo "MEASUREMENTS - SNOMED - add roots"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    0, 'MEASUREMENT',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+    CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+from
+    (
+        select distinct concept_id, concept_name, concept_code
+        from
+            (
+                select *, rank() over (partition by descendant_concept_id order by MAX_LEVELS_OF_SEPARATION desc) rnk
+                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
+                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.concept_id
+                where b.domain_id = 'Measurement'
+                    and b.vocabulary_id = 'SNOMED'
+                    and a.descendant_concept_id in
+                        (
+                            select distinct concept_id
+                            from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+                            left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+                            where standard_concept = 'S'
+                                and domain_id = 'Measurement'
+                                and vocabulary_id = 'SNOMED'
+                        )
+            ) a
+        where rnk = 1
+    ) x"
+
+echo "MEASUREMENTS - SNOMED - add level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,0,0,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'MEASUREMENT'
+    and p.type = 'SNOMED'
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        )
+    and c.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+        )"
+
+# for each loop, add all items (children/parents) directly under the items that were previously added
+# currently, there are only 6 levels, but we run it 7 times to be safe
+for i in {1..7};
+do
+    echo "MEASUREMENTS - SNOMED - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+        case when l.concept_code is null then 1 else 0 end,
+        case when l.concept_code is null then 0 else 1 end,
+        0,1,
+        CONCAT(p.path, '.',
+            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
+    left join
+        (
+            select distinct a.concept_code
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` b on a.concept_id = b.p_concept_id
+            where b.concept_id is null
+        ) l on c.concept_code = l.concept_code
+    where p.domain_id = 'MEASUREMENT'
+        and p.type = 'SNOMED'
+        and p.id not in
+            (
+                select parent_id
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )
+        and c.concept_id not in
+            (
+                select parent_id
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )"
+done
+
+echo "MEASUREMENTS - SNOMED - generate counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+        from
+            (
+                select *
+                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                where ancestor_concept_id in
+                    (
+                        select distinct concept_id
+                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        where domain_id = 'MEASUREMENT'
+                            and type = 'SNOMED'
+                    )
+            ) a
+        join \`$BQ_PROJECT.$BQ_DATASET.measurement\` b on a.descendant_concept_id = b.measurement_concept_id
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'MEASUREMENT'
+    and x.type = 'SNOMED'"
+
+echo "MEASUREMENTS - SNOMED - add parents as children"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select (row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)) as ID,
+    id as parent_id,domain_id,is_standard,type,concept_id,code,name,cnt,0,1,0,1,CONCAT(path, '.',
+    CAST(row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+from
+    (
+        select *
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+        join
+            (
+                select measurement_concept_id, count(distinct person_id) cnt
+                from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+                group by 1
+            ) b on a.concept_id = b.measurement_concept_id
+        where domain_id = 'MEASUREMENT'
+            and type = 'SNOMED'
+            and is_group = 1
+    ) x"
+
+
+################################################
+# DRUG EXPOSURE
+################################################
+#----- RXNORM / RXNORM EXTENSION -----
+# ATC4 - ATC5 --> RXNORM/RXNORM Extension ingredient
+# ATC4 - ATC5 --> RXNORM/RXNORM Extension precise ingedient --> RXNORM ingredient
+echo "DRUGS - temp table - ATC4 to RXNORM"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+SELECT distinct e.p_concept_id, e.p_concept_code, e.p_concept_name, e.p_DOMAIN_ID,
+    d.CONCEPT_ID, d.CONCEPT_CODE, d.CONCEPT_NAME, d.DOMAIN_ID
+from
+    (
+        SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c2.CONCEPT_ID atc_5
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, atc, atc_5th
+        WHERE a.RELATIONSHIP_ID IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
+            and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
+            and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 5th' and c2.STANDARD_CONCEPT = 'C'
+            and c1.concept_id in
+                (
+                    SELECT ANCESTOR_CONCEPT_ID
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                    WHERE DESCENDANT_CONCEPT_ID in
+                        (
+                            SELECT distinct DRUG_CONCEPT_ID
+                            FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                        )
+                )
+        UNION ALL
+        SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c3.CONCEPT_ID atc_5
+        FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, rxnorm, precise ingredient
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` b on a.CONCEPT_ID_2 = b.CONCEPT_ID_1
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on b.CONCEPT_ID_2 = c3.CONCEPT_ID--child, atc, atc_5th
+        WHERE a.RELATIONSHIP_ID = 'Has form' and b.RELATIONSHIP_ID = 'RxNorm - ATC'
+            and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
+            and c2.VOCABULARY_ID = 'RxNorm' and c2.CONCEPT_CLASS_ID = 'Precise Ingredient'
+            and c3.VOCABULARY_ID = 'ATC' and c3.CONCEPT_CLASS_ID = 'ATC 5th' and c3.STANDARD_CONCEPT = 'C'
+            and c1.concept_id in
+                (
+                    SELECT ANCESTOR_CONCEPT_ID
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                    WHERE DESCENDANT_CONCEPT_ID in
+                        (
+                            SELECT distinct DRUG_CONCEPT_ID
+                            FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                        )
+                )
+    ) d
+left join
+    (
+        select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+            c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID as atc_5, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+        from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID --parent, atc, atc_4
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID --child, atc, atc_5
+        where RELATIONSHIP_ID = 'Subsumes'
+            and c1.VOCABULARY_ID = 'ATC'
+            and c1.CONCEPT_CLASS_ID = 'ATC 4th'
+            and c1.STANDARD_CONCEPT = 'C'
+            and c2.VOCABULARY_ID = 'ATC'
+            and c2.CONCEPT_CLASS_ID = 'ATC 5th'
+            and c2.STANDARD_CONCEPT = 'C'
+    ) e on d.atc_5 = e.atc_5"
+
+echo "DRUGS - temp table - ATC3 to ATC4"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+    left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+    left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+where RELATIONSHIP_ID = 'Subsumes'
+    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 3rd' and c1.STANDARD_CONCEPT = 'C'
+    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 4th' and c2.STANDARD_CONCEPT = 'C'
+    and c2.concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )
+    and c2.concept_id not in
+        (
+            select CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )"
+
+echo "DRUGS - temp table - ATC2 TO ATC3"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+where RELATIONSHIP_ID = 'Subsumes'
+    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 2nd' and c1.STANDARD_CONCEPT = 'C'
+    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 3rd' and c2.STANDARD_CONCEPT = 'C'
+    and c2.concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )
+    and c2.concept_id not in
+        (
+            select CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )"
+
+echo "DRUGS - temp table - ATC1 TO ATC2"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+where RELATIONSHIP_ID = 'Subsumes'
+    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 1st' and c1.STANDARD_CONCEPT = 'C'
+    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 2nd' and c2.STANDARD_CONCEPT = 'C'
+    and c2.concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )
+    and c2.concept_id not in
+        (
+            select CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+        )"
+
+echo "DRUGS - add roots"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    0, 'DRUG', 1, 'ATC', concept_id, concept_code, CONCAT( UPPER(SUBSTR(concept_name, 1, 1)), LOWER(SUBSTR(concept_name, 2)) ),
+    1,0,0,1,1,
+    CAST(ROW_NUMBER() OVER(order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+where VOCABULARY_ID = 'ATC'
+    and CONCEPT_CLASS_ID = 'ATC 1st'
+    and STANDARD_CONCEPT = 'C'"
+
+echo "DRUGS - add root for unmapped ingredients"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'DRUG',1,'ATC','Unmapped ingredients',1,0,0,1,1,
+    CAST( (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING ) as path"
+
+echo "DRUGS - level 2"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'DRUG'
+    and p.type = 'ATC'
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            where domain_id = 'DRUG'
+                and type = 'ATC'
+        )"
+
+echo "DRUGS - level 3"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'DRUG'
+    and p.type = 'ATC'
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            where domain_id = 'DRUG'
+                and type = 'ATC'
+        )"
+
+echo "DRUGS - level 4"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'DRUG'
+    and p.type = 'ATC'
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            where domain_id = 'DRUG'
+                and type = 'ATC'
+        )"
+
+echo "DRUGS - level 5 - ingredients"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'DRUG',1,'RXNORM',c.concept_id,c.concept_code,
+    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),0,1,0,1,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'DRUG'
+    and p.type = 'ATC'
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            where domain_id = 'DRUG'
+                and type = 'ATC'
+        )"
+
+echo "DRUGS - add parents for unmapped ingredients"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    (select id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients') as parent_id,
+    'DRUG',1,'ATC',name as code, name,1,0,0,1,1,
+    CONCAT( (select CAST(id as STRING) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients'),
+        '.', CAST(ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+from
+    (
+        select distinct UPPER(SUBSTR(concept_name, 1, 1)) name
+        from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+            and CONCEPT_CLASS_ID = 'Ingredient'
+            and STANDARD_CONCEPT = 'S'
+            and concept_id in
+                (
+                    select ANCESTOR_CONCEPT_ID
+                    from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                    where DESCENDANT_CONCEPT_ID in
+                        (
+                            select distinct DRUG_CONCEPT_ID
+                            from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                        )
+                )
+            and concept_id not in
+                (
+                    select concept_id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where domain_id = 'DRUG'
+                        and concept_id is not null
+                )
+
+    ) x"
+
+echo "DRUGS - add unmapped ingredients"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+select row_number() over (order by z.id, upper(x.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    z.id,'DRUG',1,'RXNORM',x.concept_id,x.concept_code,CONCAT( UPPER(SUBSTR(x.concept_name, 1, 1)), LOWER(SUBSTR(x.concept_name, 2)) ),
+    0,1,0,1,1,
+    CONCAT(z.path, '.',
+        CAST(ROW_NUMBER() OVER(order by z.id, upper(x.concept_name)) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from
+    (
+        select *
+        from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+        where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+            and CONCEPT_CLASS_ID = 'Ingredient'
+            and STANDARD_CONCEPT = 'S'
+            and concept_id in
+                (
+                    select ANCESTOR_CONCEPT_ID
+                    from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                    where DESCENDANT_CONCEPT_ID in
+                        (
+                            select distinct DRUG_CONCEPT_ID
+                            from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                        )
+                )
+            and concept_id not in
+                (
+                    select concept_id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where domain_id = 'DRUG'
+                        and concept_id is not null
+                )
+    ) x
+join
+    (
+        select *
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        where domain_id = 'DRUG'
+            and type = 'ATC'
+            and length(name) = 1
+    ) z on UPPER(SUBSTR(x.concept_name, 1, 1)) = z.name"
+
+echo "DRUGS - generate child counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select b.ANCESTOR_CONCEPT_ID as concept_id, count(distinct a.person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+        join
+            (
+                select *
+                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` x
+                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` y on x.ANCESTOR_CONCEPT_ID = y.CONCEPT_ID
+                where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+                    and CONCEPT_CLASS_ID = 'Ingredient'
+            ) b on a.DRUG_CONCEPT_ID = b.DESCENDANT_CONCEPT_ID
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'DRUG'
+    and x.type = 'RXNORM'"
+
+echo "DRUGS - add brand names"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy)
+select ROW_NUMBER() OVER(ORDER BY upper(concept_name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+    0,'DRUG',1,'BRAND',concept_id,concept_code,concept_name,0,1,0,0
+FROM
+    (
+        select distinct b.concept_id, b.concept_name, b.concept_code
+        from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.CONCEPT_ID_1 = b.CONCEPT_ID --brands
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.CONCEPT_ID_2 = c.CONCEPT_ID --ingredients
+        where b.vocabulary_id in ('RxNorm','RxNorm Extension')
+            and b.concept_class_id = 'Brand Name'
+            and b.invalid_reason is null
+            and c.concept_id in
+                (
+                    select concept_id
+                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    where domain_id = 'DRUG'
+                        and type = 'RXNORM'
+                        and is_group = 0
+                        and is_selectable = 1
+                )
+    ) x"
+
+echo "DRUGS - add data into prep_criteria_ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+    (ancestor_id, descendant_id)
+SELECT DISTINCT a.id as ancestor_id,
+    COALESCE(e.id, d.id, c.id, b.id) as descendant_id
+FROM (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM') and is_group = 1 and is_selectable = 1) a
+JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) b on a.id = b.parent_id
+LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) c on b.id = c.parent_id
+LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) d on c.id = d.parent_id
+LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) e on d.id = e.parent_id"
+
+echo "DRUGS - generate parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select g.id, count(distinct person_id) cnt
+        from
+            (
+                select *
+                from
+                    (
+                        select id
+                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        where domain_id = 'DRUG'
+                            and type = 'ATC'
+                            and is_group = 1
+                            and is_selectable = 1
+                    ) a
+                    left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+            ) g
+        left join
+            (
+                select e.id, f.*
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` e
+                join
+                    (
+                        select d.ANCESTOR_CONCEPT_ID as concept_id, c.person_id
+                        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` c
+                        join
+                            (
+                                select *
+                                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
+                                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.CONCEPT_ID
+                                where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+                                    and CONCEPT_CLASS_ID = 'Ingredient'
+                            ) d on c.DRUG_CONCEPT_ID = d.DESCENDANT_CONCEPT_ID
+                    ) f on e.concept_id = f.concept_id
+            ) h on g.descendant_id = h.id
+        group by 1
+    ) y
+where x.id = y.id"
+
+
+################################################
+# PROCEDURES
+################################################
+#----- STANDARD SNOMED -----
+echo "PROCEDURES - STANDARD SNOMED - temp table level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
+where concept_id in
+    (
+        select distinct procedure_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
+        where procedure_concept_id != 0
+            and b.domain_id = 'Procedure'
+            and b.vocabulary_id = 'SNOMED'
+            and b.standard_concept = 'S'
+    )"
+
+# currently, there are only 8 levels, but we run it 9 times to be safe
+for i in {1..9};
+do
+    echo "PROCEDURES - STANDARD SNOMED - temp table level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
+    where
+        concept_id in
+            (
+                select P_CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+            )
+        and concept_id not in
+            (
+                select CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+            )"
+done
+
+echo "PROCEDURES - STANDARD SNOMED - add root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select (select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1,
+    0,'PROCEDURE',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+where concept_id = 4322976"
+
+echo "PROCEDURES - STANDARD SNOMED - add level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'PROCEDURE'
+    and p.type = 'SNOMED'
+    and p.is_standard = 1
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        )
+    and c.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+        )"
+
+# currently, there are only 11 levels, but we run it 12 times to be safe, If this count changes, change the query below
+for i in {1..12};
+do
+    echo "PROCEDURES - STANDARD SNOMED - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+        case when l.concept_code is null then 1 else 0 end,
+        1,0,1,
+        CONCAT(p.path, '.',
+            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
+    left join
+        (
+            select distinct a.CONCEPT_CODE
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` b on a.concept_id = b.p_concept_id
+            where b.concept_id is null
+        ) l on c.concept_code = l.concept_code
+    where p.domain_id = 'PROCEDURE'
+        and p.type = 'SNOMED'
+        and p.is_standard = 1
+        and p.id not in
+            (
+                select PARENT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )"
+done
+
+# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+echo "PROCEDURES - STANDARD SNOMED - add items into temp ancestor table for use in next query"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
+SELECT DISTINCT a.concept_id as ancestor_concept_id
+    , a.domain_id
+    , a.type
+    , a.is_standard
+    , b.concept_id c1
+    , c.concept_id c2
+    , d.concept_id c3
+    , e.concept_id c4
+    , f.concept_id c5
+    , g.concept_id c6
+    , h.concept_id c7
+    , i.concept_id c8
+    , j.concept_id c9
+    , k.concept_id c10
+    , m.concept_id c11
+    , n.concept_id as c12
+FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
+    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id"
+
+# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+# there last UNION statement is to add the ancestor item to itself
+echo "PROCEDURES - STANDARD SNOMED - add items into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+    (ancestor_concept_id, descendant_concept_id, is_standard)
+SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_12 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_11 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_10 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_9 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_8 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_7 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_6 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_5 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_4 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_3 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_2 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_1 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 1"
+
+echo "PROCEDURES - STANDARD SNOMED - generate child counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        SELECT procedure_concept_id as concept_id, count(distinct person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
+        GROUP BY 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'PROCEDURE'
+    and x.type = 'SNOMED'
+    and x.is_standard = 1
+    and x.is_group = 0
+    and x.is_selectable = 1"
+
+echo "PROCEDURES - STANDARD SNOMED - parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+        from
+            (
+                select *
+                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                where ancestor_concept_id in
+                    (
+                        select distinct concept_id
+                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        where domain_id = 'PROCEDURE'
+                            and type = 'SNOMED'
+                            and is_standard = 1
+                            and parent_id != 0
+                            and is_group = 1
+                    )
+                    and is_standard = 1
+            ) a
+        join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_concept_id
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'PROCEDURE'
+    and x.type = 'SNOMED'
+    and x.is_standard = 1
+    and x.is_group = 1"
+
+# ----- SOURCE SNOMED -----
+echo "PROCEDURES - SOURCE SNOMED - temp table level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+select *
+from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
+where concept_id in
+    (
+        select distinct procedure_source_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
+        where procedure_source_concept_id != 0
+            and b.domain_id = 'Procedure'
+            and b.vocabulary_id = 'SNOMED'
+    )"
+
+# currently, there are only 8 levels, but we run it 9 times to be safe
+for i in {1..9};
+do
+    echo "PROCEDURES - SOURCE SNOMED - temp table level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+    select *
+    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
+    where concept_id in
+        (
+            select P_CONCEPT_ID
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+        )
+        and concept_id not in
+            (
+                select CONCEPT_ID
+                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+            )"
+done
+
+echo "PROCEDURES - SOURCE SNOMED - add root"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+    0,'PROCEDURE',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+where concept_id = 4322976"
+
+echo "PROCEDURES - SOURCE SNOMED - add level 0"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+    p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+    CONCAT(p.path, '.',
+        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
+where p.domain_id = 'PROCEDURE'
+    and p.type = 'SNOMED'
+    and p.is_standard = 0
+    and p.id not in
+        (
+            select parent_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        )
+    and c.concept_id in
+        (
+            select p_concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+        )"
+
+# currently, there are only 11 levels, but we run it 12 times to be safe (if changed, change number of joins in next query)
+for i in {1..12};
+do
+    echo "PROCEDURES - SOURCE SNOMED - add level $i"
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+        p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+        case when l.concept_code is null then 1 else 0 end,
+        1,0,1,
+        CONCAT(p.path, '.',
+            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
+    left join
+        (
+            select distinct a.concept_code
+            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` a
+            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` b on a.concept_id = b.p_concept_id
+            where b.concept_id is null
+        ) l on c.concept_code = l.concept_code
+    where p.domain_id = 'PROCEDURE'
+        and p.type = 'SNOMED'
+        and p.is_standard = 0
+        and p.id not in
+            (
+                select parent_id
+                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            )"
+done
+
+# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+echo "PROCEDURES - SOURCE SNOMED - add items into temp ancestor table for use in next query"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
+SELECT DISTINCT a.concept_id as ancestor_concept_id
+    , a.domain_id
+    , a.type
+    , a.is_standard
+    , b.concept_id c1
+    , c.concept_id c2
+    , d.concept_id c3
+    , e.concept_id c4
+    , f.concept_id c5
+    , g.concept_id c6
+    , h.concept_id c7
+    , i.concept_id c8
+    , j.concept_id c9
+    , k.concept_id c10
+    , m.concept_id c11
+    , n.concept_id as c12
+FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
+    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
+    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id"
+
+# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+# there last UNION statement is to add the ancestor item to itself
+echo "PROCEDURES - SOURCE SNOMED - add items into ancestor table"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+    (ancestor_concept_id, descendant_concept_id, is_standard)
+SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_12 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_11 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_10 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_9 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_8 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_7 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_6 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_5 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_4 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_3 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_2 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE concept_id_1 is not null
+    and domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0
+UNION DISTINCT
+SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+WHERE domain_id = 'PROCEDURE'
+    and type = 'SNOMED'
+    and is_standard = 0"
+
+echo "PROCEDURES - SOURCE SNOMED - child counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.est_count = y.cnt
+from
+    (
+        select procedure_source_concept_id as concept_id, count(distinct person_id) cnt
+        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'PROCEDURE'
+    and x.type = 'SNOMED'
+    and x.is_standard = 0
+    and x.is_group = 0
+    and x.is_selectable = 1"
+
+echo "PROCEDURES - SOURCE SNOMED - parent counts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+SET x.est_count = y.cnt
+from
+    (
+        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+        from
+            (
+                select *
+                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                where ancestor_concept_id in
+                    (
+                        select distinct concept_id
+                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                        where domain_id = 'PROCEDURE'
+                            and type = 'SNOMED'
+                            and is_standard = 0
+                            and parent_id != 0
+                            and is_group = 1
+                    )
+                    and is_standard = 0
+            ) a
+        join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_source_concept_id
+        group by 1
+    ) y
+where x.concept_id = y.concept_id
+    and x.domain_id = 'PROCEDURE'
+    and x.type = 'SNOMED'
+    and x.is_standard = 0
+    and x.is_group = 1"
+
+
+################################################
+# CB_CRITERIA_ANCESTOR
+################################################
+echo "CB_CRITERIA_ANCESTOR - Drugs - add ingredients to drugs mapping"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+    (ancestor_id, descendant_id)
+select ancestor_concept_id, descendant_concept_id
+from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+where ancestor_concept_id in
+    (
+        select distinct concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        where domain_id = 'DRUG'
+            and type = 'RXNORM'
+            and is_group = 0
+            and is_selectable = 1
+    )
+and descendant_concept_id in
+    (
+        select distinct drug_concept_id
+        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+    )"
+
+
+################################################
+# ADD IN OTHER CODES NOT ALREADY CAPTURED
+################################################
+echo "CONDITIONS - add other source concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+    -1, 'CONDITION', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.condition_concept_id = c.concept_id
+        WHERE a.condition_source_concept_id NOT IN
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE is_standard = 0
+                    and concept_id is not null
+            )
+            and a.condition_source_concept_id != 0
+            and a.condition_source_concept_id is not null
+            and b.concept_id is not null
+            and b.vocabulary_id != 'PPI'
+            and (b.domain_id LIKE 'Condition%' OR c.domain_id = 'Condition')
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "CONDITIONS - add other standard concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    -1, 'CONDITION',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Condition'
+            and condition_concept_id NOT IN
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'CONDITION'
+                        and is_standard = 1
+                        and concept_id is not null
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "PROCEDURES - add other source concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+    -1, 'PROCEDURE', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.procedure_concept_id = c.concept_id
+        WHERE a.procedure_source_concept_id NOT IN
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE is_standard = 0
+                    and concept_id is not null
+            )
+            and a.procedure_source_concept_id != 0
+            and a.procedure_source_concept_id is not null
+            and b.concept_id is not null
+            and b.vocabulary_id != 'PPI'
+            and (b.domain_id = 'Procedure' OR c.domain_id = 'Procedure')
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "PROCEDURES - add other standard concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    -1, 'PROCEDURE',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Procedure'
+            and procedure_concept_id NOT IN
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'PROCEDURE'
+                        and is_standard = 1
+                        and concept_id is not null
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "MEASUREMENTS - add other standard concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    -1, 'MEASUREMENT',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Measurement'
+            and vocabulary_id not in ('PPI')
+            and measurement_concept_id NOT IN
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'MEASUREMENT'
+                        and is_standard = 1
+                        and concept_id is not null
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "DRUGS - add other standard concepts"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+    -1, 'DRUG',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+        FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.drug_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Drug'
+            and drug_concept_id NOT IN
+                (
+                    SELECT descendant_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+                    WHERE ancestor_id in
+                        (
+                            SELECT concept_id
+                            FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                            WHERE domain_id = 'DRUG'
+                                and is_standard = 1
+                        )
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
+
+################################################
+# CB_CRITERIA_ATTRIBUTE
+################################################
+echo "CB_CRITERIA_ATTRIBUTE - PPI SURVEY - add values for certain questions"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+    (id, concept_id, value_as_concept_id, concept_name, type, est_count)
+VALUES
+    (1, 1585889, 0, 'MIN', 'NUM', '0'),
+    (2, 1585889, 0, 'MAX', 'NUM', '20'),
+    (3, 1585890, 0, 'MIN', 'NUM', '0'),
+    (4, 1585890, 0, 'MAX', 'NUM', '20'),
+    (5, 1585864, 0, 'MIN', 'NUM', '0'),
+    (6, 1585864, 0, 'MAX', 'NUM', '99'),
+    (7, 1585870, 0, 'MIN', 'NUM', '0'),
+    (8, 1585870, 0, 'MAX', 'NUM', '99'),
+    (9, 1585873, 0, 'MIN', 'NUM', '0'),
+    (10, 1585873, 0, 'MAX', 'NUM', '99'),
+    (11, 1586159, 0, 'MIN', 'NUM', '0'),
+    (12, 1586159, 0, 'MAX', 'NUM', '99'),
+    (13, 1586162, 0, 'MIN', 'NUM', '0'),
+    (14, 1586162, 0, 'MAX', 'NUM', '99'),
+    (15, 1585795, 0, 'MIN', 'NUM', '0'),
+    (16, 1585795, 0, 'MAX', 'NUM', '99'),
+    (17, 1585802, 0, 'MIN', 'NUM', '0'),
+    (18, 1585802, 0, 'MAX', 'NUM', '99'),
+    (19, 1585820, 0, 'MIN', 'NUM', '0'),
+    (20, 1585820, 0, 'MAX', 'NUM', '255')
+"
+
+# this code filters out any labs where all results = 0
+echo "CB_CRITERIA_ATTRIBUTE - Measurements - add numeric results"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+    (id, concept_id, value_as_concept_id, concept_name, type, est_count)
+SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
+FROM
+    (
+        SELECT measurement_concept_id, 0, 'MIN', 'NUM', CAST(min(value_as_number) as STRING)
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+        WHERE measurement_concept_id in
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE domain_id = 'MEASUREMENT'
+            )
+            and value_as_number is not null
+        GROUP BY 1
+        HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
+
+        UNION ALL
+
+        SELECT measurement_concept_id, 0, 'MAX', 'NUM', CAST(max(value_as_number) as STRING)
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+        WHERE measurement_concept_id in
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE domain_id = 'MEASUREMENT'
+            )
+            and value_as_number is not null
+        GROUP BY 1
+        HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
+    ) a"
+
+echo "CB_CRITERIA_ATTRIBUTE - Measurements - add categorical results"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+    (id, concept_id, value_as_concept_Id, concept_name, type, est_count)
+SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
+FROM
+    (
+        SELECT measurement_concept_id, value_as_concept_id, b.concept_name, 'CAT' as type, CAST(count(distinct person_id) as STRING)
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_as_concept_Id = b.concept_id
+        WHERE measurement_concept_id in
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE domain_id = 'MEASUREMENT'
+            )
+            and value_as_concept_id != 0
+            and value_as_concept_id is not null
+        GROUP BY 1,2,3
+    ) a"
+
+
+# set has_attributes=1 for any criteria that has data in cb_criteria_attribute
+echo "CB_CRITERIA_ATTRIBUTE - update has_attributes column for measurement criteria"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+SET has_attribute = 1
+WHERE concept_id in
+    (
+        SELECT distinct concept_id
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+    )
+    and domain_id = 'MEASUREMENT'
+    and is_selectable = 1"
+
+
+################################################
+# CB_CRITERIA_RELATIONSHIP
+################################################
+echo "CB_CRITERIA_RELATIONSHIP - Drugs - add drug/ingredient relationships"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+    (concept_id_1, concept_id_2)
+select a.concept_id_1, a.concept_id_2
+from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
+where b.concept_class_id = 'Ingredient'
+    and a.concept_id_1 in
+        (
+            select concept_id
+            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            where domain_id = 'DRUG'
+                and type = 'BRAND'
+        )"
+
+echo "CB_CRITERIA_RELATIONSHIP - Source Concept -> Standard Concept Mapping"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+    (concept_id_1, concept_id_2)
+SELECT a.concept_id_1 as source_concept_id, a.concept_id_2 as standard_concept_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
+WHERE b.standard_concept = 'S'
+    AND a.relationship_id = 'Maps to'
+    AND a.concept_id_1 in
+        (
+            SELECT DISTINCT concept_id
+            FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+            WHERE concept_id is not null
+                and is_standard = 0
+        )"
+
+
+################################################
+# DATA CLEAN UP
+################################################
+echo "CLEAN UP - set est_count = -1 where the count is NULL"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set est_count = -1
+where est_count is null"
+
+echo "CLEAN UP - set has_ancestor_data = 0 for all items where it is currently NULL"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+set has_ancestor_data = 0
+where has_ancestor_data is null"
+
+echo "CLEAN UP - remove all double quotes from criteria names"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+SET name = REGEXP_REPLACE(name, r'[\"]', '')
+WHERE REGEXP_CONTAINS(name, r'[\"]')"
+
+echo "remove lab items from prep_criteria_ancestor that were added during the run"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"DELETE
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+WHERE ancestor_id IN
+    (
+        SELECT id
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        WHERE domain_id = 'MEASUREMENT'
+            and type = 'LOINC'
+            and subtype = 'LAB'
+            and parent_id != 0
+            and is_group = 1
+    )"
+
+echo "remove drug items from prep_criteria_ancestor that were added during the run"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"DELETE
+FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+WHERE ancestor_id IN
+    (
+        SELECT id
+        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        WHERE domain_id = 'DRUG'
+            and type = 'ATC'
+            and is_group = 1
+            and is_selectable = 1
+    )"
+
+
+################################################
+# SYNONYMS
+################################################
+echo "SYNONYMS - add synonym data to criteria"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.synonyms = y.synonyms
+from
+    (
+        select c.id,
+        case
+            when c.name is not null and string_agg(replace(cs.concept_synonym_name,'|','||'),'|') is null then c.name
+            else concat(c.name,'|',string_agg(replace(cs.concept_synonym_name,'|','||'),'|'))
+        end as synonyms
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+        left join \`$BQ_PROJECT.$BQ_DATASET.concept_synonym\` cs on c.concept_id = cs.concept_id
+        where domain_id not in ('SURVEY', 'PERSON')
+        group by c.id, c.name, c.code
+    ) y
+where x.id = y.id"
+
+echo "SYNONYMS - add demographics synonym data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.synonyms = y.synonyms
+from
+    (
+        select id,
+        case
+            when type = 'AGE' and parent_id = 0 then 'Age'
+            when type = 'DECEASED' and parent_id = 0 then 'Deceased'
+            when type = 'GENDER' and parent_id = 0 then 'Gender'
+            when type = 'RACE' and parent_id = 0 then 'Race'
+            when type = 'ETHNICITY' and parent_id = 0 then 'Ethnicity'
+            when type = 'AGE' and parent_id != 0 then null
+        else name
+        end as synonyms
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        where domain_id = 'PERSON'
+    ) y
+where x.id = y.id"
+
+echo "SYNONYMS - add PPI synonym data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.synonyms = x.name
+where domain_id in ('SURVEY')"
+
+# add [rank1] for all items. this is to deal with the poly-hierarchical issue in many trees
+echo "SYNONYMS - add [rank1]"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+set x.synonyms = CONCAT(x.synonyms, '|', y.rnk)
+from
+    (
+        select min(id) as id, CONCAT('[', LOWER(domain_id), '_rank1]') as rnk
+        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+        where synonyms is not null
+            and (est_count != -1 OR (est_count = -1 AND type = 'BRAND'))
+        group by domain_id, is_standard, type, subtype, concept_id, name
+    ) y
+where x.id = y.id"
+
+
+################################################
+# DATABASE CLEAN UP - drop tables/views
+################################################
+#echo "DROP - prep_criteria"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`"
+#
+#echo "DROP - prep_criteria_ancestor"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`"
+#
+#echo "DROP - prep_clinical_terms_nc"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\`"
+#
+#echo "DROP - atc_rel_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`"
+#
+#echo "DROP - loinc_rel_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`"
+#
+#echo "DROP - snomed_rel_cm_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`"
+#
+#echo "DROP - snomed_rel_cm_src_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`"
+#
+#echo "DROP - snomed_rel_pcs_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`"
+#
+#echo "DROP - snomed_rel_meas_in_data"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`"
+#
+#echo "DROP - v_loinc_rel"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\`"
+#
+#echo "DROP - v_snomed_rel_cm"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\`"
+#
+#echo "DROP - v_snomed_rel_cm_src"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\`"
+#
+#echo "DROP - v_snomed_rel_pcs"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\`"
+#
+#echo "DROP - v_snomed_rel_meas"
+#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\`"

--- a/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/generate-cb-criteria-tables.sh
@@ -10,3812 +10,3816 @@
 
 set -ex
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1        # project
+export BQ_DATASET=$2        # dataset
 export DATA_BROWSER_FLAG=$3 # data browser flag
+export DRY_RUN=$4           # dry run
 
-# Check that bq_project exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
+if [ "$DRY_RUN" == false ]
 then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-
-# Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
-then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-re=\\b$BQ_DATASET\\b
-if [[ $datasets =~ $re ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-
-
-################################################
-# CREATE TABLES
-################################################
-# table that holds temp data to get ancestor information for parent counts
-echo "CREATE TABLES - prep_concept_ancestor_temp"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-(
-    ancestor_concept_id     INT64,
-    domain_id               STRING,
-    type                    STRING,
-    is_standard             INT64,
-    concept_id_1            INT64,
-    concept_id_2            INT64,
-    concept_id_3            INT64,
-    concept_id_4            INT64,
-    concept_id_5            INT64,
-    concept_id_6            INT64,
-    concept_id_7            INT64,
-    concept_id_8            INT64,
-    concept_id_9            INT64,
-    concept_id_10           INT64,
-    concept_id_11           INT64,
-    concept_id_12           INT64,
-    concept_id_13           INT64,
-    concept_id_14           INT64,
-    concept_id_15           INT64,
-    concept_id_16           INT64,
-    concept_id_17           INT64,
-    concept_id_18           INT64,
-    concept_id_19           INT64,
-    concept_id_20           INT64
-)"
-
-# table that holds ancestor information for parent counts
-echo "CREATE TABLES - prep_concept_ancestor"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-(
-    ancestor_concept_id     INT64,
-    descendant_concept_id   INT64,
-    is_standard             INT64
-)"
-
-echo "CREATE TABLES - cb_criteria"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-(
-    id                  INT64,
-    parent_id           INT64,
-    domain_id           STRING,
-    is_standard         INT64,
-    type                STRING,
-    subtype             STRING,
-    concept_id          INT64,
-    code                STRING,
-    name                STRING,
-    value               STRING,
-    est_count           INT64,
-    is_group            INT64,
-    is_selectable       INT64,
-    has_attribute       INT64,
-    has_hierarchy       INT64,
-    has_ancestor_data   INT64,
-    path                STRING,
-    synonyms            STRING
-)"
-
-# table that holds the ingredient --> coded drugs mapping
-echo "CREATE TABLES - cb_criteria_ancestor"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-(
-    ancestor_id INT64,
-    descendant_id INT64
-)"
-
-# table that holds categorical results and min/max information about individual labs
-echo "CREATE TABLES - cb_criteria_attribute"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-(
-    id                    INT64,
-    concept_id            INT64,
-    value_as_concept_id	  INT64,
-    concept_name          STRING,
-    type                  STRING,
-    est_count             STRING
-)"
-
-# table that holds the drug brands to ingredients relationship mapping
-echo "CREATE TABLES - cb_criteria_relationship"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-(
-    concept_id_1 INT64,
-    concept_id_2 INT64
-)"
-
-echo "CREATE TABLES - atc_rel_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - loinc_rel_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - snomed_rel_cm_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - snomed_rel_cm_src_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - snomed_rel_meas_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - snomed_rel_pcs_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-echo "CREATE TABLES - snomed_rel_pcs_src_in_data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-(
-    p_concept_id    INT64,
-    p_concept_code  STRING,
-    p_concept_name  STRING,
-    p_domain_id     STRING,
-    concept_id      INT64,
-    concept_code    STRING,
-    concept_name    STRING,
-    domain_id       STRING
-)"
-
-
-################################################
-# CREATE VIEWS
-################################################
-echo "CREATE VIEWS - v_loinc_rel"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE,
-    C1.CONCEPT_NAME AS P_CONCEPT_NAME, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND CR.RELATIONSHIP_ID = 'Subsumes'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.VOCABULARY_ID = 'LOINC'
-    AND C2.VOCABULARY_ID = 'LOINC'
-    AND C1.STANDARD_CONCEPT IN ('S','C')
-    AND C2.STANDARD_CONCEPT IN ('S','C')
-    AND C1.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')
-    AND C2.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')"
-
-echo "CREATE VIEWS - v_snomed_rel_cm"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND C1.VOCABULARY_ID = 'SNOMED'
-    AND C2.VOCABULARY_ID = 'SNOMED'
-    AND C1.STANDARD_CONCEPT = 'S'
-    AND C2.STANDARD_CONCEPT = 'S'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.DOMAIN_ID = 'Condition'
-    AND C2.DOMAIN_ID = 'Condition'
-    AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-echo "CREATE VIEWS - v_snomed_rel_cm_src"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND C1.VOCABULARY_ID = 'SNOMED'
-    AND C2.VOCABULARY_ID = 'SNOMED'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.DOMAIN_ID = 'Condition'
-    AND C2.DOMAIN_ID = 'Condition'
-    AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-echo "CREATE VIEWS - v_snomed_rel_meas"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND C1.VOCABULARY_ID = 'SNOMED'
-    AND C2.VOCABULARY_ID = 'SNOMED'
-    AND C1.STANDARD_CONCEPT = 'S'
-    AND C2.STANDARD_CONCEPT = 'S'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.DOMAIN_ID = 'Measurement'
-    AND C2.DOMAIN_ID = 'Measurement'
-    AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-echo "CREATE VIEWS - v_snomed_rel_pcs"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND C1.VOCABULARY_ID = 'SNOMED'
-    AND C2.VOCABULARY_ID = 'SNOMED'
-    AND C1.STANDARD_CONCEPT = 'S'
-    AND C2.STANDARD_CONCEPT = 'S'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.DOMAIN_ID = 'Procedure'
-    AND C2.DOMAIN_ID = 'Procedure'
-    AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-echo "CREATE VIEWS - v_snomed_rel_pcs_src"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` AS
-SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
-    C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
-    \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
-    \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
-WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
-    AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
-    AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
-    AND C1.VOCABULARY_ID = 'SNOMED'
-    AND C2.VOCABULARY_ID = 'SNOMED'
-    AND R.IS_HIERARCHICAL = '1'
-    AND R.DEFINES_ANCESTRY = '1'
-    AND C1.DOMAIN_ID = 'Procedure'
-    AND C2.DOMAIN_ID = 'Procedure'
-    AND CR.RELATIONSHIP_ID = 'Subsumes'"
-
-
-################################################
-# SOURCE ICD9
-################################################
-echo "ICD9 - add data (do not insert zero count children)"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-    case when b.concept_id is not null then b.concept_name else a.name end as name,
-    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-LEFT JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        WHERE (vocabulary_id in ('ICD9CM', 'ICD9Proc') and concept_code != '92')
-            or (vocabulary_id = 'ICD9Proc' and concept_code = '92')
-    ) b on a.concept_id = b.concept_id
-LEFT JOIN
-    (
-        SELECT concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        WHERE is_standard = 0
-            and concept_id in
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                    WHERE type in ('ICD9CM', 'ICD9Proc')
-                        and is_group = 0
-                        and is_selectable = 1
-                )
-        group by 1
-    ) c on b.concept_id = c.concept_id
-WHERE type in ('ICD9CM', 'ICD9Proc')
-    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-ORDER BY 1"
-
-echo "ICD9 - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT e.id, COUNT(distinct f.person_id) cnt
-        FROM
-            (
-                SELECT *
-                FROM
-                    (
-                        SELECT id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE type in ('ICD9CM', 'ICD9Proc')
-                            and is_group = 1
-                            and is_selectable = 1
-                    ) a
-                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) e
-        LEFT JOIN
-            (
-                SELECT c.id, d.*
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                JOIN
-                    (
-                        SELECT a.person_id, a.concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                        JOIN
-                            (
-                                SELECT concept_id, path
-                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                WHERE type in ('ICD9CM', 'ICD9Proc')
-                                    and is_selectable = 1
-                            ) b on a.concept_id = b.concept_id
-                        WHERE is_standard = 0
-                    ) d on c.concept_id = d.concept_id
-            ) f on e.descendant_id = f.id
-        GROUP BY 1
-    ) y
-WHERE x.id = y.id"
-
-echo "ICD9 - delete zero count parents"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"DELETE
-FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-WHERE type in ('ICD9CM', 'ICD9Proc')
-    and is_selectable = 1
-    and (est_count is null or est_count = 0)"
-
-################################################
-# SOURCE ICD10
-################################################
-echo "ICD10CM - insert data (do not insert zero count children)"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-    case when b.concept_id is not null then b.concept_name else a.name end as name,
-    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-LEFT JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        WHERE vocabulary_id in ('ICD10CM')
-    ) b on a.concept_id = b.concept_id
-LEFT JOIN
-    (
-        SELECT concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        WHERE is_standard = 0
-            and concept_id in
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                    WHERE type = 'ICD10CM'
-                        and is_group = 0
-                        and is_selectable = 1
-                )
-        GROUP BY 1
-    ) c on b.concept_id = c.concept_id
-WHERE type = 'ICD10CM'
-    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-ORDER BY 1"
-
-echo "ICD10CM - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT e.id, count(distinct f.person_id) cnt
-        FROM
-            (
-                SELECT *
-                FROM
-                    (
-                        SELECT id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE type = 'ICD10CM'
-                            and parent_id != 0
-                            and is_group = 1
-                    ) a
-                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) e
-        LEFT JOIN
-            (
-                SELECT c.id, d.*
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                JOIN
-                    (
-                        SELECT a.person_id, a.concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                        JOIN
-                            (
-                                SELECT concept_id, path
-                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                WHERE type = 'ICD10CM'
-                                    and is_selectable = 1
-                            ) b on a.concept_id = b.concept_id
-                        WHERE is_standard = 0
-                    ) d on c.concept_id = d.concept_id
-            ) f on e.descendant_id = f.id
-        group by 1
-    ) y
-WHERE x.id = y.id"
-
-echo "ICD10PCS - insert data (do not insert zero count children)"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-    case when b.concept_id is not null then b.concept_name else a.name end as name,
-    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-LEFT JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        WHERE vocabulary_id in ('ICD10PCS')
-    ) b on a.concept_id = b.concept_id
-LEFT JOIN
-    (
-        SELECT concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        WHERE is_standard = 0
-            and concept_id in
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                    WHERE type = 'ICD10PCS'
-                        and is_group = 0
-                        and is_selectable = 1
-                )
-        GROUP BY 1
-    ) c on b.concept_id = c.concept_id
-WHERE type = 'ICD10PCS'
-    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-ORDER BY 1"
-
-echo "ICD10PCS - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT e.id, count(distinct f.person_id) cnt
-        FROM
-            (
-                SELECT *
-                FROM
-                    (
-                        SELECT id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE type = 'ICD10PCS'
-                            and parent_id != 0
-                            and is_group = 1
-                    ) a
-                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) e
-        LEFT JOIN
-            (
-                SELECT c.id, d.*
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                JOIN
-                    (
-                        SELECT a.person_id, a.concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                        JOIN
-                            (
-                                SELECT concept_id, path
-                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                WHERE type = 'ICD10PCS'
-                                    and is_selectable = 1
-                            ) b on a.concept_id = b.concept_id
-                        WHERE is_standard = 0
-                    ) d on c.concept_id = d.concept_id
-            ) f on e.descendant_id = f.id
-        group by 1
-    ) y
-WHERE x.id = y.id"
-
-echo "ICD10 - delete zero count parents"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"DELETE
-FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-WHERE type in ('ICD10CM', 'ICD10PCS')
-    and is_group = 1
-    and is_selectable = 1
-    and (est_count is null or est_count = 0)"
-
-
-################################################
-# SOURCE CPT
-################################################
-echo "CPT - insert data (do not insert zero count children)"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
-    case when b.concept_id is not null then b.concept_name else a.name end as name,
-    case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
-    a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
-LEFT JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        WHERE vocabulary_id = 'CPT4'
-    ) b on a.concept_id = b.concept_id
-LEFT JOIN
-    (
-        SELECT concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        WHERE is_standard = 0
-            and concept_id in
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-                    WHERE type = 'CPT4'
-                        and is_group = 0
-                        and is_selectable = 1
-                )
-        group by 1
-    ) c on b.concept_id = c.concept_id
-WHERE type = 'CPT4'
-    and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
-ORDER BY 1"
-
-echo "CPT - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT e.id, count(distinct f.person_id) cnt
-        FROM
-            (
-                SELECT *
-                FROM
-                    (
-                        SELECT id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE type = 'CPT4'
-                            and parent_id != 0
-                            and is_group = 1
-                    ) a
-                LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) e
-        LEFT JOIN
-            (
-                SELECT c.id, d.*
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                JOIN
-                    (
-                        SELECT a.person_id, a.concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-                        JOIN
-                            (
-                                SELECT concept_id, path
-                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                WHERE type = 'CPT4'
-                                    and is_selectable = 1
-                            ) b on a.concept_id = b.concept_id
-                        WHERE is_standard = 0
-                    ) d on c.concept_id = d.concept_id
-            ) f on e.descendant_id = f.id
-        group by 1
-    ) y
-WHERE x.id = y.id"
-
-echo "CPT - delete zero count parents"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"DELETE
-FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-WHERE type = 'CPT4'
-    and
-    (
-        (parent_id != 0 and (est_count is null or est_count = 0))
-        or
-            (
-              is_group = 1
-              and id not in
-                (
-                    SELECT parent_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    WHERE type = 'CPT4'
-                        and est_count is not null
-                )
-            )
-		)"
-
-
-################################################
-# PPI PHYSICAL MEASUREMENTS (PM)
-################################################
-echo "PM - insert data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-select id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
-    case when is_selectable = 1 then 0 else null end as est_count,
-    is_group,is_selectable,has_attribute,has_hierarchy
-from \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-where domain_id = 'PHYSICAL_MEASUREMENT'
-order by 1"
-
-echo "PM - counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select measurement_source_concept_id as concept_id, count(distinct person_id) as cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-        where measurement_source_concept_id in (903126,903133,903121,903124,903135,903136)
-        group by 1
-    ) y
-where x.domain_id = 'PHYSICAL_MEASUREMENT'
-    and x.concept_id = y.concept_id"
-
-echo "PM - counts for heart rhythm, pregnancy, and wheelchair use"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select concept_id, CAST(value_as_concept_id as STRING) as value, count(distinct person_id) as cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id IN (1586218, 903120, 903111)
-        group by 1,2
-    ) y
-where x.domain_id = 'PHYSICAL_MEASUREMENT'
-    and x.concept_id = y.concept_id
-    and x.value = y.value"
-
-#----- BLOOD PRESSURE -----
-echo "PM - blood pressure  - hypotensive"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count =
-    (
-        select count(distinct person_id)
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id in (903115, 903118)
-            and systolic <= 90
-            and diastolic <= 60
-    )
-where domain_id = 'PHYSICAL_MEASUREMENT'
-    and subtype = 'BP'
-    and name LIKE 'Hypotensive%'"
-
-echo "PM - blood pressure  - normal"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count =
-    (
-        select count(distinct person_id)
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id in (903115, 903118)
-            and systolic <= 120
-            and diastolic <= 80
-    )
-where domain_id = 'PHYSICAL_MEASUREMENT'
-    and subtype = 'BP'
-    and name LIKE 'Normal%'"
-
-echo "PM - blood pressure  - pre-hypertensive"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count =
-    (
-        select count(distinct person_id)
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id in (903115, 903118)
-            and systolic BETWEEN 120 AND 139
-            and diastolic BETWEEN 81 AND 89
-    )
-where domain_id = 'PHYSICAL_MEASUREMENT'
-    and subtype = 'BP'
-    and name LIKE 'Pre-Hypertensive%'"
-
-echo "PM - blood pressure  - hypertensive"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count =
-    (
-        select count(distinct person_id)
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id in (903115, 903118)
-            and systolic >= 140
-            and diastolic >= 90
-    )
-where domain_id = 'PHYSICAL_MEASUREMENT'
-    and subtype = 'BP'
-    and name LIKE 'Hypertensive%'"
-
-echo "PM - blood pressure  - detail"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count =
-    (
-        select count(distinct person_id)
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where concept_id in (903115, 903118)
-    )
-where domain_id = 'PHYSICAL_MEASUREMENT'
-    and subtype = 'BP'
-    and name = 'Blood Pressure'
-    and is_selectable = 1"
-
-
-################################################
-# PPI SURVEYS
-################################################
-echo "PPI SURVEYS - insert data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
-    case when (is_selectable = 1 and name != 'Select a value') then 0 else null end as est_count,
-    is_group,is_selectable,has_attribute,has_hierarchy,path
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-WHERE domain_id = 'SURVEY'
-    and type = 'PPI'
-ORDER BY 1"
-
-echo "PPI SURVEYS - insert extra answers"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-e.id as parent_id, e.domain_id, e.is_standard, e.type, 'ANSWER', e.concept_id, d.answer as name, CAST(d.value_source_concept_id as STRING), 0, 1, 0, 1,
-CONCAT(e.path, '.',
-        CAST(ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-FROM
-(
-SELECT DISTINCT a.observation_source_concept_id, a.value_source_concept_id, regexp_replace(b.concept_name, r'^.+:\s', '') as answer
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_source_concept_id = b.concept_id
-LEFT JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-        WHERE domain_id = 'SURVEY'
-    ) c on (a.observation_source_concept_id = c.concept_id and CAST(a.value_source_concept_id as STRING) = c.value)
-WHERE a.value_source_concept_id in (903096, 903079, 903087)
-    and a.observation_source_concept_id in
-        (
-            SELECT concept_id
-            FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
-            WHERE domain_id = 'SURVEY'
-                and concept_id is not null
-        )
-    and c.id is null
-) d
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` e on
-    (d.observation_source_concept_id = e.concept_id and e.domain_id = 'SURVEY' and e.is_group = 1)"
-
-echo "PPI SURVEYS - add items into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-    (ancestor_concept_id, descendant_concept_id, is_standard)
-SELECT DISTINCT b.concept_id as ancestor_concept_id, a.concept_id as descendant_concept_id, a.is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` b on CAST(regexp_extract(a.path, r'^\d+') AS INT64) = b.id
-WHERE a.domain_id = 'SURVEY'
-    and a.subtype = 'ANSWER'"
-
-echo "PPI SURVEYS - generate answer counts for all questions EXCEPT where question concept_id = 1585747"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        SELECT concept_id, CAST(value_source_concept_id as STRING) as value, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        WHERE is_standard = 0
-            and concept_id in
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    WHERE domain_id = 'SURVEY'
-                        and type = 'PPI'
-                        and subtype = 'ANSWER'
-                        and concept_id != 1585747
-                )
-        GROUP BY 1,2
-        ORDER BY 1,2
-    ) y
-where x.domain_id = 'SURVEY'
-    and x.type = 'PPI'
-    and x.subtype = 'ANSWER'
-    and x.concept_id = y.concept_id
-    and x.value = y.value"
-
-echo "PPI SURVEYS - generate answer counts for question (concept_id = 1585747)"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select concept_id, CAST(value_as_number as STRING) as value, count(distinct person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where is_standard = 0
-            and concept_id = 1585747
-        group by 1,2
-    ) y
-where x.domain_id = 'SURVEY'
-    and x.type = 'PPI'
-    and x.subtype = 'ANSWER'
-    and x.concept_id = y.concept_id
-    and x.value = y.value"
-
-echo "PPI SURVEYS - generate question counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        SELECT concept_id, count(distinct person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-        where is_standard = 0
-            and concept_id in
-                (
-                    select concept_id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where domain_id = 'SURVEY'
-                        and type = 'PPI'
-                        and is_group = 1
-                        and is_selectable = 1
-                        and parent_id != 0
-                )
-        group by 1
-    ) y
-where x.domain_id = 'SURVEY'
-    and x.type = 'PPI'
-    and x.is_group = 1
-    and x.concept_id = y.concept_id"
-
-echo "PPI SURVEYS - generate survey counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT b.ancestor_concept_id, count(DISTINCT a.person_id) as cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
-        JOIN
-            (
-                SELECT *
-                FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                WHERE ancestor_concept_id in
-                    (
-                        SELECT concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE domain_id = 'SURVEY'
-                            and parent_id = 0
-                    )
-            ) b on a.concept_id = b.descendant_concept_id
-        WHERE a.is_standard = 0
-        GROUP BY 1
-    ) y
-WHERE x.domain_id = 'SURVEY'
-    and x.concept_id = y.ancestor_concept_id"
-
-
-################################################
-# DEMOGRAPHICS
-################################################
-echo "DEMO - Age parent"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PERSON',1,'AGE','Age',1,0,0,0"
-
-echo "DEMO - Age Children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-select row_num + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'AGE' and parent_id = 0) as parent_id,
-    'PERSON',1,'AGE', CAST(row_num AS STRING) as name, CAST(row_num as STRING) as value,
-    case when b.cnt is null then 0 else b.cnt end as est_count,
-    0,1,0,0
-from
-    (
-        select ROW_NUMBER() OVER(ORDER BY person_id) as row_num
-        from \`$BQ_PROJECT.$BQ_DATASET.person\`
-        order by person_id limit 120
-    ) a
-left join
-    (
-        select CAST(FLOOR(DATE_DIFF(CURRENT_DATE(), DATE(birth_datetime), MONTH)/12) as INT64) as age, count(*) as cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.person\`
-        where person_id not in
-            (
-                select person_id
-                from \`$BQ_PROJECT.$BQ_DATASET.death\`
-            )
-        group by 1
-    ) b on a.row_num = b.age
-order by 1"
-
-echo "DEMO - Deceased"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PERSON',1,'DECEASED','Deceased',
-    (select count(distinct person_id) from \`$BQ_PROJECT.$BQ_DATASET.death\`),
-    0,1,0,0"
-
-echo "DEMO - Gender parent"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PERSON',1,'GENDER','Gender',1,0,0,0"
-
-echo "DEMO - Gender children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
-    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'GENDER' and parent_id = 0) as parent_id,
-    'PERSON',1,'GENDER',concept_id,
-    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
-    a.cnt,0,1,0,0
-FROM
-    (
-        SELECT gender_concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-        GROUP BY 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.gender_concept_id = b.concept_id"
-
-echo "DEMO - Sex at birth parent"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
-    0,'PERSON',1,'SEX','Sex',1,0,0,0"
-
-if [ "$DATA_BROWSER_FLAG" == false ]
-then
-echo "DEMO - Sex at birth children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
-    (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
-    'PERSON',1,'SEX',concept_id,
-    CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
-    a.cnt,0,1,0,0
-FROM
-    (
-        SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-        GROUP BY 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
-fi
-
-echo "DEMO - Race parent"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PERSON',1,'RACE','Race',1,0,0,0"
-
-echo "DEMO - Race children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'RACE' and parent_id = 0) as parent_id,
-    'PERSON',1,'RACE',concept_id,
-    CASE
-        WHEN a.race_concept_id = 0 THEN 'Unknown'
-        ELSE regexp_replace(b.concept_name, r'^.+:\s', '')
-    END as name,
-    a.cnt,0,1,0,0
-FROM
-    (
-        SELECT race_concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-        GROUP BY 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.race_concept_id = b.concept_id
-WHERE b.concept_id is not null"
-
-echo "DEMO - Ethnicity parent"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PERSON',1,'ETHNICITY','Ethnicity',1,0,0,0"
-
-echo "DEMO - Ethnicity children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'ETHNICITY' and parent_id = 0) as parent_id,
-    'PERSON',1,'ETHNICITY',concept_id,
-    regexp_replace(b.concept_name, r'^.+:\s', ''),
-    a.cnt,0,1,0,0
-FROM
-    (
-        SELECT ethnicity_concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
-        GROUP BY 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ethnicity_concept_id = b.concept_id
-WHERE b.concept_id is not null"
-
-
-################################################
-# VISITS
-################################################
-echo "VISITS - add items with counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
-SELECT ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-    0,'VISIT',1,'VISIT',concept_id,concept_name,a.cnt,0,1,0,0
-FROM
-    (
-        select visit_concept_id, count(distinct person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\`
-        group by 1
-    ) a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b ON a.visit_concept_id = b.concept_id
-where b.domain_id = 'Visit'
-    and b.standard_concept = 'S'"
-
-
-################################################
-# CONDITIONS
-################################################
-# ----- SOURCE SNOMED -----
-echo "CONDITIONS - SOURCE SNOMED - temp table level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
-where concept_id in
-    (
-        select distinct condition_source_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
-        where condition_source_concept_id != 0
-            and b.domain_id = 'Condition'
-            and b.vocabulary_id = 'SNOMED'
-    )"
-
-# currently, there are only 5 levels, but we run it 6 times to be safe
-for i in {1..6};
-do
-    echo "CONDITIONS - SOURCE SNOMED - temp table level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
-    where concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-        )
+  # Check that bq_project exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+
+  # Check that bq_dataset exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  re=\\b$BQ_DATASET\\b
+  if [[ $datasets =~ $re ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+
+
+  ################################################
+  # CREATE TABLES
+  ################################################
+  # table that holds temp data to get ancestor information for parent counts
+  echo "CREATE TABLES - prep_concept_ancestor_temp"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  (
+      ancestor_concept_id     INT64,
+      domain_id               STRING,
+      type                    STRING,
+      is_standard             INT64,
+      concept_id_1            INT64,
+      concept_id_2            INT64,
+      concept_id_3            INT64,
+      concept_id_4            INT64,
+      concept_id_5            INT64,
+      concept_id_6            INT64,
+      concept_id_7            INT64,
+      concept_id_8            INT64,
+      concept_id_9            INT64,
+      concept_id_10           INT64,
+      concept_id_11           INT64,
+      concept_id_12           INT64,
+      concept_id_13           INT64,
+      concept_id_14           INT64,
+      concept_id_15           INT64,
+      concept_id_16           INT64,
+      concept_id_17           INT64,
+      concept_id_18           INT64,
+      concept_id_19           INT64,
+      concept_id_20           INT64
+  )"
+
+  # table that holds ancestor information for parent counts
+  echo "CREATE TABLES - prep_concept_ancestor"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+  (
+      ancestor_concept_id     INT64,
+      descendant_concept_id   INT64,
+      is_standard             INT64
+  )"
+
+  echo "CREATE TABLES - cb_criteria"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  (
+      id                  INT64,
+      parent_id           INT64,
+      domain_id           STRING,
+      is_standard         INT64,
+      type                STRING,
+      subtype             STRING,
+      concept_id          INT64,
+      code                STRING,
+      name                STRING,
+      value               STRING,
+      est_count           INT64,
+      is_group            INT64,
+      is_selectable       INT64,
+      has_attribute       INT64,
+      has_hierarchy       INT64,
+      has_ancestor_data   INT64,
+      path                STRING,
+      synonyms            STRING
+  )"
+
+  # table that holds the ingredient --> coded drugs mapping
+  echo "CREATE TABLES - cb_criteria_ancestor"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+  (
+      ancestor_id INT64,
+      descendant_id INT64
+  )"
+
+  # table that holds categorical results and min/max information about individual labs
+  echo "CREATE TABLES - cb_criteria_attribute"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+  (
+      id                    INT64,
+      concept_id            INT64,
+      value_as_concept_id	  INT64,
+      concept_name          STRING,
+      type                  STRING,
+      est_count             STRING
+  )"
+
+  # table that holds the drug brands to ingredients relationship mapping
+  echo "CREATE TABLES - cb_criteria_relationship"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+  (
+      concept_id_1 INT64,
+      concept_id_2 INT64
+  )"
+
+  echo "CREATE TABLES - atc_rel_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - loinc_rel_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - snomed_rel_cm_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - snomed_rel_cm_src_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - snomed_rel_meas_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - snomed_rel_pcs_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+  echo "CREATE TABLES - snomed_rel_pcs_src_in_data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+  (
+      p_concept_id    INT64,
+      p_concept_code  STRING,
+      p_concept_name  STRING,
+      p_domain_id     STRING,
+      concept_id      INT64,
+      concept_code    STRING,
+      concept_name    STRING,
+      domain_id       STRING
+  )"
+
+
+  ################################################
+  # CREATE VIEWS
+  ################################################
+  echo "CREATE VIEWS - v_loinc_rel"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE,
+      C1.CONCEPT_NAME AS P_CONCEPT_NAME, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND CR.RELATIONSHIP_ID = 'Subsumes'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.VOCABULARY_ID = 'LOINC'
+      AND C2.VOCABULARY_ID = 'LOINC'
+      AND C1.STANDARD_CONCEPT IN ('S','C')
+      AND C2.STANDARD_CONCEPT IN ('S','C')
+      AND C1.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')
+      AND C2.CONCEPT_CLASS_ID IN ('LOINC Hierarchy', 'Lab Test')"
+
+  echo "CREATE VIEWS - v_snomed_rel_cm"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND C1.VOCABULARY_ID = 'SNOMED'
+      AND C2.VOCABULARY_ID = 'SNOMED'
+      AND C1.STANDARD_CONCEPT = 'S'
+      AND C2.STANDARD_CONCEPT = 'S'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.DOMAIN_ID = 'Condition'
+      AND C2.DOMAIN_ID = 'Condition'
+      AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+  echo "CREATE VIEWS - v_snomed_rel_cm_src"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND C1.VOCABULARY_ID = 'SNOMED'
+      AND C2.VOCABULARY_ID = 'SNOMED'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.DOMAIN_ID = 'Condition'
+      AND C2.DOMAIN_ID = 'Condition'
+      AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+  echo "CREATE VIEWS - v_snomed_rel_meas"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND C1.VOCABULARY_ID = 'SNOMED'
+      AND C2.VOCABULARY_ID = 'SNOMED'
+      AND C1.STANDARD_CONCEPT = 'S'
+      AND C2.STANDARD_CONCEPT = 'S'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.DOMAIN_ID = 'Measurement'
+      AND C2.DOMAIN_ID = 'Measurement'
+      AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+  echo "CREATE VIEWS - v_snomed_rel_pcs"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND C1.VOCABULARY_ID = 'SNOMED'
+      AND C2.VOCABULARY_ID = 'SNOMED'
+      AND C1.STANDARD_CONCEPT = 'S'
+      AND C2.STANDARD_CONCEPT = 'S'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.DOMAIN_ID = 'Procedure'
+      AND C2.DOMAIN_ID = 'Procedure'
+      AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+  echo "CREATE VIEWS - v_snomed_rel_pcs_src"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE VIEW \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` AS
+  SELECT DISTINCT C1.CONCEPT_ID AS P_CONCEPT_ID, C1.CONCEPT_CODE AS P_CONCEPT_CODE, C1.CONCEPT_NAME AS P_CONCEPT_NAME,
+      C1.DOMAIN_ID AS P_DOMAIN_ID, C2.CONCEPT_ID, C2.CONCEPT_CODE, C2.CONCEPT_NAME, C2.DOMAIN_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` CR,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C1,
+      \`$BQ_PROJECT.$BQ_DATASET.concept\` C2,
+      \`$BQ_PROJECT.$BQ_DATASET.relationship\` R
+  WHERE CR.CONCEPT_ID_1 = C1.CONCEPT_ID
+      AND CR.CONCEPT_ID_2 = C2.CONCEPT_ID
+      AND CR.RELATIONSHIP_ID = R.RELATIONSHIP_ID
+      AND C1.VOCABULARY_ID = 'SNOMED'
+      AND C2.VOCABULARY_ID = 'SNOMED'
+      AND R.IS_HIERARCHICAL = '1'
+      AND R.DEFINES_ANCESTRY = '1'
+      AND C1.DOMAIN_ID = 'Procedure'
+      AND C2.DOMAIN_ID = 'Procedure'
+      AND CR.RELATIONSHIP_ID = 'Subsumes'"
+
+
+  ################################################
+  # SOURCE ICD9
+  ################################################
+  echo "ICD9 - add data (do not insert zero count children)"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+      case when b.concept_id is not null then b.concept_name else a.name end as name,
+      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+  LEFT JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          WHERE (vocabulary_id in ('ICD9CM', 'ICD9Proc') and concept_code != '92')
+              or (vocabulary_id = 'ICD9Proc' and concept_code = '92')
+      ) b on a.concept_id = b.concept_id
+  LEFT JOIN
+      (
+          SELECT concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          WHERE is_standard = 0
+              and concept_id in
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                      WHERE type in ('ICD9CM', 'ICD9Proc')
+                          and is_group = 0
+                          and is_selectable = 1
+                  )
+          group by 1
+      ) c on b.concept_id = c.concept_id
+  WHERE type in ('ICD9CM', 'ICD9Proc')
+      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+  ORDER BY 1"
+
+  echo "ICD9 - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT e.id, COUNT(distinct f.person_id) cnt
+          FROM
+              (
+                  SELECT *
+                  FROM
+                      (
+                          SELECT id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE type in ('ICD9CM', 'ICD9Proc')
+                              and is_group = 1
+                              and is_selectable = 1
+                      ) a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) e
+          LEFT JOIN
+              (
+                  SELECT c.id, d.*
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                  JOIN
+                      (
+                          SELECT a.person_id, a.concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                          JOIN
+                              (
+                                  SELECT concept_id, path
+                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                  WHERE type in ('ICD9CM', 'ICD9Proc')
+                                      and is_selectable = 1
+                              ) b on a.concept_id = b.concept_id
+                          WHERE is_standard = 0
+                      ) d on c.concept_id = d.concept_id
+              ) f on e.descendant_id = f.id
+          GROUP BY 1
+      ) y
+  WHERE x.id = y.id"
+
+  echo "ICD9 - delete zero count parents"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "DELETE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  WHERE type in ('ICD9CM', 'ICD9Proc')
+      and is_selectable = 1
+      and (est_count is null or est_count = 0)"
+
+  ################################################
+  # SOURCE ICD10
+  ################################################
+  echo "ICD10CM - insert data (do not insert zero count children)"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+      case when b.concept_id is not null then b.concept_name else a.name end as name,
+      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+  LEFT JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          WHERE vocabulary_id in ('ICD10CM')
+      ) b on a.concept_id = b.concept_id
+  LEFT JOIN
+      (
+          SELECT concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          WHERE is_standard = 0
+              and concept_id in
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                      WHERE type = 'ICD10CM'
+                          and is_group = 0
+                          and is_selectable = 1
+                  )
+          GROUP BY 1
+      ) c on b.concept_id = c.concept_id
+  WHERE type = 'ICD10CM'
+      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+  ORDER BY 1"
+
+  echo "ICD10CM - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT e.id, count(distinct f.person_id) cnt
+          FROM
+              (
+                  SELECT *
+                  FROM
+                      (
+                          SELECT id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE type = 'ICD10CM'
+                              and parent_id != 0
+                              and is_group = 1
+                      ) a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) e
+          LEFT JOIN
+              (
+                  SELECT c.id, d.*
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                  JOIN
+                      (
+                          SELECT a.person_id, a.concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                          JOIN
+                              (
+                                  SELECT concept_id, path
+                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                  WHERE type = 'ICD10CM'
+                                      and is_selectable = 1
+                              ) b on a.concept_id = b.concept_id
+                          WHERE is_standard = 0
+                      ) d on c.concept_id = d.concept_id
+              ) f on e.descendant_id = f.id
+          group by 1
+      ) y
+  WHERE x.id = y.id"
+
+  echo "ICD10PCS - insert data (do not insert zero count children)"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+      case when b.concept_id is not null then b.concept_name else a.name end as name,
+      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+  LEFT JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          WHERE vocabulary_id in ('ICD10PCS')
+      ) b on a.concept_id = b.concept_id
+  LEFT JOIN
+      (
+          SELECT concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          WHERE is_standard = 0
+              and concept_id in
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                      WHERE type = 'ICD10PCS'
+                          and is_group = 0
+                          and is_selectable = 1
+                  )
+          GROUP BY 1
+      ) c on b.concept_id = c.concept_id
+  WHERE type = 'ICD10PCS'
+      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+  ORDER BY 1"
+
+  echo "ICD10PCS - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT e.id, count(distinct f.person_id) cnt
+          FROM
+              (
+                  SELECT *
+                  FROM
+                      (
+                          SELECT id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE type = 'ICD10PCS'
+                              and parent_id != 0
+                              and is_group = 1
+                      ) a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) e
+          LEFT JOIN
+              (
+                  SELECT c.id, d.*
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                  JOIN
+                      (
+                          SELECT a.person_id, a.concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                          JOIN
+                              (
+                                  SELECT concept_id, path
+                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                  WHERE type = 'ICD10PCS'
+                                      and is_selectable = 1
+                              ) b on a.concept_id = b.concept_id
+                          WHERE is_standard = 0
+                      ) d on c.concept_id = d.concept_id
+              ) f on e.descendant_id = f.id
+          group by 1
+      ) y
+  WHERE x.id = y.id"
+
+  echo "ICD10 - delete zero count parents"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "DELETE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  WHERE type in ('ICD10CM', 'ICD10PCS')
+      and is_group = 1
+      and is_selectable = 1
+      and (est_count is null or est_count = 0)"
+
+
+  ################################################
+  # SOURCE CPT
+  ################################################
+  echo "CPT - insert data (do not insert zero count children)"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT a.id, a.parent_id, a.domain_id, a.is_standard, a.type, a.subtype, a.concept_id, a.code,
+      case when b.concept_id is not null then b.concept_name else a.name end as name,
+      case when a.is_group = 0 and a.is_selectable = 1 then c.cnt else null end as est_count,
+      a.is_group, a.is_selectable, a.has_attribute, a.has_hierarchy, a.path
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` a
+  LEFT JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          WHERE vocabulary_id = 'CPT4'
+      ) b on a.concept_id = b.concept_id
+  LEFT JOIN
+      (
+          SELECT concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          WHERE is_standard = 0
+              and concept_id in
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+                      WHERE type = 'CPT4'
+                          and is_group = 0
+                          and is_selectable = 1
+                  )
+          group by 1
+      ) c on b.concept_id = c.concept_id
+  WHERE type = 'CPT4'
+      and (is_group = 1 or (is_group = 0 and is_selectable = 1 and (c.cnt != 0 or c.cnt is not null)))
+  ORDER BY 1"
+
+  echo "CPT - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT e.id, count(distinct f.person_id) cnt
+          FROM
+              (
+                  SELECT *
+                  FROM
+                      (
+                          SELECT id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE type = 'CPT4'
+                              and parent_id != 0
+                              and is_group = 1
+                      ) a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) e
+          LEFT JOIN
+              (
+                  SELECT c.id, d.*
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                  JOIN
+                      (
+                          SELECT a.person_id, a.concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+                          JOIN
+                              (
+                                  SELECT concept_id, path
+                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                  WHERE type = 'CPT4'
+                                      and is_selectable = 1
+                              ) b on a.concept_id = b.concept_id
+                          WHERE is_standard = 0
+                      ) d on c.concept_id = d.concept_id
+              ) f on e.descendant_id = f.id
+          group by 1
+      ) y
+  WHERE x.id = y.id"
+
+  echo "CPT - delete zero count parents"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "DELETE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  WHERE type = 'CPT4'
+      and
+      (
+          (parent_id != 0 and (est_count is null or est_count = 0))
+          or
+              (
+                is_group = 1
+                and id not in
+                  (
+                      SELECT parent_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      WHERE type = 'CPT4'
+                          and est_count is not null
+                  )
+              )
+      )"
+
+
+  ################################################
+  # PPI PHYSICAL MEASUREMENTS (PM)
+  ################################################
+  echo "PM - insert data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  select id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
+      case when is_selectable = 1 then 0 else null end as est_count,
+      is_group,is_selectable,has_attribute,has_hierarchy
+  from \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+  order by 1"
+
+  echo "PM - counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select measurement_source_concept_id as concept_id, count(distinct person_id) as cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+          where measurement_source_concept_id in (903126,903133,903121,903124,903135,903136)
+          group by 1
+      ) y
+  where x.domain_id = 'PHYSICAL_MEASUREMENT'
+      and x.concept_id = y.concept_id"
+
+  echo "PM - counts for heart rhythm, pregnancy, and wheelchair use"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select concept_id, CAST(value_as_concept_id as STRING) as value, count(distinct person_id) as cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id IN (1586218, 903120, 903111)
+          group by 1,2
+      ) y
+  where x.domain_id = 'PHYSICAL_MEASUREMENT'
+      and x.concept_id = y.concept_id
+      and x.value = y.value"
+
+  #----- BLOOD PRESSURE -----
+  echo "PM - blood pressure  - hypotensive"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count =
+      (
+          select count(distinct person_id)
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id in (903115, 903118)
+              and systolic <= 90
+              and diastolic <= 60
+      )
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+      and subtype = 'BP'
+      and name LIKE 'Hypotensive%'"
+
+  echo "PM - blood pressure  - normal"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count =
+      (
+          select count(distinct person_id)
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id in (903115, 903118)
+              and systolic <= 120
+              and diastolic <= 80
+      )
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+      and subtype = 'BP'
+      and name LIKE 'Normal%'"
+
+  echo "PM - blood pressure  - pre-hypertensive"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count =
+      (
+          select count(distinct person_id)
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id in (903115, 903118)
+              and systolic BETWEEN 120 AND 139
+              and diastolic BETWEEN 81 AND 89
+      )
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+      and subtype = 'BP'
+      and name LIKE 'Pre-Hypertensive%'"
+
+  echo "PM - blood pressure  - hypertensive"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count =
+      (
+          select count(distinct person_id)
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id in (903115, 903118)
+              and systolic >= 140
+              and diastolic >= 90
+      )
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+      and subtype = 'BP'
+      and name LIKE 'Hypertensive%'"
+
+  echo "PM - blood pressure  - detail"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count =
+      (
+          select count(distinct person_id)
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where concept_id in (903115, 903118)
+      )
+  where domain_id = 'PHYSICAL_MEASUREMENT'
+      and subtype = 'BP'
+      and name = 'Blood Pressure'
+      and is_selectable = 1"
+
+
+  ################################################
+  # PPI SURVEYS
+  ################################################
+  echo "PPI SURVEYS - insert data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,
+      case when (is_selectable = 1 and name != 'Select a value') then 0 else null end as est_count,
+      is_group,is_selectable,has_attribute,has_hierarchy,path
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+  WHERE domain_id = 'SURVEY'
+      and type = 'PPI'
+  ORDER BY 1"
+
+  echo "PPI SURVEYS - insert extra answers"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,name,value,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+  e.id as parent_id, e.domain_id, e.is_standard, e.type, 'ANSWER', e.concept_id, d.answer as name, CAST(d.value_source_concept_id as STRING), 0, 1, 0, 1,
+  CONCAT(e.path, '.',
+          CAST(ROW_NUMBER() OVER (order by e.id, d.answer) + (SELECT MAX(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  FROM
+  (
+  SELECT DISTINCT a.observation_source_concept_id, a.value_source_concept_id, regexp_replace(b.concept_name, r'^.+:\s', '') as answer
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_source_concept_id = b.concept_id
+  LEFT JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+          WHERE domain_id = 'SURVEY'
+      ) c on (a.observation_source_concept_id = c.concept_id and CAST(a.value_source_concept_id as STRING) = c.value)
+  WHERE a.value_source_concept_id in (903096, 903079, 903087)
+      and a.observation_source_concept_id in
+          (
+              SELECT concept_id
+              FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`
+              WHERE domain_id = 'SURVEY'
+                  and concept_id is not null
+          )
+      and c.id is null
+  ) d
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\` e on
+      (d.observation_source_concept_id = e.concept_id and e.domain_id = 'SURVEY' and e.is_group = 1)"
+
+  echo "PPI SURVEYS - add items into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+      (ancestor_concept_id, descendant_concept_id, is_standard)
+  SELECT DISTINCT b.concept_id as ancestor_concept_id, a.concept_id as descendant_concept_id, a.is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` b on CAST(regexp_extract(a.path, r'^\d+') AS INT64) = b.id
+  WHERE a.domain_id = 'SURVEY'
+      and a.subtype = 'ANSWER'"
+
+  echo "PPI SURVEYS - generate answer counts for all questions EXCEPT where question concept_id = 1585747"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          SELECT concept_id, CAST(value_source_concept_id as STRING) as value, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          WHERE is_standard = 0
+              and concept_id in
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      WHERE domain_id = 'SURVEY'
+                          and type = 'PPI'
+                          and subtype = 'ANSWER'
+                          and concept_id != 1585747
+                  )
+          GROUP BY 1,2
+          ORDER BY 1,2
+      ) y
+  where x.domain_id = 'SURVEY'
+      and x.type = 'PPI'
+      and x.subtype = 'ANSWER'
+      and x.concept_id = y.concept_id
+      and x.value = y.value"
+
+  echo "PPI SURVEYS - generate answer counts for question (concept_id = 1585747)"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select concept_id, CAST(value_as_number as STRING) as value, count(distinct person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where is_standard = 0
+              and concept_id = 1585747
+          group by 1,2
+      ) y
+  where x.domain_id = 'SURVEY'
+      and x.type = 'PPI'
+      and x.subtype = 'ANSWER'
+      and x.concept_id = y.concept_id
+      and x.value = y.value"
+
+  echo "PPI SURVEYS - generate question counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          SELECT concept_id, count(distinct person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+          where is_standard = 0
+              and concept_id in
+                  (
+                      select concept_id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where domain_id = 'SURVEY'
+                          and type = 'PPI'
+                          and is_group = 1
+                          and is_selectable = 1
+                          and parent_id != 0
+                  )
+          group by 1
+      ) y
+  where x.domain_id = 'SURVEY'
+      and x.type = 'PPI'
+      and x.is_group = 1
+      and x.concept_id = y.concept_id"
+
+  echo "PPI SURVEYS - generate survey counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT b.ancestor_concept_id, count(DISTINCT a.person_id) as cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` a
+          JOIN
+              (
+                  SELECT *
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                  WHERE ancestor_concept_id in
+                      (
+                          SELECT concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE domain_id = 'SURVEY'
+                              and parent_id = 0
+                      )
+              ) b on a.concept_id = b.descendant_concept_id
+          WHERE a.is_standard = 0
+          GROUP BY 1
+      ) y
+  WHERE x.domain_id = 'SURVEY'
+      and x.concept_id = y.ancestor_concept_id"
+
+
+  ################################################
+  # DEMOGRAPHICS
+  ################################################
+  echo "DEMO - Age parent"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PERSON',1,'AGE','Age',1,0,0,0"
+
+  echo "DEMO - Age Children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,value,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  select row_num + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'AGE' and parent_id = 0) as parent_id,
+      'PERSON',1,'AGE', CAST(row_num AS STRING) as name, CAST(row_num as STRING) as value,
+      case when b.cnt is null then 0 else b.cnt end as est_count,
+      0,1,0,0
+  from
+      (
+          select ROW_NUMBER() OVER(ORDER BY person_id) as row_num
+          from \`$BQ_PROJECT.$BQ_DATASET.person\`
+          order by person_id limit 120
+      ) a
+  left join
+      (
+          select CAST(FLOOR(DATE_DIFF(CURRENT_DATE(), DATE(birth_datetime), MONTH)/12) as INT64) as age, count(*) as cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.person\`
+          where person_id not in
+              (
+                  select person_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.death\`
+              )
+          group by 1
+      ) b on a.row_num = b.age
+  order by 1"
+
+  echo "DEMO - Deceased"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PERSON',1,'DECEASED','Deceased',
+      (select count(distinct person_id) from \`$BQ_PROJECT.$BQ_DATASET.death\`),
+      0,1,0,0"
+
+  echo "DEMO - Gender parent"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PERSON',1,'GENDER','Gender',1,0,0,0"
+
+  echo "DEMO - Gender children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
+      (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'GENDER' and parent_id = 0) as parent_id,
+      'PERSON',1,'GENDER',concept_id,
+      CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
+      a.cnt,0,1,0,0
+  FROM
+      (
+          SELECT gender_concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+          GROUP BY 1
+      ) a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.gender_concept_id = b.concept_id"
+
+  echo "DEMO - Sex at birth parent"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  SELECT (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as id,
+      0,'PERSON',1,'SEX','Sex',1,0,0,0"
+
+  if [ "$DATA_BROWSER_FLAG" == false ]
+  then
+  echo "DEMO - Sex at birth children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  SELECT ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS id,
+      (SELECT id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'SEX' and parent_id = 0) as parent_id,
+      'PERSON',1,'SEX',concept_id,
+      CASE WHEN b.concept_id = 0 THEN 'Unknown' ELSE b.concept_name END as name,
+      a.cnt,0,1,0,0
+  FROM
+      (
+          SELECT sex_at_birth_concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+          GROUP BY 1
+      ) a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.sex_at_birth_concept_id = b.concept_id"
+  fi
+
+  echo "DEMO - Race parent"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PERSON',1,'RACE','Race',1,0,0,0"
+
+  echo "DEMO - Race children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'RACE' and parent_id = 0) as parent_id,
+      'PERSON',1,'RACE',concept_id,
+      CASE
+          WHEN a.race_concept_id = 0 THEN 'Unknown'
+          ELSE regexp_replace(b.concept_name, r'^.+:\s', '')
+      END as name,
+      a.cnt,0,1,0,0
+  FROM
+      (
+          SELECT race_concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+          GROUP BY 1
+      ) a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.race_concept_id = b.concept_id
+  WHERE b.concept_id is not null"
+
+  echo "DEMO - Ethnicity parent"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PERSON',1,'ETHNICITY','Ethnicity',1,0,0,0"
+
+  echo "DEMO - Ethnicity children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  select ROW_NUMBER() OVER(ORDER BY concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'ETHNICITY' and parent_id = 0) as parent_id,
+      'PERSON',1,'ETHNICITY',concept_id,
+      regexp_replace(b.concept_name, r'^.+:\s', ''),
+      a.cnt,0,1,0,0
+  FROM
+      (
+          SELECT ethnicity_concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\`
+          GROUP BY 1
+      ) a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ethnicity_concept_id = b.concept_id
+  WHERE b.concept_id is not null"
+
+
+  ################################################
+  # VISITS
+  ################################################
+  echo "VISITS - add items with counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy)
+  SELECT ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+      0,'VISIT',1,'VISIT',concept_id,concept_name,a.cnt,0,1,0,0
+  FROM
+      (
+          select visit_concept_id, count(distinct person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\`
+          group by 1
+      ) a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b ON a.visit_concept_id = b.concept_id
+  where b.domain_id = 'Visit'
+      and b.standard_concept = 'S'"
+
+
+  ################################################
+  # CONDITIONS
+  ################################################
+  # ----- SOURCE SNOMED -----
+  echo "CONDITIONS - SOURCE SNOMED - temp table level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
+  where concept_id in
+      (
+          select distinct condition_source_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
+          where condition_source_concept_id != 0
+              and b.domain_id = 'Condition'
+              and b.vocabulary_id = 'SNOMED'
+      )"
+
+  # currently, there are only 5 levels, but we run it 6 times to be safe
+  for i in {1..6};
+  do
+      echo "CONDITIONS - SOURCE SNOMED - temp table level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\` a
+      where concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+          )
+          and concept_id not in
+              (
+                  select CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+              )"
+  done
+
+  echo "CONDITIONS - SOURCE SNOMED - add root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'CONDITION',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+  where concept_id = 441840"
+
+  echo "CONDITIONS - SOURCE SNOMED - add level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'CONDITION'
+      and p.type = 'SNOMED'
+      and p.is_standard = 0
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          )
+      and c.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
+          )"
+
+  # currently, there are only 16 levels, but we run it 18 times to be safe (if changed, change number of joins in next query)
+  for i in {1..18};
+  do
+      echo "CONDITIONS - SOURCE SNOMED - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+          case when l.concept_code is null then 1 else 0 end,
+          1,0,1,
+          CONCAT(p.path, '.',
+              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
+      left join
+          (
+              select distinct a.concept_code
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` b on a.concept_id = b.p_concept_id
+              where b.concept_id is null
+          ) l on c.concept_code = l.concept_code
+      where p.domain_id = 'CONDITION'
+          and p.type = 'SNOMED'
+          and p.is_standard = 0
+          and p.id not in
+              (
+                  select parent_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )"
+  done
+
+  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+  echo "CONDITIONS - SOURCE SNOMED - add items into temp ancestor table for use in next query"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
+      concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
+  SELECT DISTINCT a.concept_id as ancestor_concept_id
+      , a.domain_id
+      , a.type
+      , a.is_standard
+      , b.concept_id c1
+      , c.concept_id c2
+      , d.concept_id c3
+      , e.concept_id c4
+      , f.concept_id c5
+      , g.concept_id c6
+      , h.concept_id c7
+      , i.concept_id c8
+      , j.concept_id c9
+      , k.concept_id c10
+      , m.concept_id c11
+      , n.concept_id as c12
+      , o.concept_id as c13
+      , p.concept_id as c14
+      , q.concept_id as c15
+      , r.concept_id as c16
+      , s.concept_id as c17
+      , t.concept_id as c18
+  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
+      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) o on n.id = o.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) p on o.id = p.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) q on p.id = q.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) r on q.id = r.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) s on r.id = s.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) t on s.id = t.parent_id"
+
+  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+  # the last UNION statement is to add the ancestor item to itself
+  echo "CONDITIONS - SOURCE SNOMED - add items into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+      (ancestor_concept_id, descendant_concept_id, is_standard)
+  SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_18 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_17 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_16 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_15 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_14 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_13 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_12 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_11 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_10 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_9 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_8 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_7 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_6 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_5 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_4 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_3 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_2 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_1 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 0"
+
+  echo "CONDITIONS - SOURCE SNOMED - child counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT condition_source_concept_id as concept_id, COUNT(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
+          GROUP BY 1
+      ) y
+  WHERE x.concept_id = y.concept_id
+      and x.domain_id = 'CONDITION'
+      and x.type = 'SNOMED'
+      and x.is_standard = 0
+      and x.is_group = 0
+      and x.is_selectable = 1"
+
+  echo "CONDITIONS - SOURCE SNOMED - parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  FROM
+      (
+          SELECT ancestor_concept_id as concept_id, COUNT(distinct person_id) cnt
+          FROM
+              (
+                  SELECT *
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                  WHERE ancestor_concept_id in
+                      (
+                          SELECT distinct concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          WHERE domain_id = 'CONDITION'
+                              and type = 'SNOMED'
+                              and is_standard = 0
+                              and parent_id != 0
+                              and is_group = 1
+                      )
+                      and is_standard = 0
+              ) a
+          JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_source_concept_id
+          GROUP BY 1
+      ) y
+  WHERE x.concept_id = y.concept_id
+      and x.domain_id = 'CONDITION'
+      and x.type = 'SNOMED'
+      and x.is_standard = 0
+      and x.is_group = 1"
+
+  # ----- STANDARD SNOMED -----
+  echo "CONDITIONS - STANDARD SNOMED - temp table level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
+  where concept_id in
+      (
+          select distinct condition_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
+          where condition_concept_id != 0
+              and b.domain_id = 'Condition'
+              and b.standard_concept = 'S'
+              and b.vocabulary_id = 'SNOMED'
+      )"
+
+  # currently, there are only 5 levels, but we run it 6 times to be safe
+  for i in {1..6};
+  do
+      echo "CONDITIONS - STANDARD SNOMED - temp table level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
+      where concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+          )
         and concept_id not in
-            (
-                select CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-            )"
-done
+          (
+              select CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+          )"
+  done
 
-echo "CONDITIONS - SOURCE SNOMED - add root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'CONDITION',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-where concept_id = 441840"
+  echo "CONDITIONS - STANDARD SNOMED - add root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'CONDITION',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+  where concept_id = 441840"
 
-echo "CONDITIONS - SOURCE SNOMED - add level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'CONDITION'
-    and p.type = 'SNOMED'
-    and p.is_standard = 0
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        )
-    and c.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`
-        )"
+  echo "CONDITIONS - STANDARD SNOMED - add level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'CONDITION'
+      and p.type = 'SNOMED'
+      and p.is_standard = 1
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          )
+      and c.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
+          )"
 
-# currently, there are only 16 levels, but we run it 18 times to be safe (if changed, change number of joins in next query)
-for i in {1..18};
-do
-    echo "CONDITIONS - SOURCE SNOMED - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        p.id,'CONDITION',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-        case when l.concept_code is null then 1 else 0 end,
-        1,0,1,
-        CONCAT(p.path, '.',
-            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` c on p.code = c.p_concept_code
-    left join
-        (
-            select distinct a.concept_code
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\` b on a.concept_id = b.p_concept_id
-            where b.concept_id is null
-        ) l on c.concept_code = l.concept_code
-    where p.domain_id = 'CONDITION'
-        and p.type = 'SNOMED'
-        and p.is_standard = 0
-        and p.id not in
-            (
-                select parent_id
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )"
-done
+  # currently, there are only 17 levels, but we run it 18 times to be safe. If this changes, change the next query
+  for i in {1..18};
+  do
+      echo "CONDITIONS - STANDARD SNOMED - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+          case when l.concept_code is null then 1 else 0 end,
+          1,0,1,
+          CONCAT(p.path, '.',
+              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
+      left join
+          (
+              select distinct a.CONCEPT_CODE
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` b on a.concept_id = b.p_concept_id
+              where b.concept_id is null
+          ) l on c.concept_code = l.concept_code
+      where p.domain_id = 'CONDITION'
+          and p.type = 'SNOMED'
+          and p.is_standard = 1
+          and p.id not in
+              (
+                  select PARENT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )"
+  done
 
-# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-echo "CONDITIONS - SOURCE SNOMED - add items into temp ancestor table for use in next query"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
-    concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
-SELECT DISTINCT a.concept_id as ancestor_concept_id
-    , a.domain_id
-    , a.type
-    , a.is_standard
-    , b.concept_id c1
-    , c.concept_id c2
-    , d.concept_id c3
-    , e.concept_id c4
-    , f.concept_id c5
-    , g.concept_id c6
-    , h.concept_id c7
-    , i.concept_id c8
-    , j.concept_id c9
-    , k.concept_id c10
-    , m.concept_id c11
-    , n.concept_id as c12
-    , o.concept_id as c13
-    , p.concept_id as c14
-    , q.concept_id as c15
-    , r.concept_id as c16
-    , s.concept_id as c17
-    , t.concept_id as c18
-FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
-    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) o on n.id = o.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) p on o.id = p.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) q on p.id = q.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) r on q.id = r.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) s on r.id = s.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 0) t on s.id = t.parent_id"
+  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+  echo "CONDITIONS - STANDARD SNOMED - add items into temp ancestor table for use in next query"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
+      concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
+  SELECT DISTINCT a.concept_id as ancestor_concept_id
+      , a.domain_id
+      , a.type
+      , a.is_standard
+      , b.concept_id c1
+      , c.concept_id c2
+      , d.concept_id c3
+      , e.concept_id c4
+      , f.concept_id c5
+      , g.concept_id c6
+      , h.concept_id c7
+      , i.concept_id c8
+      , j.concept_id c9
+      , k.concept_id c10
+      , m.concept_id c11
+      , n.concept_id as c12
+      , o.concept_id as c13
+      , p.concept_id as c14
+      , q.concept_id as c15
+      , r.concept_id as c16
+      , s.concept_id as c17
+      , t.concept_id as c18
+  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
+      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) o on n.id = o.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) p on o.id = p.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) q on p.id = q.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) r on q.id = r.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) s on r.id = s.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) t on s.id = t.parent_id"
 
-# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-# the last UNION statement is to add the ancestor item to itself
-echo "CONDITIONS - SOURCE SNOMED - add items into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-    (ancestor_concept_id, descendant_concept_id, is_standard)
-SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_18 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_17 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_16 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_15 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_14 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_13 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_12 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_11 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_10 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_9 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_8 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_7 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_6 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_5 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_4 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_3 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_2 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_1 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 0"
+  # Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
+  # there last UNION statement is to add the ancestor item to itself
+  echo "CONDITIONS - STANDARD SNOMED - add items into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+      (ancestor_concept_id, descendant_concept_id, is_standard)
+  SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_18 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_17 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_16 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_15 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_14 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_13 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_12 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_11 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_10 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_9 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_8 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_7 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_6 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_5 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_4 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_3 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_2 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_1 is not null
+      and domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE domain_id = 'CONDITION'
+      and type = 'SNOMED'
+      and is_standard = 1"
 
-echo "CONDITIONS - SOURCE SNOMED - child counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT condition_source_concept_id as concept_id, COUNT(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
-        GROUP BY 1
-    ) y
-WHERE x.concept_id = y.concept_id
-    and x.domain_id = 'CONDITION'
-    and x.type = 'SNOMED'
-    and x.is_standard = 0
-    and x.is_group = 0
-    and x.is_selectable = 1"
+  echo "CONDITIONS - STANDARD SNOMED - child counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select condition_concept_id as concept_id, count(distinct person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'CONDITION'
+      and x.type = 'SNOMED'
+      and x.is_standard = 1
+      and x.is_group = 0
+      and x.is_selectable = 1"
 
-echo "CONDITIONS - SOURCE SNOMED - parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-FROM
-    (
-        SELECT ancestor_concept_id as concept_id, COUNT(distinct person_id) cnt
-        FROM
-            (
-                SELECT *
-                FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                WHERE ancestor_concept_id in
+  echo "CONDITIONS - STANDARD SNOMED - parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+          from
+              (
+                  select *
+                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                  where ancestor_concept_id in
+                      (
+                          select distinct concept_id
+                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where domain_id = 'CONDITION'
+                              and type = 'SNOMED'
+                              and is_standard = 1
+                              and parent_id != 0
+                              and is_group = 1
+                      )
+                      and is_standard = 1
+              ) a
+          join \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_concept_id
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'CONDITION'
+      and x.type = 'SNOMED'
+      and x.is_standard = 1
+      and x.is_group = 1"
+
+
+  ################################################
+  # MEASUREMENTS
+  ################################################
+  echo "MEASUREMENTS - add clinical root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+      0,'MEASUREMENT',1,'LOINC','CLIN',36207527,'LP248771-0','Clinical',1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
+
+  echo "MEASUREMENTS - add lab root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+      0,'MEASUREMENT',1,'LOINC','LAB',36206173,'LP29693-6','Lab',1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
+
+  # ----- LOINC CLINICAL -----
+  echo "MEASUREMENTS - clinical - add parents"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN') as parent_id,
+      'MEASUREMENT',1,'LOINC','CLIN',name,1,0,0,1,
+      CONCAT( (SELECT PATH FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN'), '.',
+          CAST(ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+  from
+      (
+          select distinct parent as name
+          from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b using (concept_id)
+          where b.concept_id in
+              (
+                  select distinct measurement_concept_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+              )
+      ) x"
+
+  # add items with vocabulary_id = 'LOINC' and concept_class_id = 'Clinical Observation' where we have categorized them
+  echo "MEASUREMENTS - clinical - add children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      parent_id,'MEASUREMENT',1,'LOINC','CLIN',concept_id,concept_code,concept_name,est_count,0,1,0,1,
+      CONCAT(parent_path, '.',
+          CAST(ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from
+      (
+          select z.*, y.id as parent_id, y.path as parent_path
+          from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` x
+          join
+              (
+                  select id,name,path
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  where type = 'LOINC'
+                      and subtype = 'CLIN'
+                      and is_group = 1
+              ) y on x.parent = y.name
+          join
+              (
+                  select concept_name, concept_id, concept_code, count(distinct person_id) est_count
+                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+                  where standard_concept = 'S'
+                      and domain_id = 'Measurement'
+                      and vocabulary_id = 'LOINC'
+                  group by 1,2,3
+              ) z on x.concept_id = z.concept_id
+      ) g"
+
+  #----- LOINC LABS -----
+  echo "MEASUREMENTS - labs - load temp table 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
+  where concept_id in
+      (
+          select distinct MEASUREMENT_CONCEPT_ID
+          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.MEASUREMENT_CONCEPT_ID = b.concept_id
+          where MEASUREMENT_CONCEPT_ID != 0
+              and b.vocabulary_id = 'LOINC'
+              and b.STANDARD_CONCEPT = 'S'
+              and b.domain_id = 'Measurement'
+      )"
+
+  # currently, there are only 4 levels, but we run it 5 times to be safe
+  for i in {1..5};
+  do
+      echo "MEASUREMENTS - labs - load temp table $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
+      where concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+          )
+          and concept_id not in
+              (
+                  select CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+              )"
+  done
+
+  echo "MEASUREMENTS - labs - add roots - level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      t.ID,'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE,b.CONCEPT_NAME,1,0,0,1,
+      CONCAT( t.path, '.',
+          CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
+  join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
+  where (t.id) not in (select PARENT_ID from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)
+      and t.type = 'LOINC'
+      and t.subtype = 'LAB'
+      and b.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
+          )"
+
+  # for each loop, add all items (children/parents) directly under the items that were previously added
+  # currently, there are only 11 levels, but we run it 12 times to be safe
+  # if this number is changed, you will need to change the number of JOINS in the query below adding data to the ancestor table
+  for i in {1..12};
+  do
+      echo "MEASUREMENTS - labs - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          t.ID, 'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE, b.CONCEPT_NAME,
+          case when l.CONCEPT_CODE is null then null else m.cnt end as est_count,
+          case when l.CONCEPT_CODE is null then 1 else 0 end as is_group,
+          case when l.CONCEPT_CODE is null then 0 else 1 end as is_selectable,
+          0,1,
+          CONCAT(t.path, '.',
+              CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
+      join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
+      left join
+          (
+              select distinct a.CONCEPT_CODE
+              from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on a.CONCEPT_ID = b.P_CONCEPT_ID
+              where b.CONCEPT_ID is null
+          ) l on b.CONCEPT_CODE = l.CONCEPT_CODE
+      left join
+          (
+              select measurement_concept_id, count(distinct person_id) cnt
+              from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+              group by 1
+          ) m on b.concept_id = m.measurement_concept_id
+      where
+          t.id not in
+              (
+                  select parent_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  where type = 'LOINC'
+                      and subtype = 'LAB'
+              )
+          and parent_id != 0"
+  done
+
+  echo "MEASUREMENTS - labs - add parent for uncategorized labs"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
+      a.id as parent_id,'MEASUREMENT',1,'LOINC','LAB','Uncategorized',1,0,0,1,
+      CONCAT(a.path, '.', CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING))
+  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+  WHERE type = 'LOINC' and subtype = 'LAB' and parent_id = 0"
+
+  echo "MEASUREMENTS - labs - add uncategorized labs"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as parent_id,
+      'MEASUREMENT',1,'LOINC','LAB',concept_id,concept_code,concept_name,est_count,0,1,0,1,
+      CONCAT( (select path from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` where type = 'LOINC' and subtype = 'LAB' and name = 'Uncategorized'), '.',
+          CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+  from
+      (
+          select concept_id, concept_code, concept_name, count(distinct person_id) est_count
+          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+          where standard_concept = 'S'
+              and domain_id = 'Measurement'
+              and vocabulary_id = 'LOINC'
+              and measurement_concept_id not in
+                  (
+                      select concept_id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where type = 'LOINC'
+                      and concept_id is not null
+                  )
+          group by 1,2,3
+      ) x"
+
+  # if loop count above is changed, the number of JOINS below must be updated
+  echo "MEASUREMENTS - labs - add data into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+      (ancestor_id, descendant_id)
+  SELECT DISTINCT a.id as ancestor_id,
+      COALESCE(n.id, m.id, k.id, j.id, i.id, h.id, g.id, f.id, e.id, d.id, c.id, b.id) as descendant_id
+  FROM
+      (SELECT id, parent_id, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB' and parent_id != 0 and is_group = 1) a
+      JOIN (SELECT id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') b on a.id = b.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') c on b.id = c.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') d on c.id = d.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') e on d.id = e.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') f on e.id = f.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') g on f.id = g.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') h on g.id = h.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') i on h.id = i.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') j on i.id = j.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') k on j.id = k.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') m on k.id = m.parent_id
+      LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') n on m.id = n.parent_id"
+
+  echo "MEASUREMENTS - labs - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select e.id, count(distinct person_id) cnt
+          from
+              (
+                  select * from
+                  (
+                      select id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where type = 'LOINC'
+                          and subtype = 'LAB'
+                          and is_group = 1
+                          and parent_id != 0
+                  ) a
+                  left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) e
+          left join
+              (
+                  select c.id, d.*
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+                  join
                     (
-                        SELECT distinct concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        WHERE domain_id = 'CONDITION'
-                            and type = 'SNOMED'
-                            and is_standard = 0
-                            and parent_id != 0
-                            and is_group = 1
-                    )
-                    and is_standard = 0
-            ) a
-        JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_source_concept_id
-        GROUP BY 1
-    ) y
-WHERE x.concept_id = y.concept_id
-    and x.domain_id = 'CONDITION'
-    and x.type = 'SNOMED'
-    and x.is_standard = 0
-    and x.is_group = 1"
-
-# ----- STANDARD SNOMED -----
-echo "CONDITIONS - STANDARD SNOMED - temp table level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
-where concept_id in
-    (
-        select distinct condition_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
-        where condition_concept_id != 0
-            and b.domain_id = 'Condition'
-            and b.standard_concept = 'S'
-            and b.vocabulary_id = 'SNOMED'
-    )"
-
-# currently, there are only 5 levels, but we run it 6 times to be safe
-for i in {1..6};
-do
-    echo "CONDITIONS - STANDARD SNOMED - temp table level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\` a
-    where concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-        )
-      and concept_id not in
-        (
-            select CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-        )"
-done
-
-echo "CONDITIONS - STANDARD SNOMED - add root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'CONDITION',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-where concept_id = 441840"
-
-echo "CONDITIONS - STANDARD SNOMED - add level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'CONDITION'
-    and p.type = 'SNOMED'
-    and p.is_standard = 1
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        )
-    and c.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`
-        )"
-
-# currently, there are only 17 levels, but we run it 18 times to be safe. If this changes, change the next query
-for i in {1..18};
-do
-    echo "CONDITIONS - STANDARD SNOMED - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        p.id,'CONDITION',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-        case when l.concept_code is null then 1 else 0 end,
-        1,0,1,
-        CONCAT(p.path, '.',
-            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` c on p.code = c.p_concept_code
-    left join
-        (
-            select distinct a.CONCEPT_CODE
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\` b on a.concept_id = b.p_concept_id
-            where b.concept_id is null
-        ) l on c.concept_code = l.concept_code
-    where p.domain_id = 'CONDITION'
-        and p.type = 'SNOMED'
-        and p.is_standard = 1
-        and p.id not in
-            (
-                select PARENT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )"
-done
-
-# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-echo "CONDITIONS - STANDARD SNOMED - add items into temp ancestor table for use in next query"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12,
-    concept_id_13, concept_id_14, concept_id_15, concept_id_16, concept_id_17, concept_id_18)
-SELECT DISTINCT a.concept_id as ancestor_concept_id
-    , a.domain_id
-    , a.type
-    , a.is_standard
-    , b.concept_id c1
-    , c.concept_id c2
-    , d.concept_id c3
-    , e.concept_id c4
-    , f.concept_id c5
-    , g.concept_id c6
-    , h.concept_id c7
-    , i.concept_id c8
-    , j.concept_id c9
-    , k.concept_id c10
-    , m.concept_id c11
-    , n.concept_id as c12
-    , o.concept_id as c13
-    , p.concept_id as c14
-    , q.concept_id as c15
-    , r.concept_id as c16
-    , s.concept_id as c17
-    , t.concept_id as c18
-FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
-    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) o on n.id = o.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) p on o.id = p.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) q on p.id = q.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) r on q.id = r.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) s on r.id = s.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'CONDITION' and type = 'SNOMED' and is_standard = 1) t on s.id = t.parent_id"
-
-# Join Count: 19 - If loop count above is changed, the number of JOINS below must be updated
-# there last UNION statement is to add the ancestor item to itself
-echo "CONDITIONS - STANDARD SNOMED - add items into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-    (ancestor_concept_id, descendant_concept_id, is_standard)
-SELECT DISTINCT ancestor_concept_id, concept_id_18 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_18 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_17 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_17 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_16 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_16 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_15 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_15 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_14 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_14 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_13 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_13 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_12 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_11 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_10 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_9 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_8 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_7 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_6 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_5 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_4 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_3 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_2 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_1 is not null
-    and domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE domain_id = 'CONDITION'
-    and type = 'SNOMED'
-    and is_standard = 1"
-
-echo "CONDITIONS - STANDARD SNOMED - child counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select condition_concept_id as concept_id, count(distinct person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\`
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'CONDITION'
-    and x.type = 'SNOMED'
-    and x.is_standard = 1
-    and x.is_group = 0
-    and x.is_selectable = 1"
-
-echo "CONDITIONS - STANDARD SNOMED - parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-        from
-            (
-                select *
-                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                where ancestor_concept_id in
-                    (
-                        select distinct concept_id
-                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        where domain_id = 'CONDITION'
-                            and type = 'SNOMED'
-                            and is_standard = 1
-                            and parent_id != 0
-                            and is_group = 1
-                    )
-                    and is_standard = 1
-            ) a
-        join \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` b on a.descendant_concept_id = b.condition_concept_id
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'CONDITION'
-    and x.type = 'SNOMED'
-    and x.is_standard = 1
-    and x.is_group = 1"
-
-
-################################################
-# MEASUREMENTS
-################################################
-echo "MEASUREMENTS - add clinical root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-    0,'MEASUREMENT',1,'LOINC','CLIN',36207527,'LP248771-0','Clinical',1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
-
-echo "MEASUREMENTS - add lab root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-    0,'MEASUREMENT',1,'LOINC','LAB',36206173,'LP29693-6','Lab',1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING)"
-
-# ----- LOINC CLINICAL -----
-echo "MEASUREMENTS - clinical - add parents"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    (SELECT ID FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN') as parent_id,
-    'MEASUREMENT',1,'LOINC','CLIN',name,1,0,0,1,
-    CONCAT( (SELECT PATH FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'CLIN'), '.',
-        CAST(ROW_NUMBER() OVER(order by name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-from
-    (
-        select distinct parent as name
-        from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b using (concept_id)
-        where b.concept_id in
-            (
-                select distinct measurement_concept_id
-                from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-            )
-    ) x"
-
-# add items with vocabulary_id = 'LOINC' and concept_class_id = 'Clinical Observation' where we have categorized them
-echo "MEASUREMENTS - clinical - add children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    parent_id,'MEASUREMENT',1,'LOINC','CLIN',concept_id,concept_code,concept_name,est_count,0,1,0,1,
-    CONCAT(parent_path, '.',
-        CAST(ROW_NUMBER() OVER(order by parent_id, concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from
-    (
-        select z.*, y.id as parent_id, y.path as parent_path
-        from \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\` x
-        join
-            (
-                select id,name,path
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                where type = 'LOINC'
-                    and subtype = 'CLIN'
-                    and is_group = 1
-            ) y on x.parent = y.name
-        join
-            (
-                select concept_name, concept_id, concept_code, count(distinct person_id) est_count
-                from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-                where standard_concept = 'S'
-                    and domain_id = 'Measurement'
-                    and vocabulary_id = 'LOINC'
-                group by 1,2,3
-            ) z on x.concept_id = z.concept_id
-    ) g"
-
-#----- LOINC LABS -----
-echo "MEASUREMENTS - labs - load temp table 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
-where concept_id in
-    (
-        select distinct MEASUREMENT_CONCEPT_ID
-        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.MEASUREMENT_CONCEPT_ID = b.concept_id
-        where MEASUREMENT_CONCEPT_ID != 0
-            and b.vocabulary_id = 'LOINC'
-            and b.STANDARD_CONCEPT = 'S'
-            and b.domain_id = 'Measurement'
-    )"
-
-# currently, there are only 4 levels, but we run it 5 times to be safe
-for i in {1..5};
-do
-    echo "MEASUREMENTS - labs - load temp table $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, concept_id, concept_code, concept_name)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\` a
-    where concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-        )
-        and concept_id not in
-            (
-                select CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-            )"
-done
-
-echo "MEASUREMENTS - labs - add roots - level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    t.ID,'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE,b.CONCEPT_NAME,1,0,0,1,
-    CONCAT( t.path, '.',
-        CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
-join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
-where (t.id) not in (select PARENT_ID from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)
-    and t.type = 'LOINC'
-    and t.subtype = 'LAB'
-    and b.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`
-        )"
-
-# for each loop, add all items (children/parents) directly under the items that were previously added
-# currently, there are only 11 levels, but we run it 12 times to be safe
-# if this number is changed, you will need to change the number of JOINS in the query below adding data to the ancestor table
-for i in {1..12};
-do
-    echo "MEASUREMENTS - labs - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        t.ID, 'MEASUREMENT',1,'LOINC','LAB',b.CONCEPT_ID,b.CONCEPT_CODE, b.CONCEPT_NAME,
-        case when l.CONCEPT_CODE is null then null else m.cnt end as est_count,
-        case when l.CONCEPT_CODE is null then 1 else 0 end as is_group,
-        case when l.CONCEPT_CODE is null then 0 else 1 end as is_selectable,
-        0,1,
-        CONCAT(t.path, '.',
-            CAST(row_number() over (order by t.ID, b.CONCEPT_NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` t
-    join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on t.code = b.p_concept_code
-    left join
-        (
-            select distinct a.CONCEPT_CODE
-            from \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\` b on a.CONCEPT_ID = b.P_CONCEPT_ID
-            where b.CONCEPT_ID is null
-        ) l on b.CONCEPT_CODE = l.CONCEPT_CODE
-    left join
-        (
-            select measurement_concept_id, count(distinct person_id) cnt
-            from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-            group by 1
-        ) m on b.concept_id = m.measurement_concept_id
-    where
-        t.id not in
-            (
-                select parent_id
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                where type = 'LOINC'
+                      SELECT person_id, concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+              join
+                        (
+                  select concept_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where type = 'LOINC'
                     and subtype = 'LAB'
-            )
-        and parent_id != 0"
-done
-
-echo "MEASUREMENTS - labs - add parent for uncategorized labs"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as ID,
-    a.id as parent_id,'MEASUREMENT',1,'LOINC','LAB','Uncategorized',1,0,0,1,
-    CONCAT(a.path, '.', CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS STRING))
-FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-WHERE type = 'LOINC' and subtype = 'LAB' and parent_id = 0"
-
-echo "MEASUREMENTS - labs - add uncategorized labs"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,subtype,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as parent_id,
-    'MEASUREMENT',1,'LOINC','LAB',concept_id,concept_code,concept_name,est_count,0,1,0,1,
-    CONCAT( (select path from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` where type = 'LOINC' and subtype = 'LAB' and name = 'Uncategorized'), '.',
-        CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-from
-    (
-        select concept_id, concept_code, concept_name, count(distinct person_id) est_count
-        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-        where standard_concept = 'S'
-            and domain_id = 'Measurement'
-            and vocabulary_id = 'LOINC'
-            and measurement_concept_id not in
-                (
-                    select concept_id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where type = 'LOINC'
-                    and concept_id is not null
-                )
-        group by 1,2,3
-    ) x"
-
-# if loop count above is changed, the number of JOINS below must be updated
-echo "MEASUREMENTS - labs - add data into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-    (ancestor_id, descendant_id)
-SELECT DISTINCT a.id as ancestor_id,
-    COALESCE(n.id, m.id, k.id, j.id, i.id, h.id, g.id, f.id, e.id, d.id, c.id, b.id) as descendant_id
-FROM
-    (SELECT id, parent_id, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB' and parent_id != 0 and is_group = 1) a
-    JOIN (SELECT id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') b on a.id = b.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') c on b.id = c.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') d on c.id = d.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') e on d.id = e.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') f on e.id = f.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') g on f.id = g.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') h on g.id = h.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') i on h.id = i.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') j on i.id = j.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') k on j.id = k.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') m on k.id = m.parent_id
-    LEFT JOIN (SELECT id, parent_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE type = 'LOINC' and subtype = 'LAB') n on m.id = n.parent_id"
-
-echo "MEASUREMENTS - labs - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select e.id, count(distinct person_id) cnt
-        from
-            (
-                select * from
-                (
-                    select id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where type = 'LOINC'
-                        and subtype = 'LAB'
-                        and is_group = 1
-                        and parent_id != 0
-                ) a
-                left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) e
-        left join
-            (
-                select c.id, d.*
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-                join
-	                (
-		                SELECT person_id, concept_id
-		                FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-						join
-			                (
-								select concept_id
-								from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-			                	where type = 'LOINC'
-									and subtype = 'LAB'
-									and is_selectable = 1
-			                ) b on a.measurement_concept_id = b.concept_id
-	                ) d on c.concept_id = d.concept_id
-            ) f on e.descendant_id = f.id
-        group by 1
-    ) y
-where x.id = y.id"
-
-
-#----- SNOMED -----
-echo "MEASUREMENTS - SNOMED - temp table level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
-where concept_id in
-    (
-        select distinct measurement_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-        where measurement_concept_id != 0
-            and b.vocabulary_id = 'SNOMED'
-            and b.STANDARD_CONCEPT = 'S'
-            and b.domain_id = 'Measurement'
-    )"
-
-# for each loop, add all items (children/parents) directly under the items that were previously added
-# currently, there are only 3 levels, but we run it 4 times to be safe
-for i in {1..4};
-do
-    echo "MEASUREMENTS - SNOMED - temp table level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
-    where concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-        )
-        and concept_id not in
-            (
-                select CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-            )"
-done
-
-echo "MEASUREMENTS - SNOMED - add roots"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    0, 'MEASUREMENT',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-    CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-from
-    (
-        select distinct concept_id, concept_name, concept_code
-        from
-            (
-                select *, rank() over (partition by descendant_concept_id order by MAX_LEVELS_OF_SEPARATION desc) rnk
-                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
-                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.concept_id
-                where b.domain_id = 'Measurement'
-                    and b.vocabulary_id = 'SNOMED'
-                    and a.descendant_concept_id in
-                        (
-                            select distinct concept_id
-                            from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-                            left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-                            where standard_concept = 'S'
-                                and domain_id = 'Measurement'
-                                and vocabulary_id = 'SNOMED'
-                        )
-            ) a
-        where rnk = 1
-    ) x"
-
-echo "MEASUREMENTS - SNOMED - add level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,0,0,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'MEASUREMENT'
-    and p.type = 'SNOMED'
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        )
-    and c.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
-        )"
-
-# for each loop, add all items (children/parents) directly under the items that were previously added
-# currently, there are only 6 levels, but we run it 7 times to be safe
-for i in {1..7};
-do
-    echo "MEASUREMENTS - SNOMED - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-        case when l.concept_code is null then 1 else 0 end,
-        case when l.concept_code is null then 0 else 1 end,
-        0,1,
-        CONCAT(p.path, '.',
-            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
-    left join
-        (
-            select distinct a.concept_code
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` b on a.concept_id = b.p_concept_id
-            where b.concept_id is null
-        ) l on c.concept_code = l.concept_code
-    where p.domain_id = 'MEASUREMENT'
-        and p.type = 'SNOMED'
-        and p.id not in
-            (
-                select parent_id
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )
-        and c.concept_id not in
-            (
-                select parent_id
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )"
-done
-
-echo "MEASUREMENTS - SNOMED - generate counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-        from
-            (
-                select *
-                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                where ancestor_concept_id in
-                    (
-                        select distinct concept_id
-                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        where domain_id = 'MEASUREMENT'
-                            and type = 'SNOMED'
-                    )
-            ) a
-        join \`$BQ_PROJECT.$BQ_DATASET.measurement\` b on a.descendant_concept_id = b.measurement_concept_id
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'MEASUREMENT'
-    and x.type = 'SNOMED'"
-
-echo "MEASUREMENTS - SNOMED - add parents as children"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select (row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)) as ID,
-    id as parent_id,domain_id,is_standard,type,concept_id,code,name,cnt,0,1,0,1,CONCAT(path, '.',
-    CAST(row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-from
-    (
-        select *
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
-        join
-            (
-                select measurement_concept_id, count(distinct person_id) cnt
-                from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-                group by 1
-            ) b on a.concept_id = b.measurement_concept_id
-        where domain_id = 'MEASUREMENT'
-            and type = 'SNOMED'
-            and is_group = 1
-    ) x"
-
-
-################################################
-# DRUG EXPOSURE
-################################################
-#----- RXNORM / RXNORM EXTENSION -----
-# ATC4 - ATC5 --> RXNORM/RXNORM Extension ingredient
-# ATC4 - ATC5 --> RXNORM/RXNORM Extension precise ingedient --> RXNORM ingredient
-echo "DRUGS - temp table - ATC4 to RXNORM"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-SELECT distinct e.p_concept_id, e.p_concept_code, e.p_concept_name, e.p_DOMAIN_ID,
-    d.CONCEPT_ID, d.CONCEPT_CODE, d.CONCEPT_NAME, d.DOMAIN_ID
-from
-    (
-        SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c2.CONCEPT_ID atc_5
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, atc, atc_5th
-        WHERE a.RELATIONSHIP_ID IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
-            and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
-            and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 5th' and c2.STANDARD_CONCEPT = 'C'
-            and c1.concept_id in
-                (
-                    SELECT ANCESTOR_CONCEPT_ID
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                    WHERE DESCENDANT_CONCEPT_ID in
-                        (
-                            SELECT distinct DRUG_CONCEPT_ID
-                            FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                        )
-                )
-        UNION ALL
-        SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c3.CONCEPT_ID atc_5
-        FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, rxnorm, precise ingredient
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` b on a.CONCEPT_ID_2 = b.CONCEPT_ID_1
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on b.CONCEPT_ID_2 = c3.CONCEPT_ID--child, atc, atc_5th
-        WHERE a.RELATIONSHIP_ID = 'Has form' and b.RELATIONSHIP_ID = 'RxNorm - ATC'
-            and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
-            and c2.VOCABULARY_ID = 'RxNorm' and c2.CONCEPT_CLASS_ID = 'Precise Ingredient'
-            and c3.VOCABULARY_ID = 'ATC' and c3.CONCEPT_CLASS_ID = 'ATC 5th' and c3.STANDARD_CONCEPT = 'C'
-            and c1.concept_id in
-                (
-                    SELECT ANCESTOR_CONCEPT_ID
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                    WHERE DESCENDANT_CONCEPT_ID in
-                        (
-                            SELECT distinct DRUG_CONCEPT_ID
-                            FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                        )
-                )
-    ) d
-left join
-    (
-        select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-            c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID as atc_5, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-        from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID --parent, atc, atc_4
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID --child, atc, atc_5
-        where RELATIONSHIP_ID = 'Subsumes'
-            and c1.VOCABULARY_ID = 'ATC'
-            and c1.CONCEPT_CLASS_ID = 'ATC 4th'
-            and c1.STANDARD_CONCEPT = 'C'
-            and c2.VOCABULARY_ID = 'ATC'
-            and c2.CONCEPT_CLASS_ID = 'ATC 5th'
-            and c2.STANDARD_CONCEPT = 'C'
-    ) e on d.atc_5 = e.atc_5"
-
-echo "DRUGS - temp table - ATC3 to ATC4"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-    left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-    left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-where RELATIONSHIP_ID = 'Subsumes'
-    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 3rd' and c1.STANDARD_CONCEPT = 'C'
-    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 4th' and c2.STANDARD_CONCEPT = 'C'
-    and c2.concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )
-    and c2.concept_id not in
-        (
-            select CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )"
-
-echo "DRUGS - temp table - ATC2 TO ATC3"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-where RELATIONSHIP_ID = 'Subsumes'
-    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 2nd' and c1.STANDARD_CONCEPT = 'C'
-    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 3rd' and c2.STANDARD_CONCEPT = 'C'
-    and c2.concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )
-    and c2.concept_id not in
-        (
-            select CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )"
-
-echo "DRUGS - temp table - ATC1 TO ATC2"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
-    c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
-from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
-where RELATIONSHIP_ID = 'Subsumes'
-    and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 1st' and c1.STANDARD_CONCEPT = 'C'
-    and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 2nd' and c2.STANDARD_CONCEPT = 'C'
-    and c2.concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )
-    and c2.concept_id not in
-        (
-            select CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
-        )"
-
-echo "DRUGS - add roots"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    0, 'DRUG', 1, 'ATC', concept_id, concept_code, CONCAT( UPPER(SUBSTR(concept_name, 1, 1)), LOWER(SUBSTR(concept_name, 2)) ),
-    1,0,0,1,1,
-    CAST(ROW_NUMBER() OVER(order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-where VOCABULARY_ID = 'ATC'
-    and CONCEPT_CLASS_ID = 'ATC 1st'
-    and STANDARD_CONCEPT = 'C'"
-
-echo "DRUGS - add root for unmapped ingredients"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'DRUG',1,'ATC','Unmapped ingredients',1,0,0,1,1,
-    CAST( (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING ) as path"
-
-echo "DRUGS - level 2"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'DRUG'
-    and p.type = 'ATC'
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            where domain_id = 'DRUG'
-                and type = 'ATC'
-        )"
-
-echo "DRUGS - level 3"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'DRUG'
-    and p.type = 'ATC'
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            where domain_id = 'DRUG'
-                and type = 'ATC'
-        )"
-
-echo "DRUGS - level 4"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
-    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'DRUG'
-    and p.type = 'ATC'
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            where domain_id = 'DRUG'
-                and type = 'ATC'
-        )"
-
-echo "DRUGS - level 5 - ingredients"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'DRUG',1,'RXNORM',c.concept_id,c.concept_code,
-    CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),0,1,0,1,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'DRUG'
-    and p.type = 'ATC'
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            where domain_id = 'DRUG'
-                and type = 'ATC'
-        )"
-
-echo "DRUGS - add parents for unmapped ingredients"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    (select id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients') as parent_id,
-    'DRUG',1,'ATC',name as code, name,1,0,0,1,1,
-    CONCAT( (select CAST(id as STRING) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients'),
-        '.', CAST(ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
-from
-    (
-        select distinct UPPER(SUBSTR(concept_name, 1, 1)) name
-        from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-            and CONCEPT_CLASS_ID = 'Ingredient'
-            and STANDARD_CONCEPT = 'S'
-            and concept_id in
-                (
-                    select ANCESTOR_CONCEPT_ID
-                    from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                    where DESCENDANT_CONCEPT_ID in
-                        (
-                            select distinct DRUG_CONCEPT_ID
-                            from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                        )
-                )
-            and concept_id not in
-                (
-                    select concept_id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where domain_id = 'DRUG'
-                        and concept_id is not null
-                )
-
-    ) x"
-
-echo "DRUGS - add unmapped ingredients"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
-select row_number() over (order by z.id, upper(x.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    z.id,'DRUG',1,'RXNORM',x.concept_id,x.concept_code,CONCAT( UPPER(SUBSTR(x.concept_name, 1, 1)), LOWER(SUBSTR(x.concept_name, 2)) ),
-    0,1,0,1,1,
-    CONCAT(z.path, '.',
-        CAST(ROW_NUMBER() OVER(order by z.id, upper(x.concept_name)) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from
-    (
-        select *
-        from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-        where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-            and CONCEPT_CLASS_ID = 'Ingredient'
-            and STANDARD_CONCEPT = 'S'
-            and concept_id in
-                (
-                    select ANCESTOR_CONCEPT_ID
-                    from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-                    where DESCENDANT_CONCEPT_ID in
-                        (
-                            select distinct DRUG_CONCEPT_ID
-                            from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-                        )
-                )
-            and concept_id not in
-                (
-                    select concept_id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where domain_id = 'DRUG'
-                        and concept_id is not null
-                )
-    ) x
-join
-    (
-        select *
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        where domain_id = 'DRUG'
-            and type = 'ATC'
-            and length(name) = 1
-    ) z on UPPER(SUBSTR(x.concept_name, 1, 1)) = z.name"
-
-echo "DRUGS - generate child counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select b.ANCESTOR_CONCEPT_ID as concept_id, count(distinct a.person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-        join
-            (
-                select *
-                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` x
-                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` y on x.ANCESTOR_CONCEPT_ID = y.CONCEPT_ID
-                where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-                    and CONCEPT_CLASS_ID = 'Ingredient'
-            ) b on a.DRUG_CONCEPT_ID = b.DESCENDANT_CONCEPT_ID
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'DRUG'
-    and x.type = 'RXNORM'"
-
-echo "DRUGS - add brand names"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy)
-select ROW_NUMBER() OVER(ORDER BY upper(concept_name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
-    0,'DRUG',1,'BRAND',concept_id,concept_code,concept_name,0,1,0,0
-FROM
-    (
-        select distinct b.concept_id, b.concept_name, b.concept_code
-        from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.CONCEPT_ID_1 = b.CONCEPT_ID --brands
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.CONCEPT_ID_2 = c.CONCEPT_ID --ingredients
-        where b.vocabulary_id in ('RxNorm','RxNorm Extension')
-            and b.concept_class_id = 'Brand Name'
-            and b.invalid_reason is null
-            and c.concept_id in
-                (
-                    select concept_id
-                    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    where domain_id = 'DRUG'
-                        and type = 'RXNORM'
-                        and is_group = 0
-                        and is_selectable = 1
-                )
-    ) x"
-
-echo "DRUGS - add data into prep_criteria_ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-    (ancestor_id, descendant_id)
-SELECT DISTINCT a.id as ancestor_id,
-    COALESCE(e.id, d.id, c.id, b.id) as descendant_id
-FROM (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM') and is_group = 1 and is_selectable = 1) a
-JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) b on a.id = b.parent_id
-LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) c on b.id = c.parent_id
-LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) d on c.id = d.parent_id
-LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) e on d.id = e.parent_id"
-
-echo "DRUGS - generate parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select g.id, count(distinct person_id) cnt
-        from
-            (
-                select *
-                from
-                    (
-                        select id
-                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        where domain_id = 'DRUG'
-                            and type = 'ATC'
-                            and is_group = 1
-                            and is_selectable = 1
-                    ) a
-                    left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
-            ) g
-        left join
-            (
-                select e.id, f.*
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` e
-                join
-                    (
-                        select d.ANCESTOR_CONCEPT_ID as concept_id, c.person_id
-                        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` c
-                        join
-                            (
-                                select *
-                                from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
-                                left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.CONCEPT_ID
-                                where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
-                                    and CONCEPT_CLASS_ID = 'Ingredient'
-                            ) d on c.DRUG_CONCEPT_ID = d.DESCENDANT_CONCEPT_ID
-                    ) f on e.concept_id = f.concept_id
-            ) h on g.descendant_id = h.id
-        group by 1
-    ) y
-where x.id = y.id"
-
-
-################################################
-# PROCEDURES
-################################################
-#----- STANDARD SNOMED -----
-echo "PROCEDURES - STANDARD SNOMED - temp table level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
-where concept_id in
-    (
-        select distinct procedure_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
-        where procedure_concept_id != 0
-            and b.domain_id = 'Procedure'
-            and b.vocabulary_id = 'SNOMED'
-            and b.standard_concept = 'S'
-    )"
-
-# currently, there are only 8 levels, but we run it 9 times to be safe
-for i in {1..9};
-do
-    echo "PROCEDURES - STANDARD SNOMED - temp table level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
-    where
-        concept_id in
-            (
-                select P_CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-            )
-        and concept_id not in
-            (
-                select CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-            )"
-done
-
-echo "PROCEDURES - STANDARD SNOMED - add root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select (select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1,
-    0,'PROCEDURE',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-where concept_id = 4322976"
-
-echo "PROCEDURES - STANDARD SNOMED - add level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'PROCEDURE'
-    and p.type = 'SNOMED'
-    and p.is_standard = 1
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        )
-    and c.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
-        )"
-
-# currently, there are only 11 levels, but we run it 12 times to be safe, If this count changes, change the query below
-for i in {1..12};
-do
-    echo "PROCEDURES - STANDARD SNOMED - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-        case when l.concept_code is null then 1 else 0 end,
-        1,0,1,
-        CONCAT(p.path, '.',
-            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
-    left join
-        (
-            select distinct a.CONCEPT_CODE
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` b on a.concept_id = b.p_concept_id
-            where b.concept_id is null
-        ) l on c.concept_code = l.concept_code
-    where p.domain_id = 'PROCEDURE'
-        and p.type = 'SNOMED'
-        and p.is_standard = 1
-        and p.id not in
-            (
-                select PARENT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )"
-done
-
-# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-echo "PROCEDURES - STANDARD SNOMED - add items into temp ancestor table for use in next query"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
-SELECT DISTINCT a.concept_id as ancestor_concept_id
-    , a.domain_id
-    , a.type
-    , a.is_standard
-    , b.concept_id c1
-    , c.concept_id c2
-    , d.concept_id c3
-    , e.concept_id c4
-    , f.concept_id c5
-    , g.concept_id c6
-    , h.concept_id c7
-    , i.concept_id c8
-    , j.concept_id c9
-    , k.concept_id c10
-    , m.concept_id c11
-    , n.concept_id as c12
-FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
-    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id"
-
-# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-# there last UNION statement is to add the ancestor item to itself
-echo "PROCEDURES - STANDARD SNOMED - add items into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-    (ancestor_concept_id, descendant_concept_id, is_standard)
-SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_12 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_11 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_10 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_9 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_8 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_7 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_6 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_5 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_4 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_3 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_2 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_1 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 1"
-
-echo "PROCEDURES - STANDARD SNOMED - generate child counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        SELECT procedure_concept_id as concept_id, count(distinct person_id) cnt
-        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
-        GROUP BY 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'PROCEDURE'
-    and x.type = 'SNOMED'
-    and x.is_standard = 1
-    and x.is_group = 0
-    and x.is_selectable = 1"
-
-echo "PROCEDURES - STANDARD SNOMED - parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-        from
-            (
-                select *
-                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                where ancestor_concept_id in
-                    (
-                        select distinct concept_id
-                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        where domain_id = 'PROCEDURE'
-                            and type = 'SNOMED'
-                            and is_standard = 1
-                            and parent_id != 0
-                            and is_group = 1
-                    )
-                    and is_standard = 1
-            ) a
-        join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_concept_id
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'PROCEDURE'
-    and x.type = 'SNOMED'
-    and x.is_standard = 1
-    and x.is_group = 1"
-
-# ----- SOURCE SNOMED -----
-echo "PROCEDURES - SOURCE SNOMED - temp table level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-    (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-select *
-from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
-where concept_id in
-    (
-        select distinct procedure_source_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
-        where procedure_source_concept_id != 0
-            and b.domain_id = 'Procedure'
-            and b.vocabulary_id = 'SNOMED'
-    )"
-
-# currently, there are only 8 levels, but we run it 9 times to be safe
-for i in {1..9};
-do
-    echo "PROCEDURES - SOURCE SNOMED - temp table level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-        (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
-    select *
-    from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
-    where concept_id in
-        (
-            select P_CONCEPT_ID
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-        )
-        and concept_id not in
-            (
-                select CONCEPT_ID
-                from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-            )"
-done
-
-echo "PROCEDURES - SOURCE SNOMED - add root"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
-    0,'PROCEDURE',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
-    CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
-from \`$BQ_PROJECT.$BQ_DATASET.concept\`
-where concept_id = 4322976"
-
-echo "PROCEDURES - SOURCE SNOMED - add level 0"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-    p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
-    CONCAT(p.path, '.',
-        CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
-from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
-where p.domain_id = 'PROCEDURE'
-    and p.type = 'SNOMED'
-    and p.is_standard = 0
-    and p.id not in
-        (
-            select parent_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        )
-    and c.concept_id in
-        (
-            select p_concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
-        )"
-
-# currently, there are only 11 levels, but we run it 12 times to be safe (if changed, change number of joins in next query)
-for i in {1..12};
-do
-    echo "PROCEDURES - SOURCE SNOMED - add level $i"
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
-    select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
-        p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
-        case when l.concept_code is null then 1 else 0 end,
-        1,0,1,
-        CONCAT(p.path, '.',
-            CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
-    from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
-    join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
-    left join
-        (
-            select distinct a.concept_code
-            from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` a
-            left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` b on a.concept_id = b.p_concept_id
-            where b.concept_id is null
-        ) l on c.concept_code = l.concept_code
-    where p.domain_id = 'PROCEDURE'
-        and p.type = 'SNOMED'
-        and p.is_standard = 0
-        and p.id not in
-            (
-                select parent_id
-                from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            )"
-done
-
-# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-echo "PROCEDURES - SOURCE SNOMED - add items into temp ancestor table for use in next query"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-    (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
-    concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
-SELECT DISTINCT a.concept_id as ancestor_concept_id
-    , a.domain_id
-    , a.type
-    , a.is_standard
-    , b.concept_id c1
-    , c.concept_id c2
-    , d.concept_id c3
-    , e.concept_id c4
-    , f.concept_id c5
-    , g.concept_id c6
-    , h.concept_id c7
-    , i.concept_id c8
-    , j.concept_id c9
-    , k.concept_id c10
-    , m.concept_id c11
-    , n.concept_id as c12
-FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
-    JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
-    LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id"
-
-# Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
-# there last UNION statement is to add the ancestor item to itself
-echo "PROCEDURES - SOURCE SNOMED - add items into ancestor table"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-    (ancestor_concept_id, descendant_concept_id, is_standard)
-SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_12 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_11 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_10 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_9 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_8 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_7 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_6 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_5 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_4 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_3 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_2 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE concept_id_1 is not null
-    and domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0
-UNION DISTINCT
-SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
-WHERE domain_id = 'PROCEDURE'
-    and type = 'SNOMED'
-    and is_standard = 0"
-
-echo "PROCEDURES - SOURCE SNOMED - child counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.est_count = y.cnt
-from
-    (
-        select procedure_source_concept_id as concept_id, count(distinct person_id) cnt
-        from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'PROCEDURE'
-    and x.type = 'SNOMED'
-    and x.is_standard = 0
-    and x.is_group = 0
-    and x.is_selectable = 1"
-
-echo "PROCEDURES - SOURCE SNOMED - parent counts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-SET x.est_count = y.cnt
-from
-    (
-        select ancestor_concept_id as concept_id, count(distinct person_id) cnt
-        from
-            (
-                select *
-                from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                where ancestor_concept_id in
-                    (
-                        select distinct concept_id
-                        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                        where domain_id = 'PROCEDURE'
-                            and type = 'SNOMED'
-                            and is_standard = 0
-                            and parent_id != 0
-                            and is_group = 1
-                    )
-                    and is_standard = 0
-            ) a
-        join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_source_concept_id
-        group by 1
-    ) y
-where x.concept_id = y.concept_id
-    and x.domain_id = 'PROCEDURE'
-    and x.type = 'SNOMED'
-    and x.is_standard = 0
-    and x.is_group = 1"
-
-
-################################################
-# CB_CRITERIA_ANCESTOR
-################################################
-echo "CB_CRITERIA_ANCESTOR - Drugs - add ingredients to drugs mapping"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-    (ancestor_id, descendant_id)
-select ancestor_concept_id, descendant_concept_id
-from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
-where ancestor_concept_id in
-    (
-        select distinct concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        where domain_id = 'DRUG'
-            and type = 'RXNORM'
-            and is_group = 0
-            and is_selectable = 1
-    )
-and descendant_concept_id in
-    (
-        select distinct drug_concept_id
-        from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-    )"
-
-
-################################################
-# ADD IN OTHER CODES NOT ALREADY CAPTURED
-################################################
-echo "CONDITIONS - add other source concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-    -1, 'CONDITION', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.condition_concept_id = c.concept_id
-        WHERE a.condition_source_concept_id NOT IN
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE is_standard = 0
-                    and concept_id is not null
-            )
-            and a.condition_source_concept_id != 0
-            and a.condition_source_concept_id is not null
-            and b.concept_id is not null
-            and b.vocabulary_id != 'PPI'
-            and (b.domain_id LIKE 'Condition%' OR c.domain_id = 'Condition')
-        GROUP BY 1,2,3,4
-    ) x"
-
-echo "CONDITIONS - add other standard concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    -1, 'CONDITION',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
-        WHERE standard_concept = 'S'
-            and domain_id = 'Condition'
-            and condition_concept_id NOT IN
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    WHERE domain_id = 'CONDITION'
-                        and is_standard = 1
-                        and concept_id is not null
-                )
-        GROUP BY 1,2,3,4
-    ) x"
-
-echo "PROCEDURES - add other source concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
-    -1, 'PROCEDURE', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.procedure_concept_id = c.concept_id
-        WHERE a.procedure_source_concept_id NOT IN
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE is_standard = 0
-                    and concept_id is not null
-            )
-            and a.procedure_source_concept_id != 0
-            and a.procedure_source_concept_id is not null
-            and b.concept_id is not null
-            and b.vocabulary_id != 'PPI'
-            and (b.domain_id = 'Procedure' OR c.domain_id = 'Procedure')
-        GROUP BY 1,2,3,4
-    ) x"
-
-echo "PROCEDURES - add other standard concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    -1, 'PROCEDURE',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
-        WHERE standard_concept = 'S'
-            and domain_id = 'Procedure'
-            and procedure_concept_id NOT IN
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    WHERE domain_id = 'PROCEDURE'
-                        and is_standard = 1
-                        and concept_id is not null
-                )
-        GROUP BY 1,2,3,4
-    ) x"
-
-echo "MEASUREMENTS - add other standard concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    -1, 'MEASUREMENT',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
-        WHERE standard_concept = 'S'
-            and domain_id = 'Measurement'
-            and vocabulary_id not in ('PPI')
-            and measurement_concept_id NOT IN
-                (
-                    SELECT concept_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                    WHERE domain_id = 'MEASUREMENT'
-                        and is_standard = 1
-                        and concept_id is not null
-                )
-        GROUP BY 1,2,3,4
-    ) x"
-
-echo "DRUGS - add other standard concepts"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-    (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
-SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
-    -1, 'DRUG',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
-    CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
-FROM
-    (
-        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
-        FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.drug_concept_id = b.concept_id
-        WHERE standard_concept = 'S'
-            and domain_id = 'Drug'
-            and drug_concept_id NOT IN
-                (
-                    SELECT descendant_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
-                    WHERE ancestor_id in
-                        (
-                            SELECT concept_id
-                            FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                            WHERE domain_id = 'DRUG'
-                                and is_standard = 1
-                        )
-                )
-        GROUP BY 1,2,3,4
-    ) x"
-
-
-################################################
-# CB_CRITERIA_ATTRIBUTE
-################################################
-echo "CB_CRITERIA_ATTRIBUTE - PPI SURVEY - add values for certain questions"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-    (id, concept_id, value_as_concept_id, concept_name, type, est_count)
-VALUES
-    (1, 1585889, 0, 'MIN', 'NUM', '0'),
-    (2, 1585889, 0, 'MAX', 'NUM', '20'),
-    (3, 1585890, 0, 'MIN', 'NUM', '0'),
-    (4, 1585890, 0, 'MAX', 'NUM', '20'),
-    (5, 1585864, 0, 'MIN', 'NUM', '0'),
-    (6, 1585864, 0, 'MAX', 'NUM', '99'),
-    (7, 1585870, 0, 'MIN', 'NUM', '0'),
-    (8, 1585870, 0, 'MAX', 'NUM', '99'),
-    (9, 1585873, 0, 'MIN', 'NUM', '0'),
-    (10, 1585873, 0, 'MAX', 'NUM', '99'),
-    (11, 1586159, 0, 'MIN', 'NUM', '0'),
-    (12, 1586159, 0, 'MAX', 'NUM', '99'),
-    (13, 1586162, 0, 'MIN', 'NUM', '0'),
-    (14, 1586162, 0, 'MAX', 'NUM', '99'),
-    (15, 1585795, 0, 'MIN', 'NUM', '0'),
-    (16, 1585795, 0, 'MAX', 'NUM', '99'),
-    (17, 1585802, 0, 'MIN', 'NUM', '0'),
-    (18, 1585802, 0, 'MAX', 'NUM', '99'),
-    (19, 1585820, 0, 'MIN', 'NUM', '0'),
-    (20, 1585820, 0, 'MAX', 'NUM', '255')
-"
-
-# this code filters out any labs where all results = 0
-echo "CB_CRITERIA_ATTRIBUTE - Measurements - add numeric results"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-    (id, concept_id, value_as_concept_id, concept_name, type, est_count)
-SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
-FROM
-    (
-        SELECT measurement_concept_id, 0, 'MIN', 'NUM', CAST(min(value_as_number) as STRING)
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-        WHERE measurement_concept_id in
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE domain_id = 'MEASUREMENT'
-            )
-            and value_as_number is not null
-        GROUP BY 1
-        HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
-
-        UNION ALL
-
-        SELECT measurement_concept_id, 0, 'MAX', 'NUM', CAST(max(value_as_number) as STRING)
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-        WHERE measurement_concept_id in
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE domain_id = 'MEASUREMENT'
-            )
-            and value_as_number is not null
-        GROUP BY 1
-        HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
-    ) a"
-
-echo "CB_CRITERIA_ATTRIBUTE - Measurements - add categorical results"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-    (id, concept_id, value_as_concept_Id, concept_name, type, est_count)
-SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
-FROM
-    (
-        SELECT measurement_concept_id, value_as_concept_id, b.concept_name, 'CAT' as type, CAST(count(distinct person_id) as STRING)
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_as_concept_Id = b.concept_id
-        WHERE measurement_concept_id in
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE domain_id = 'MEASUREMENT'
-            )
-            and value_as_concept_id != 0
-            and value_as_concept_id is not null
-        GROUP BY 1,2,3
-    ) a"
-
-
-# set has_attributes=1 for any criteria that has data in cb_criteria_attribute
-echo "CB_CRITERIA_ATTRIBUTE - update has_attributes column for measurement criteria"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-SET has_attribute = 1
-WHERE concept_id in
-    (
-        SELECT distinct concept_id
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
-    )
-    and domain_id = 'MEASUREMENT'
-    and is_selectable = 1"
-
-
-################################################
-# CB_CRITERIA_RELATIONSHIP
-################################################
-echo "CB_CRITERIA_RELATIONSHIP - Drugs - add drug/ingredient relationships"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-    (concept_id_1, concept_id_2)
-select a.concept_id_1, a.concept_id_2
-from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
-where b.concept_class_id = 'Ingredient'
-    and a.concept_id_1 in
-        (
-            select concept_id
-            from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            where domain_id = 'DRUG'
-                and type = 'BRAND'
-        )"
-
-echo "CB_CRITERIA_RELATIONSHIP - Source Concept -> Standard Concept Mapping"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
-    (concept_id_1, concept_id_2)
-SELECT a.concept_id_1 as source_concept_id, a.concept_id_2 as standard_concept_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
-WHERE b.standard_concept = 'S'
-    AND a.relationship_id = 'Maps to'
-    AND a.concept_id_1 in
-        (
-            SELECT DISTINCT concept_id
-            FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-            WHERE concept_id is not null
-                and is_standard = 0
-        )"
-
-
-################################################
-# DATA CLEAN UP
-################################################
-echo "CLEAN UP - set est_count = -1 where the count is NULL"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set est_count = -1
-where est_count is null"
-
-echo "CLEAN UP - set has_ancestor_data = 0 for all items where it is currently NULL"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-set has_ancestor_data = 0
-where has_ancestor_data is null"
-
-echo "CLEAN UP - remove all double quotes from criteria names"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-SET name = REGEXP_REPLACE(name, r'[\"]', '')
-WHERE REGEXP_CONTAINS(name, r'[\"]')"
-
-echo "remove lab items from prep_criteria_ancestor that were added during the run"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"DELETE
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-WHERE ancestor_id IN
-    (
-        SELECT id
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        WHERE domain_id = 'MEASUREMENT'
-            and type = 'LOINC'
-            and subtype = 'LAB'
-            and parent_id != 0
-            and is_group = 1
-    )"
-
-echo "remove drug items from prep_criteria_ancestor that were added during the run"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"DELETE
-FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
-WHERE ancestor_id IN
-    (
-        SELECT id
-        FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        WHERE domain_id = 'DRUG'
-            and type = 'ATC'
-            and is_group = 1
-            and is_selectable = 1
-    )"
-
-
-################################################
-# SYNONYMS
-################################################
-echo "SYNONYMS - add synonym data to criteria"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.synonyms = y.synonyms
-from
-    (
-        select c.id,
-        case
-            when c.name is not null and string_agg(replace(cs.concept_synonym_name,'|','||'),'|') is null then c.name
-            else concat(c.name,'|',string_agg(replace(cs.concept_synonym_name,'|','||'),'|'))
-        end as synonyms
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
-        left join \`$BQ_PROJECT.$BQ_DATASET.concept_synonym\` cs on c.concept_id = cs.concept_id
-        where domain_id not in ('SURVEY', 'PERSON')
-        group by c.id, c.name, c.code
-    ) y
-where x.id = y.id"
-
-echo "SYNONYMS - add demographics synonym data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.synonyms = y.synonyms
-from
-    (
-        select id,
-        case
-            when type = 'AGE' and parent_id = 0 then 'Age'
-            when type = 'DECEASED' and parent_id = 0 then 'Deceased'
-            when type = 'GENDER' and parent_id = 0 then 'Gender'
-            when type = 'RACE' and parent_id = 0 then 'Race'
-            when type = 'ETHNICITY' and parent_id = 0 then 'Ethnicity'
-            when type = 'AGE' and parent_id != 0 then null
-        else name
-        end as synonyms
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        where domain_id = 'PERSON'
-    ) y
-where x.id = y.id"
-
-echo "SYNONYMS - add PPI synonym data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.synonyms = x.name
-where domain_id in ('SURVEY')"
-
-# add [rank1] for all items. this is to deal with the poly-hierarchical issue in many trees
-echo "SYNONYMS - add [rank1]"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
-set x.synonyms = CONCAT(x.synonyms, '|', y.rnk)
-from
-    (
-        select min(id) as id, CONCAT('[', LOWER(domain_id), '_rank1]') as rnk
-        from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-        where synonyms is not null
-            and (est_count != -1 OR (est_count = -1 AND type = 'BRAND'))
-        group by domain_id, is_standard, type, subtype, concept_id, name
-    ) y
-where x.id = y.id"
-
-
-################################################
-# DATABASE CLEAN UP - drop tables/views
-################################################
-#echo "DROP - prep_criteria"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`"
-#
-#echo "DROP - prep_criteria_ancestor"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`"
-#
-#echo "DROP - prep_clinical_terms_nc"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\`"
-#
-#echo "DROP - atc_rel_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`"
-#
-#echo "DROP - loinc_rel_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`"
-#
-#echo "DROP - snomed_rel_cm_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`"
-#
-#echo "DROP - snomed_rel_cm_src_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`"
-#
-#echo "DROP - snomed_rel_pcs_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`"
-#
-#echo "DROP - snomed_rel_meas_in_data"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`"
-#
-#echo "DROP - v_loinc_rel"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\`"
-#
-#echo "DROP - v_snomed_rel_cm"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\`"
-#
-#echo "DROP - v_snomed_rel_cm_src"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\`"
-#
-#echo "DROP - v_snomed_rel_pcs"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\`"
-#
-#echo "DROP - v_snomed_rel_meas"
-#bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-#"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\`"
+                    and is_selectable = 1
+                        ) b on a.measurement_concept_id = b.concept_id
+                    ) d on c.concept_id = d.concept_id
+              ) f on e.descendant_id = f.id
+          group by 1
+      ) y
+  where x.id = y.id"
+
+
+  #----- SNOMED -----
+  echo "MEASUREMENTS - SNOMED - temp table level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
+  where concept_id in
+      (
+          select distinct measurement_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+          where measurement_concept_id != 0
+              and b.vocabulary_id = 'SNOMED'
+              and b.STANDARD_CONCEPT = 'S'
+              and b.domain_id = 'Measurement'
+      )"
+
+  # for each loop, add all items (children/parents) directly under the items that were previously added
+  # currently, there are only 3 levels, but we run it 4 times to be safe
+  for i in {1..4};
+  do
+      echo "MEASUREMENTS - SNOMED - temp table level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\` a
+      where concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+          )
+          and concept_id not in
+              (
+                  select CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+              )"
+  done
+
+  echo "MEASUREMENTS - SNOMED - add roots"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      0, 'MEASUREMENT',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+      CAST(ROW_NUMBER() OVER(order by concept_name) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  from
+      (
+          select distinct concept_id, concept_name, concept_code
+          from
+              (
+                  select *, rank() over (partition by descendant_concept_id order by MAX_LEVELS_OF_SEPARATION desc) rnk
+                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
+                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.concept_id
+                  where b.domain_id = 'Measurement'
+                      and b.vocabulary_id = 'SNOMED'
+                      and a.descendant_concept_id in
+                          (
+                              select distinct concept_id
+                              from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+                              left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+                              where standard_concept = 'S'
+                                  and domain_id = 'Measurement'
+                                  and vocabulary_id = 'SNOMED'
+                          )
+              ) a
+          where rnk = 1
+      ) x"
+
+  echo "MEASUREMENTS - SNOMED - add level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,0,0,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'MEASUREMENT'
+      and p.type = 'SNOMED'
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          )
+      and c.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`
+          )"
+
+  # for each loop, add all items (children/parents) directly under the items that were previously added
+  # currently, there are only 6 levels, but we run it 7 times to be safe
+  for i in {1..7};
+  do
+      echo "MEASUREMENTS - SNOMED - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          p.id, 'MEASUREMENT',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+          case when l.concept_code is null then 1 else 0 end,
+          case when l.concept_code is null then 0 else 1 end,
+          0,1,
+          CONCAT(p.path, '.',
+              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` c on p.code = c.p_concept_code
+      left join
+          (
+              select distinct a.concept_code
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\` b on a.concept_id = b.p_concept_id
+              where b.concept_id is null
+          ) l on c.concept_code = l.concept_code
+      where p.domain_id = 'MEASUREMENT'
+          and p.type = 'SNOMED'
+          and p.id not in
+              (
+                  select parent_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )
+          and c.concept_id not in
+              (
+                  select parent_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )"
+  done
+
+  echo "MEASUREMENTS - SNOMED - generate counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+          from
+              (
+                  select *
+                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                  where ancestor_concept_id in
+                      (
+                          select distinct concept_id
+                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where domain_id = 'MEASUREMENT'
+                              and type = 'SNOMED'
+                      )
+              ) a
+          join \`$BQ_PROJECT.$BQ_DATASET.measurement\` b on a.descendant_concept_id = b.measurement_concept_id
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'MEASUREMENT'
+      and x.type = 'SNOMED'"
+
+  echo "MEASUREMENTS - SNOMED - add parents as children"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select (row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)) as ID,
+      id as parent_id,domain_id,is_standard,type,concept_id,code,name,cnt,0,1,0,1,CONCAT(path, '.',
+      CAST(row_number() over (order by PARENT_ID, NAME)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+  from
+      (
+          select *
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` a
+          join
+              (
+                  select measurement_concept_id, count(distinct person_id) cnt
+                  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+                  group by 1
+              ) b on a.concept_id = b.measurement_concept_id
+          where domain_id = 'MEASUREMENT'
+              and type = 'SNOMED'
+              and is_group = 1
+      ) x"
+
+
+  ################################################
+  # DRUG EXPOSURE
+  ################################################
+  #----- RXNORM / RXNORM EXTENSION -----
+  # ATC4 - ATC5 --> RXNORM/RXNORM Extension ingredient
+  # ATC4 - ATC5 --> RXNORM/RXNORM Extension precise ingedient --> RXNORM ingredient
+  echo "DRUGS - temp table - ATC4 to RXNORM"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  SELECT distinct e.p_concept_id, e.p_concept_code, e.p_concept_name, e.p_DOMAIN_ID,
+      d.CONCEPT_ID, d.CONCEPT_CODE, d.CONCEPT_NAME, d.DOMAIN_ID
+  from
+      (
+          SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c2.CONCEPT_ID atc_5
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, atc, atc_5th
+          WHERE a.RELATIONSHIP_ID IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
+              and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
+              and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 5th' and c2.STANDARD_CONCEPT = 'C'
+              and c1.concept_id in
+                  (
+                      SELECT ANCESTOR_CONCEPT_ID
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                      WHERE DESCENDANT_CONCEPT_ID in
+                          (
+                              SELECT distinct DRUG_CONCEPT_ID
+                              FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                          )
+                  )
+          UNION ALL
+          SELECT c1.CONCEPT_ID, c1.CONCEPT_CODE, c1.CONCEPT_NAME, c1.DOMAIN_ID, c3.CONCEPT_ID atc_5
+          FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID--parent, rxnorm, ingredient
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID--child, rxnorm, precise ingredient
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` b on a.CONCEPT_ID_2 = b.CONCEPT_ID_1
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on b.CONCEPT_ID_2 = c3.CONCEPT_ID--child, atc, atc_5th
+          WHERE a.RELATIONSHIP_ID = 'Has form' and b.RELATIONSHIP_ID = 'RxNorm - ATC'
+              and c1.VOCABULARY_ID = 'RxNorm' and c1.CONCEPT_CLASS_ID = 'Ingredient' and c1.STANDARD_CONCEPT = 'S'
+              and c2.VOCABULARY_ID = 'RxNorm' and c2.CONCEPT_CLASS_ID = 'Precise Ingredient'
+              and c3.VOCABULARY_ID = 'ATC' and c3.CONCEPT_CLASS_ID = 'ATC 5th' and c3.STANDARD_CONCEPT = 'C'
+              and c1.concept_id in
+                  (
+                      SELECT ANCESTOR_CONCEPT_ID
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                      WHERE DESCENDANT_CONCEPT_ID in
+                          (
+                              SELECT distinct DRUG_CONCEPT_ID
+                              FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                          )
+                  )
+      ) d
+  left join
+      (
+          select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+              c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID as atc_5, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+          from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID --parent, atc, atc_4
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID --child, atc, atc_5
+          where RELATIONSHIP_ID = 'Subsumes'
+              and c1.VOCABULARY_ID = 'ATC'
+              and c1.CONCEPT_CLASS_ID = 'ATC 4th'
+              and c1.STANDARD_CONCEPT = 'C'
+              and c2.VOCABULARY_ID = 'ATC'
+              and c2.CONCEPT_CLASS_ID = 'ATC 5th'
+              and c2.STANDARD_CONCEPT = 'C'
+      ) e on d.atc_5 = e.atc_5"
+
+  echo "DRUGS - temp table - ATC3 to ATC4"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+      left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+      left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+  where RELATIONSHIP_ID = 'Subsumes'
+      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 3rd' and c1.STANDARD_CONCEPT = 'C'
+      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 4th' and c2.STANDARD_CONCEPT = 'C'
+      and c2.concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )
+      and c2.concept_id not in
+          (
+              select CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )"
+
+  echo "DRUGS - temp table - ATC2 TO ATC3"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+  where RELATIONSHIP_ID = 'Subsumes'
+      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 2nd' and c1.STANDARD_CONCEPT = 'C'
+      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 3rd' and c2.STANDARD_CONCEPT = 'C'
+      and c2.concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )
+      and c2.concept_id not in
+          (
+              select CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )"
+
+  echo "DRUGS - temp table - ATC1 TO ATC2"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select c1.CONCEPT_ID as p_concept_id, c1.CONCEPT_CODE as p_concept_code, c1.CONCEPT_NAME as p_concept_name,
+      c1.DOMAIN_ID as p_DOMAIN_ID, c2.CONCEPT_ID, c2.CONCEPT_CODE, c2.CONCEPT_NAME, c2.DOMAIN_ID
+  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONCEPT_ID_1 = c1.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONCEPT_ID_2 = c2.CONCEPT_ID
+  where RELATIONSHIP_ID = 'Subsumes'
+      and c1.VOCABULARY_ID = 'ATC' and c1.CONCEPT_CLASS_ID = 'ATC 1st' and c1.STANDARD_CONCEPT = 'C'
+      and c2.VOCABULARY_ID = 'ATC' and c2.CONCEPT_CLASS_ID = 'ATC 2nd' and c2.STANDARD_CONCEPT = 'C'
+      and c2.concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )
+      and c2.concept_id not in
+          (
+              select CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`
+          )"
+
+  echo "DRUGS - add roots"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      0, 'DRUG', 1, 'ATC', concept_id, concept_code, CONCAT( UPPER(SUBSTR(concept_name, 1, 1)), LOWER(SUBSTR(concept_name, 2)) ),
+      1,0,0,1,1,
+      CAST(ROW_NUMBER() OVER(order by concept_code) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+  where VOCABULARY_ID = 'ATC'
+      and CONCEPT_CLASS_ID = 'ATC 1st'
+      and STANDARD_CONCEPT = 'C'"
+
+  echo "DRUGS - add root for unmapped ingredients"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'DRUG',1,'ATC','Unmapped ingredients',1,0,0,1,1,
+      CAST( (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING ) as path"
+
+  echo "DRUGS - level 2"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'DRUG'
+      and p.type = 'ATC'
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              where domain_id = 'DRUG'
+                  and type = 'ATC'
+          )"
+
+  echo "DRUGS - level 3"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'DRUG'
+      and p.type = 'ATC'
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              where domain_id = 'DRUG'
+                  and type = 'ATC'
+          )"
+
+  echo "DRUGS - level 4"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'DRUG',1,'ATC',c.concept_id,c.concept_code,
+      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),1,1,0,1,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_code)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'DRUG'
+      and p.type = 'ATC'
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              where domain_id = 'DRUG'
+                  and type = 'ATC'
+          )"
+
+  echo "DRUGS - level 5 - ingredients"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'DRUG',1,'RXNORM',c.concept_id,c.concept_code,
+      CONCAT( UPPER(SUBSTR(c.concept_name, 1, 1)), LOWER(SUBSTR(c.concept_name, 2)) ),0,1,0,1,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, UPPER(c.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'DRUG'
+      and p.type = 'ATC'
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              where domain_id = 'DRUG'
+                  and type = 'ATC'
+          )"
+
+  echo "DRUGS - add parents for unmapped ingredients"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      (select id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients') as parent_id,
+      'DRUG',1,'ATC',name as code, name,1,0,0,1,1,
+      CONCAT( (select CAST(id as STRING) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`  where name = 'Unmapped ingredients'),
+          '.', CAST(ROW_NUMBER() OVER(ORDER BY upper(name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING) )
+  from
+      (
+          select distinct UPPER(SUBSTR(concept_name, 1, 1)) name
+          from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+              and CONCEPT_CLASS_ID = 'Ingredient'
+              and STANDARD_CONCEPT = 'S'
+              and concept_id in
+                  (
+                      select ANCESTOR_CONCEPT_ID
+                      from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                      where DESCENDANT_CONCEPT_ID in
+                          (
+                              select distinct DRUG_CONCEPT_ID
+                              from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                          )
+                  )
+              and concept_id not in
+                  (
+                      select concept_id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where domain_id = 'DRUG'
+                          and concept_id is not null
+                  )
+
+      ) x"
+
+  echo "DRUGS - add unmapped ingredients"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,has_ancestor_data,path)
+  select row_number() over (order by z.id, upper(x.concept_name))+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      z.id,'DRUG',1,'RXNORM',x.concept_id,x.concept_code,CONCAT( UPPER(SUBSTR(x.concept_name, 1, 1)), LOWER(SUBSTR(x.concept_name, 2)) ),
+      0,1,0,1,1,
+      CONCAT(z.path, '.',
+          CAST(ROW_NUMBER() OVER(order by z.id, upper(x.concept_name)) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from
+      (
+          select *
+          from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+              and CONCEPT_CLASS_ID = 'Ingredient'
+              and STANDARD_CONCEPT = 'S'
+              and concept_id in
+                  (
+                      select ANCESTOR_CONCEPT_ID
+                      from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+                      where DESCENDANT_CONCEPT_ID in
+                          (
+                              select distinct DRUG_CONCEPT_ID
+                              from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+                          )
+                  )
+              and concept_id not in
+                  (
+                      select concept_id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where domain_id = 'DRUG'
+                          and concept_id is not null
+                  )
+      ) x
+  join
+      (
+          select *
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          where domain_id = 'DRUG'
+              and type = 'ATC'
+              and length(name) = 1
+      ) z on UPPER(SUBSTR(x.concept_name, 1, 1)) = z.name"
+
+  echo "DRUGS - generate child counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select b.ANCESTOR_CONCEPT_ID as concept_id, count(distinct a.person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+          join
+              (
+                  select *
+                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` x
+                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` y on x.ANCESTOR_CONCEPT_ID = y.CONCEPT_ID
+                  where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+                      and CONCEPT_CLASS_ID = 'Ingredient'
+              ) b on a.DRUG_CONCEPT_ID = b.DESCENDANT_CONCEPT_ID
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'DRUG'
+      and x.type = 'RXNORM'"
+
+  echo "DRUGS - add brand names"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy)
+  select ROW_NUMBER() OVER(ORDER BY upper(concept_name)) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS ID,
+      0,'DRUG',1,'BRAND',concept_id,concept_code,concept_name,0,1,0,0
+  FROM
+      (
+          select distinct b.concept_id, b.concept_name, b.concept_code
+          from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.CONCEPT_ID_1 = b.CONCEPT_ID --brands
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.CONCEPT_ID_2 = c.CONCEPT_ID --ingredients
+          where b.vocabulary_id in ('RxNorm','RxNorm Extension')
+              and b.concept_class_id = 'Brand Name'
+              and b.invalid_reason is null
+              and c.concept_id in
+                  (
+                      select concept_id
+                      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      where domain_id = 'DRUG'
+                          and type = 'RXNORM'
+                          and is_group = 0
+                          and is_selectable = 1
+                  )
+      ) x"
+
+  echo "DRUGS - add data into prep_criteria_ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+      (ancestor_id, descendant_id)
+  SELECT DISTINCT a.id as ancestor_id,
+      COALESCE(e.id, d.id, c.id, b.id) as descendant_id
+  FROM (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM') and is_group = 1 and is_selectable = 1) a
+  JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) b on a.id = b.parent_id
+  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) c on b.id = c.parent_id
+  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) d on c.id = d.parent_id
+  LEFT JOIN (select id, parent_id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'DRUG' and type in ('ATC','RXNORM')) e on d.id = e.parent_id"
+
+  echo "DRUGS - generate parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select g.id, count(distinct person_id) cnt
+          from
+              (
+                  select *
+                  from
+                      (
+                          select id
+                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where domain_id = 'DRUG'
+                              and type = 'ATC'
+                              and is_group = 1
+                              and is_selectable = 1
+                      ) a
+                      left join \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\` b on a.id = b.ancestor_id
+              ) g
+          left join
+              (
+                  select e.id, f.*
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` e
+                  join
+                      (
+                          select d.ANCESTOR_CONCEPT_ID as concept_id, c.person_id
+                          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` c
+                          join
+                              (
+                                  select *
+                                  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\` a
+                                  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ANCESTOR_CONCEPT_ID = b.CONCEPT_ID
+                                  where VOCABULARY_ID in  ('RxNorm', 'RxNorm Extension')
+                                      and CONCEPT_CLASS_ID = 'Ingredient'
+                              ) d on c.DRUG_CONCEPT_ID = d.DESCENDANT_CONCEPT_ID
+                      ) f on e.concept_id = f.concept_id
+              ) h on g.descendant_id = h.id
+          group by 1
+      ) y
+  where x.id = y.id"
+
+
+  ################################################
+  # PROCEDURES
+  ################################################
+  #----- STANDARD SNOMED -----
+  echo "PROCEDURES - STANDARD SNOMED - temp table level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
+  where concept_id in
+      (
+          select distinct procedure_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
+          where procedure_concept_id != 0
+              and b.domain_id = 'Procedure'
+              and b.vocabulary_id = 'SNOMED'
+              and b.standard_concept = 'S'
+      )"
+
+  # currently, there are only 8 levels, but we run it 9 times to be safe
+  for i in {1..9};
+  do
+      echo "PROCEDURES - STANDARD SNOMED - temp table level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\` a
+      where
+          concept_id in
+              (
+                  select P_CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+              )
+          and concept_id not in
+              (
+                  select CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+              )"
+  done
+
+  echo "PROCEDURES - STANDARD SNOMED - add root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select (select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1,
+      0,'PROCEDURE',1,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+  where concept_id = 4322976"
+
+  echo "PROCEDURES - STANDARD SNOMED - add level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'PROCEDURE'
+      and p.type = 'SNOMED'
+      and p.is_standard = 1
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          )
+      and c.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`
+          )"
+
+  # currently, there are only 11 levels, but we run it 12 times to be safe, If this count changes, change the query below
+  for i in {1..12};
+  do
+      echo "PROCEDURES - STANDARD SNOMED - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          p.id,'PROCEDURE',1,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+          case when l.concept_code is null then 1 else 0 end,
+          1,0,1,
+          CONCAT(p.path, '.',
+              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` c on p.code = c.p_concept_code
+      left join
+          (
+              select distinct a.CONCEPT_CODE
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\` b on a.concept_id = b.p_concept_id
+              where b.concept_id is null
+          ) l on c.concept_code = l.concept_code
+      where p.domain_id = 'PROCEDURE'
+          and p.type = 'SNOMED'
+          and p.is_standard = 1
+          and p.id not in
+              (
+                  select PARENT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )"
+  done
+
+  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+  echo "PROCEDURES - STANDARD SNOMED - add items into temp ancestor table for use in next query"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
+  SELECT DISTINCT a.concept_id as ancestor_concept_id
+      , a.domain_id
+      , a.type
+      , a.is_standard
+      , b.concept_id c1
+      , c.concept_id c2
+      , d.concept_id c3
+      , e.concept_id c4
+      , f.concept_id c5
+      , g.concept_id c6
+      , h.concept_id c7
+      , i.concept_id c8
+      , j.concept_id c9
+      , k.concept_id c10
+      , m.concept_id c11
+      , n.concept_id as c12
+  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1 and parent_id != 0 and is_group = 1) a
+      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) b on a.id = b.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) c on b.id = c.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) d on c.id = d.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) e on d.id = e.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) f on e.id = f.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) g on f.id = g.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) h on g.id = h.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) i on h.id = i.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) j on i.id = j.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) k on j.id = k.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) m on k.id = m.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 1) n on m.id = n.parent_id"
+
+  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+  # there last UNION statement is to add the ancestor item to itself
+  echo "PROCEDURES - STANDARD SNOMED - add items into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+      (ancestor_concept_id, descendant_concept_id, is_standard)
+  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_12 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_11 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_10 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_9 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_8 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_7 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_6 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_5 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_4 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_3 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_2 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_1 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 1"
+
+  echo "PROCEDURES - STANDARD SNOMED - generate child counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          SELECT procedure_concept_id as concept_id, count(distinct person_id) cnt
+          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
+          GROUP BY 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'PROCEDURE'
+      and x.type = 'SNOMED'
+      and x.is_standard = 1
+      and x.is_group = 0
+      and x.is_selectable = 1"
+
+  echo "PROCEDURES - STANDARD SNOMED - parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+          from
+              (
+                  select *
+                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                  where ancestor_concept_id in
+                      (
+                          select distinct concept_id
+                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where domain_id = 'PROCEDURE'
+                              and type = 'SNOMED'
+                              and is_standard = 1
+                              and parent_id != 0
+                              and is_group = 1
+                      )
+                      and is_standard = 1
+              ) a
+          join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_concept_id
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'PROCEDURE'
+      and x.type = 'SNOMED'
+      and x.is_standard = 1
+      and x.is_group = 1"
+
+  # ----- SOURCE SNOMED -----
+  echo "PROCEDURES - SOURCE SNOMED - temp table level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+      (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+  select *
+  from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
+  where concept_id in
+      (
+          select distinct procedure_source_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
+          where procedure_source_concept_id != 0
+              and b.domain_id = 'Procedure'
+              and b.vocabulary_id = 'SNOMED'
+      )"
+
+  # currently, there are only 8 levels, but we run it 9 times to be safe
+  for i in {1..9};
+  do
+      echo "PROCEDURES - SOURCE SNOMED - temp table level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+          (p_concept_id, p_concept_code, p_concept_name, p_domain_id, concept_id, concept_code, concept_name, domain_id)
+      select *
+      from \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs_src\` a
+      where concept_id in
+          (
+              select P_CONCEPT_ID
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+          )
+          and concept_id not in
+              (
+                  select CONCEPT_ID
+                  from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+              )"
+  done
+
+  echo "PROCEDURES - SOURCE SNOMED - add root"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 AS ID,
+      0,'PROCEDURE',0,'SNOMED',concept_id,concept_code,concept_name,1,0,0,1,
+      CAST((SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`)+1 as STRING) as path
+  from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+  where concept_id = 4322976"
+
+  echo "PROCEDURES - SOURCE SNOMED - add level 0"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+      p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,1,1,0,1,
+      CONCAT(p.path, '.',
+          CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) AS STRING))
+  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+  join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
+  where p.domain_id = 'PROCEDURE'
+      and p.type = 'SNOMED'
+      and p.is_standard = 0
+      and p.id not in
+          (
+              select parent_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          )
+      and c.concept_id in
+          (
+              select p_concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\`
+          )"
+
+  # currently, there are only 11 levels, but we run it 12 times to be safe (if changed, change number of joins in next query)
+  for i in {1..12};
+  do
+      echo "PROCEDURES - SOURCE SNOMED - add level $i"
+      bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+      "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          (id,parent_id,domain_id,is_standard,type,concept_id,code,name,is_group,is_selectable,has_attribute,has_hierarchy,path)
+      select row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`),
+          p.id,'PROCEDURE',0,'SNOMED',c.concept_id,c.concept_code,c.concept_name,
+          case when l.concept_code is null then 1 else 0 end,
+          1,0,1,
+          CONCAT(p.path, '.',
+              CAST(row_number() over (order by p.id, c.concept_name)+(select max(id) from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING))
+      from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` p
+      join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` c on p.code = c.p_concept_code
+      left join
+          (
+              select distinct a.concept_code
+              from \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` a
+              left join \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_src_in_data\` b on a.concept_id = b.p_concept_id
+              where b.concept_id is null
+          ) l on c.concept_code = l.concept_code
+      where p.domain_id = 'PROCEDURE'
+          and p.type = 'SNOMED'
+          and p.is_standard = 0
+          and p.id not in
+              (
+                  select parent_id
+                  from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              )"
+  done
+
+  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+  echo "PROCEDURES - SOURCE SNOMED - add items into temp ancestor table for use in next query"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+      (ancestor_concept_id, domain_id, type, is_standard, concept_id_1, concept_id_2, concept_id_3, concept_id_4,
+      concept_id_5, concept_id_6, concept_id_7, concept_id_8, concept_id_9, concept_id_10, concept_id_11, concept_id_12)
+  SELECT DISTINCT a.concept_id as ancestor_concept_id
+      , a.domain_id
+      , a.type
+      , a.is_standard
+      , b.concept_id c1
+      , c.concept_id c2
+      , d.concept_id c3
+      , e.concept_id c4
+      , f.concept_id c5
+      , g.concept_id c6
+      , h.concept_id c7
+      , i.concept_id c8
+      , j.concept_id c9
+      , k.concept_id c10
+      , m.concept_id c11
+      , n.concept_id as c12
+  FROM (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0 and parent_id != 0 and is_group = 1) a
+      JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) b on a.id = b.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) c on b.id = c.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) d on c.id = d.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) e on d.id = e.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) f on e.id = f.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) g on f.id = g.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) h on g.id = h.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) i on h.id = i.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) j on i.id = j.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) k on j.id = k.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) m on k.id = m.parent_id
+      LEFT JOIN (SELECT id, parent_id, domain_id, type, is_standard, concept_id FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` WHERE domain_id = 'PROCEDURE' and type = 'SNOMED' and is_standard = 0) n on m.id = n.parent_id"
+
+  # Join Count: 13 - If loop count above is changed, the number of JOINS below must be updated
+  # there last UNION statement is to add the ancestor item to itself
+  echo "PROCEDURES - SOURCE SNOMED - add items into ancestor table"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+      (ancestor_concept_id, descendant_concept_id, is_standard)
+  SELECT DISTINCT ancestor_concept_id, concept_id_12 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_12 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_11 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_11 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_10 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_10 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_9 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_9 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_8 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_8 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_7 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_7 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_6 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_6 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_5 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_5 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_4 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_4 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_3 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_3 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_2 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_2 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, concept_id_1 as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE concept_id_1 is not null
+      and domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0
+  UNION DISTINCT
+  SELECT DISTINCT ancestor_concept_id, ancestor_concept_id as descendant_concept_id, is_standard
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor_temp\`
+  WHERE domain_id = 'PROCEDURE'
+      and type = 'SNOMED'
+      and is_standard = 0"
+
+  echo "PROCEDURES - SOURCE SNOMED - child counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.est_count = y.cnt
+  from
+      (
+          select procedure_source_concept_id as concept_id, count(distinct person_id) cnt
+          from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\`
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'PROCEDURE'
+      and x.type = 'SNOMED'
+      and x.is_standard = 0
+      and x.is_group = 0
+      and x.is_selectable = 1"
+
+  echo "PROCEDURES - SOURCE SNOMED - parent counts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  SET x.est_count = y.cnt
+  from
+      (
+          select ancestor_concept_id as concept_id, count(distinct person_id) cnt
+          from
+              (
+                  select *
+                  from \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                  where ancestor_concept_id in
+                      (
+                          select distinct concept_id
+                          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                          where domain_id = 'PROCEDURE'
+                              and type = 'SNOMED'
+                              and is_standard = 0
+                              and parent_id != 0
+                              and is_group = 1
+                      )
+                      and is_standard = 0
+              ) a
+          join \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` b on a.descendant_concept_id = b.procedure_source_concept_id
+          group by 1
+      ) y
+  where x.concept_id = y.concept_id
+      and x.domain_id = 'PROCEDURE'
+      and x.type = 'SNOMED'
+      and x.is_standard = 0
+      and x.is_group = 1"
+
+
+  ################################################
+  # CB_CRITERIA_ANCESTOR
+  ################################################
+  echo "CB_CRITERIA_ANCESTOR - Drugs - add ingredients to drugs mapping"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+      (ancestor_id, descendant_id)
+  select ancestor_concept_id, descendant_concept_id
+  from \`$BQ_PROJECT.$BQ_DATASET.concept_ancestor\`
+  where ancestor_concept_id in
+      (
+          select distinct concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          where domain_id = 'DRUG'
+              and type = 'RXNORM'
+              and is_group = 0
+              and is_selectable = 1
+      )
+  and descendant_concept_id in
+      (
+          select distinct drug_concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+      )"
+
+
+  ################################################
+  # ADD IN OTHER CODES NOT ALREADY CAPTURED
+  ################################################
+  echo "CONDITIONS - add other source concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+      -1, 'CONDITION', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_source_concept_id = b.concept_id
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.condition_concept_id = c.concept_id
+          WHERE a.condition_source_concept_id NOT IN
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE is_standard = 0
+                      and concept_id is not null
+              )
+              and a.condition_source_concept_id != 0
+              and a.condition_source_concept_id is not null
+              and b.concept_id is not null
+              and b.vocabulary_id != 'PPI'
+              and (b.domain_id LIKE 'Condition%' OR c.domain_id = 'Condition')
+          GROUP BY 1,2,3,4
+      ) x"
+
+  echo "CONDITIONS - add other standard concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      -1, 'CONDITION',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.condition_concept_id = b.concept_id
+          WHERE standard_concept = 'S'
+              and domain_id = 'Condition'
+              and condition_concept_id NOT IN
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      WHERE domain_id = 'CONDITION'
+                          and is_standard = 1
+                          and concept_id is not null
+                  )
+          GROUP BY 1,2,3,4
+      ) x"
+
+  echo "PROCEDURES - add other source concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER (order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as id,
+      -1, 'PROCEDURE', 0, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT b.concept_name, b.vocabulary_id, b.concept_id, b.concept_code, count(distinct a.person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_source_concept_id = b.concept_id
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on a.procedure_concept_id = c.concept_id
+          WHERE a.procedure_source_concept_id NOT IN
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE is_standard = 0
+                      and concept_id is not null
+              )
+              and a.procedure_source_concept_id != 0
+              and a.procedure_source_concept_id is not null
+              and b.concept_id is not null
+              and b.vocabulary_id != 'PPI'
+              and (b.domain_id = 'Procedure' OR c.domain_id = 'Procedure')
+          GROUP BY 1,2,3,4
+      ) x"
+
+  echo "PROCEDURES - add other standard concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      -1, 'PROCEDURE',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.procedure_concept_id = b.concept_id
+          WHERE standard_concept = 'S'
+              and domain_id = 'Procedure'
+              and procedure_concept_id NOT IN
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      WHERE domain_id = 'PROCEDURE'
+                          and is_standard = 1
+                          and concept_id is not null
+                  )
+          GROUP BY 1,2,3,4
+      ) x"
+
+  echo "MEASUREMENTS - add other standard concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      -1, 'MEASUREMENT',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+          WHERE standard_concept = 'S'
+              and domain_id = 'Measurement'
+              and vocabulary_id not in ('PPI')
+              and measurement_concept_id NOT IN
+                  (
+                      SELECT concept_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                      WHERE domain_id = 'MEASUREMENT'
+                          and is_standard = 1
+                          and concept_id is not null
+                  )
+          GROUP BY 1,2,3,4
+      ) x"
+
+  echo "DRUGS - add other standard concepts"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+      (id,parent_id,domain_id,is_standard,type,concept_id,code,name,est_count,is_group,is_selectable,has_attribute,has_hierarchy,path)
+  SELECT ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID,
+      -1, 'DRUG',1, vocabulary_id,concept_id,concept_code,concept_name,est_count,0,1,0,0,
+      CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+  FROM
+      (
+          SELECT concept_name, vocabulary_id, concept_id, concept_code, count(distinct person_id) est_count
+          FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.drug_concept_id = b.concept_id
+          WHERE standard_concept = 'S'
+              and domain_id = 'Drug'
+              and drug_concept_id NOT IN
+                  (
+                      SELECT descendant_id
+                      FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_ancestor\`
+                      WHERE ancestor_id in
+                          (
+                              SELECT concept_id
+                              FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                              WHERE domain_id = 'DRUG'
+                                  and is_standard = 1
+                          )
+                  )
+          GROUP BY 1,2,3,4
+      ) x"
+
+
+  ################################################
+  # CB_CRITERIA_ATTRIBUTE
+  ################################################
+  echo "CB_CRITERIA_ATTRIBUTE - PPI SURVEY - add values for certain questions"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+      (id, concept_id, value_as_concept_id, concept_name, type, est_count)
+  VALUES
+      (1, 1585889, 0, 'MIN', 'NUM', '0'),
+      (2, 1585889, 0, 'MAX', 'NUM', '20'),
+      (3, 1585890, 0, 'MIN', 'NUM', '0'),
+      (4, 1585890, 0, 'MAX', 'NUM', '20'),
+      (5, 1585864, 0, 'MIN', 'NUM', '0'),
+      (6, 1585864, 0, 'MAX', 'NUM', '99'),
+      (7, 1585870, 0, 'MIN', 'NUM', '0'),
+      (8, 1585870, 0, 'MAX', 'NUM', '99'),
+      (9, 1585873, 0, 'MIN', 'NUM', '0'),
+      (10, 1585873, 0, 'MAX', 'NUM', '99'),
+      (11, 1586159, 0, 'MIN', 'NUM', '0'),
+      (12, 1586159, 0, 'MAX', 'NUM', '99'),
+      (13, 1586162, 0, 'MIN', 'NUM', '0'),
+      (14, 1586162, 0, 'MAX', 'NUM', '99'),
+      (15, 1585795, 0, 'MIN', 'NUM', '0'),
+      (16, 1585795, 0, 'MAX', 'NUM', '99'),
+      (17, 1585802, 0, 'MIN', 'NUM', '0'),
+      (18, 1585802, 0, 'MAX', 'NUM', '99'),
+      (19, 1585820, 0, 'MIN', 'NUM', '0'),
+      (20, 1585820, 0, 'MAX', 'NUM', '255')
+  "
+
+  # this code filters out any labs where all results = 0
+  echo "CB_CRITERIA_ATTRIBUTE - Measurements - add numeric results"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+      (id, concept_id, value_as_concept_id, concept_name, type, est_count)
+  SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
+  FROM
+      (
+          SELECT measurement_concept_id, 0, 'MIN', 'NUM', CAST(min(value_as_number) as STRING)
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+          WHERE measurement_concept_id in
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE domain_id = 'MEASUREMENT'
+              )
+              and value_as_number is not null
+          GROUP BY 1
+          HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
+
+          UNION ALL
+
+          SELECT measurement_concept_id, 0, 'MAX', 'NUM', CAST(max(value_as_number) as STRING)
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+          WHERE measurement_concept_id in
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE domain_id = 'MEASUREMENT'
+              )
+              and value_as_number is not null
+          GROUP BY 1
+          HAVING NOT (min(value_as_number) = 0 and max(value_as_number) = 0)
+      ) a"
+
+  echo "CB_CRITERIA_ATTRIBUTE - Measurements - add categorical results"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+      (id, concept_id, value_as_concept_Id, concept_name, type, est_count)
+  SELECT ROW_NUMBER() OVER (order by measurement_concept_id) + (SELECT MAX(ID) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`) as id, *
+  FROM
+      (
+          SELECT measurement_concept_id, value_as_concept_id, b.concept_name, 'CAT' as type, CAST(count(distinct person_id) as STRING)
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+          LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.value_as_concept_Id = b.concept_id
+          WHERE measurement_concept_id in
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE domain_id = 'MEASUREMENT'
+              )
+              and value_as_concept_id != 0
+              and value_as_concept_id is not null
+          GROUP BY 1,2,3
+      ) a"
+
+
+  # set has_attributes=1 for any criteria that has data in cb_criteria_attribute
+  echo "CB_CRITERIA_ATTRIBUTE - update has_attributes column for measurement criteria"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  SET has_attribute = 1
+  WHERE concept_id in
+      (
+          SELECT distinct concept_id
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_attribute\`
+      )
+      and domain_id = 'MEASUREMENT'
+      and is_selectable = 1"
+
+
+  ################################################
+  # CB_CRITERIA_RELATIONSHIP
+  ################################################
+  echo "CB_CRITERIA_RELATIONSHIP - Drugs - add drug/ingredient relationships"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+      (concept_id_1, concept_id_2)
+  select a.concept_id_1, a.concept_id_2
+  from \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+  join \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
+  where b.concept_class_id = 'Ingredient'
+      and a.concept_id_1 in
+          (
+              select concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              where domain_id = 'DRUG'
+                  and type = 'BRAND'
+          )"
+
+  echo "CB_CRITERIA_RELATIONSHIP - Source Concept -> Standard Concept Mapping"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "insert into \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_relationship\`
+      (concept_id_1, concept_id_2)
+  SELECT a.concept_id_1 as source_concept_id, a.concept_id_2 as standard_concept_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.concept_relationship\` a
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.concept_id_2 = b.concept_id
+  WHERE b.standard_concept = 'S'
+      AND a.relationship_id = 'Maps to'
+      AND a.concept_id_1 in
+          (
+              SELECT DISTINCT concept_id
+              FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+              WHERE concept_id is not null
+                  and is_standard = 0
+          )"
+
+
+  ################################################
+  # DATA CLEAN UP
+  ################################################
+  echo "CLEAN UP - set est_count = -1 where the count is NULL"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set est_count = -1
+  where est_count is null"
+
+  echo "CLEAN UP - set has_ancestor_data = 0 for all items where it is currently NULL"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  set has_ancestor_data = 0
+  where has_ancestor_data is null"
+
+  echo "CLEAN UP - remove all double quotes from criteria names"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+  SET name = REGEXP_REPLACE(name, r'[\"]', '')
+  WHERE REGEXP_CONTAINS(name, r'[\"]')"
+
+  echo "remove lab items from prep_criteria_ancestor that were added during the run"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "DELETE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+  WHERE ancestor_id IN
+      (
+          SELECT id
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          WHERE domain_id = 'MEASUREMENT'
+              and type = 'LOINC'
+              and subtype = 'LAB'
+              and parent_id != 0
+              and is_group = 1
+      )"
+
+  echo "remove drug items from prep_criteria_ancestor that were added during the run"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "DELETE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`
+  WHERE ancestor_id IN
+      (
+          SELECT id
+          FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          WHERE domain_id = 'DRUG'
+              and type = 'ATC'
+              and is_group = 1
+              and is_selectable = 1
+      )"
+
+
+  ################################################
+  # SYNONYMS
+  ################################################
+  echo "SYNONYMS - add synonym data to criteria"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.synonyms = y.synonyms
+  from
+      (
+          select c.id,
+          case
+              when c.name is not null and string_agg(replace(cs.concept_synonym_name,'|','||'),'|') is null then c.name
+              else concat(c.name,'|',string_agg(replace(cs.concept_synonym_name,'|','||'),'|'))
+          end as synonyms
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c
+          left join \`$BQ_PROJECT.$BQ_DATASET.concept_synonym\` cs on c.concept_id = cs.concept_id
+          where domain_id not in ('SURVEY', 'PERSON')
+          group by c.id, c.name, c.code
+      ) y
+  where x.id = y.id"
+
+  echo "SYNONYMS - add demographics synonym data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.synonyms = y.synonyms
+  from
+      (
+          select id,
+          case
+              when type = 'AGE' and parent_id = 0 then 'Age'
+              when type = 'DECEASED' and parent_id = 0 then 'Deceased'
+              when type = 'GENDER' and parent_id = 0 then 'Gender'
+              when type = 'RACE' and parent_id = 0 then 'Race'
+              when type = 'ETHNICITY' and parent_id = 0 then 'Ethnicity'
+              when type = 'AGE' and parent_id != 0 then null
+          else name
+          end as synonyms
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          where domain_id = 'PERSON'
+      ) y
+  where x.id = y.id"
+
+  echo "SYNONYMS - add PPI synonym data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.synonyms = x.name
+  where domain_id in ('SURVEY')"
+
+  # add [rank1] for all items. this is to deal with the poly-hierarchical issue in many trees
+  echo "SYNONYMS - add [rank1]"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "update \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
+  set x.synonyms = CONCAT(x.synonyms, '|', y.rnk)
+  from
+      (
+          select min(id) as id, CONCAT('[', LOWER(domain_id), '_rank1]') as rnk
+          from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+          where synonyms is not null
+              and (est_count != -1 OR (est_count = -1 AND type = 'BRAND'))
+          group by domain_id, is_standard, type, subtype, concept_id, name
+      ) y
+  where x.id = y.id"
+
+
+  ################################################
+  # DATABASE CLEAN UP - drop tables/views
+  ################################################
+  #echo "DROP - prep_criteria"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria\`"
+  #
+  #echo "DROP - prep_criteria_ancestor"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_criteria_ancestor\`"
+  #
+  #echo "DROP - prep_clinical_terms_nc"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.prep_clinical_terms_nc\`"
+  #
+  #echo "DROP - atc_rel_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.atc_rel_in_data\`"
+  #
+  #echo "DROP - loinc_rel_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.loinc_rel_in_data\`"
+  #
+  #echo "DROP - snomed_rel_cm_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_in_data\`"
+  #
+  #echo "DROP - snomed_rel_cm_src_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_cm_src_in_data\`"
+  #
+  #echo "DROP - snomed_rel_pcs_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP TABLE IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_pcs_in_data\`"
+  #
+  #echo "DROP - snomed_rel_meas_in_data"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.snomed_rel_meas_in_data\`"
+  #
+  #echo "DROP - v_loinc_rel"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_loinc_rel\`"
+  #
+  #echo "DROP - v_snomed_rel_cm"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm\`"
+  #
+  #echo "DROP - v_snomed_rel_cm_src"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_cm_src\`"
+  #
+  #echo "DROP - v_snomed_rel_pcs"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_pcs\`"
+  #
+  #echo "DROP - v_snomed_rel_meas"
+  #bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  #"DROP VIEW IF EXISTS \`$BQ_PROJECT.$BQ_DATASET.v_snomed_rel_meas\`"
+fi

--- a/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
+++ b/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
@@ -8,250 +8,253 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export DRY_RUN=$3     # dry run
 
-if [ "$DRY_RUN" == false ]
+if [ "$DRY_RUN" == true ]
 then
-  # Check that bq_dataset exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
-  then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
+  test=$(bq ls "$BQ_PROJECT:$BQ_DATASET")
+  exit 0
+fi
 
-  ################################################
-  # CREATE LINKING TABLE
-  ################################################
-  echo "CREATE TABLE - ds_linking"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`
-  (
-      DENORMALIZED_NAME               STRING,
-      OMOP_SQL                        STRING,
-      JOIN_VALUE                      STRING,
-      DOMAIN                          STRING
-  )"
+# Check that bq_dataset exists and exit if not
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+if [ -z "$datasets" ]
+then
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+else
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
 
-  ################################################
-  # INSERT DATA
-  ################################################
-  echo "ds_linking - inserting condition data"
+################################################
+# CREATE LINKING TABLE
+################################################
+echo "CREATE TABLE - ds_linking"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`
+(
+    DENORMALIZED_NAME               STRING,
+    OMOP_SQL                        STRING,
+    JOIN_VALUE                      STRING,
+    DOMAIN                          STRING
+)"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      # We add the core table for domain row to ensure we have a single place to make certain we load in the base table.
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('PERSON_ID', 'c_occurrence.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_CONCEPT_ID', 'c_occurrence.CONDITION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('STANDARD_CONCEPT_NAME', 'c_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-      ('STANDARD_CONCEPT_CODE', 'c_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-      ('STANDARD_VOCABULARY', 'c_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-      ('CONDITION_START_DATETIME', 'c_occurrence.CONDITION_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_END_DATETIME', 'c_occurrence.CONDITION_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_TYPE_CONCEPT_ID', 'c_occurrence.CONDITION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_TYPE_CONCEPT_NAME', 'c_type.concept_name as CONDITION_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_type on c_occurrence.CONDITION_TYPE_CONCEPT_ID = c_type.CONCEPT_ID', 'Condition'),
-      ('STOP_REASON', 'c_occurrence.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('VISIT_OCCURRENCE_ID', 'c_occurrence.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on c_occurrence.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` visit on v.visit_concept_id = visit.concept_id', 'Condition'),
-      ('CONDITION_SOURCE_VALUE', 'c_occurrence.CONDITION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_SOURCE_CONCEPT_ID', 'c_occurrence.CONDITION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('SOURCE_CONCEPT_NAME', 'c_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-      ('SOURCE_CONCEPT_CODE', 'c_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-      ('SOURCE_VOCABULARY', 'c_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-      ('CONDITION_STATUS_SOURCE_VALUE', 'c_occurrence.CONDITION_STATUS_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_STATUS_CONCEPT_ID', 'c_occurrence.CONDITION_STATUS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-      ('CONDITION_STATUS_CONCEPT_NAME', 'c_status.concept_name as CONDITION_STATUS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_status on c_occurrence.CONDITION_STATUS_CONCEPT_ID = c_status.CONCEPT_ID', 'Condition')"
+################################################
+# INSERT DATA
+################################################
+echo "ds_linking - inserting condition data"
 
-  echo "ds_linking - inserting drug exposure data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    # We add the core table for domain row to ensure we have a single place to make certain we load in the base table.
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('PERSON_ID', 'c_occurrence.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_CONCEPT_ID', 'c_occurrence.CONDITION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('STANDARD_CONCEPT_NAME', 'c_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+    ('STANDARD_CONCEPT_CODE', 'c_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+    ('STANDARD_VOCABULARY', 'c_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+    ('CONDITION_START_DATETIME', 'c_occurrence.CONDITION_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_END_DATETIME', 'c_occurrence.CONDITION_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_TYPE_CONCEPT_ID', 'c_occurrence.CONDITION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_TYPE_CONCEPT_NAME', 'c_type.concept_name as CONDITION_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_type on c_occurrence.CONDITION_TYPE_CONCEPT_ID = c_type.CONCEPT_ID', 'Condition'),
+    ('STOP_REASON', 'c_occurrence.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('VISIT_OCCURRENCE_ID', 'c_occurrence.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on c_occurrence.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` visit on v.visit_concept_id = visit.concept_id', 'Condition'),
+    ('CONDITION_SOURCE_VALUE', 'c_occurrence.CONDITION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_SOURCE_CONCEPT_ID', 'c_occurrence.CONDITION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('SOURCE_CONCEPT_NAME', 'c_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+    ('SOURCE_CONCEPT_CODE', 'c_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+    ('SOURCE_VOCABULARY', 'c_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+    ('CONDITION_STATUS_SOURCE_VALUE', 'c_occurrence.CONDITION_STATUS_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_STATUS_CONCEPT_ID', 'c_occurrence.CONDITION_STATUS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+    ('CONDITION_STATUS_CONCEPT_NAME', 'c_status.concept_name as CONDITION_STATUS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_status on c_occurrence.CONDITION_STATUS_CONCEPT_ID = c_status.CONCEPT_ID', 'Condition')"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('PERSON_ID', 'd_exposure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DRUG_CONCEPT_ID', 'd_exposure.DRUG_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('STANDARD_CONCEPT_NAME', 'd_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-      ('STANDARD_CONCEPT_CODE', 'd_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-      ('STANDARD_VOCABULARY', 'd_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-      ('DRUG_EXPOSURE_START_DATETIME', 'd_exposure.DRUG_EXPOSURE_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DRUG_EXPOSURE_END_DATETIME', 'd_exposure.DRUG_EXPOSURE_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('VERBATIM_END_DATE', 'd_exposure.VERBATIM_END_DATE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DRUG_TYPE_CONCEPT_ID', 'd_exposure.DRUG_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DRUG_TYPE_CONCEPT_NAME', 'd_type.concept_name as DRUG_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_type on d_exposure.drug_type_concept_id = d_type.CONCEPT_ID', 'Drug'),
-      ('STOP_REASON', 'd_exposure.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('REFILLS', 'd_exposure.REFILLS', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('QUANTITY', 'd_exposure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DAYS_SUPPLY', 'd_exposure.DAYS_SUPPLY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('SIG', 'd_exposure.SIG', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('ROUTE_CONCEPT_ID', 'd_exposure.ROUTE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('ROUTE_CONCEPT_NAME', 'd_route.concept_name as ROUTE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_route on d_exposure.ROUTE_CONCEPT_ID = d_route.CONCEPT_ID', 'Drug'),
-      ('LOT_NUMBER', 'd_exposure.LOT_NUMBER', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('VISIT_OCCURRENCE_ID', 'd_exposure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'd_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on d_exposure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_visit on v.VISIT_CONCEPT_ID = d_visit.CONCEPT_ID', 'Drug'),
-      ('DRUG_SOURCE_VALUE', 'd_exposure.DRUG_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DRUG_SOURCE_CONCEPT_ID', 'd_exposure.DRUG_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('SOURCE_CONCEPT_NAME', 'd_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-      ('SOURCE_CONCEPT_CODE', 'd_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-      ('SOURCE_VOCABULARY', 'd_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-      ('ROUTE_SOURCE_VALUE', 'd_exposure.ROUTE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-      ('DOSE_UNIT_SOURCE_VALUE', 'd_exposure.DOSE_UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug')"
+echo "ds_linking - inserting drug exposure data"
 
-  echo "ds_linking - inserting measurement data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('PERSON_ID', 'd_exposure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DRUG_CONCEPT_ID', 'd_exposure.DRUG_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('STANDARD_CONCEPT_NAME', 'd_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+    ('STANDARD_CONCEPT_CODE', 'd_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+    ('STANDARD_VOCABULARY', 'd_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+    ('DRUG_EXPOSURE_START_DATETIME', 'd_exposure.DRUG_EXPOSURE_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DRUG_EXPOSURE_END_DATETIME', 'd_exposure.DRUG_EXPOSURE_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('VERBATIM_END_DATE', 'd_exposure.VERBATIM_END_DATE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DRUG_TYPE_CONCEPT_ID', 'd_exposure.DRUG_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DRUG_TYPE_CONCEPT_NAME', 'd_type.concept_name as DRUG_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_type on d_exposure.drug_type_concept_id = d_type.CONCEPT_ID', 'Drug'),
+    ('STOP_REASON', 'd_exposure.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('REFILLS', 'd_exposure.REFILLS', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('QUANTITY', 'd_exposure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DAYS_SUPPLY', 'd_exposure.DAYS_SUPPLY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('SIG', 'd_exposure.SIG', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('ROUTE_CONCEPT_ID', 'd_exposure.ROUTE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('ROUTE_CONCEPT_NAME', 'd_route.concept_name as ROUTE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_route on d_exposure.ROUTE_CONCEPT_ID = d_route.CONCEPT_ID', 'Drug'),
+    ('LOT_NUMBER', 'd_exposure.LOT_NUMBER', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('VISIT_OCCURRENCE_ID', 'd_exposure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'd_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on d_exposure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_visit on v.VISIT_CONCEPT_ID = d_visit.CONCEPT_ID', 'Drug'),
+    ('DRUG_SOURCE_VALUE', 'd_exposure.DRUG_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DRUG_SOURCE_CONCEPT_ID', 'd_exposure.DRUG_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('SOURCE_CONCEPT_NAME', 'd_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+    ('SOURCE_CONCEPT_CODE', 'd_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+    ('SOURCE_VOCABULARY', 'd_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+    ('ROUTE_SOURCE_VALUE', 'd_exposure.ROUTE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+    ('DOSE_UNIT_SOURCE_VALUE', 'd_exposure.DOSE_UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug')"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('PERSON_ID', 'measurement.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('MEASUREMENT_CONCEPT_ID', 'measurement.MEASUREMENT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('STANDARD_CONCEPT_NAME', 'm_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-      ('STANDARD_CONCEPT_CODE', 'm_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-      ('STANDARD_VOCABULARY', 'm_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-      ('MEASUREMENT_DATETIME', 'measurement.MEASUREMENT_DATETIME', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('MEASUREMENT_TYPE_CONCEPT_ID', 'measurement.MEASUREMENT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('MEASUREMENT_TYPE_CONCEPT_NAME', 'm_type.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_type on measurement.measurement_type_concept_id = m_type.concept_id', 'Measurement'),
-      ('OPERATOR_CONCEPT_ID', 'measurement.OPERATOR_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('OPERATOR_CONCEPT_NAME', 'm_operator.concept_name as OPERATOR_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_operator on measurement.operator_concept_id = m_operator.concept_id', 'Measurement'),
-      ('VALUE_AS_NUMBER', 'measurement.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('VALUE_AS_CONCEPT_ID', 'measurement.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('VALUE_AS_CONCEPT_NAME', 'm_value.concept_name as VALUE_AS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_value on measurement.value_as_concept_id = m_value.concept_id', 'Measurement'),
-      ('UNIT_CONCEPT_ID', 'measurement.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('UNIT_CONCEPT_NAME', 'm_unit.concept_name as UNIT_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_unit on measurement.unit_concept_id = m_unit.concept_id', 'Measurement'),
-      ('RANGE_LOW', 'measurement.RANGE_LOW', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('RANGE_HIGH', 'measurement.RANGE_HIGH', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('VISIT_OCCURRENCE_ID', 'measurement.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'm_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on measurement.visit_occurrence_id = v.visit_occurrence_id left join \`\${projectId}.\${dataSetId}.concept\` m_visit on v.visit_concept_id = m_visit.concept_id', 'Measurement'),
-      ('MEASUREMENT_SOURCE_VALUE', 'measurement.MEASUREMENT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('MEASUREMENT_SOURCE_CONCEPT_ID', 'measurement.MEASUREMENT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('SOURCE_CONCEPT_NAME', 'm_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-      ('SOURCE_CONCEPT_CODE', 'm_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-      ('SOURCE_VOCABULARY', 'm_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-      ('UNIT_SOURCE_VALUE', 'measurement.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-      ('VALUE_SOURCE_VALUE', 'measurement.VALUE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement')"
+echo "ds_linking - inserting measurement data"
 
-  echo "ds_linking - inserting observation data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('PERSON_ID', 'measurement.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('MEASUREMENT_CONCEPT_ID', 'measurement.MEASUREMENT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('STANDARD_CONCEPT_NAME', 'm_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+    ('STANDARD_CONCEPT_CODE', 'm_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+    ('STANDARD_VOCABULARY', 'm_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+    ('MEASUREMENT_DATETIME', 'measurement.MEASUREMENT_DATETIME', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('MEASUREMENT_TYPE_CONCEPT_ID', 'measurement.MEASUREMENT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('MEASUREMENT_TYPE_CONCEPT_NAME', 'm_type.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_type on measurement.measurement_type_concept_id = m_type.concept_id', 'Measurement'),
+    ('OPERATOR_CONCEPT_ID', 'measurement.OPERATOR_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('OPERATOR_CONCEPT_NAME', 'm_operator.concept_name as OPERATOR_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_operator on measurement.operator_concept_id = m_operator.concept_id', 'Measurement'),
+    ('VALUE_AS_NUMBER', 'measurement.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('VALUE_AS_CONCEPT_ID', 'measurement.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('VALUE_AS_CONCEPT_NAME', 'm_value.concept_name as VALUE_AS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_value on measurement.value_as_concept_id = m_value.concept_id', 'Measurement'),
+    ('UNIT_CONCEPT_ID', 'measurement.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('UNIT_CONCEPT_NAME', 'm_unit.concept_name as UNIT_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_unit on measurement.unit_concept_id = m_unit.concept_id', 'Measurement'),
+    ('RANGE_LOW', 'measurement.RANGE_LOW', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('RANGE_HIGH', 'measurement.RANGE_HIGH', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('VISIT_OCCURRENCE_ID', 'measurement.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'm_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on measurement.visit_occurrence_id = v.visit_occurrence_id left join \`\${projectId}.\${dataSetId}.concept\` m_visit on v.visit_concept_id = m_visit.concept_id', 'Measurement'),
+    ('MEASUREMENT_SOURCE_VALUE', 'measurement.MEASUREMENT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('MEASUREMENT_SOURCE_CONCEPT_ID', 'measurement.MEASUREMENT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('SOURCE_CONCEPT_NAME', 'm_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+    ('SOURCE_CONCEPT_CODE', 'm_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+    ('SOURCE_VOCABULARY', 'm_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+    ('UNIT_SOURCE_VALUE', 'measurement.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+    ('VALUE_SOURCE_VALUE', 'measurement.VALUE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement')"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('PERSON_ID', 'observation.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('OBSERVATION_CONCEPT_ID', 'observation.OBSERVATION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('STANDARD_CONCEPT_NAME', 'o_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-      ('STANDARD_CONCEPT_CODE', 'o_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-      ('STANDARD_VOCABULARY', 'o_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-      ('OBSERVATION_DATETIME', 'observation.OBSERVATION_DATETIME', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('OBSERVATION_TYPE_CONCEPT_ID', 'observation.OBSERVATION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('OBSERVATION_TYPE_CONCEPT_NAME', 'o_type.concept_name as OBSERVATION_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_type on observation.OBSERVATION_TYPE_CONCEPT_ID = o_type.CONCEPT_ID', 'Observation'),
-      ('VALUE_AS_NUMBER', 'observation.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('VALUE_AS_STRING', 'observation.VALUE_AS_STRING', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('VALUE_AS_CONCEPT_ID', 'observation.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('VALUE_AS_CONCEPT_NAME', 'o_value.concept_name as VALUE_AS_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_value on observation.value_as_concept_id = o_value.CONCEPT_ID', 'Observation'),
-      ('QUALIFIER_CONCEPT_ID', 'observation.QUALIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('QUALIFIER_CONCEPT_NAME', 'o_qualifier.concept_name as QUALIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_qualifier on observation.qualifier_concept_id = o_qualifier.CONCEPT_ID', 'Observation'),
-      ('UNIT_CONCEPT_ID', 'observation.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('UNIT_CONCEPT_NAME', 'o_unit.concept_name as UNIT_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_unit on observation.unit_concept_id = o_unit.CONCEPT_ID', 'Observation'),
-      ('VISIT_OCCURRENCE_ID', 'observation.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'o_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on observation.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` o_visit on v.visit_concept_id = o_visit.concept_id', 'Observation'),
-      ('OBSERVATION_SOURCE_VALUE', 'observation.OBSERVATION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('OBSERVATION_SOURCE_CONCEPT_ID', 'observation.OBSERVATION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('SOURCE_CONCEPT_NAME', 'o_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-      ('SOURCE_CONCEPT_CODE', 'o_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-      ('SOURCE_VOCABULARY', 'o_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-      ('UNIT_SOURCE_VALUE', 'observation.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('QUALIFIER_SOURCE_VALUE', 'observation.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('value_source_concept_id', 'observation.value_source_concept_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('value_source_value', 'observation.value_source_value', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-      ('questionnaire_response_id', 'observation.questionnaire_response_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation')"
+echo "ds_linking - inserting observation data"
+
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('PERSON_ID', 'observation.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('OBSERVATION_CONCEPT_ID', 'observation.OBSERVATION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('STANDARD_CONCEPT_NAME', 'o_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+    ('STANDARD_CONCEPT_CODE', 'o_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+    ('STANDARD_VOCABULARY', 'o_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+    ('OBSERVATION_DATETIME', 'observation.OBSERVATION_DATETIME', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('OBSERVATION_TYPE_CONCEPT_ID', 'observation.OBSERVATION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('OBSERVATION_TYPE_CONCEPT_NAME', 'o_type.concept_name as OBSERVATION_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_type on observation.OBSERVATION_TYPE_CONCEPT_ID = o_type.CONCEPT_ID', 'Observation'),
+    ('VALUE_AS_NUMBER', 'observation.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('VALUE_AS_STRING', 'observation.VALUE_AS_STRING', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('VALUE_AS_CONCEPT_ID', 'observation.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('VALUE_AS_CONCEPT_NAME', 'o_value.concept_name as VALUE_AS_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_value on observation.value_as_concept_id = o_value.CONCEPT_ID', 'Observation'),
+    ('QUALIFIER_CONCEPT_ID', 'observation.QUALIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('QUALIFIER_CONCEPT_NAME', 'o_qualifier.concept_name as QUALIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_qualifier on observation.qualifier_concept_id = o_qualifier.CONCEPT_ID', 'Observation'),
+    ('UNIT_CONCEPT_ID', 'observation.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('UNIT_CONCEPT_NAME', 'o_unit.concept_name as UNIT_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_unit on observation.unit_concept_id = o_unit.CONCEPT_ID', 'Observation'),
+    ('VISIT_OCCURRENCE_ID', 'observation.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'o_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on observation.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` o_visit on v.visit_concept_id = o_visit.concept_id', 'Observation'),
+    ('OBSERVATION_SOURCE_VALUE', 'observation.OBSERVATION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('OBSERVATION_SOURCE_CONCEPT_ID', 'observation.OBSERVATION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('SOURCE_CONCEPT_NAME', 'o_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+    ('SOURCE_CONCEPT_CODE', 'o_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+    ('SOURCE_VOCABULARY', 'o_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+    ('UNIT_SOURCE_VALUE', 'observation.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('QUALIFIER_SOURCE_VALUE', 'observation.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('value_source_concept_id', 'observation.value_source_concept_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('value_source_value', 'observation.value_source_value', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+    ('questionnaire_response_id', 'observation.questionnaire_response_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation')"
 
 
-  echo "ds_linking - inserting person data"
+echo "ds_linking - inserting person data"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('PERSON_ID', 'person.PERSON_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('GENDER_CONCEPT_ID', 'person.GENDER_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('GENDER', 'p_gender_concept.concept_name as GENDER', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept on person.gender_concept_id = p_gender_concept.CONCEPT_ID', 'Person'),
-      ('DATE_OF_BIRTH', 'person.BIRTH_DATETIME as DATE_OF_BIRTH', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('RACE_CONCEPT_ID', 'person.RACE_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('RACE', 'p_race_concept.concept_name as RACE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept on person.race_concept_id = p_race_concept.CONCEPT_ID', 'Person'),
-      ('ETHNICITY_CONCEPT_ID', 'person.ETHNICITY_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('ETHNICITY', 'p_ethnicity_concept.concept_name as ETHNICITY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept on person.ethnicity_concept_id = p_ethnicity_concept.CONCEPT_ID', 'Person'),
-      ('SEX_AT_BIRTH_CONCEPT_ID', 'person.SEX_AT_BIRTH_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-      ('SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as SEX_AT_BIRTH', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept on person.sex_at_birth_concept_id = p_sex_at_birth_concept.CONCEPT_ID', 'Person')"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('PERSON_ID', 'person.PERSON_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('GENDER_CONCEPT_ID', 'person.GENDER_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('GENDER', 'p_gender_concept.concept_name as GENDER', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept on person.gender_concept_id = p_gender_concept.CONCEPT_ID', 'Person'),
+    ('DATE_OF_BIRTH', 'person.BIRTH_DATETIME as DATE_OF_BIRTH', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('RACE_CONCEPT_ID', 'person.RACE_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('RACE', 'p_race_concept.concept_name as RACE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept on person.race_concept_id = p_race_concept.CONCEPT_ID', 'Person'),
+    ('ETHNICITY_CONCEPT_ID', 'person.ETHNICITY_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('ETHNICITY', 'p_ethnicity_concept.concept_name as ETHNICITY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept on person.ethnicity_concept_id = p_ethnicity_concept.CONCEPT_ID', 'Person'),
+    ('SEX_AT_BIRTH_CONCEPT_ID', 'person.SEX_AT_BIRTH_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+    ('SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as SEX_AT_BIRTH', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept on person.sex_at_birth_concept_id = p_sex_at_birth_concept.CONCEPT_ID', 'Person')"
 
-  echo "ds_linking - inserting procedure data"
+echo "ds_linking - inserting procedure data"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('PERSON_ID', 'procedure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('PROCEDURE_CONCEPT_ID', 'procedure.PROCEDURE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('STANDARD_CONCEPT_NAME', 'p_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-      ('STANDARD_CONCEPT_CODE', 'p_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-      ('STANDARD_VOCABULARY', 'p_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-      ('PROCEDURE_DATETIME', 'procedure.PROCEDURE_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('PROCEDURE_TYPE_CONCEPT_ID', 'procedure.PROCEDURE_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('PROCEDURE_TYPE_CONCEPT_NAME', 'p_type.concept_name as PROCEDURE_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_type on procedure.PROCEDURE_TYPE_CONCEPT_ID = p_type.CONCEPT_ID', 'Procedure'),
-      ('MODIFIER_CONCEPT_ID', 'procedure.MODIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('MODIFIER_CONCEPT_NAME', 'p_modifier.concept_name as MODIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_modifier on procedure.MODIFIER_CONCEPT_ID = p_modifier.CONCEPT_ID', 'Procedure'),
-      ('QUANTITY', 'procedure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('VISIT_OCCURRENCE_ID', 'procedure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'p_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on procedure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` p_visit on v.visit_concept_id = p_visit.concept_id', 'Procedure'),
-      ('PROCEDURE_SOURCE_VALUE', 'procedure.PROCEDURE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('PROCEDURE_SOURCE_CONCEPT_ID', 'procedure.PROCEDURE_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-      ('SOURCE_CONCEPT_NAME', 'p_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-      ('SOURCE_CONCEPT_CODE', 'p_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-      ('SOURCE_VOCABULARY', 'p_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-      ('QUALIFIER_SOURCE_VALUE', 'procedure.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure')"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('PERSON_ID', 'procedure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('PROCEDURE_CONCEPT_ID', 'procedure.PROCEDURE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('STANDARD_CONCEPT_NAME', 'p_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+    ('STANDARD_CONCEPT_CODE', 'p_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+    ('STANDARD_VOCABULARY', 'p_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+    ('PROCEDURE_DATETIME', 'procedure.PROCEDURE_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('PROCEDURE_TYPE_CONCEPT_ID', 'procedure.PROCEDURE_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('PROCEDURE_TYPE_CONCEPT_NAME', 'p_type.concept_name as PROCEDURE_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_type on procedure.PROCEDURE_TYPE_CONCEPT_ID = p_type.CONCEPT_ID', 'Procedure'),
+    ('MODIFIER_CONCEPT_ID', 'procedure.MODIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('MODIFIER_CONCEPT_NAME', 'p_modifier.concept_name as MODIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_modifier on procedure.MODIFIER_CONCEPT_ID = p_modifier.CONCEPT_ID', 'Procedure'),
+    ('QUANTITY', 'procedure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('VISIT_OCCURRENCE_ID', 'procedure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'p_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on procedure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` p_visit on v.visit_concept_id = p_visit.concept_id', 'Procedure'),
+    ('PROCEDURE_SOURCE_VALUE', 'procedure.PROCEDURE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('PROCEDURE_SOURCE_CONCEPT_ID', 'procedure.PROCEDURE_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+    ('SOURCE_CONCEPT_NAME', 'p_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+    ('SOURCE_CONCEPT_CODE', 'p_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+    ('SOURCE_VOCABULARY', 'p_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+    ('QUALIFIER_SOURCE_VALUE', 'procedure.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure')"
 
-  echo "ds_linking - inserting survey data"
+echo "ds_linking - inserting survey data"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', ' FROM \`\${projectId}.\${dataSetId}.ds_survey\` answer', 'Survey'),
-      ('PERSON_ID', 'answer.person_id', ' ', 'Survey'),
-      ('SURVEY_DATETIME', 'answer.survey_datetime', ' ', 'Survey'),
-      ('SURVEY', 'answer.survey', ' ', 'Survey'),
-      ('QUESTION_CONCEPT_ID', 'answer.question_concept_id', ' ', 'Survey'),
-      ('QUESTION', 'answer.question', ' ', 'Survey'),
-      ('ANSWER_CONCEPT_ID', 'answer.answer_concept_id', ' ', 'Survey'),
-      ('ANSWER', 'answer.answer', ' ', 'Survey')"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', ' FROM \`\${projectId}.\${dataSetId}.ds_survey\` answer', 'Survey'),
+    ('PERSON_ID', 'answer.person_id', ' ', 'Survey'),
+    ('SURVEY_DATETIME', 'answer.survey_datetime', ' ', 'Survey'),
+    ('SURVEY', 'answer.survey', ' ', 'Survey'),
+    ('QUESTION_CONCEPT_ID', 'answer.question_concept_id', ' ', 'Survey'),
+    ('QUESTION', 'answer.question', ' ', 'Survey'),
+    ('ANSWER_CONCEPT_ID', 'answer.answer_concept_id', ' ', 'Survey'),
+    ('ANSWER', 'answer.answer', ' ', 'Survey')"
 
-  echo "ds_linking - inserting visit data"
+echo "ds_linking - inserting visit data"
 
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-  VALUES
-      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('PERSON_ID', 'visit.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('VISIT_CONCEPT_ID', 'visit.VISIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('STANDARD_CONCEPT_NAME', 'v_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-      ('STANDARD_CONCEPT_CODE', 'v_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-      ('STANDARD_VOCABULARY', 'v_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-      ('VISIT_START_DATETIME', 'visit.VISIT_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('VISIT_END_DATETIME', 'visit.VISIT_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('VISIT_TYPE_CONCEPT_ID', 'visit.VISIT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('VISIT_TYPE_CONCEPT_NAME', 'v_type.concept_name as VISIT_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_type on visit.VISIT_TYPE_CONCEPT_ID = v_type.CONCEPT_ID', 'Visit'),
-      ('VISIT_SOURCE_VALUE', 'visit.VISIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('VISIT_SOURCE_CONCEPT_ID', 'visit.VISIT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('SOURCE_CONCEPT_NAME', 'v_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-      ('SOURCE_CONCEPT_CODE', 'v_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-      ('SOURCE_VOCABULARY', 'v_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-      ('ADMITTING_SOURCE_CONCEPT_ID', 'visit.ADMITTING_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('ADMITTING_SOURCE_CONCEPT_NAME', 'v_admitting_source_concept.concept_name as ADMITTING_SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` v_admitting_source_concept on visit.ADMITTING_SOURCE_CONCEPT_ID = v_admitting_source_concept.CONCEPT_ID', 'Visit'),
-      ('ADMITTING_SOURCE_VALUE', 'visit.ADMITTING_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('DISCHARGE_TO_CONCEPT_ID', 'visit.DISCHARGE_TO_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-      ('DISCHARGE_TO_CONCEPT_NAME', 'v_discharge.concept_name as DISCHARGE_TO_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_discharge on visit.DISCHARGE_TO_CONCEPT_ID = v_discharge.CONCEPT_ID', 'Visit'),
-      ('DISCHARGE_TO_SOURCE_VALUE', 'visit.DISCHARGE_TO_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit')"
-  fi
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('PERSON_ID', 'visit.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('VISIT_CONCEPT_ID', 'visit.VISIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('STANDARD_CONCEPT_NAME', 'v_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+    ('STANDARD_CONCEPT_CODE', 'v_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+    ('STANDARD_VOCABULARY', 'v_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+    ('VISIT_START_DATETIME', 'visit.VISIT_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('VISIT_END_DATETIME', 'visit.VISIT_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('VISIT_TYPE_CONCEPT_ID', 'visit.VISIT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('VISIT_TYPE_CONCEPT_NAME', 'v_type.concept_name as VISIT_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_type on visit.VISIT_TYPE_CONCEPT_ID = v_type.CONCEPT_ID', 'Visit'),
+    ('VISIT_SOURCE_VALUE', 'visit.VISIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('VISIT_SOURCE_CONCEPT_ID', 'visit.VISIT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('SOURCE_CONCEPT_NAME', 'v_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+    ('SOURCE_CONCEPT_CODE', 'v_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+    ('SOURCE_VOCABULARY', 'v_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+    ('ADMITTING_SOURCE_CONCEPT_ID', 'visit.ADMITTING_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('ADMITTING_SOURCE_CONCEPT_NAME', 'v_admitting_source_concept.concept_name as ADMITTING_SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` v_admitting_source_concept on visit.ADMITTING_SOURCE_CONCEPT_ID = v_admitting_source_concept.CONCEPT_ID', 'Visit'),
+    ('ADMITTING_SOURCE_VALUE', 'visit.ADMITTING_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('DISCHARGE_TO_CONCEPT_ID', 'visit.DISCHARGE_TO_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+    ('DISCHARGE_TO_CONCEPT_NAME', 'v_discharge.concept_name as DISCHARGE_TO_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_discharge on visit.DISCHARGE_TO_CONCEPT_ID = v_discharge.CONCEPT_ID', 'Visit'),
+    ('DISCHARGE_TO_SOURCE_VALUE', 'visit.DISCHARGE_TO_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit')"

--- a/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
+++ b/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
@@ -6,248 +6,252 @@ set -ex
 
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
+export DRY_RUN=$3     # dry run
 
-# Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
+if [ "$DRY_RUN" == false ]
 then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
+  # Check that bq_dataset exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
 
-################################################
-# CREATE LINKING TABLE
-################################################
-echo "CREATE TABLE - ds_linking"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`
-(
-    DENORMALIZED_NAME               STRING,
-    OMOP_SQL                        STRING,
-    JOIN_VALUE                      STRING,
-    DOMAIN                          STRING
-)"
+  ################################################
+  # CREATE LINKING TABLE
+  ################################################
+  echo "CREATE TABLE - ds_linking"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`
+  (
+      DENORMALIZED_NAME               STRING,
+      OMOP_SQL                        STRING,
+      JOIN_VALUE                      STRING,
+      DOMAIN                          STRING
+  )"
 
-################################################
-# INSERT DATA
-################################################
-echo "ds_linking - inserting condition data"
+  ################################################
+  # INSERT DATA
+  ################################################
+  echo "ds_linking - inserting condition data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    # We add the core table for domain row to ensure we have a single place to make certain we load in the base table.
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('PERSON_ID', 'c_occurrence.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_CONCEPT_ID', 'c_occurrence.CONDITION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('STANDARD_CONCEPT_NAME', 'c_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-    ('STANDARD_CONCEPT_CODE', 'c_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-    ('STANDARD_VOCABULARY', 'c_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
-    ('CONDITION_START_DATETIME', 'c_occurrence.CONDITION_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_END_DATETIME', 'c_occurrence.CONDITION_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_TYPE_CONCEPT_ID', 'c_occurrence.CONDITION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_TYPE_CONCEPT_NAME', 'c_type.concept_name as CONDITION_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_type on c_occurrence.CONDITION_TYPE_CONCEPT_ID = c_type.CONCEPT_ID', 'Condition'),
-    ('STOP_REASON', 'c_occurrence.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('VISIT_OCCURRENCE_ID', 'c_occurrence.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on c_occurrence.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` visit on v.visit_concept_id = visit.concept_id', 'Condition'),
-    ('CONDITION_SOURCE_VALUE', 'c_occurrence.CONDITION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_SOURCE_CONCEPT_ID', 'c_occurrence.CONDITION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('SOURCE_CONCEPT_NAME', 'c_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-    ('SOURCE_CONCEPT_CODE', 'c_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-    ('SOURCE_VOCABULARY', 'c_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
-    ('CONDITION_STATUS_SOURCE_VALUE', 'c_occurrence.CONDITION_STATUS_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_STATUS_CONCEPT_ID', 'c_occurrence.CONDITION_STATUS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
-    ('CONDITION_STATUS_CONCEPT_NAME', 'c_status.concept_name as CONDITION_STATUS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_status on c_occurrence.CONDITION_STATUS_CONCEPT_ID = c_status.CONCEPT_ID', 'Condition')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      # We add the core table for domain row to ensure we have a single place to make certain we load in the base table.
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('PERSON_ID', 'c_occurrence.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_CONCEPT_ID', 'c_occurrence.CONDITION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('STANDARD_CONCEPT_NAME', 'c_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+      ('STANDARD_CONCEPT_CODE', 'c_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+      ('STANDARD_VOCABULARY', 'c_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_standard_concept on c_occurrence.CONDITION_CONCEPT_ID = c_standard_concept.CONCEPT_ID', 'Condition'),
+      ('CONDITION_START_DATETIME', 'c_occurrence.CONDITION_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_END_DATETIME', 'c_occurrence.CONDITION_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_TYPE_CONCEPT_ID', 'c_occurrence.CONDITION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_TYPE_CONCEPT_NAME', 'c_type.concept_name as CONDITION_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_type on c_occurrence.CONDITION_TYPE_CONCEPT_ID = c_type.CONCEPT_ID', 'Condition'),
+      ('STOP_REASON', 'c_occurrence.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('VISIT_OCCURRENCE_ID', 'c_occurrence.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on c_occurrence.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` visit on v.visit_concept_id = visit.concept_id', 'Condition'),
+      ('CONDITION_SOURCE_VALUE', 'c_occurrence.CONDITION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_SOURCE_CONCEPT_ID', 'c_occurrence.CONDITION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('SOURCE_CONCEPT_NAME', 'c_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+      ('SOURCE_CONCEPT_CODE', 'c_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+      ('SOURCE_VOCABULARY', 'c_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` c_source_concept on c_occurrence.CONDITION_SOURCE_CONCEPT_ID = c_source_concept.CONCEPT_ID', 'Condition'),
+      ('CONDITION_STATUS_SOURCE_VALUE', 'c_occurrence.CONDITION_STATUS_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_STATUS_CONCEPT_ID', 'c_occurrence.CONDITION_STATUS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.condition_occurrence\` c_occurrence', 'Condition'),
+      ('CONDITION_STATUS_CONCEPT_NAME', 'c_status.concept_name as CONDITION_STATUS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` c_status on c_occurrence.CONDITION_STATUS_CONCEPT_ID = c_status.CONCEPT_ID', 'Condition')"
 
-echo "ds_linking - inserting drug exposure data"
+  echo "ds_linking - inserting drug exposure data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('PERSON_ID', 'd_exposure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DRUG_CONCEPT_ID', 'd_exposure.DRUG_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('STANDARD_CONCEPT_NAME', 'd_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-    ('STANDARD_CONCEPT_CODE', 'd_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-    ('STANDARD_VOCABULARY', 'd_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
-    ('DRUG_EXPOSURE_START_DATETIME', 'd_exposure.DRUG_EXPOSURE_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DRUG_EXPOSURE_END_DATETIME', 'd_exposure.DRUG_EXPOSURE_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('VERBATIM_END_DATE', 'd_exposure.VERBATIM_END_DATE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DRUG_TYPE_CONCEPT_ID', 'd_exposure.DRUG_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DRUG_TYPE_CONCEPT_NAME', 'd_type.concept_name as DRUG_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_type on d_exposure.drug_type_concept_id = d_type.CONCEPT_ID', 'Drug'),
-    ('STOP_REASON', 'd_exposure.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('REFILLS', 'd_exposure.REFILLS', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('QUANTITY', 'd_exposure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DAYS_SUPPLY', 'd_exposure.DAYS_SUPPLY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('SIG', 'd_exposure.SIG', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('ROUTE_CONCEPT_ID', 'd_exposure.ROUTE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('ROUTE_CONCEPT_NAME', 'd_route.concept_name as ROUTE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_route on d_exposure.ROUTE_CONCEPT_ID = d_route.CONCEPT_ID', 'Drug'),
-    ('LOT_NUMBER', 'd_exposure.LOT_NUMBER', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('VISIT_OCCURRENCE_ID', 'd_exposure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'd_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on d_exposure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_visit on v.VISIT_CONCEPT_ID = d_visit.CONCEPT_ID', 'Drug'),
-    ('DRUG_SOURCE_VALUE', 'd_exposure.DRUG_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DRUG_SOURCE_CONCEPT_ID', 'd_exposure.DRUG_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('SOURCE_CONCEPT_NAME', 'd_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-    ('SOURCE_CONCEPT_CODE', 'd_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-    ('SOURCE_VOCABULARY', 'd_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
-    ('ROUTE_SOURCE_VALUE', 'd_exposure.ROUTE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
-    ('DOSE_UNIT_SOURCE_VALUE', 'd_exposure.DOSE_UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('PERSON_ID', 'd_exposure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DRUG_CONCEPT_ID', 'd_exposure.DRUG_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('STANDARD_CONCEPT_NAME', 'd_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+      ('STANDARD_CONCEPT_CODE', 'd_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+      ('STANDARD_VOCABULARY', 'd_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` d_standard_concept on d_exposure.DRUG_CONCEPT_ID = d_standard_concept.CONCEPT_ID', 'Drug'),
+      ('DRUG_EXPOSURE_START_DATETIME', 'd_exposure.DRUG_EXPOSURE_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DRUG_EXPOSURE_END_DATETIME', 'd_exposure.DRUG_EXPOSURE_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('VERBATIM_END_DATE', 'd_exposure.VERBATIM_END_DATE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DRUG_TYPE_CONCEPT_ID', 'd_exposure.DRUG_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DRUG_TYPE_CONCEPT_NAME', 'd_type.concept_name as DRUG_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_type on d_exposure.drug_type_concept_id = d_type.CONCEPT_ID', 'Drug'),
+      ('STOP_REASON', 'd_exposure.STOP_REASON', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('REFILLS', 'd_exposure.REFILLS', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('QUANTITY', 'd_exposure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DAYS_SUPPLY', 'd_exposure.DAYS_SUPPLY', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('SIG', 'd_exposure.SIG', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('ROUTE_CONCEPT_ID', 'd_exposure.ROUTE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('ROUTE_CONCEPT_NAME', 'd_route.concept_name as ROUTE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_route on d_exposure.ROUTE_CONCEPT_ID = d_route.CONCEPT_ID', 'Drug'),
+      ('LOT_NUMBER', 'd_exposure.LOT_NUMBER', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('VISIT_OCCURRENCE_ID', 'd_exposure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'd_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on d_exposure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_visit on v.VISIT_CONCEPT_ID = d_visit.CONCEPT_ID', 'Drug'),
+      ('DRUG_SOURCE_VALUE', 'd_exposure.DRUG_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DRUG_SOURCE_CONCEPT_ID', 'd_exposure.DRUG_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('SOURCE_CONCEPT_NAME', 'd_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+      ('SOURCE_CONCEPT_CODE', 'd_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+      ('SOURCE_VOCABULARY', 'd_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` d_source_concept on d_exposure.DRUG_SOURCE_CONCEPT_ID = d_source_concept.CONCEPT_ID', 'Drug'),
+      ('ROUTE_SOURCE_VALUE', 'd_exposure.ROUTE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug'),
+      ('DOSE_UNIT_SOURCE_VALUE', 'd_exposure.DOSE_UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.drug_exposure\` d_exposure', 'Drug')"
 
-echo "ds_linking - inserting measurement data"
+  echo "ds_linking - inserting measurement data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('PERSON_ID', 'measurement.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('MEASUREMENT_CONCEPT_ID', 'measurement.MEASUREMENT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('STANDARD_CONCEPT_NAME', 'm_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-    ('STANDARD_CONCEPT_CODE', 'm_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-    ('STANDARD_VOCABULARY', 'm_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
-    ('MEASUREMENT_DATETIME', 'measurement.MEASUREMENT_DATETIME', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('MEASUREMENT_TYPE_CONCEPT_ID', 'measurement.MEASUREMENT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('MEASUREMENT_TYPE_CONCEPT_NAME', 'm_type.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_type on measurement.measurement_type_concept_id = m_type.concept_id', 'Measurement'),
-    ('OPERATOR_CONCEPT_ID', 'measurement.OPERATOR_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('OPERATOR_CONCEPT_NAME', 'm_operator.concept_name as OPERATOR_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_operator on measurement.operator_concept_id = m_operator.concept_id', 'Measurement'),
-    ('VALUE_AS_NUMBER', 'measurement.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('VALUE_AS_CONCEPT_ID', 'measurement.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('VALUE_AS_CONCEPT_NAME', 'm_value.concept_name as VALUE_AS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_value on measurement.value_as_concept_id = m_value.concept_id', 'Measurement'),
-    ('UNIT_CONCEPT_ID', 'measurement.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('UNIT_CONCEPT_NAME', 'm_unit.concept_name as UNIT_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_unit on measurement.unit_concept_id = m_unit.concept_id', 'Measurement'),
-    ('RANGE_LOW', 'measurement.RANGE_LOW', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('RANGE_HIGH', 'measurement.RANGE_HIGH', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('VISIT_OCCURRENCE_ID', 'measurement.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'm_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on measurement.visit_occurrence_id = v.visit_occurrence_id left join \`\${projectId}.\${dataSetId}.concept\` m_visit on v.visit_concept_id = m_visit.concept_id', 'Measurement'),
-    ('MEASUREMENT_SOURCE_VALUE', 'measurement.MEASUREMENT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('MEASUREMENT_SOURCE_CONCEPT_ID', 'measurement.MEASUREMENT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('SOURCE_CONCEPT_NAME', 'm_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-    ('SOURCE_CONCEPT_CODE', 'm_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-    ('SOURCE_VOCABULARY', 'm_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
-    ('UNIT_SOURCE_VALUE', 'measurement.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
-    ('VALUE_SOURCE_VALUE', 'measurement.VALUE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('PERSON_ID', 'measurement.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('MEASUREMENT_CONCEPT_ID', 'measurement.MEASUREMENT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('STANDARD_CONCEPT_NAME', 'm_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+      ('STANDARD_CONCEPT_CODE', 'm_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+      ('STANDARD_VOCABULARY', 'm_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_standard_concept on measurement.measurement_concept_id = m_standard_concept.concept_id', 'Measurement'),
+      ('MEASUREMENT_DATETIME', 'measurement.MEASUREMENT_DATETIME', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('MEASUREMENT_TYPE_CONCEPT_ID', 'measurement.MEASUREMENT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('MEASUREMENT_TYPE_CONCEPT_NAME', 'm_type.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_type on measurement.measurement_type_concept_id = m_type.concept_id', 'Measurement'),
+      ('OPERATOR_CONCEPT_ID', 'measurement.OPERATOR_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('OPERATOR_CONCEPT_NAME', 'm_operator.concept_name as OPERATOR_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_operator on measurement.operator_concept_id = m_operator.concept_id', 'Measurement'),
+      ('VALUE_AS_NUMBER', 'measurement.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('VALUE_AS_CONCEPT_ID', 'measurement.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('VALUE_AS_CONCEPT_NAME', 'm_value.concept_name as VALUE_AS_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_value on measurement.value_as_concept_id = m_value.concept_id', 'Measurement'),
+      ('UNIT_CONCEPT_ID', 'measurement.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('UNIT_CONCEPT_NAME', 'm_unit.concept_name as UNIT_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_unit on measurement.unit_concept_id = m_unit.concept_id', 'Measurement'),
+      ('RANGE_LOW', 'measurement.RANGE_LOW', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('RANGE_HIGH', 'measurement.RANGE_HIGH', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('VISIT_OCCURRENCE_ID', 'measurement.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'm_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on measurement.visit_occurrence_id = v.visit_occurrence_id left join \`\${projectId}.\${dataSetId}.concept\` m_visit on v.visit_concept_id = m_visit.concept_id', 'Measurement'),
+      ('MEASUREMENT_SOURCE_VALUE', 'measurement.MEASUREMENT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('MEASUREMENT_SOURCE_CONCEPT_ID', 'measurement.MEASUREMENT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('SOURCE_CONCEPT_NAME', 'm_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+      ('SOURCE_CONCEPT_CODE', 'm_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+      ('SOURCE_VOCABULARY', 'm_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'left join \`\${projectId}.\${dataSetId}.concept\` m_source_concept on measurement.measurement_source_concept_id = m_source_concept.concept_id', 'Measurement'),
+      ('UNIT_SOURCE_VALUE', 'measurement.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement'),
+      ('VALUE_SOURCE_VALUE', 'measurement.VALUE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.measurement\` measurement', 'Measurement')"
 
-echo "ds_linking - inserting observation data"
+  echo "ds_linking - inserting observation data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('PERSON_ID', 'observation.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('OBSERVATION_CONCEPT_ID', 'observation.OBSERVATION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('STANDARD_CONCEPT_NAME', 'o_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-    ('STANDARD_CONCEPT_CODE', 'o_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-    ('STANDARD_VOCABULARY', 'o_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
-    ('OBSERVATION_DATETIME', 'observation.OBSERVATION_DATETIME', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('OBSERVATION_TYPE_CONCEPT_ID', 'observation.OBSERVATION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('OBSERVATION_TYPE_CONCEPT_NAME', 'o_type.concept_name as OBSERVATION_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_type on observation.OBSERVATION_TYPE_CONCEPT_ID = o_type.CONCEPT_ID', 'Observation'),
-    ('VALUE_AS_NUMBER', 'observation.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('VALUE_AS_STRING', 'observation.VALUE_AS_STRING', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('VALUE_AS_CONCEPT_ID', 'observation.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('VALUE_AS_CONCEPT_NAME', 'o_value.concept_name as VALUE_AS_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_value on observation.value_as_concept_id = o_value.CONCEPT_ID', 'Observation'),
-    ('QUALIFIER_CONCEPT_ID', 'observation.QUALIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('QUALIFIER_CONCEPT_NAME', 'o_qualifier.concept_name as QUALIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_qualifier on observation.qualifier_concept_id = o_qualifier.CONCEPT_ID', 'Observation'),
-    ('UNIT_CONCEPT_ID', 'observation.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('UNIT_CONCEPT_NAME', 'o_unit.concept_name as UNIT_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_unit on observation.unit_concept_id = o_unit.CONCEPT_ID', 'Observation'),
-    ('VISIT_OCCURRENCE_ID', 'observation.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'o_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on observation.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` o_visit on v.visit_concept_id = o_visit.concept_id', 'Observation'),
-    ('OBSERVATION_SOURCE_VALUE', 'observation.OBSERVATION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('OBSERVATION_SOURCE_CONCEPT_ID', 'observation.OBSERVATION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('SOURCE_CONCEPT_NAME', 'o_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-    ('SOURCE_CONCEPT_CODE', 'o_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-    ('SOURCE_VOCABULARY', 'o_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
-    ('UNIT_SOURCE_VALUE', 'observation.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('QUALIFIER_SOURCE_VALUE', 'observation.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('value_source_concept_id', 'observation.value_source_concept_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('value_source_value', 'observation.value_source_value', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
-    ('questionnaire_response_id', 'observation.questionnaire_response_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('PERSON_ID', 'observation.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('OBSERVATION_CONCEPT_ID', 'observation.OBSERVATION_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('STANDARD_CONCEPT_NAME', 'o_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+      ('STANDARD_CONCEPT_CODE', 'o_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+      ('STANDARD_VOCABULARY', 'o_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_standard_concept on observation.OBSERVATION_CONCEPT_ID = o_standard_concept.CONCEPT_ID', 'Observation'),
+      ('OBSERVATION_DATETIME', 'observation.OBSERVATION_DATETIME', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('OBSERVATION_TYPE_CONCEPT_ID', 'observation.OBSERVATION_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('OBSERVATION_TYPE_CONCEPT_NAME', 'o_type.concept_name as OBSERVATION_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_type on observation.OBSERVATION_TYPE_CONCEPT_ID = o_type.CONCEPT_ID', 'Observation'),
+      ('VALUE_AS_NUMBER', 'observation.VALUE_AS_NUMBER', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('VALUE_AS_STRING', 'observation.VALUE_AS_STRING', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('VALUE_AS_CONCEPT_ID', 'observation.VALUE_AS_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('VALUE_AS_CONCEPT_NAME', 'o_value.concept_name as VALUE_AS_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_value on observation.value_as_concept_id = o_value.CONCEPT_ID', 'Observation'),
+      ('QUALIFIER_CONCEPT_ID', 'observation.QUALIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('QUALIFIER_CONCEPT_NAME', 'o_qualifier.concept_name as QUALIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_qualifier on observation.qualifier_concept_id = o_qualifier.CONCEPT_ID', 'Observation'),
+      ('UNIT_CONCEPT_ID', 'observation.UNIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('UNIT_CONCEPT_NAME', 'o_unit.concept_name as UNIT_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_unit on observation.unit_concept_id = o_unit.CONCEPT_ID', 'Observation'),
+      ('VISIT_OCCURRENCE_ID', 'observation.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'o_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on observation.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` o_visit on v.visit_concept_id = o_visit.concept_id', 'Observation'),
+      ('OBSERVATION_SOURCE_VALUE', 'observation.OBSERVATION_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('OBSERVATION_SOURCE_CONCEPT_ID', 'observation.OBSERVATION_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('SOURCE_CONCEPT_NAME', 'o_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+      ('SOURCE_CONCEPT_CODE', 'o_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+      ('SOURCE_VOCABULARY', 'o_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` o_source_concept on observation.OBSERVATION_SOURCE_CONCEPT_ID = o_source_concept.CONCEPT_ID', 'Observation'),
+      ('UNIT_SOURCE_VALUE', 'observation.UNIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('QUALIFIER_SOURCE_VALUE', 'observation.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('value_source_concept_id', 'observation.value_source_concept_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('value_source_value', 'observation.value_source_value', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation'),
+      ('questionnaire_response_id', 'observation.questionnaire_response_id', 'from \`\${projectId}.\${dataSetId}.ds_observation\` observation', 'Observation')"
 
 
-echo "ds_linking - inserting person data"
+  echo "ds_linking - inserting person data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('PERSON_ID', 'person.PERSON_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('GENDER_CONCEPT_ID', 'person.GENDER_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('GENDER', 'p_gender_concept.concept_name as GENDER', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept on person.gender_concept_id = p_gender_concept.CONCEPT_ID', 'Person'),
-    ('DATE_OF_BIRTH', 'person.BIRTH_DATETIME as DATE_OF_BIRTH', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('RACE_CONCEPT_ID', 'person.RACE_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('RACE', 'p_race_concept.concept_name as RACE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept on person.race_concept_id = p_race_concept.CONCEPT_ID', 'Person'),
-    ('ETHNICITY_CONCEPT_ID', 'person.ETHNICITY_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('ETHNICITY', 'p_ethnicity_concept.concept_name as ETHNICITY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept on person.ethnicity_concept_id = p_ethnicity_concept.CONCEPT_ID', 'Person'),
-    ('SEX_AT_BIRTH_CONCEPT_ID', 'person.SEX_AT_BIRTH_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
-    ('SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as SEX_AT_BIRTH', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept on person.sex_at_birth_concept_id = p_sex_at_birth_concept.CONCEPT_ID', 'Person')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('PERSON_ID', 'person.PERSON_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('GENDER_CONCEPT_ID', 'person.GENDER_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('GENDER', 'p_gender_concept.concept_name as GENDER', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept on person.gender_concept_id = p_gender_concept.CONCEPT_ID', 'Person'),
+      ('DATE_OF_BIRTH', 'person.BIRTH_DATETIME as DATE_OF_BIRTH', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('RACE_CONCEPT_ID', 'person.RACE_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('RACE', 'p_race_concept.concept_name as RACE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept on person.race_concept_id = p_race_concept.CONCEPT_ID', 'Person'),
+      ('ETHNICITY_CONCEPT_ID', 'person.ETHNICITY_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('ETHNICITY', 'p_ethnicity_concept.concept_name as ETHNICITY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept on person.ethnicity_concept_id = p_ethnicity_concept.CONCEPT_ID', 'Person'),
+      ('SEX_AT_BIRTH_CONCEPT_ID', 'person.SEX_AT_BIRTH_CONCEPT_ID', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person'),
+      ('SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as SEX_AT_BIRTH', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept on person.sex_at_birth_concept_id = p_sex_at_birth_concept.CONCEPT_ID', 'Person')"
 
-echo "ds_linking - inserting procedure data"
+  echo "ds_linking - inserting procedure data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('PERSON_ID', 'procedure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('PROCEDURE_CONCEPT_ID', 'procedure.PROCEDURE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('STANDARD_CONCEPT_NAME', 'p_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-    ('STANDARD_CONCEPT_CODE', 'p_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-    ('STANDARD_VOCABULARY', 'p_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
-    ('PROCEDURE_DATETIME', 'procedure.PROCEDURE_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('PROCEDURE_TYPE_CONCEPT_ID', 'procedure.PROCEDURE_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('PROCEDURE_TYPE_CONCEPT_NAME', 'p_type.concept_name as PROCEDURE_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_type on procedure.PROCEDURE_TYPE_CONCEPT_ID = p_type.CONCEPT_ID', 'Procedure'),
-    ('MODIFIER_CONCEPT_ID', 'procedure.MODIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('MODIFIER_CONCEPT_NAME', 'p_modifier.concept_name as MODIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_modifier on procedure.MODIFIER_CONCEPT_ID = p_modifier.CONCEPT_ID', 'Procedure'),
-    ('QUANTITY', 'procedure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('VISIT_OCCURRENCE_ID', 'procedure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('VISIT_OCCURRENCE_CONCEPT_NAME', 'p_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on procedure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` p_visit on v.visit_concept_id = p_visit.concept_id', 'Procedure'),
-    ('PROCEDURE_SOURCE_VALUE', 'procedure.PROCEDURE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('PROCEDURE_SOURCE_CONCEPT_ID', 'procedure.PROCEDURE_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
-    ('SOURCE_CONCEPT_NAME', 'p_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-    ('SOURCE_CONCEPT_CODE', 'p_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-    ('SOURCE_VOCABULARY', 'p_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
-    ('QUALIFIER_SOURCE_VALUE', 'procedure.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('PERSON_ID', 'procedure.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('PROCEDURE_CONCEPT_ID', 'procedure.PROCEDURE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('STANDARD_CONCEPT_NAME', 'p_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+      ('STANDARD_CONCEPT_CODE', 'p_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+      ('STANDARD_VOCABULARY', 'p_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_standard_concept on procedure.PROCEDURE_CONCEPT_ID = p_standard_concept.CONCEPT_ID', 'Procedure'),
+      ('PROCEDURE_DATETIME', 'procedure.PROCEDURE_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('PROCEDURE_TYPE_CONCEPT_ID', 'procedure.PROCEDURE_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('PROCEDURE_TYPE_CONCEPT_NAME', 'p_type.concept_name as PROCEDURE_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_type on procedure.PROCEDURE_TYPE_CONCEPT_ID = p_type.CONCEPT_ID', 'Procedure'),
+      ('MODIFIER_CONCEPT_ID', 'procedure.MODIFIER_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('MODIFIER_CONCEPT_NAME', 'p_modifier.concept_name as MODIFIER_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_modifier on procedure.MODIFIER_CONCEPT_ID = p_modifier.CONCEPT_ID', 'Procedure'),
+      ('QUANTITY', 'procedure.QUANTITY', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('VISIT_OCCURRENCE_ID', 'procedure.VISIT_OCCURRENCE_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('VISIT_OCCURRENCE_CONCEPT_NAME', 'p_visit.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.visit_occurrence\` v on procedure.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID left join \`\${projectId}.\${dataSetId}.concept\` p_visit on v.visit_concept_id = p_visit.concept_id', 'Procedure'),
+      ('PROCEDURE_SOURCE_VALUE', 'procedure.PROCEDURE_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('PROCEDURE_SOURCE_CONCEPT_ID', 'procedure.PROCEDURE_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure'),
+      ('SOURCE_CONCEPT_NAME', 'p_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+      ('SOURCE_CONCEPT_CODE', 'p_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+      ('SOURCE_VOCABULARY', 'p_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_source_concept on procedure.PROCEDURE_SOURCE_CONCEPT_ID = p_source_concept.CONCEPT_ID', 'Procedure'),
+      ('QUALIFIER_SOURCE_VALUE', 'procedure.QUALIFIER_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` procedure', 'Procedure')"
 
-echo "ds_linking - inserting survey data"
+  echo "ds_linking - inserting survey data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', ' FROM \`\${projectId}.\${dataSetId}.ds_survey\` answer', 'Survey'),
-    ('PERSON_ID', 'answer.person_id', ' ', 'Survey'),
-    ('SURVEY_DATETIME', 'answer.survey_datetime', ' ', 'Survey'),
-    ('SURVEY', 'answer.survey', ' ', 'Survey'),
-    ('QUESTION_CONCEPT_ID', 'answer.question_concept_id', ' ', 'Survey'),
-    ('QUESTION', 'answer.question', ' ', 'Survey'),
-    ('ANSWER_CONCEPT_ID', 'answer.answer_concept_id', ' ', 'Survey'),
-    ('ANSWER', 'answer.answer', ' ', 'Survey')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', ' FROM \`\${projectId}.\${dataSetId}.ds_survey\` answer', 'Survey'),
+      ('PERSON_ID', 'answer.person_id', ' ', 'Survey'),
+      ('SURVEY_DATETIME', 'answer.survey_datetime', ' ', 'Survey'),
+      ('SURVEY', 'answer.survey', ' ', 'Survey'),
+      ('QUESTION_CONCEPT_ID', 'answer.question_concept_id', ' ', 'Survey'),
+      ('QUESTION', 'answer.question', ' ', 'Survey'),
+      ('ANSWER_CONCEPT_ID', 'answer.answer_concept_id', ' ', 'Survey'),
+      ('ANSWER', 'answer.answer', ' ', 'Survey')"
 
-echo "ds_linking - inserting visit data"
+  echo "ds_linking - inserting visit data"
 
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('PERSON_ID', 'visit.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('VISIT_CONCEPT_ID', 'visit.VISIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('STANDARD_CONCEPT_NAME', 'v_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-    ('STANDARD_CONCEPT_CODE', 'v_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-    ('STANDARD_VOCABULARY', 'v_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
-    ('VISIT_START_DATETIME', 'visit.VISIT_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('VISIT_END_DATETIME', 'visit.VISIT_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('VISIT_TYPE_CONCEPT_ID', 'visit.VISIT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('VISIT_TYPE_CONCEPT_NAME', 'v_type.concept_name as VISIT_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_type on visit.VISIT_TYPE_CONCEPT_ID = v_type.CONCEPT_ID', 'Visit'),
-    ('VISIT_SOURCE_VALUE', 'visit.VISIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('VISIT_SOURCE_CONCEPT_ID', 'visit.VISIT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('SOURCE_CONCEPT_NAME', 'v_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-    ('SOURCE_CONCEPT_CODE', 'v_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-    ('SOURCE_VOCABULARY', 'v_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
-    ('ADMITTING_SOURCE_CONCEPT_ID', 'visit.ADMITTING_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('ADMITTING_SOURCE_CONCEPT_NAME', 'v_admitting_source_concept.concept_name as ADMITTING_SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` v_admitting_source_concept on visit.ADMITTING_SOURCE_CONCEPT_ID = v_admitting_source_concept.CONCEPT_ID', 'Visit'),
-    ('ADMITTING_SOURCE_VALUE', 'visit.ADMITTING_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('DISCHARGE_TO_CONCEPT_ID', 'visit.DISCHARGE_TO_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
-    ('DISCHARGE_TO_CONCEPT_NAME', 'v_discharge.concept_name as DISCHARGE_TO_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_discharge on visit.DISCHARGE_TO_CONCEPT_ID = v_discharge.CONCEPT_ID', 'Visit'),
-    ('DISCHARGE_TO_SOURCE_VALUE', 'visit.DISCHARGE_TO_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit')"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+  VALUES
+      ('CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('PERSON_ID', 'visit.PERSON_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('VISIT_CONCEPT_ID', 'visit.VISIT_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('STANDARD_CONCEPT_NAME', 'v_standard_concept.concept_name as STANDARD_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+      ('STANDARD_CONCEPT_CODE', 'v_standard_concept.concept_code as STANDARD_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+      ('STANDARD_VOCABULARY', 'v_standard_concept.vocabulary_id as STANDARD_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_standard_concept on visit.VISIT_CONCEPT_ID = v_standard_concept.CONCEPT_ID', 'Visit'),
+      ('VISIT_START_DATETIME', 'visit.VISIT_START_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('VISIT_END_DATETIME', 'visit.VISIT_END_DATETIME', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('VISIT_TYPE_CONCEPT_ID', 'visit.VISIT_TYPE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('VISIT_TYPE_CONCEPT_NAME', 'v_type.concept_name as VISIT_TYPE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_type on visit.VISIT_TYPE_CONCEPT_ID = v_type.CONCEPT_ID', 'Visit'),
+      ('VISIT_SOURCE_VALUE', 'visit.VISIT_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('VISIT_SOURCE_CONCEPT_ID', 'visit.VISIT_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('SOURCE_CONCEPT_NAME', 'v_source_concept.concept_name as SOURCE_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+      ('SOURCE_CONCEPT_CODE', 'v_source_concept.concept_code as SOURCE_CONCEPT_CODE', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+      ('SOURCE_VOCABULARY', 'v_source_concept.vocabulary_id as SOURCE_VOCABULARY', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_source_concept on visit.VISIT_SOURCE_CONCEPT_ID = v_source_concept.CONCEPT_ID', 'Visit'),
+      ('ADMITTING_SOURCE_CONCEPT_ID', 'visit.ADMITTING_SOURCE_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('ADMITTING_SOURCE_CONCEPT_NAME', 'v_admitting_source_concept.concept_name as ADMITTING_SOURCE_CONCEPT_NAME', 'left join \`\${projectId}.\${dataSetId}.concept\` v_admitting_source_concept on visit.ADMITTING_SOURCE_CONCEPT_ID = v_admitting_source_concept.CONCEPT_ID', 'Visit'),
+      ('ADMITTING_SOURCE_VALUE', 'visit.ADMITTING_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('DISCHARGE_TO_CONCEPT_ID', 'visit.DISCHARGE_TO_CONCEPT_ID', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit'),
+      ('DISCHARGE_TO_CONCEPT_NAME', 'v_discharge.concept_name as DISCHARGE_TO_CONCEPT_NAME', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` v_discharge on visit.DISCHARGE_TO_CONCEPT_ID = v_discharge.CONCEPT_ID', 'Visit'),
+      ('DISCHARGE_TO_SOURCE_VALUE', 'visit.DISCHARGE_TO_SOURCE_VALUE', 'from \`\${projectId}.\${dataSetId}.procedure_occurrence\` visit', 'Visit')"
+  fi

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
@@ -8,415 +8,427 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export DRY_RUN=$3     # dry run
 
-if [ "$DRY_RUN" == false ]
+if [ "$DRY_RUN" == true ]
 then
-  # Check that bq_dataset exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
-  then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-
-  ################################################
-  # CREATE TABLES
-  ################################################
-  echo "CREATE TABLE - ds_condition_occurrence"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
-  (
-      PERSON_ID                       INT64,
-      CONDITION_CONCEPT_ID            INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      CONDITION_START_DATETIME        TIMESTAMP,
-      CONDITION_END_DATETIME          TIMESTAMP,
-      CONDITION_TYPE_CONCEPT_ID       INT64,
-      CONDITION_TYPE_CONCEPT_NAME     STRING,
-      STOP_REASON                     STRING,
-      VISIT_OCCURRENCE_ID             INT64,
-      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-      CONDITION_SOURCE_VALUE          STRING,
-      CONDITION_SOURCE_CONCEPT_ID     INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      CONDITION_STATUS_SOURCE_VALUE   STRING,
-      CONDITION_STATUS_CONCEPT_ID     INT64,
-      CONDITION_STATUS_CONCEPT_NAME   STRING
-  )"
-
-  echo "CREATE TABLE - ds_drug_exposure"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
-  (
-      PERSON_ID                       INT64,
-      DRUG_CONCEPT_ID                 INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      DRUG_EXPOSURE_START_DATETIME    TIMESTAMP,
-      DRUG_EXPOSURE_END_DATETIME      TIMESTAMP,
-      VERBATIM_END_DATE               DATE,
-      DRUG_TYPE_CONCEPT_ID            INT64,
-      DRUG_TYPE_CONCEPT_NAME          STRING,
-      STOP_REASON                     STRING,
-      REFILLS                         INT64,
-      QUANTITY                        FLOAT64,
-      DAYS_SUPPLY                     INT64,
-      SIG                             STRING,
-      ROUTE_CONCEPT_ID                INT64,
-      ROUTE_CONCEPT_NAME              STRING,
-      LOT_NUMBER                      STRING,
-      VISIT_OCCURRENCE_ID             INT64,
-      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-      DRUG_SOURCE_VALUE               STRING,
-      DRUG_SOURCE_CONCEPT_ID          INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      ROUTE_SOURCE_VALUE              STRING,
-      DOSE_UNIT_SOURCE_VALUE          STRING
-  )"
-
-  echo "CREATE TABLE - ds_measurement"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
-  (
-      PERSON_ID                       INT64,
-      MEASUREMENT_CONCEPT_ID          INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      MEASUREMENT_DATETIME            TIMESTAMP,
-      MEASUREMENT_TYPE_CONCEPT_ID     INT64,
-      MEASUREMENT_TYPE_CONCEPT_NAME   STRING,
-      OPERATOR_CONCEPT_ID             INT64,
-      OPERATOR_CONCEPT_NAME           STRING,
-      VALUE_AS_NUMBER                 FLOAT64,
-      VALUE_AS_CONCEPT_ID             INT64,
-      VALUE_AS_CONCEPT_NAME           STRING,
-      UNIT_CONCEPT_ID                 INT64,
-      UNIT_CONCEPT_NAME               STRING,
-      RANGE_LOW                       FLOAT64,
-      RANGE_HIGH                      FLOAT64,
-      VISIT_OCCURRENCE_ID             INT64,
-      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-      MEASUREMENT_SOURCE_VALUE        STRING,
-      MEASUREMENT_SOURCE_CONCEPT_ID   INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      UNIT_SOURCE_VALUE               STRING,
-      VALUE_SOURCE_VALUE              STRING
-  )"
-
-  echo "CREATE TABLE - ds_observation"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
-  (
-      PERSON_ID                       INT64,
-      OBSERVATION_CONCEPT_ID          INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      OBSERVATION_DATETIME            TIMESTAMP,
-      OBSERVATION_TYPE_CONCEPT_ID     INT64,
-      OBSERVATION_TYPE_CONCEPT_NAME   STRING,
-      VALUE_AS_NUMBER                 FLOAT64,
-      VALUE_AS_STRING                 STRING,
-      VALUE_AS_CONCEPT_ID             INT64,
-      VALUE_AS_CONCEPT_NAME           STRING,
-      QUALIFIER_CONCEPT_ID            INT64,
-      QUALIFIER_CONCEPT_NAME          STRING,
-      UNIT_CONCEPT_ID                 INT64,
-      UNIT_CONCEPT_NAME               STRING,
-      VISIT_OCCURRENCE_ID             INT64,
-      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-      OBSERVATION_SOURCE_VALUE        STRING,
-      OBSERVATION_SOURCE_CONCEPT_ID   INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      UNIT_SOURCE_VALUE               STRING,
-      QUALIFIER_SOURCE_VALUE          STRING,
-      value_source_concept_id         INT64,
-      value_source_value              STRING,
-      questionnaire_response_id       INT64
-  )"
-
-  echo "CREATE TABLE - ds_person"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
-  (
-      PERSON_ID               INT64,
-      GENDER_CONCEPT_ID       INT64,
-      GENDER                  STRING,
-      DATE_OF_BIRTH           TIMESTAMP,
-      RACE_CONCEPT_ID         INT64,
-      RACE                    STRING,
-      ETHNICITY_CONCEPT_ID    INT64,
-      ETHNICITY               STRING,
-      SEX_AT_BIRTH_CONCEPT_ID INT64,
-      SEX_AT_BIRTH            STRING
-  )"
-
-  echo "CREATE TABLE - ds_procedure_occurrence"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
-  (
-      PERSON_ID                       INT64,
-      PROCEDURE_CONCEPT_ID            INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      PROCEDURE_DATETIME              TIMESTAMP,
-      PROCEDURE_TYPE_CONCEPT_ID       INT64,
-      PROCEDURE_TYPE_CONCEPT_NAME     STRING,
-      MODIFIER_CONCEPT_ID             INT64,
-      MODIFIER_CONCEPT_NAME           STRING,
-      QUANTITY                        INT64,
-      VISIT_OCCURRENCE_ID             INT64,
-      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-      PROCEDURE_SOURCE_VALUE          STRING,
-      PROCEDURE_SOURCE_CONCEPT_ID     INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      QUALIFIER_SOURCE_VALUE          STRING
-  )"
-
-  echo "CREATE TABLE - ds_survey"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
-  (
-      person_id           INT64,
-      survey_datetime     TIMESTAMP,
-      survey              STRING,
-      question_concept_id INT64,
-      question            STRING,
-      answer_concept_id   INT64,
-      answer              STRING
-  )"
-
-  echo "CREATE TABLE - ds_visit_occurrence"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
-  (
-      PERSON_ID                       INT64,
-      VISIT_CONCEPT_ID                INT64,
-      STANDARD_CONCEPT_NAME           STRING,
-      STANDARD_CONCEPT_CODE           STRING,
-      STANDARD_VOCABULARY             STRING,
-      VISIT_START_DATETIME            TIMESTAMP,
-      VISIT_END_DATETIME              TIMESTAMP,
-      VISIT_TYPE_CONCEPT_ID           INT64,
-      VISIT_TYPE_CONCEPT_NAME         STRING,
-      VISIT_SOURCE_VALUE              STRING,
-      VISIT_SOURCE_CONCEPT_ID         INT64,
-      SOURCE_CONCEPT_NAME             STRING,
-      SOURCE_CONCEPT_CODE             STRING,
-      SOURCE_VOCABULARY               STRING,
-      ADMITTING_SOURCE_CONCEPT_ID     INT64,
-      ADMITTING_SOURCE_CONCEPT_NAME   STRING,
-      ADMITTING_SOURCE_VALUE          STRING,
-      DISCHARGE_TO_CONCEPT_ID         INT64,
-      DISCHARGE_TO_CONCEPT_NAME       STRING,
-      DISCHARGE_TO_SOURCE_VALUE       STRING
-  )"
-
-  ################################################
-  # INSERT DATA
-  ################################################
-  echo "ds_condition_occurrence - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
-      (PERSON_ID, CONDITION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-      CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID, CONDITION_TYPE_CONCEPT_NAME,
-      STOP_REASON, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID,
-      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE,
-      CONDITION_STATUS_CONCEPT_ID, CONDITION_STATUS_CONCEPT_NAME)
-  select a.PERSON_ID, CONDITION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID,
-      c2.concept_name as CONDITION_TYPE_CONCEPT_NAME, STOP_REASON, a.VISIT_OCCURRENCE_ID, c3.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
-      CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID, c4.concept_name as SOURCE_CONCEPT_NAME, c4.concept_code as SOURCE_CONCEPT_CODE,
-      c4.vocabulary_id as SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE, CONDITION_STATUS_CONCEPT_ID,
-      c5.concept_name as CONDITION_STATUS_CONCEPT_NAME
-  from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.CONDITION_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.CONDITION_STATUS_CONCEPT_ID = c5.CONCEPT_ID"
-
-  echo "ds_drug_exposure - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
-      (PERSON_ID, DRUG_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME,
-      DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE, DRUG_TYPE_CONCEPT_ID, DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY,
-      DAYS_SUPPLY, SIG, ROUTE_CONCEPT_ID, ROUTE_CONCEPT_NAME, LOT_NUMBER, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE,
-      DRUG_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE)
-  SELECT
-      a.PERSON_ID, DRUG_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME, DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE,
-      DRUG_TYPE_CONCEPT_ID, c2.concept_name as DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY, DAYS_SUPPLY, SIG,
-      ROUTE_CONCEPT_ID, c3.concept_name as ROUTE_CONCEPT_NAME, LOT_NUMBER, a.VISIT_OCCURRENCE_ID,
-      c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE, DRUG_SOURCE_CONCEPT_ID,
-      c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE, c5.vocabulary_id as SOURCE_VOCABULARY,
-      ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE
-  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.DRUG_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.drug_type_concept_id = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DRUG_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
-
-  echo "ds_measurement - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
-      (PERSON_ID, MEASUREMENT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-      MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID, MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID,
-      OPERATOR_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID, UNIT_CONCEPT_NAME,
-      RANGE_LOW, RANGE_HIGH, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE,
-      MEASUREMENT_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-      VALUE_SOURCE_VALUE)
-  select
-      a.PERSON_ID, MEASUREMENT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID,
-      c2.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID, c3.concept_name as OPERATOR_CONCEPT_NAME,
-      VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, c4.concept_name as VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID,
-      c5.concept_name as UNIT_CONCEPT_NAME, RANGE_LOW, RANGE_HIGH, a.VISIT_OCCURRENCE_ID,
-      c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE, MEASUREMENT_SOURCE_CONCEPT_ID,
-      c7.concept_name as SOURCE_CONCEPT_NAME, c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY,
-      UNIT_SOURCE_VALUE, VALUE_SOURCE_VALUE
-  from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.measurement_concept_id = c1.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.measurement_type_concept_id = c2.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.operator_concept_id = c3.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.value_as_concept_id = c4.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.visit_occurrence_id = v.visit_occurrence_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.measurement_source_concept_id = c7.concept_id"
-
-  echo "ds_observation - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
-      (PERSON_ID, OBSERVATION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-      OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID, OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING,
-      VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, QUALIFIER_CONCEPT_NAME, UNIT_CONCEPT_ID,
-      UNIT_CONCEPT_NAME, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, OBSERVATION_SOURCE_VALUE,
-      OBSERVATION_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-      QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id)
-  SELECT
-      a.PERSON_ID, OBSERVATION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID,
-      c2.concept_name as OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING, VALUE_AS_CONCEPT_ID,
-      c3.concept_name as VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, c4.concept_name as QUALIFIER_CONCEPT_NAME,
-      UNIT_CONCEPT_ID, c5.concept_name as UNIT_CONCEPT_NAME, a.VISIT_OCCURRENCE_ID, c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
-      OBSERVATION_SOURCE_VALUE, OBSERVATION_SOURCE_CONCEPT_ID, c7.concept_name as SOURCE_CONCEPT_NAME,
-      c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-      QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.OBSERVATION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.value_as_concept_id = c3.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.qualifier_concept_id = c4.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.OBSERVATION_SOURCE_CONCEPT_ID = c7.CONCEPT_ID"
-
-  echo "ds_person - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
-      (PERSON_ID, GENDER_CONCEPT_ID, GENDER, DATE_OF_BIRTH, RACE_CONCEPT_ID, RACE, ETHNICITY_CONCEPT_ID, ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, SEX_AT_BIRTH)
-  SELECT
-      PERSON_ID, GENDER_CONCEPT_ID, c1.concept_name as GENDER, BIRTH_DATETIME as DATE_OF_BIRTH, RACE_CONCEPT_ID,
-      c2.concept_name as RACE, ETHNICITY_CONCEPT_ID, c3.concept_name as ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, c4.concept_name as SEX_AT_BIRTH
-  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.gender_concept_id = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.race_concept_id = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ethnicity_concept_id = c3.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.sex_at_birth_concept_id = c4.CONCEPT_ID"
-
-  echo "ds_procedure_occurrence - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
-      (PERSON_ID, PROCEDURE_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-      PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID, PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, MODIFIER_CONCEPT_NAME,
-      QUANTITY, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE, PROCEDURE_SOURCE_CONCEPT_ID,
-      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE)
-  select
-      a.PERSON_ID, PROCEDURE_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID,
-      c2.concept_name as PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, c3.concept_name as MODIFIER_CONCEPT_NAME,
-      QUANTITY, a.VISIT_OCCURRENCE_ID, c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE,
-      PROCEDURE_SOURCE_CONCEPT_ID, c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE,
-      c5.vocabulary_id as SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE
-  from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.MODIFIER_CONCEPT_ID = c3.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.PROCEDURE_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
-
-  echo "ds_survey - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
-     (person_id, survey_datetime, survey, question_concept_id, question, answer_concept_id, answer)
-  SELECT  a.person_id,
-          a.observation_datetime as survey_datetime,
-          c.name as survey,
-          d.concept_id as question_concept_id,
-          d.concept_name as question,
-          e.concept_id as answer_concept_id,
-          case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-  JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-          WHERE ancestor_concept_id in
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE domain_id = 'SURVEY'
-                      and parent_id = 0
-              )
-      ) b on a.observation_source_concept_id = b.descendant_concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
-
-  echo "ds_visit_occurrence - inserting data"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
-      (PERSON_ID, VISIT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, VISIT_START_DATETIME,
-      VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID, VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID,
-      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID, ADMITTING_SOURCE_CONCEPT_NAME,
-      ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID, DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE)
-  select
-      a.PERSON_ID, VISIT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-      c1.vocabulary_id as STANDARD_VOCABULARY, VISIT_START_DATETIME, VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID,
-      c2.concept_name as VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID, c3.concept_name as SOURCE_CONCEPT_NAME,
-      c3.concept_code as SOURCE_CONCEPT_CODE, c3.vocabulary_id as SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID,
-      c4.concept_name as ADMITTING_SOURCE_CONCEPT_NAME, ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID,
-      c5.concept_name as DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE
-  from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.VISIT_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.VISIT_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.VISIT_SOURCE_CONCEPT_ID = c3.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.ADMITTING_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DISCHARGE_TO_CONCEPT_ID = c5.CONCEPT_ID"
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_criteria")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
+  exit 0
 fi
+
+# Check that bq_dataset exists and exit if not
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+if [ -z "$datasets" ]
+then
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+else
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+
+################################################
+# CREATE TABLES
+################################################
+echo "CREATE TABLE - ds_condition_occurrence"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
+(
+    PERSON_ID                       INT64,
+    CONDITION_CONCEPT_ID            INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    CONDITION_START_DATETIME        TIMESTAMP,
+    CONDITION_END_DATETIME          TIMESTAMP,
+    CONDITION_TYPE_CONCEPT_ID       INT64,
+    CONDITION_TYPE_CONCEPT_NAME     STRING,
+    STOP_REASON                     STRING,
+    VISIT_OCCURRENCE_ID             INT64,
+    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+    CONDITION_SOURCE_VALUE          STRING,
+    CONDITION_SOURCE_CONCEPT_ID     INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    CONDITION_STATUS_SOURCE_VALUE   STRING,
+    CONDITION_STATUS_CONCEPT_ID     INT64,
+    CONDITION_STATUS_CONCEPT_NAME   STRING
+)"
+
+echo "CREATE TABLE - ds_drug_exposure"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
+(
+    PERSON_ID                       INT64,
+    DRUG_CONCEPT_ID                 INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    DRUG_EXPOSURE_START_DATETIME    TIMESTAMP,
+    DRUG_EXPOSURE_END_DATETIME      TIMESTAMP,
+    VERBATIM_END_DATE               DATE,
+    DRUG_TYPE_CONCEPT_ID            INT64,
+    DRUG_TYPE_CONCEPT_NAME          STRING,
+    STOP_REASON                     STRING,
+    REFILLS                         INT64,
+    QUANTITY                        FLOAT64,
+    DAYS_SUPPLY                     INT64,
+    SIG                             STRING,
+    ROUTE_CONCEPT_ID                INT64,
+    ROUTE_CONCEPT_NAME              STRING,
+    LOT_NUMBER                      STRING,
+    VISIT_OCCURRENCE_ID             INT64,
+    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+    DRUG_SOURCE_VALUE               STRING,
+    DRUG_SOURCE_CONCEPT_ID          INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    ROUTE_SOURCE_VALUE              STRING,
+    DOSE_UNIT_SOURCE_VALUE          STRING
+)"
+
+echo "CREATE TABLE - ds_measurement"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
+(
+    PERSON_ID                       INT64,
+    MEASUREMENT_CONCEPT_ID          INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    MEASUREMENT_DATETIME            TIMESTAMP,
+    MEASUREMENT_TYPE_CONCEPT_ID     INT64,
+    MEASUREMENT_TYPE_CONCEPT_NAME   STRING,
+    OPERATOR_CONCEPT_ID             INT64,
+    OPERATOR_CONCEPT_NAME           STRING,
+    VALUE_AS_NUMBER                 FLOAT64,
+    VALUE_AS_CONCEPT_ID             INT64,
+    VALUE_AS_CONCEPT_NAME           STRING,
+    UNIT_CONCEPT_ID                 INT64,
+    UNIT_CONCEPT_NAME               STRING,
+    RANGE_LOW                       FLOAT64,
+    RANGE_HIGH                      FLOAT64,
+    VISIT_OCCURRENCE_ID             INT64,
+    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+    MEASUREMENT_SOURCE_VALUE        STRING,
+    MEASUREMENT_SOURCE_CONCEPT_ID   INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    UNIT_SOURCE_VALUE               STRING,
+    VALUE_SOURCE_VALUE              STRING
+)"
+
+echo "CREATE TABLE - ds_observation"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
+(
+    PERSON_ID                       INT64,
+    OBSERVATION_CONCEPT_ID          INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    OBSERVATION_DATETIME            TIMESTAMP,
+    OBSERVATION_TYPE_CONCEPT_ID     INT64,
+    OBSERVATION_TYPE_CONCEPT_NAME   STRING,
+    VALUE_AS_NUMBER                 FLOAT64,
+    VALUE_AS_STRING                 STRING,
+    VALUE_AS_CONCEPT_ID             INT64,
+    VALUE_AS_CONCEPT_NAME           STRING,
+    QUALIFIER_CONCEPT_ID            INT64,
+    QUALIFIER_CONCEPT_NAME          STRING,
+    UNIT_CONCEPT_ID                 INT64,
+    UNIT_CONCEPT_NAME               STRING,
+    VISIT_OCCURRENCE_ID             INT64,
+    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+    OBSERVATION_SOURCE_VALUE        STRING,
+    OBSERVATION_SOURCE_CONCEPT_ID   INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    UNIT_SOURCE_VALUE               STRING,
+    QUALIFIER_SOURCE_VALUE          STRING,
+    value_source_concept_id         INT64,
+    value_source_value              STRING,
+    questionnaire_response_id       INT64
+)"
+
+echo "CREATE TABLE - ds_person"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
+(
+    PERSON_ID               INT64,
+    GENDER_CONCEPT_ID       INT64,
+    GENDER                  STRING,
+    DATE_OF_BIRTH           TIMESTAMP,
+    RACE_CONCEPT_ID         INT64,
+    RACE                    STRING,
+    ETHNICITY_CONCEPT_ID    INT64,
+    ETHNICITY               STRING,
+    SEX_AT_BIRTH_CONCEPT_ID INT64,
+    SEX_AT_BIRTH            STRING
+)"
+
+echo "CREATE TABLE - ds_procedure_occurrence"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
+(
+    PERSON_ID                       INT64,
+    PROCEDURE_CONCEPT_ID            INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    PROCEDURE_DATETIME              TIMESTAMP,
+    PROCEDURE_TYPE_CONCEPT_ID       INT64,
+    PROCEDURE_TYPE_CONCEPT_NAME     STRING,
+    MODIFIER_CONCEPT_ID             INT64,
+    MODIFIER_CONCEPT_NAME           STRING,
+    QUANTITY                        INT64,
+    VISIT_OCCURRENCE_ID             INT64,
+    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+    PROCEDURE_SOURCE_VALUE          STRING,
+    PROCEDURE_SOURCE_CONCEPT_ID     INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    QUALIFIER_SOURCE_VALUE          STRING
+)"
+
+echo "CREATE TABLE - ds_survey"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
+(
+    person_id           INT64,
+    survey_datetime     TIMESTAMP,
+    survey              STRING,
+    question_concept_id INT64,
+    question            STRING,
+    answer_concept_id   INT64,
+    answer              STRING
+)"
+
+echo "CREATE TABLE - ds_visit_occurrence"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
+(
+    PERSON_ID                       INT64,
+    VISIT_CONCEPT_ID                INT64,
+    STANDARD_CONCEPT_NAME           STRING,
+    STANDARD_CONCEPT_CODE           STRING,
+    STANDARD_VOCABULARY             STRING,
+    VISIT_START_DATETIME            TIMESTAMP,
+    VISIT_END_DATETIME              TIMESTAMP,
+    VISIT_TYPE_CONCEPT_ID           INT64,
+    VISIT_TYPE_CONCEPT_NAME         STRING,
+    VISIT_SOURCE_VALUE              STRING,
+    VISIT_SOURCE_CONCEPT_ID         INT64,
+    SOURCE_CONCEPT_NAME             STRING,
+    SOURCE_CONCEPT_CODE             STRING,
+    SOURCE_VOCABULARY               STRING,
+    ADMITTING_SOURCE_CONCEPT_ID     INT64,
+    ADMITTING_SOURCE_CONCEPT_NAME   STRING,
+    ADMITTING_SOURCE_VALUE          STRING,
+    DISCHARGE_TO_CONCEPT_ID         INT64,
+    DISCHARGE_TO_CONCEPT_NAME       STRING,
+    DISCHARGE_TO_SOURCE_VALUE       STRING
+)"
+
+################################################
+# INSERT DATA
+################################################
+echo "ds_condition_occurrence - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
+    (PERSON_ID, CONDITION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+    CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID, CONDITION_TYPE_CONCEPT_NAME,
+    STOP_REASON, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID,
+    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE,
+    CONDITION_STATUS_CONCEPT_ID, CONDITION_STATUS_CONCEPT_NAME)
+select a.PERSON_ID, CONDITION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID,
+    c2.concept_name as CONDITION_TYPE_CONCEPT_NAME, STOP_REASON, a.VISIT_OCCURRENCE_ID, c3.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
+    CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID, c4.concept_name as SOURCE_CONCEPT_NAME, c4.concept_code as SOURCE_CONCEPT_CODE,
+    c4.vocabulary_id as SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE, CONDITION_STATUS_CONCEPT_ID,
+    c5.concept_name as CONDITION_STATUS_CONCEPT_NAME
+from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.CONDITION_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.CONDITION_STATUS_CONCEPT_ID = c5.CONCEPT_ID"
+
+echo "ds_drug_exposure - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
+    (PERSON_ID, DRUG_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME,
+    DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE, DRUG_TYPE_CONCEPT_ID, DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY,
+    DAYS_SUPPLY, SIG, ROUTE_CONCEPT_ID, ROUTE_CONCEPT_NAME, LOT_NUMBER, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE,
+    DRUG_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE)
+SELECT
+    a.PERSON_ID, DRUG_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME, DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE,
+    DRUG_TYPE_CONCEPT_ID, c2.concept_name as DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY, DAYS_SUPPLY, SIG,
+    ROUTE_CONCEPT_ID, c3.concept_name as ROUTE_CONCEPT_NAME, LOT_NUMBER, a.VISIT_OCCURRENCE_ID,
+    c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE, DRUG_SOURCE_CONCEPT_ID,
+    c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE, c5.vocabulary_id as SOURCE_VOCABULARY,
+    ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE
+FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.DRUG_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.drug_type_concept_id = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DRUG_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
+
+echo "ds_measurement - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
+    (PERSON_ID, MEASUREMENT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+    MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID, MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID,
+    OPERATOR_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID, UNIT_CONCEPT_NAME,
+    RANGE_LOW, RANGE_HIGH, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE,
+    MEASUREMENT_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+    VALUE_SOURCE_VALUE)
+select
+    a.PERSON_ID, MEASUREMENT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID,
+    c2.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID, c3.concept_name as OPERATOR_CONCEPT_NAME,
+    VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, c4.concept_name as VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID,
+    c5.concept_name as UNIT_CONCEPT_NAME, RANGE_LOW, RANGE_HIGH, a.VISIT_OCCURRENCE_ID,
+    c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE, MEASUREMENT_SOURCE_CONCEPT_ID,
+    c7.concept_name as SOURCE_CONCEPT_NAME, c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY,
+    UNIT_SOURCE_VALUE, VALUE_SOURCE_VALUE
+from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.measurement_concept_id = c1.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.measurement_type_concept_id = c2.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.operator_concept_id = c3.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.value_as_concept_id = c4.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.visit_occurrence_id = v.visit_occurrence_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.measurement_source_concept_id = c7.concept_id"
+
+echo "ds_observation - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
+    (PERSON_ID, OBSERVATION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+    OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID, OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING,
+    VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, QUALIFIER_CONCEPT_NAME, UNIT_CONCEPT_ID,
+    UNIT_CONCEPT_NAME, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, OBSERVATION_SOURCE_VALUE,
+    OBSERVATION_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+    QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id)
+SELECT
+    a.PERSON_ID, OBSERVATION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID,
+    c2.concept_name as OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING, VALUE_AS_CONCEPT_ID,
+    c3.concept_name as VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, c4.concept_name as QUALIFIER_CONCEPT_NAME,
+    UNIT_CONCEPT_ID, c5.concept_name as UNIT_CONCEPT_NAME, a.VISIT_OCCURRENCE_ID, c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
+    OBSERVATION_SOURCE_VALUE, OBSERVATION_SOURCE_CONCEPT_ID, c7.concept_name as SOURCE_CONCEPT_NAME,
+    c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+    QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.OBSERVATION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.value_as_concept_id = c3.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.qualifier_concept_id = c4.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.OBSERVATION_SOURCE_CONCEPT_ID = c7.CONCEPT_ID"
+
+echo "ds_person - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
+    (PERSON_ID, GENDER_CONCEPT_ID, GENDER, DATE_OF_BIRTH, RACE_CONCEPT_ID, RACE, ETHNICITY_CONCEPT_ID, ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, SEX_AT_BIRTH)
+SELECT
+    PERSON_ID, GENDER_CONCEPT_ID, c1.concept_name as GENDER, BIRTH_DATETIME as DATE_OF_BIRTH, RACE_CONCEPT_ID,
+    c2.concept_name as RACE, ETHNICITY_CONCEPT_ID, c3.concept_name as ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, c4.concept_name as SEX_AT_BIRTH
+FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.gender_concept_id = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.race_concept_id = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ethnicity_concept_id = c3.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.sex_at_birth_concept_id = c4.CONCEPT_ID"
+
+echo "ds_procedure_occurrence - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
+    (PERSON_ID, PROCEDURE_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+    PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID, PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, MODIFIER_CONCEPT_NAME,
+    QUANTITY, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE, PROCEDURE_SOURCE_CONCEPT_ID,
+    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE)
+select
+    a.PERSON_ID, PROCEDURE_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID,
+    c2.concept_name as PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, c3.concept_name as MODIFIER_CONCEPT_NAME,
+    QUANTITY, a.VISIT_OCCURRENCE_ID, c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE,
+    PROCEDURE_SOURCE_CONCEPT_ID, c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE,
+    c5.vocabulary_id as SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE
+from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.MODIFIER_CONCEPT_ID = c3.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.PROCEDURE_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
+
+echo "ds_survey - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
+   (person_id, survey_datetime, survey, question_concept_id, question, answer_concept_id, answer)
+SELECT  a.person_id,
+        a.observation_datetime as survey_datetime,
+        c.name as survey,
+        d.concept_id as question_concept_id,
+        d.concept_name as question,
+        e.concept_id as answer_concept_id,
+        case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+        WHERE ancestor_concept_id in
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE domain_id = 'SURVEY'
+                    and parent_id = 0
+            )
+    ) b on a.observation_source_concept_id = b.descendant_concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
+
+echo "ds_visit_occurrence - inserting data"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
+    (PERSON_ID, VISIT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, VISIT_START_DATETIME,
+    VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID, VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID,
+    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID, ADMITTING_SOURCE_CONCEPT_NAME,
+    ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID, DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE)
+select
+    a.PERSON_ID, VISIT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+    c1.vocabulary_id as STANDARD_VOCABULARY, VISIT_START_DATETIME, VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID,
+    c2.concept_name as VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID, c3.concept_name as SOURCE_CONCEPT_NAME,
+    c3.concept_code as SOURCE_CONCEPT_CODE, c3.vocabulary_id as SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID,
+    c4.concept_name as ADMITTING_SOURCE_CONCEPT_NAME, ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID,
+    c5.concept_name as DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE
+from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.VISIT_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.VISIT_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.VISIT_SOURCE_CONCEPT_ID = c3.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.ADMITTING_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DISCHARGE_TO_CONCEPT_ID = c5.CONCEPT_ID"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
@@ -6,413 +6,417 @@ set -ex
 
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
+export DRY_RUN=$3     # dry run
 
-# Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
+if [ "$DRY_RUN" == false ]
 then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
+  # Check that bq_dataset exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+
+  ################################################
+  # CREATE TABLES
+  ################################################
+  echo "CREATE TABLE - ds_condition_occurrence"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
+  (
+      PERSON_ID                       INT64,
+      CONDITION_CONCEPT_ID            INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      CONDITION_START_DATETIME        TIMESTAMP,
+      CONDITION_END_DATETIME          TIMESTAMP,
+      CONDITION_TYPE_CONCEPT_ID       INT64,
+      CONDITION_TYPE_CONCEPT_NAME     STRING,
+      STOP_REASON                     STRING,
+      VISIT_OCCURRENCE_ID             INT64,
+      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+      CONDITION_SOURCE_VALUE          STRING,
+      CONDITION_SOURCE_CONCEPT_ID     INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      CONDITION_STATUS_SOURCE_VALUE   STRING,
+      CONDITION_STATUS_CONCEPT_ID     INT64,
+      CONDITION_STATUS_CONCEPT_NAME   STRING
+  )"
+
+  echo "CREATE TABLE - ds_drug_exposure"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
+  (
+      PERSON_ID                       INT64,
+      DRUG_CONCEPT_ID                 INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      DRUG_EXPOSURE_START_DATETIME    TIMESTAMP,
+      DRUG_EXPOSURE_END_DATETIME      TIMESTAMP,
+      VERBATIM_END_DATE               DATE,
+      DRUG_TYPE_CONCEPT_ID            INT64,
+      DRUG_TYPE_CONCEPT_NAME          STRING,
+      STOP_REASON                     STRING,
+      REFILLS                         INT64,
+      QUANTITY                        FLOAT64,
+      DAYS_SUPPLY                     INT64,
+      SIG                             STRING,
+      ROUTE_CONCEPT_ID                INT64,
+      ROUTE_CONCEPT_NAME              STRING,
+      LOT_NUMBER                      STRING,
+      VISIT_OCCURRENCE_ID             INT64,
+      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+      DRUG_SOURCE_VALUE               STRING,
+      DRUG_SOURCE_CONCEPT_ID          INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      ROUTE_SOURCE_VALUE              STRING,
+      DOSE_UNIT_SOURCE_VALUE          STRING
+  )"
+
+  echo "CREATE TABLE - ds_measurement"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
+  (
+      PERSON_ID                       INT64,
+      MEASUREMENT_CONCEPT_ID          INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      MEASUREMENT_DATETIME            TIMESTAMP,
+      MEASUREMENT_TYPE_CONCEPT_ID     INT64,
+      MEASUREMENT_TYPE_CONCEPT_NAME   STRING,
+      OPERATOR_CONCEPT_ID             INT64,
+      OPERATOR_CONCEPT_NAME           STRING,
+      VALUE_AS_NUMBER                 FLOAT64,
+      VALUE_AS_CONCEPT_ID             INT64,
+      VALUE_AS_CONCEPT_NAME           STRING,
+      UNIT_CONCEPT_ID                 INT64,
+      UNIT_CONCEPT_NAME               STRING,
+      RANGE_LOW                       FLOAT64,
+      RANGE_HIGH                      FLOAT64,
+      VISIT_OCCURRENCE_ID             INT64,
+      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+      MEASUREMENT_SOURCE_VALUE        STRING,
+      MEASUREMENT_SOURCE_CONCEPT_ID   INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      UNIT_SOURCE_VALUE               STRING,
+      VALUE_SOURCE_VALUE              STRING
+  )"
+
+  echo "CREATE TABLE - ds_observation"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
+  (
+      PERSON_ID                       INT64,
+      OBSERVATION_CONCEPT_ID          INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      OBSERVATION_DATETIME            TIMESTAMP,
+      OBSERVATION_TYPE_CONCEPT_ID     INT64,
+      OBSERVATION_TYPE_CONCEPT_NAME   STRING,
+      VALUE_AS_NUMBER                 FLOAT64,
+      VALUE_AS_STRING                 STRING,
+      VALUE_AS_CONCEPT_ID             INT64,
+      VALUE_AS_CONCEPT_NAME           STRING,
+      QUALIFIER_CONCEPT_ID            INT64,
+      QUALIFIER_CONCEPT_NAME          STRING,
+      UNIT_CONCEPT_ID                 INT64,
+      UNIT_CONCEPT_NAME               STRING,
+      VISIT_OCCURRENCE_ID             INT64,
+      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+      OBSERVATION_SOURCE_VALUE        STRING,
+      OBSERVATION_SOURCE_CONCEPT_ID   INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      UNIT_SOURCE_VALUE               STRING,
+      QUALIFIER_SOURCE_VALUE          STRING,
+      value_source_concept_id         INT64,
+      value_source_value              STRING,
+      questionnaire_response_id       INT64
+  )"
+
+  echo "CREATE TABLE - ds_person"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
+  (
+      PERSON_ID               INT64,
+      GENDER_CONCEPT_ID       INT64,
+      GENDER                  STRING,
+      DATE_OF_BIRTH           TIMESTAMP,
+      RACE_CONCEPT_ID         INT64,
+      RACE                    STRING,
+      ETHNICITY_CONCEPT_ID    INT64,
+      ETHNICITY               STRING,
+      SEX_AT_BIRTH_CONCEPT_ID INT64,
+      SEX_AT_BIRTH            STRING
+  )"
+
+  echo "CREATE TABLE - ds_procedure_occurrence"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
+  (
+      PERSON_ID                       INT64,
+      PROCEDURE_CONCEPT_ID            INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      PROCEDURE_DATETIME              TIMESTAMP,
+      PROCEDURE_TYPE_CONCEPT_ID       INT64,
+      PROCEDURE_TYPE_CONCEPT_NAME     STRING,
+      MODIFIER_CONCEPT_ID             INT64,
+      MODIFIER_CONCEPT_NAME           STRING,
+      QUANTITY                        INT64,
+      VISIT_OCCURRENCE_ID             INT64,
+      VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
+      PROCEDURE_SOURCE_VALUE          STRING,
+      PROCEDURE_SOURCE_CONCEPT_ID     INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      QUALIFIER_SOURCE_VALUE          STRING
+  )"
+
+  echo "CREATE TABLE - ds_survey"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
+  (
+      person_id           INT64,
+      survey_datetime     TIMESTAMP,
+      survey              STRING,
+      question_concept_id INT64,
+      question            STRING,
+      answer_concept_id   INT64,
+      answer              STRING
+  )"
+
+  echo "CREATE TABLE - ds_visit_occurrence"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
+  (
+      PERSON_ID                       INT64,
+      VISIT_CONCEPT_ID                INT64,
+      STANDARD_CONCEPT_NAME           STRING,
+      STANDARD_CONCEPT_CODE           STRING,
+      STANDARD_VOCABULARY             STRING,
+      VISIT_START_DATETIME            TIMESTAMP,
+      VISIT_END_DATETIME              TIMESTAMP,
+      VISIT_TYPE_CONCEPT_ID           INT64,
+      VISIT_TYPE_CONCEPT_NAME         STRING,
+      VISIT_SOURCE_VALUE              STRING,
+      VISIT_SOURCE_CONCEPT_ID         INT64,
+      SOURCE_CONCEPT_NAME             STRING,
+      SOURCE_CONCEPT_CODE             STRING,
+      SOURCE_VOCABULARY               STRING,
+      ADMITTING_SOURCE_CONCEPT_ID     INT64,
+      ADMITTING_SOURCE_CONCEPT_NAME   STRING,
+      ADMITTING_SOURCE_VALUE          STRING,
+      DISCHARGE_TO_CONCEPT_ID         INT64,
+      DISCHARGE_TO_CONCEPT_NAME       STRING,
+      DISCHARGE_TO_SOURCE_VALUE       STRING
+  )"
+
+  ################################################
+  # INSERT DATA
+  ################################################
+  echo "ds_condition_occurrence - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
+      (PERSON_ID, CONDITION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+      CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID, CONDITION_TYPE_CONCEPT_NAME,
+      STOP_REASON, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID,
+      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE,
+      CONDITION_STATUS_CONCEPT_ID, CONDITION_STATUS_CONCEPT_NAME)
+  select a.PERSON_ID, CONDITION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID,
+      c2.concept_name as CONDITION_TYPE_CONCEPT_NAME, STOP_REASON, a.VISIT_OCCURRENCE_ID, c3.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
+      CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID, c4.concept_name as SOURCE_CONCEPT_NAME, c4.concept_code as SOURCE_CONCEPT_CODE,
+      c4.vocabulary_id as SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE, CONDITION_STATUS_CONCEPT_ID,
+      c5.concept_name as CONDITION_STATUS_CONCEPT_NAME
+  from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.CONDITION_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.CONDITION_STATUS_CONCEPT_ID = c5.CONCEPT_ID"
+
+  echo "ds_drug_exposure - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
+      (PERSON_ID, DRUG_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME,
+      DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE, DRUG_TYPE_CONCEPT_ID, DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY,
+      DAYS_SUPPLY, SIG, ROUTE_CONCEPT_ID, ROUTE_CONCEPT_NAME, LOT_NUMBER, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE,
+      DRUG_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE)
+  SELECT
+      a.PERSON_ID, DRUG_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME, DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE,
+      DRUG_TYPE_CONCEPT_ID, c2.concept_name as DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY, DAYS_SUPPLY, SIG,
+      ROUTE_CONCEPT_ID, c3.concept_name as ROUTE_CONCEPT_NAME, LOT_NUMBER, a.VISIT_OCCURRENCE_ID,
+      c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE, DRUG_SOURCE_CONCEPT_ID,
+      c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE, c5.vocabulary_id as SOURCE_VOCABULARY,
+      ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE
+  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.DRUG_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.drug_type_concept_id = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DRUG_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
+
+  echo "ds_measurement - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
+      (PERSON_ID, MEASUREMENT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+      MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID, MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID,
+      OPERATOR_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID, UNIT_CONCEPT_NAME,
+      RANGE_LOW, RANGE_HIGH, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE,
+      MEASUREMENT_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+      VALUE_SOURCE_VALUE)
+  select
+      a.PERSON_ID, MEASUREMENT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID,
+      c2.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID, c3.concept_name as OPERATOR_CONCEPT_NAME,
+      VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, c4.concept_name as VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID,
+      c5.concept_name as UNIT_CONCEPT_NAME, RANGE_LOW, RANGE_HIGH, a.VISIT_OCCURRENCE_ID,
+      c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE, MEASUREMENT_SOURCE_CONCEPT_ID,
+      c7.concept_name as SOURCE_CONCEPT_NAME, c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY,
+      UNIT_SOURCE_VALUE, VALUE_SOURCE_VALUE
+  from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.measurement_concept_id = c1.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.measurement_type_concept_id = c2.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.operator_concept_id = c3.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.value_as_concept_id = c4.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.visit_occurrence_id = v.visit_occurrence_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.measurement_source_concept_id = c7.concept_id"
+
+  echo "ds_observation - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
+      (PERSON_ID, OBSERVATION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+      OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID, OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING,
+      VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, QUALIFIER_CONCEPT_NAME, UNIT_CONCEPT_ID,
+      UNIT_CONCEPT_NAME, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, OBSERVATION_SOURCE_VALUE,
+      OBSERVATION_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+      QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id)
+  SELECT
+      a.PERSON_ID, OBSERVATION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID,
+      c2.concept_name as OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING, VALUE_AS_CONCEPT_ID,
+      c3.concept_name as VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, c4.concept_name as QUALIFIER_CONCEPT_NAME,
+      UNIT_CONCEPT_ID, c5.concept_name as UNIT_CONCEPT_NAME, a.VISIT_OCCURRENCE_ID, c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
+      OBSERVATION_SOURCE_VALUE, OBSERVATION_SOURCE_CONCEPT_ID, c7.concept_name as SOURCE_CONCEPT_NAME,
+      c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
+      QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.OBSERVATION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.value_as_concept_id = c3.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.qualifier_concept_id = c4.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.OBSERVATION_SOURCE_CONCEPT_ID = c7.CONCEPT_ID"
+
+  echo "ds_person - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
+      (PERSON_ID, GENDER_CONCEPT_ID, GENDER, DATE_OF_BIRTH, RACE_CONCEPT_ID, RACE, ETHNICITY_CONCEPT_ID, ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, SEX_AT_BIRTH)
+  SELECT
+      PERSON_ID, GENDER_CONCEPT_ID, c1.concept_name as GENDER, BIRTH_DATETIME as DATE_OF_BIRTH, RACE_CONCEPT_ID,
+      c2.concept_name as RACE, ETHNICITY_CONCEPT_ID, c3.concept_name as ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, c4.concept_name as SEX_AT_BIRTH
+  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.gender_concept_id = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.race_concept_id = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ethnicity_concept_id = c3.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.sex_at_birth_concept_id = c4.CONCEPT_ID"
+
+  echo "ds_procedure_occurrence - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
+      (PERSON_ID, PROCEDURE_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
+      PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID, PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, MODIFIER_CONCEPT_NAME,
+      QUANTITY, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE, PROCEDURE_SOURCE_CONCEPT_ID,
+      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE)
+  select
+      a.PERSON_ID, PROCEDURE_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID,
+      c2.concept_name as PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, c3.concept_name as MODIFIER_CONCEPT_NAME,
+      QUANTITY, a.VISIT_OCCURRENCE_ID, c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE,
+      PROCEDURE_SOURCE_CONCEPT_ID, c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE,
+      c5.vocabulary_id as SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE
+  from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.MODIFIER_CONCEPT_ID = c3.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.PROCEDURE_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
+
+  echo "ds_survey - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
+     (person_id, survey_datetime, survey, question_concept_id, question, answer_concept_id, answer)
+  SELECT  a.person_id,
+          a.observation_datetime as survey_datetime,
+          c.name as survey,
+          d.concept_id as question_concept_id,
+          d.concept_name as question,
+          e.concept_id as answer_concept_id,
+          case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+  JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+          WHERE ancestor_concept_id in
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE domain_id = 'SURVEY'
+                      and parent_id = 0
+              )
+      ) b on a.observation_source_concept_id = b.descendant_concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
+
+  echo "ds_visit_occurrence - inserting data"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
+      (PERSON_ID, VISIT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, VISIT_START_DATETIME,
+      VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID, VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID,
+      SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID, ADMITTING_SOURCE_CONCEPT_NAME,
+      ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID, DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE)
+  select
+      a.PERSON_ID, VISIT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
+      c1.vocabulary_id as STANDARD_VOCABULARY, VISIT_START_DATETIME, VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID,
+      c2.concept_name as VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID, c3.concept_name as SOURCE_CONCEPT_NAME,
+      c3.concept_code as SOURCE_CONCEPT_CODE, c3.vocabulary_id as SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID,
+      c4.concept_name as ADMITTING_SOURCE_CONCEPT_NAME, ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID,
+      c5.concept_name as DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE
+  from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.VISIT_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.VISIT_TYPE_CONCEPT_ID = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.VISIT_SOURCE_CONCEPT_ID = c3.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.ADMITTING_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DISCHARGE_TO_CONCEPT_ID = c5.CONCEPT_ID"
 fi
-if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-
-################################################
-# CREATE TABLES
-################################################
-echo "CREATE TABLE - ds_condition_occurrence"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
-(
-    PERSON_ID                       INT64,
-    CONDITION_CONCEPT_ID            INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    CONDITION_START_DATETIME        TIMESTAMP,
-    CONDITION_END_DATETIME          TIMESTAMP,
-    CONDITION_TYPE_CONCEPT_ID       INT64,
-    CONDITION_TYPE_CONCEPT_NAME     STRING,
-    STOP_REASON                     STRING,
-    VISIT_OCCURRENCE_ID             INT64,
-    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-    CONDITION_SOURCE_VALUE          STRING,
-    CONDITION_SOURCE_CONCEPT_ID     INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    CONDITION_STATUS_SOURCE_VALUE   STRING,
-    CONDITION_STATUS_CONCEPT_ID     INT64,
-    CONDITION_STATUS_CONCEPT_NAME   STRING
-)"
-
-echo "CREATE TABLE - ds_drug_exposure"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
-(
-    PERSON_ID                       INT64,
-    DRUG_CONCEPT_ID                 INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    DRUG_EXPOSURE_START_DATETIME    TIMESTAMP,
-    DRUG_EXPOSURE_END_DATETIME      TIMESTAMP,
-    VERBATIM_END_DATE               DATE,
-    DRUG_TYPE_CONCEPT_ID            INT64,
-    DRUG_TYPE_CONCEPT_NAME          STRING,
-    STOP_REASON                     STRING,
-    REFILLS                         INT64,
-    QUANTITY                        FLOAT64,
-    DAYS_SUPPLY                     INT64,
-    SIG                             STRING,
-    ROUTE_CONCEPT_ID                INT64,
-    ROUTE_CONCEPT_NAME              STRING,
-    LOT_NUMBER                      STRING,
-    VISIT_OCCURRENCE_ID             INT64,
-    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-    DRUG_SOURCE_VALUE               STRING,
-    DRUG_SOURCE_CONCEPT_ID          INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    ROUTE_SOURCE_VALUE              STRING,
-    DOSE_UNIT_SOURCE_VALUE          STRING
-)"
-
-echo "CREATE TABLE - ds_measurement"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
-(
-    PERSON_ID                       INT64,
-    MEASUREMENT_CONCEPT_ID          INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    MEASUREMENT_DATETIME            TIMESTAMP,
-    MEASUREMENT_TYPE_CONCEPT_ID     INT64,
-    MEASUREMENT_TYPE_CONCEPT_NAME   STRING,
-    OPERATOR_CONCEPT_ID             INT64,
-    OPERATOR_CONCEPT_NAME           STRING,
-    VALUE_AS_NUMBER                 FLOAT64,
-    VALUE_AS_CONCEPT_ID             INT64,
-    VALUE_AS_CONCEPT_NAME           STRING,
-    UNIT_CONCEPT_ID                 INT64,
-    UNIT_CONCEPT_NAME               STRING,
-    RANGE_LOW                       FLOAT64,
-    RANGE_HIGH                      FLOAT64,
-    VISIT_OCCURRENCE_ID             INT64,
-    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-    MEASUREMENT_SOURCE_VALUE        STRING,
-    MEASUREMENT_SOURCE_CONCEPT_ID   INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    UNIT_SOURCE_VALUE               STRING,
-    VALUE_SOURCE_VALUE              STRING
-)"
-
-echo "CREATE TABLE - ds_observation"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
-(
-    PERSON_ID                       INT64,
-    OBSERVATION_CONCEPT_ID          INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    OBSERVATION_DATETIME            TIMESTAMP,
-    OBSERVATION_TYPE_CONCEPT_ID     INT64,
-    OBSERVATION_TYPE_CONCEPT_NAME   STRING,
-    VALUE_AS_NUMBER                 FLOAT64,
-    VALUE_AS_STRING                 STRING,
-    VALUE_AS_CONCEPT_ID             INT64,
-    VALUE_AS_CONCEPT_NAME           STRING,
-    QUALIFIER_CONCEPT_ID            INT64,
-    QUALIFIER_CONCEPT_NAME          STRING,
-    UNIT_CONCEPT_ID                 INT64,
-    UNIT_CONCEPT_NAME               STRING,
-    VISIT_OCCURRENCE_ID             INT64,
-    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-    OBSERVATION_SOURCE_VALUE        STRING,
-    OBSERVATION_SOURCE_CONCEPT_ID   INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    UNIT_SOURCE_VALUE               STRING,
-    QUALIFIER_SOURCE_VALUE          STRING,
-    value_source_concept_id         INT64,
-    value_source_value              STRING,
-    questionnaire_response_id       INT64
-)"
-
-echo "CREATE TABLE - ds_person"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
-(
-    PERSON_ID               INT64,
-    GENDER_CONCEPT_ID       INT64,
-    GENDER                  STRING,
-    DATE_OF_BIRTH           TIMESTAMP,
-    RACE_CONCEPT_ID         INT64,
-    RACE                    STRING,
-    ETHNICITY_CONCEPT_ID    INT64,
-    ETHNICITY               STRING,
-    SEX_AT_BIRTH_CONCEPT_ID INT64,
-    SEX_AT_BIRTH            STRING
-)"
-
-echo "CREATE TABLE - ds_procedure_occurrence"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
-(
-    PERSON_ID                       INT64,
-    PROCEDURE_CONCEPT_ID            INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    PROCEDURE_DATETIME              TIMESTAMP,
-    PROCEDURE_TYPE_CONCEPT_ID       INT64,
-    PROCEDURE_TYPE_CONCEPT_NAME     STRING,
-    MODIFIER_CONCEPT_ID             INT64,
-    MODIFIER_CONCEPT_NAME           STRING,
-    QUANTITY                        INT64,
-    VISIT_OCCURRENCE_ID             INT64,
-    VISIT_OCCURRENCE_CONCEPT_NAME   STRING,
-    PROCEDURE_SOURCE_VALUE          STRING,
-    PROCEDURE_SOURCE_CONCEPT_ID     INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    QUALIFIER_SOURCE_VALUE          STRING
-)"
-
-echo "CREATE TABLE - ds_survey"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
-(
-    person_id           INT64,
-    survey_datetime     TIMESTAMP,
-    survey              STRING,
-    question_concept_id INT64,
-    question            STRING,
-    answer_concept_id   INT64,
-    answer              STRING
-)"
-
-echo "CREATE TABLE - ds_visit_occurrence"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
-(
-    PERSON_ID                       INT64,
-    VISIT_CONCEPT_ID                INT64,
-    STANDARD_CONCEPT_NAME           STRING,
-    STANDARD_CONCEPT_CODE           STRING,
-    STANDARD_VOCABULARY             STRING,
-    VISIT_START_DATETIME            TIMESTAMP,
-    VISIT_END_DATETIME              TIMESTAMP,
-    VISIT_TYPE_CONCEPT_ID           INT64,
-    VISIT_TYPE_CONCEPT_NAME         STRING,
-    VISIT_SOURCE_VALUE              STRING,
-    VISIT_SOURCE_CONCEPT_ID         INT64,
-    SOURCE_CONCEPT_NAME             STRING,
-    SOURCE_CONCEPT_CODE             STRING,
-    SOURCE_VOCABULARY               STRING,
-    ADMITTING_SOURCE_CONCEPT_ID     INT64,
-    ADMITTING_SOURCE_CONCEPT_NAME   STRING,
-    ADMITTING_SOURCE_VALUE          STRING,
-    DISCHARGE_TO_CONCEPT_ID         INT64,
-    DISCHARGE_TO_CONCEPT_NAME       STRING,
-    DISCHARGE_TO_SOURCE_VALUE       STRING
-)"
-
-################################################
-# INSERT DATA
-################################################
-echo "ds_condition_occurrence - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_condition_occurrence\`
-    (PERSON_ID, CONDITION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-    CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID, CONDITION_TYPE_CONCEPT_NAME,
-    STOP_REASON, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID,
-    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE,
-    CONDITION_STATUS_CONCEPT_ID, CONDITION_STATUS_CONCEPT_NAME)
-select a.PERSON_ID, CONDITION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, CONDITION_START_DATETIME, CONDITION_END_DATETIME, CONDITION_TYPE_CONCEPT_ID,
-    c2.concept_name as CONDITION_TYPE_CONCEPT_NAME, STOP_REASON, a.VISIT_OCCURRENCE_ID, c3.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
-    CONDITION_SOURCE_VALUE, CONDITION_SOURCE_CONCEPT_ID, c4.concept_name as SOURCE_CONCEPT_NAME, c4.concept_code as SOURCE_CONCEPT_CODE,
-    c4.vocabulary_id as SOURCE_VOCABULARY, CONDITION_STATUS_SOURCE_VALUE, CONDITION_STATUS_CONCEPT_ID,
-    c5.concept_name as CONDITION_STATUS_CONCEPT_NAME
-from \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.CONDITION_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.CONDITION_STATUS_CONCEPT_ID = c5.CONCEPT_ID"
-
-echo "ds_drug_exposure - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_drug_exposure\`
-    (PERSON_ID, DRUG_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME,
-    DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE, DRUG_TYPE_CONCEPT_ID, DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY,
-    DAYS_SUPPLY, SIG, ROUTE_CONCEPT_ID, ROUTE_CONCEPT_NAME, LOT_NUMBER, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE,
-    DRUG_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE)
-SELECT
-    a.PERSON_ID, DRUG_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, DRUG_EXPOSURE_START_DATETIME, DRUG_EXPOSURE_END_DATETIME, VERBATIM_END_DATE,
-    DRUG_TYPE_CONCEPT_ID, c2.concept_name as DRUG_TYPE_CONCEPT_NAME, STOP_REASON, REFILLS, QUANTITY, DAYS_SUPPLY, SIG,
-    ROUTE_CONCEPT_ID, c3.concept_name as ROUTE_CONCEPT_NAME, LOT_NUMBER, a.VISIT_OCCURRENCE_ID,
-    c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, DRUG_SOURCE_VALUE, DRUG_SOURCE_CONCEPT_ID,
-    c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE, c5.vocabulary_id as SOURCE_VOCABULARY,
-    ROUTE_SOURCE_VALUE, DOSE_UNIT_SOURCE_VALUE
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.DRUG_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.drug_type_concept_id = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DRUG_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
-
-echo "ds_measurement - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_measurement\`
-    (PERSON_ID, MEASUREMENT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-    MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID, MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID,
-    OPERATOR_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID, UNIT_CONCEPT_NAME,
-    RANGE_LOW, RANGE_HIGH, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE,
-    MEASUREMENT_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-    VALUE_SOURCE_VALUE)
-select
-    a.PERSON_ID, MEASUREMENT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, MEASUREMENT_DATETIME, MEASUREMENT_TYPE_CONCEPT_ID,
-    c2.concept_name as MEASUREMENT_TYPE_CONCEPT_NAME, OPERATOR_CONCEPT_ID, c3.concept_name as OPERATOR_CONCEPT_NAME,
-    VALUE_AS_NUMBER, VALUE_AS_CONCEPT_ID, c4.concept_name as VALUE_AS_CONCEPT_NAME, UNIT_CONCEPT_ID,
-    c5.concept_name as UNIT_CONCEPT_NAME, RANGE_LOW, RANGE_HIGH, a.VISIT_OCCURRENCE_ID,
-    c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, MEASUREMENT_SOURCE_VALUE, MEASUREMENT_SOURCE_CONCEPT_ID,
-    c7.concept_name as SOURCE_CONCEPT_NAME, c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY,
-    UNIT_SOURCE_VALUE, VALUE_SOURCE_VALUE
-from \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.measurement_concept_id = c1.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.measurement_type_concept_id = c2.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.operator_concept_id = c3.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.value_as_concept_id = c4.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.visit_occurrence_id = v.visit_occurrence_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.measurement_source_concept_id = c7.concept_id"
-
-echo "ds_observation - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_observation\`
-    (PERSON_ID, OBSERVATION_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-    OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID, OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING,
-    VALUE_AS_CONCEPT_ID, VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, QUALIFIER_CONCEPT_NAME, UNIT_CONCEPT_ID,
-    UNIT_CONCEPT_NAME, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, OBSERVATION_SOURCE_VALUE,
-    OBSERVATION_SOURCE_CONCEPT_ID, SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-    QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id)
-SELECT
-    a.PERSON_ID, OBSERVATION_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, OBSERVATION_DATETIME, OBSERVATION_TYPE_CONCEPT_ID,
-    c2.concept_name as OBSERVATION_TYPE_CONCEPT_NAME, VALUE_AS_NUMBER, VALUE_AS_STRING, VALUE_AS_CONCEPT_ID,
-    c3.concept_name as VALUE_AS_CONCEPT_NAME, QUALIFIER_CONCEPT_ID, c4.concept_name as QUALIFIER_CONCEPT_NAME,
-    UNIT_CONCEPT_ID, c5.concept_name as UNIT_CONCEPT_NAME, a.VISIT_OCCURRENCE_ID, c6.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME,
-    OBSERVATION_SOURCE_VALUE, OBSERVATION_SOURCE_CONCEPT_ID, c7.concept_name as SOURCE_CONCEPT_NAME,
-    c7.concept_code as SOURCE_CONCEPT_CODE, c7.vocabulary_id as SOURCE_VOCABULARY, UNIT_SOURCE_VALUE,
-    QUALIFIER_SOURCE_VALUE, value_source_concept_id, value_source_value, questionnaire_response_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.OBSERVATION_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.value_as_concept_id = c3.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.qualifier_concept_id = c4.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.unit_concept_id = c5.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c6 on v.visit_concept_id = c6.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c7 on a.OBSERVATION_SOURCE_CONCEPT_ID = c7.CONCEPT_ID"
-
-echo "ds_person - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_person\`
-    (PERSON_ID, GENDER_CONCEPT_ID, GENDER, DATE_OF_BIRTH, RACE_CONCEPT_ID, RACE, ETHNICITY_CONCEPT_ID, ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, SEX_AT_BIRTH)
-SELECT
-    PERSON_ID, GENDER_CONCEPT_ID, c1.concept_name as GENDER, BIRTH_DATETIME as DATE_OF_BIRTH, RACE_CONCEPT_ID,
-    c2.concept_name as RACE, ETHNICITY_CONCEPT_ID, c3.concept_name as ETHNICITY, SEX_AT_BIRTH_CONCEPT_ID, c4.concept_name as SEX_AT_BIRTH
-FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.gender_concept_id = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.race_concept_id = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.ethnicity_concept_id = c3.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.sex_at_birth_concept_id = c4.CONCEPT_ID"
-
-echo "ds_procedure_occurrence - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_procedure_occurrence\`
-    (PERSON_ID, PROCEDURE_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY,
-    PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID, PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, MODIFIER_CONCEPT_NAME,
-    QUANTITY, VISIT_OCCURRENCE_ID, VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE, PROCEDURE_SOURCE_CONCEPT_ID,
-    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE)
-select
-    a.PERSON_ID, PROCEDURE_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, PROCEDURE_DATETIME, PROCEDURE_TYPE_CONCEPT_ID,
-    c2.concept_name as PROCEDURE_TYPE_CONCEPT_NAME, MODIFIER_CONCEPT_ID, c3.concept_name as MODIFIER_CONCEPT_NAME,
-    QUANTITY, a.VISIT_OCCURRENCE_ID, c4.concept_name as VISIT_OCCURRENCE_CONCEPT_NAME, PROCEDURE_SOURCE_VALUE,
-    PROCEDURE_SOURCE_CONCEPT_ID, c5.concept_name as SOURCE_CONCEPT_NAME, c5.concept_code as SOURCE_CONCEPT_CODE,
-    c5.vocabulary_id as SOURCE_VOCABULARY, QUALIFIER_SOURCE_VALUE
-from \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.MODIFIER_CONCEPT_ID = c3.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.PROCEDURE_SOURCE_CONCEPT_ID = c5.CONCEPT_ID"
-
-echo "ds_survey - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_survey\`
-   (person_id, survey_datetime, survey, question_concept_id, question, answer_concept_id, answer)
-SELECT  a.person_id,
-        a.observation_datetime as survey_datetime,
-        c.name as survey,
-        d.concept_id as question_concept_id,
-        d.concept_name as question,
-        e.concept_id as answer_concept_id,
-        case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-        WHERE ancestor_concept_id in
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE domain_id = 'SURVEY'
-                    and parent_id = 0
-            )
-    ) b on a.observation_source_concept_id = b.descendant_concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
-
-echo "ds_visit_occurrence - inserting data"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_visit_occurrence\`
-    (PERSON_ID, VISIT_CONCEPT_ID, STANDARD_CONCEPT_NAME, STANDARD_CONCEPT_CODE, STANDARD_VOCABULARY, VISIT_START_DATETIME,
-    VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID, VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID,
-    SOURCE_CONCEPT_NAME, SOURCE_CONCEPT_CODE, SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID, ADMITTING_SOURCE_CONCEPT_NAME,
-    ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID, DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE)
-select
-    a.PERSON_ID, VISIT_CONCEPT_ID, c1.concept_name as STANDARD_CONCEPT_NAME, c1.concept_code as STANDARD_CONCEPT_CODE,
-    c1.vocabulary_id as STANDARD_VOCABULARY, VISIT_START_DATETIME, VISIT_END_DATETIME, VISIT_TYPE_CONCEPT_ID,
-    c2.concept_name as VISIT_TYPE_CONCEPT_NAME, VISIT_SOURCE_VALUE, VISIT_SOURCE_CONCEPT_ID, c3.concept_name as SOURCE_CONCEPT_NAME,
-    c3.concept_code as SOURCE_CONCEPT_CODE, c3.vocabulary_id as SOURCE_VOCABULARY, ADMITTING_SOURCE_CONCEPT_ID,
-    c4.concept_name as ADMITTING_SOURCE_CONCEPT_NAME, ADMITTING_SOURCE_VALUE, DISCHARGE_TO_CONCEPT_ID,
-    c5.concept_name as DISCHARGE_TO_CONCEPT_NAME, DISCHARGE_TO_SOURCE_VALUE
-from \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.VISIT_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.VISIT_TYPE_CONCEPT_ID = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on a.VISIT_SOURCE_CONCEPT_ID = c3.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on a.ADMITTING_SOURCE_CONCEPT_ID = c4.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c5 on a.DISCHARGE_TO_CONCEPT_ID = c5.CONCEPT_ID"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
@@ -6,298 +6,302 @@ set -ex
 
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
+export DRY_RUN=$3     # dry run
 
-# Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
+if [ "$DRY_RUN" == false ]
 then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
+  # Check that bq_dataset exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
 
-# Create bq tables we have json schema for
-schema_path=generate-cdr/bq-schemas
+  # Create bq tables we have json schema for
+  schema_path=generate-cdr/bq-schemas
 
-bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_survey
-bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_survey.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_review_survey
+  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_survey
+  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_survey.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_review_survey
 
-#########################################
-# insert survey data into cb_review_survey #
-#########################################
-echo "Inserting survey data into cb_review_survey"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_survey\`
-   (person_id, data_id, start_datetime, survey, question, answer)
-SELECT  a.person_id,
-        a.observation_id as data_id,
-        a.observation_datetime as survey_datetime,
-        c.name as survey,
-        d.concept_name as question,
-        case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-JOIN
-    (
-        SELECT *
-        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-        WHERE ancestor_concept_id in
-            (
-                SELECT concept_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                WHERE domain_id = 'SURVEY'
-                    and parent_id = 0
-            )
-    ) b on a.observation_source_concept_id = b.descendant_concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
+  #########################################
+  # insert survey data into cb_review_survey #
+  #########################################
+  echo "Inserting survey data into cb_review_survey"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_survey\`
+     (person_id, data_id, start_datetime, survey, question, answer)
+  SELECT  a.person_id,
+          a.observation_id as data_id,
+          a.observation_datetime as survey_datetime,
+          c.name as survey,
+          d.concept_name as question,
+          case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+  JOIN
+      (
+          SELECT *
+          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+          WHERE ancestor_concept_id in
+              (
+                  SELECT concept_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                  WHERE domain_id = 'SURVEY'
+                      and parent_id = 0
+              )
+      ) b on a.observation_source_concept_id = b.descendant_concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
 
-# Create bq tables we have json schema for
-bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_all_events
-bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_all_events.json --time_partitioning_type=DAY --clustering_fields person_id,domain $BQ_DATASET.cb_review_all_events
+  # Create bq tables we have json schema for
+  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_all_events
+  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_all_events.json --time_partitioning_type=DAY --clustering_fields person_id,domain $BQ_DATASET.cb_review_all_events
 
-###########################################
-# insert drug data into cb_review_all_events #
-###########################################
-echo "Inserting drug data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
- (person_id, data_id, start_datetime, standard_name, standard_code, standard_vocabulary, standard_concept_id, source_name, source_code, source_vocabulary,
- source_concept_id, visit_type, age_at_event, NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, dose, strength, route, domain)
-SELECT P.PERSON_ID,
-    t.DRUG_EXPOSURE_ID AS DATA_ID,
-    t.DRUG_EXPOSURE_START_DATETIME as START_DATETIME,
+  ###########################################
+  # insert drug data into cb_review_all_events #
+  ###########################################
+  echo "Inserting drug data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_name, standard_code, standard_vocabulary, standard_concept_id, source_name, source_code, source_vocabulary,
+   source_concept_id, visit_type, age_at_event, NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, dose, strength, route, domain)
+  SELECT P.PERSON_ID,
+      t.DRUG_EXPOSURE_ID AS DATA_ID,
+      t.DRUG_EXPOSURE_START_DATETIME as START_DATETIME,
+      case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+      case when c1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+      case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+      case when c2.VOCABULARY_ID is null then 'None' else C2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
+      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+      case when c4.CONCEPT_NAME is null then '' else c4.CONCEPT_NAME end as VISIT_TYPE,
+      CAST(FLOOR(DATE_DIFF(t.DRUG_EXPOSURE_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+      T.NUM_MENTIONS,
+      T.FIRST_MENTION,
+      T.LAST_MENTION,
+      T.QUANTITY as dose,
+      '' as strength,
+      case when C3.CONCEPT_NAME is null then '' else C3.CONCEPT_NAME end as ROUTE,
+      'DRUG' as domain
+  FROM
+  (SELECT DRUG_EXPOSURE_ID, a.PERSON_ID, a.DRUG_CONCEPT_ID, a.DRUG_SOURCE_CONCEPT_ID, DRUG_EXPOSURE_START_DATE, DRUG_EXPOSURE_START_DATETIME, VISIT_OCCURRENCE_ID,
+  NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, QUANTITY, ROUTE_CONCEPT_ID
+  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` A,
+  (SELECT PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID, COUNT(*) AS NUM_MENTIONS,
+  min(DRUG_EXPOSURE_START_DATETIME) as FIRST_MENTION, max(DRUG_EXPOSURE_START_DATETIME) as LAST_MENTION
+  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+  GROUP BY PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID) B
+  WHERE a.PERSON_ID = b.PERSON_ID and a.DRUG_CONCEPT_ID = b.DRUG_CONCEPT_ID and a.DRUG_SOURCE_CONCEPT_ID = b.DRUG_SOURCE_CONCEPT_ID) t
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.DRUG_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.DRUG_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+
+  ################################################
+  # insert condition data into cb_review_all_events #
+  ################################################
+  echo "Inserting conditions data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code,
+   source_vocabulary, source_name, source_concept_id, age_at_event, visit_type, domain)
+  SELECT P.PERSON_ID,
+    a.CONDITION_OCCURRENCE_ID AS DATA_ID,
+    a.CONDITION_START_DATETIME as START_DATETIME,
+      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+      case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-    case when c1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-    case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-    case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+      case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-    case when c2.VOCABULARY_ID is null then 'None' else C2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
-    case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-    case when c4.CONCEPT_NAME is null then '' else c4.CONCEPT_NAME end as VISIT_TYPE,
-    CAST(FLOOR(DATE_DIFF(t.DRUG_EXPOSURE_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-    T.NUM_MENTIONS,
-    T.FIRST_MENTION,
-    T.LAST_MENTION,
-    T.QUANTITY as dose,
-    '' as strength,
-    case when C3.CONCEPT_NAME is null then '' else C3.CONCEPT_NAME end as ROUTE,
-    'DRUG' as domain
-FROM
-(SELECT DRUG_EXPOSURE_ID, a.PERSON_ID, a.DRUG_CONCEPT_ID, a.DRUG_SOURCE_CONCEPT_ID, DRUG_EXPOSURE_START_DATE, DRUG_EXPOSURE_START_DATETIME, VISIT_OCCURRENCE_ID,
-NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, QUANTITY, ROUTE_CONCEPT_ID
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` A,
-(SELECT PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID, COUNT(*) AS NUM_MENTIONS,
-min(DRUG_EXPOSURE_START_DATETIME) as FIRST_MENTION, max(DRUG_EXPOSURE_START_DATETIME) as LAST_MENTION
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-GROUP BY PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID) B
-WHERE a.PERSON_ID = b.PERSON_ID and a.DRUG_CONCEPT_ID = b.DRUG_CONCEPT_ID and a.DRUG_SOURCE_CONCEPT_ID = b.DRUG_SOURCE_CONCEPT_ID) t
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.DRUG_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.DRUG_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
-
-################################################
-# insert condition data into cb_review_all_events #
-################################################
-echo "Inserting conditions data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
- (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code,
- source_vocabulary, source_name, source_concept_id, age_at_event, visit_type, domain)
-SELECT P.PERSON_ID,
-	a.CONDITION_OCCURRENCE_ID AS DATA_ID,
-	a.CONDITION_START_DATETIME as START_DATETIME,
-    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-    case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-	case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-    case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-	case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-	case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-	case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-	CAST(FLOOR(DATE_DIFF(a.CONDITION_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-	case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-	'CONDITION' as domain
-FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
-
-##########################################
-# insert lab data into cb_review_all_events #
-##########################################
-echo "Inserting lab data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-   source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
-SELECT m.person_id,
-    m.measurement_id as data_id,
-    m.measurement_datetime as start_datetime,
-    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-    case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-    case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
-    case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
-    case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-    case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
-    m.unit_source_value as unit,
-    case when range_low IS NULL and range_high IS NULL then NULL
-              when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
-              when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
-              else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
-              end as ref_range,
-    CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
+    CAST(FLOOR(DATE_DIFF(a.CONDITION_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-    'LAB' as domain
-FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
-where c1.concept_class_id = 'Lab Test'"
+    'CONDITION' as domain
+  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
 
-############################################
-# insert vital data into cb_review_all_events #
-############################################
-echo "Inserting vital data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-    source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
-SELECT m.person_id,
-    m.measurement_id as data_id,
-    m.measurement_datetime as start_datetime,
-    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-    case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-    case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
-    case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
-    case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-    case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-    case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-    case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
-    m.unit_source_value as unit,
-    case when range_low IS NULL and range_high IS NULL then NULL
-              when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
-              when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
-              else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
-              end as ref_range,
-    CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
-    case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-    'VITAL' as domain
-FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
-where c1.concept_class_id != 'Lab Test'"
+  ##########################################
+  # insert lab data into cb_review_all_events #
+  ##########################################
+  echo "Inserting lab data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+     source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
+  SELECT m.person_id,
+      m.measurement_id as data_id,
+      m.measurement_datetime as start_datetime,
+      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+      case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+      case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
+      case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
+      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+      case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
+      m.unit_source_value as unit,
+      case when range_low IS NULL and range_high IS NULL then NULL
+                when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
+                when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
+                else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
+                end as ref_range,
+      CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
+      case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+      'LAB' as domain
+  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
+  where c1.concept_class_id = 'Lab Test'"
 
-###################################################
-# insert observation data into cb_review_all_events #
-###################################################
-echo "Inserting observation data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_name, standard_code, standard_concept_id, standard_vocabulary, source_name,
- source_code, source_concept_id, source_vocabulary, visit_type, age_at_event, domain)
-SELECT P.PERSON_ID,
-	 t.OBSERVATION_ID AS DATA_ID,
-     t.OBSERVATION_DATETIME as START_DATETIME,
-     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-	 case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-     CAST(FLOOR(DATE_DIFF(t.OBSERVATION_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-     'OBSERVATION' as domain
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` t
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.OBSERVATION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+  ############################################
+  # insert vital data into cb_review_all_events #
+  ############################################
+  echo "Inserting vital data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+      source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
+  SELECT m.person_id,
+      m.measurement_id as data_id,
+      m.measurement_datetime as start_datetime,
+      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+      case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+      case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
+      case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
+      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+      case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
+      m.unit_source_value as unit,
+      case when range_low IS NULL and range_high IS NULL then NULL
+                when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
+                when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
+                else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
+                end as ref_range,
+      CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
+      case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+      'VITAL' as domain
+  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
+  where c1.concept_class_id != 'Lab Test'"
 
-##########################################################
-# insert physicalMeasurement data into cb_review_all_events #
-##########################################################
-echo "Inserting pm data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-   source_concept_id, value_as_number, unit, age_at_event, domain, visit_type)
-SELECT P.PERSON_ID,
-	 t.MEASUREMENT_ID AS DATA_ID,
-     t.MEASUREMENT_DATETIME as START_DATETIME,
-     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-     case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
-     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-     case when VALUE_AS_NUMBER is null then VALUE_AS_CONCEPT_ID else VALUE_AS_NUMBER end as VALUE_AS_NUMBER,
-     c3.CONCEPT_NAME AS UNIT,
-     CAST(FLOOR(DATE_DIFF(t.MEASUREMENT_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-     'PHYSICAL_MEASUREMENT' as domain,
-     case when c4.concept_name is null then '' else c4.concept_name end as visit_type
-FROM
-(select *
-from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-where measurement_source_concept_id in
-(select concept_id from \`$BQ_PROJECT.$BQ_DATASET.concept\` where vocabulary_id = 'PPI' and domain_id = 'Measurement' and CONCEPT_CLASS_ID = 'Clinical Observation')) t
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.MEASUREMENT_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.MEASUREMENT_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.UNIT_CONCEPT_ID = c3.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
-
-################################################
-# insert procedure data into cb_review_all_events #
-################################################
-echo "Inserting procedure data into cb_review_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-   source_concept_id, age_at_event, visit_type, domain)
-SELECT P.PERSON_ID,
-	 a.PROCEDURE_OCCURRENCE_ID AS DATA_ID,
-     a.PROCEDURE_DATETIME as START_DATETIME,
-     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+  ###################################################
+  # insert observation data into cb_review_all_events #
+  ###################################################
+  echo "Inserting observation data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+     (person_id, data_id, start_datetime, standard_name, standard_code, standard_concept_id, standard_vocabulary, source_name,
+   source_code, source_concept_id, source_vocabulary, visit_type, age_at_event, domain)
+  SELECT P.PERSON_ID,
+     t.OBSERVATION_ID AS DATA_ID,
+       t.OBSERVATION_DATETIME as START_DATETIME,
+       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
      case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-     CAST(FLOOR(DATE_DIFF(a.PROCEDURE_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-     'PROCEDURE' as domain
-FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
+       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+       case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+       CAST(FLOOR(DATE_DIFF(t.OBSERVATION_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+       'OBSERVATION' as domain
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` t
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.OBSERVATION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+
+  ##########################################################
+  # insert physicalMeasurement data into cb_review_all_events #
+  ##########################################################
+  echo "Inserting pm data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+     source_concept_id, value_as_number, unit, age_at_event, domain, visit_type)
+  SELECT P.PERSON_ID,
+     t.MEASUREMENT_ID AS DATA_ID,
+       t.MEASUREMENT_DATETIME as START_DATETIME,
+       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+       case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
+       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+       case when VALUE_AS_NUMBER is null then VALUE_AS_CONCEPT_ID else VALUE_AS_NUMBER end as VALUE_AS_NUMBER,
+       c3.CONCEPT_NAME AS UNIT,
+       CAST(FLOOR(DATE_DIFF(t.MEASUREMENT_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+       'PHYSICAL_MEASUREMENT' as domain,
+       case when c4.concept_name is null then '' else c4.concept_name end as visit_type
+  FROM
+  (select *
+  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+  where measurement_source_concept_id in
+  (select concept_id from \`$BQ_PROJECT.$BQ_DATASET.concept\` where vocabulary_id = 'PPI' and domain_id = 'Measurement' and CONCEPT_CLASS_ID = 'Clinical Observation')) t
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.MEASUREMENT_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.MEASUREMENT_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.UNIT_CONCEPT_ID = c3.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+
+  ################################################
+  # insert procedure data into cb_review_all_events #
+  ################################################
+  echo "Inserting procedure data into cb_review_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+     source_concept_id, age_at_event, visit_type, domain)
+  SELECT P.PERSON_ID,
+     a.PROCEDURE_OCCURRENCE_ID AS DATA_ID,
+       a.PROCEDURE_DATETIME as START_DATETIME,
+       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+       case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+       CAST(FLOOR(DATE_DIFF(a.PROCEDURE_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+       case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+       'PROCEDURE' as domain
+  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
+fi

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
@@ -8,300 +8,312 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export DRY_RUN=$3     # dry run
 
-if [ "$DRY_RUN" == false ]
+if [ "$DRY_RUN" == true ]
 then
-  # Check that bq_dataset exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
-  then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_criteria")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
+  exit 0
+fi
 
-  # Create bq tables we have json schema for
-  schema_path=generate-cdr/bq-schemas
+# Check that bq_dataset exists and exit if not
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+if [ -z "$datasets" ]
+then
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+else
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
 
-  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_survey
-  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_survey.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_review_survey
+# Create bq tables we have json schema for
+schema_path=generate-cdr/bq-schemas
 
-  #########################################
-  # insert survey data into cb_review_survey #
-  #########################################
-  echo "Inserting survey data into cb_review_survey"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_survey\`
-     (person_id, data_id, start_datetime, survey, question, answer)
-  SELECT  a.person_id,
-          a.observation_id as data_id,
-          a.observation_datetime as survey_datetime,
-          c.name as survey,
-          d.concept_name as question,
-          case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
-  JOIN
-      (
-          SELECT *
-          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-          WHERE ancestor_concept_id in
-              (
-                  SELECT concept_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                  WHERE domain_id = 'SURVEY'
-                      and parent_id = 0
-              )
-      ) b on a.observation_source_concept_id = b.descendant_concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
+bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_survey
+bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_survey.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_review_survey
 
-  # Create bq tables we have json schema for
-  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_all_events
-  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_all_events.json --time_partitioning_type=DAY --clustering_fields person_id,domain $BQ_DATASET.cb_review_all_events
+#########################################
+# insert survey data into cb_review_survey #
+#########################################
+echo "Inserting survey data into cb_review_survey"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_survey\`
+   (person_id, data_id, start_datetime, survey, question, answer)
+SELECT  a.person_id,
+        a.observation_id as data_id,
+        a.observation_datetime as survey_datetime,
+        c.name as survey,
+        d.concept_name as question,
+        case when a.value_as_number is not null then CAST(a.value_as_number as STRING) else e.concept_name END as answer
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+JOIN
+    (
+        SELECT *
+        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+        WHERE ancestor_concept_id in
+            (
+                SELECT concept_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                WHERE domain_id = 'SURVEY'
+                    and parent_id = 0
+            )
+    ) b on a.observation_source_concept_id = b.descendant_concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` c ON b.ancestor_concept_id = c.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` d on a.observation_source_concept_id = d.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on a.value_source_concept_id = e.concept_id"
 
-  ###########################################
-  # insert drug data into cb_review_all_events #
-  ###########################################
-  echo "Inserting drug data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_name, standard_code, standard_vocabulary, standard_concept_id, source_name, source_code, source_vocabulary,
-   source_concept_id, visit_type, age_at_event, NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, dose, strength, route, domain)
-  SELECT P.PERSON_ID,
-      t.DRUG_EXPOSURE_ID AS DATA_ID,
-      t.DRUG_EXPOSURE_START_DATETIME as START_DATETIME,
-      case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-      case when c1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-      case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-      case when c2.VOCABULARY_ID is null then 'None' else C2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
-      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-      case when c4.CONCEPT_NAME is null then '' else c4.CONCEPT_NAME end as VISIT_TYPE,
-      CAST(FLOOR(DATE_DIFF(t.DRUG_EXPOSURE_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-      T.NUM_MENTIONS,
-      T.FIRST_MENTION,
-      T.LAST_MENTION,
-      T.QUANTITY as dose,
-      '' as strength,
-      case when C3.CONCEPT_NAME is null then '' else C3.CONCEPT_NAME end as ROUTE,
-      'DRUG' as domain
-  FROM
-  (SELECT DRUG_EXPOSURE_ID, a.PERSON_ID, a.DRUG_CONCEPT_ID, a.DRUG_SOURCE_CONCEPT_ID, DRUG_EXPOSURE_START_DATE, DRUG_EXPOSURE_START_DATETIME, VISIT_OCCURRENCE_ID,
-  NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, QUANTITY, ROUTE_CONCEPT_ID
-  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` A,
-  (SELECT PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID, COUNT(*) AS NUM_MENTIONS,
-  min(DRUG_EXPOSURE_START_DATETIME) as FIRST_MENTION, max(DRUG_EXPOSURE_START_DATETIME) as LAST_MENTION
-  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
-  GROUP BY PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID) B
-  WHERE a.PERSON_ID = b.PERSON_ID and a.DRUG_CONCEPT_ID = b.DRUG_CONCEPT_ID and a.DRUG_SOURCE_CONCEPT_ID = b.DRUG_SOURCE_CONCEPT_ID) t
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.DRUG_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.DRUG_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+# Create bq tables we have json schema for
+bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_review_all_events
+bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_review_all_events.json --time_partitioning_type=DAY --clustering_fields person_id,domain $BQ_DATASET.cb_review_all_events
 
-  ################################################
-  # insert condition data into cb_review_all_events #
-  ################################################
-  echo "Inserting conditions data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code,
-   source_vocabulary, source_name, source_concept_id, age_at_event, visit_type, domain)
-  SELECT P.PERSON_ID,
-    a.CONDITION_OCCURRENCE_ID AS DATA_ID,
-    a.CONDITION_START_DATETIME as START_DATETIME,
-      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-      case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+###########################################
+# insert drug data into cb_review_all_events #
+###########################################
+echo "Inserting drug data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+ (person_id, data_id, start_datetime, standard_name, standard_code, standard_vocabulary, standard_concept_id, source_name, source_code, source_vocabulary,
+ source_concept_id, visit_type, age_at_event, NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, dose, strength, route, domain)
+SELECT P.PERSON_ID,
+    t.DRUG_EXPOSURE_ID AS DATA_ID,
+    t.DRUG_EXPOSURE_START_DATETIME as START_DATETIME,
     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-      case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+    case when c1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+    case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+    case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+    case when c2.VOCABULARY_ID is null then 'None' else C2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
+    case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+    case when c4.CONCEPT_NAME is null then '' else c4.CONCEPT_NAME end as VISIT_TYPE,
+    CAST(FLOOR(DATE_DIFF(t.DRUG_EXPOSURE_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+    T.NUM_MENTIONS,
+    T.FIRST_MENTION,
+    T.LAST_MENTION,
+    T.QUANTITY as dose,
+    '' as strength,
+    case when C3.CONCEPT_NAME is null then '' else C3.CONCEPT_NAME end as ROUTE,
+    'DRUG' as domain
+FROM
+(SELECT DRUG_EXPOSURE_ID, a.PERSON_ID, a.DRUG_CONCEPT_ID, a.DRUG_SOURCE_CONCEPT_ID, DRUG_EXPOSURE_START_DATE, DRUG_EXPOSURE_START_DATETIME, VISIT_OCCURRENCE_ID,
+NUM_MENTIONS, FIRST_MENTION, LAST_MENTION, QUANTITY, ROUTE_CONCEPT_ID
+FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` A,
+(SELECT PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID, COUNT(*) AS NUM_MENTIONS,
+min(DRUG_EXPOSURE_START_DATETIME) as FIRST_MENTION, max(DRUG_EXPOSURE_START_DATETIME) as LAST_MENTION
+FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
+GROUP BY PERSON_ID, DRUG_CONCEPT_ID, DRUG_SOURCE_CONCEPT_ID) B
+WHERE a.PERSON_ID = b.PERSON_ID and a.DRUG_CONCEPT_ID = b.DRUG_CONCEPT_ID and a.DRUG_SOURCE_CONCEPT_ID = b.DRUG_SOURCE_CONCEPT_ID) t
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.DRUG_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.DRUG_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.ROUTE_CONCEPT_ID = c3.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.VISIT_CONCEPT_ID = c4.CONCEPT_ID
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+
+################################################
+# insert condition data into cb_review_all_events #
+################################################
+echo "Inserting conditions data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+ (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code,
+ source_vocabulary, source_name, source_concept_id, age_at_event, visit_type, domain)
+SELECT P.PERSON_ID,
+	a.CONDITION_OCCURRENCE_ID AS DATA_ID,
+	a.CONDITION_START_DATETIME as START_DATETIME,
+    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+    case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+	case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+    case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+	case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+	case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+	case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+	CAST(FLOOR(DATE_DIFF(a.CONDITION_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+	case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+	'CONDITION' as domain
+FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
+
+##########################################
+# insert lab data into cb_review_all_events #
+##########################################
+echo "Inserting lab data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+   source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
+SELECT m.person_id,
+    m.measurement_id as data_id,
+    m.measurement_datetime as start_datetime,
+    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+    case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+    case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
+    case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
+    case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-    CAST(FLOOR(DATE_DIFF(a.CONDITION_START_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+    case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
+    m.unit_source_value as unit,
+    case when range_low IS NULL and range_high IS NULL then NULL
+              when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
+              when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
+              else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
+              end as ref_range,
+    CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-    'CONDITION' as domain
-  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.CONDITION_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.CONDITION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
+    'LAB' as domain
+FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
+where c1.concept_class_id = 'Lab Test'"
 
-  ##########################################
-  # insert lab data into cb_review_all_events #
-  ##########################################
-  echo "Inserting lab data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-     source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
-  SELECT m.person_id,
-      m.measurement_id as data_id,
-      m.measurement_datetime as start_datetime,
-      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-      case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-      case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
-      case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
-      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-      case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
-      m.unit_source_value as unit,
-      case when range_low IS NULL and range_high IS NULL then NULL
-                when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
-                when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
-                else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
-                end as ref_range,
-      CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
-      case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-      'LAB' as domain
-  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
-  where c1.concept_class_id = 'Lab Test'"
+############################################
+# insert vital data into cb_review_all_events #
+############################################
+echo "Inserting vital data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+    source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
+SELECT m.person_id,
+    m.measurement_id as data_id,
+    m.measurement_datetime as start_datetime,
+    case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+    case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+    case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
+    case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
+    case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+    case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+    case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+    case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+    case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
+    m.unit_source_value as unit,
+    case when range_low IS NULL and range_high IS NULL then NULL
+              when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
+              when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
+              else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
+              end as ref_range,
+    CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
+    case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+    'VITAL' as domain
+FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
+where c1.concept_class_id != 'Lab Test'"
 
-  ############################################
-  # insert vital data into cb_review_all_events #
-  ############################################
-  echo "Inserting vital data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-      source_concept_id, value_as_number, unit, ref_range, age_at_event, visit_type, domain)
-  SELECT m.person_id,
-      m.measurement_id as data_id,
-      m.measurement_datetime as start_datetime,
-      case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-      case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-      case when c1.concept_name is null then 'No matching concept' else c1.concept_name end as standard_name,
-      case when c1.concept_id is null then 0 else c1.concept_id end as standard_concept_id,
-      case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-      case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-      case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-      case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-      case when m.value_as_number is null then m.value_as_concept_id else value_as_number end as value_as_number,
-      m.unit_source_value as unit,
-      case when range_low IS NULL and range_high IS NULL then NULL
-                when range_low IS NULL and range_high iS NOT NULL then cast(range_high AS STRING)
-                when range_low IS NOT NULL and range_high IS NULL then cast(range_low AS STRING)
-                else concat(cast(range_low AS STRING) ,'-',cast(range_high AS STRING) )
-                end as ref_range,
-      CAST(FLOOR(DATE_DIFF(m.measurement_date, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as age_at_event,
-      case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-      'VITAL' as domain
-  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on m.measurement_concept_id = c1.concept_id
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on m.measurement_source_concept_id = c2.concept_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on m.visit_occurrence_id = v.visit_occurrence_id
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on m.person_id = p.person_id
-  where c1.concept_class_id != 'Lab Test'"
+###################################################
+# insert observation data into cb_review_all_events #
+###################################################
+echo "Inserting observation data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_name, standard_code, standard_concept_id, standard_vocabulary, source_name,
+ source_code, source_concept_id, source_vocabulary, visit_type, age_at_event, domain)
+SELECT P.PERSON_ID,
+	 t.OBSERVATION_ID AS DATA_ID,
+     t.OBSERVATION_DATETIME as START_DATETIME,
+     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+	 case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+     CAST(FLOOR(DATE_DIFF(t.OBSERVATION_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+     'OBSERVATION' as domain
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` t
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.OBSERVATION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
 
-  ###################################################
-  # insert observation data into cb_review_all_events #
-  ###################################################
-  echo "Inserting observation data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-     (person_id, data_id, start_datetime, standard_name, standard_code, standard_concept_id, standard_vocabulary, source_name,
-   source_code, source_concept_id, source_vocabulary, visit_type, age_at_event, domain)
-  SELECT P.PERSON_ID,
-     t.OBSERVATION_ID AS DATA_ID,
-       t.OBSERVATION_DATETIME as START_DATETIME,
-       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+##########################################################
+# insert physicalMeasurement data into cb_review_all_events #
+##########################################################
+echo "Inserting pm data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+   source_concept_id, value_as_number, unit, age_at_event, domain, visit_type)
+SELECT P.PERSON_ID,
+	 t.MEASUREMENT_ID AS DATA_ID,
+     t.MEASUREMENT_DATETIME as START_DATETIME,
+     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
+     case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
+     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
+     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+     case when VALUE_AS_NUMBER is null then VALUE_AS_CONCEPT_ID else VALUE_AS_NUMBER end as VALUE_AS_NUMBER,
+     c3.CONCEPT_NAME AS UNIT,
+     CAST(FLOOR(DATE_DIFF(t.MEASUREMENT_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+     'PHYSICAL_MEASUREMENT' as domain,
+     case when c4.concept_name is null then '' else c4.concept_name end as visit_type
+FROM
+(select *
+from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+where measurement_source_concept_id in
+(select concept_id from \`$BQ_PROJECT.$BQ_DATASET.concept\` where vocabulary_id = 'PPI' and domain_id = 'Measurement' and CONCEPT_CLASS_ID = 'Clinical Observation')) t
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.MEASUREMENT_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.MEASUREMENT_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.UNIT_CONCEPT_ID = c3.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
+
+################################################
+# insert procedure data into cb_review_all_events #
+################################################
+echo "Inserting procedure data into cb_review_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
+   (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
+   source_concept_id, age_at_event, visit_type, domain)
+SELECT P.PERSON_ID,
+	 a.PROCEDURE_OCCURRENCE_ID AS DATA_ID,
+     a.PROCEDURE_DATETIME as START_DATETIME,
+     case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
      case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-       case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-       CAST(FLOOR(DATE_DIFF(t.OBSERVATION_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-       'OBSERVATION' as domain
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` t
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.OBSERVATION_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.OBSERVATION_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
-
-  ##########################################################
-  # insert physicalMeasurement data into cb_review_all_events #
-  ##########################################################
-  echo "Inserting pm data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-     source_concept_id, value_as_number, unit, age_at_event, domain, visit_type)
-  SELECT P.PERSON_ID,
-     t.MEASUREMENT_ID AS DATA_ID,
-       t.MEASUREMENT_DATETIME as START_DATETIME,
-       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-       case when c1.VOCABULARY_ID is null then 'None' else c1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end AS SOURCE_VOCABULARY,
-       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-       case when VALUE_AS_NUMBER is null then VALUE_AS_CONCEPT_ID else VALUE_AS_NUMBER end as VALUE_AS_NUMBER,
-       c3.CONCEPT_NAME AS UNIT,
-       CAST(FLOOR(DATE_DIFF(t.MEASUREMENT_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-       'PHYSICAL_MEASUREMENT' as domain,
-       case when c4.concept_name is null then '' else c4.concept_name end as visit_type
-  FROM
-  (select *
-  from \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-  where measurement_source_concept_id in
-  (select concept_id from \`$BQ_PROJECT.$BQ_DATASET.concept\` where vocabulary_id = 'PPI' and domain_id = 'Measurement' and CONCEPT_CLASS_ID = 'Clinical Observation')) t
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on t.MEASUREMENT_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on t.MEASUREMENT_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on t.UNIT_CONCEPT_ID = c3.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on t.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c4 on v.visit_concept_id = c4.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on t.PERSON_ID = p.PERSON_ID"
-
-  ################################################
-  # insert procedure data into cb_review_all_events #
-  ################################################
-  echo "Inserting procedure data into cb_review_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_review_all_events\`
-     (person_id, data_id, start_datetime, standard_code, standard_vocabulary, standard_name, standard_concept_id, source_code, source_vocabulary, source_name,
-     source_concept_id, age_at_event, visit_type, domain)
-  SELECT P.PERSON_ID,
-     a.PROCEDURE_OCCURRENCE_ID AS DATA_ID,
-       a.PROCEDURE_DATETIME as START_DATETIME,
-       case when c1.CONCEPT_CODE is null then 'No matching concept' else c1.CONCEPT_CODE end as STANDARD_CODE,
-       case when C1.VOCABULARY_ID is null then 'None' else C1.VOCABULARY_ID end AS STANDARD_VOCABULARY,
-       case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
-       case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
-       case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
-       case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
-       case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
-       case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
-       CAST(FLOOR(DATE_DIFF(a.PROCEDURE_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
-       case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
-       'PROCEDURE' as domain
-  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
-  left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"
-fi
+     case when c1.CONCEPT_NAME is null then 'No matching concept' else c1.CONCEPT_NAME end as STANDARD_NAME,
+     case when c1.CONCEPT_ID is null then 0 else c1.CONCEPT_ID end as STANDARD_CONCEPT_ID,
+     case when c2.CONCEPT_CODE is null then 'No matching concept' else c2.CONCEPT_CODE end as SOURCE_CODE,
+     case when c2.VOCABULARY_ID is null then 'None' else c2.VOCABULARY_ID end as SOURCE_VOCABULARY,
+     case when c2.CONCEPT_NAME is null then 'No matching concept' else c2.CONCEPT_NAME end as SOURCE_NAME,
+     case when c2.CONCEPT_ID is null then 0 else c2.CONCEPT_ID end as SOURCE_CONCEPT_ID,
+     CAST(FLOOR(DATE_DIFF(a.PROCEDURE_DATE, DATE(p.YEAR_OF_BIRTH, p.MONTH_OF_BIRTH, p.DAY_OF_BIRTH), MONTH)/12) as INT64) as AGE_AT_EVENT,
+     case when c3.concept_name is null then '' else c3.concept_name end as visit_type,
+     'PROCEDURE' as domain
+FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` a
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c1 on a.PROCEDURE_CONCEPT_ID = c1.CONCEPT_ID
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c2 on a.PROCEDURE_SOURCE_CONCEPT_ID = c2.CONCEPT_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v on a.VISIT_OCCURRENCE_ID = v.VISIT_OCCURRENCE_ID
+left join \`$BQ_PROJECT.$BQ_DATASET.concept\` c3 on v.visit_concept_id = c3.concept_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on a.PERSON_ID = p.PERSON_ID"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
@@ -10,630 +10,653 @@ export CDR_DATE=$3          # cdr date
 export DATA_BROWSER=$4      # data browser flag
 export DRY_RUN=$5           # dry run
 
-if [ "$DRY_RUN" == false ]
+if [ "$DRY_RUN" == true ]
 then
-  # Check that bq_dataset exists and exit if not
-  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-  if [ -z "$datasets" ]
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.device_exposure")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
+  test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
+  if [ "$BQ_PROJECT:$BQ_DATASET" != "all-of-us-ehr-dev:synthetic_cdr20180606" ]
   then
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.device_exposure_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement_ext")
+    test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence_ext")
   fi
-  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-  else
-    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-    exit 1
-  fi
-
-  # Create bq tables we have json schema for
-  schema_path=generate-cdr/bq-schemas
-
-  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_person
-  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_person.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_search_person
-
-  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_all_events
-  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_all_events.json --time_partitioning_type=DAY --clustering_fields concept_id $BQ_DATASET.cb_search_all_events
-
-  ################################################
-  # insert person data into cb_search_person
-  ################################################
-  echo "Inserting person data into cb_search_person"
-  if [ "$DATA_BROWSER" == true ]
-  then
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
-      (person_id, gender, race, ethnicity, dob)
-    SELECT p.person_id,
-      case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
-      case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
-      case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
-      date(birth_datetime) as dob
-    FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
-  else
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
-      (person_id, gender, sex_at_birth, race, ethnicity, dob)
-    SELECT p.person_id,
-      case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
-      case when p.sex_at_birth_concept_id = 0 then 'Unknown' else s.concept_name end as sex_at_birth,
-      case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
-      case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
-      date(birth_datetime) as dob
-    FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
-    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
-  fi
-
-  ################################################
-  # set age_at_consent and age_at_cdr to each subject
-  ################################################
-  # To get date_of_consent, we first try to find a consent date, if none, we fall back to Street Address: PII State
-  # If that does not exist, we fall back to the MINIMUM date of The Basics Survey
-  echo "adding age data to cb_search_person"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-  SET x.age_at_consent = y.age_at_consent,
-      x.age_at_cdr = y.age_at_cdr
-  FROM
-      (
-          SELECT person_id
-              ,date_of_birth
-              ,CAST(FLOOR(DATE_DIFF(date_of_consent, date_of_birth, month)/12) as INT64) as age_at_consent
-              ,CAST(FLOOR(DATE_DIFF(date_of_cdr, date_of_birth, month)/12) as INT64) as age_at_cdr
-          FROM
-          (
-              SELECT a.person_id
-                  , date(a.birth_datetime) as date_of_birth
-                  , coalesce(b.observation_date, c.observation_date, d.observation_date) as date_of_consent
-                  , date('$CDR_DATE') as date_of_cdr
-              FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-              LEFT JOIN
-              (
-                  -- Consent Date
-                  SELECT *
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                  WHERE observation_source_concept_id = 1585482
-              ) b on a.person_id = b.person_id
-              LEFT JOIN
-              (
-                  -- Street Address: PII State
-                  SELECT *
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                  WHERE observation_source_concept_id = 1585249
-              ) c on a.person_id = c.person_id
-              LEFT JOIN
-              (
-                  -- The Basics
-                  SELECT person_id, MIN(observation_date) as observation_date
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                  WHERE observation_source_concept_id in
-                      (
-                          SELECT descendant_concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                          WHERE ancestor_concept_id = 1586134
-                      )
-                  GROUP BY 1
-              ) d on a.person_id = d.person_id
-          )
-      ) y
-  WHERE x.person_id = y.person_id"
-
-  ################################################
-  # set has physical measurement data flag
-  ################################################
-  echo "set has physical measurement data flag in cb_search_person"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-  SET x.has_physical_measurement_data = y.has_data
-  FROM
-      (
-          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-          LEFT JOIN
-              (
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-                  WHERE measurement_source_concept_id in
-                      (
-                          SELECT concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-                          WHERE vocabulary_id = 'PPI'
-                              and concept_class_id = 'Clinical Observation'
-                              and domain_id = 'Measurement'
-                      )
-              ) b on a.person_id = b.person_id
-      ) y
-  WHERE x.person_id = y.person_id"
-
-  ################################################
-  # set has ppi survey data flag
-  ################################################
-  echo "set has ppi survey data flag in cb_search_person"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-  SET x.has_ppi_survey_data = y.has_data
-  FROM
-      (
-          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-          LEFT JOIN
-              (
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                  WHERE observation_source_concept_id in
-                      (
-                          SELECT descendant_concept_id
-                          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                          WHERE ancestor_concept_id in
-                              (
-                                  SELECT concept_id
-                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                  WHERE domain_id = 'SURVEY'
-                                      and parent_id = 0
-                              )
-                      )
-              ) b on a.person_id = b.person_id
-      ) y
-  WHERE x.person_id = y.person_id"
-
-  ################################################
-  # set has EHR data flag
-  ################################################
-  echo "set has EHR data flag in cb_search_person"
-  if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ] || [ "$DATA_BROWSER" == true ]
-  then
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-    SET x.has_ehr_data = y.has_data
-    FROM
-        (
-            SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-            FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-            LEFT JOIN
-                (
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.measurement_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.condition_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.device_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.drug_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.observation_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.procedure_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.visit_source_concept_id = b.concept_id
-                    WHERE b.vocabulary_id != 'PPI'
-                ) b on a.person_id = b.person_id
-        ) y
-    WHERE x.person_id = y.person_id"
-  else
-    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-    "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-    SET x.has_ehr_data = y.has_data
-    FROM
-        (
-            SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-            FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-            LEFT JOIN
-                (
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.measurement_ext\` as b on a.measurement_id = b.measurement_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence_ext\` as b on a.condition_occurrence_id = b.condition_occurrence_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.device_exposure_ext\` as b on a.device_exposure_id = b.device_exposure_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.drug_exposure_ext\` as b on a.drug_exposure_id = b.drug_exposure_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.observation_ext\` as b on a.observation_id = b.observation_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence_ext\` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                    UNION DISTINCT
-                    SELECT DISTINCT person_id
-                    FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
-                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence_ext\` as b on a.visit_occurrence_id = b.visit_occurrence_id
-                    WHERE lower(b.src_id) like 'ehr site%'
-                ) b on a.person_id = b.person_id
-        ) y
-    WHERE x.person_id = y.person_id"
-  fi
-
-  ############################################################
-  # insert source condition data into cb_search_all_events
-  ############################################################
-  echo "Inserting source conditions data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      co.condition_start_date as entry_date,
-      co.condition_start_datetime as entry_datetime,
-      0 as is_standard,
-      co.condition_source_concept_id as concept_id,
-      'Condition' as domain,
-      cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_source_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
-  where co.condition_source_concept_id is not null
-      and co.condition_source_concept_id != 0"
-
-  ##############################################################
-  # insert standard condition data into cb_search_all_events
-  ##############################################################
-  echo "Inserting standard conditions data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      co.condition_start_date as entry_date,
-      co.condition_start_datetime as entry_datetime,
-      1 as is_standard,
-      co.condition_concept_id as concept_id,
-      'Condition' as domain,
-      cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
-  WHERE co.condition_concept_id is not null
-      and co.condition_concept_id != 0"
-
-  ############################################################
-  #   insert source procedure data into cb_search_all_events
-  ############################################################
-  echo "Inserting source procedures data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      po.procedure_date as entry_date,
-      po.procedure_datetime as entry_datetime,
-      0 as is_standard,
-      po.procedure_source_concept_id as concept_id,
-      'Procedure' as domain,
-      cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_source_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
-  WHERE po.procedure_source_concept_id is not null
-      and po.procedure_source_concept_id != 0"
-
-  ##############################################################
-  #   insert standard procedure data into cb_search_all_events
-  ##############################################################
-  echo "Inserting standard procedures data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      po.procedure_date as entry_date,
-      po.procedure_datetime as entry_datetime,
-      1 as is_standard,
-      po.procedure_concept_id as concept_id,
-      'Procedure' as domain,
-      cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
-  WHERE po.procedure_concept_id is not null
-      and po.procedure_concept_id != 0"
-
-  ##############################################################
-  # insert source measurement data into cb_search_all_events
-  ##############################################################
-  echo "Inserting source measurement data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-      visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
-  SELECT p.person_id,
-      m.measurement_date as entry_date,
-      m.measurement_datetime as entry_datetime,
-      0 as is_standard,
-      m.measurement_source_concept_id as concept_id,
-      'Measurement' as domain,
-      cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id,
-      m.value_as_number,
-      m.value_as_concept_id,
-      case when measurement_source_concept_id = 903118 then m.value_as_number end as systolic,
-      case when measurement_source_concept_id = 903115 then m.value_as_number end as diastolic
-  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_source_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
-  WHERE m.measurement_source_concept_id is not null
-      and m.measurement_source_concept_id != 0"
-
-  #####################################################################
-  # update source diastolic pressure data into cb_search_all_events
-  #####################################################################
-  echo "Updating diastolic pressure data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-  SET sad.diastolic = meas.diastolic
-  FROM
-      (
-          SELECT m.person_id,
-              m.measurement_datetime,
-              m.value_as_number as diastolic
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-          WHERE m.measurement_source_concept_id = 903115
-          GROUP BY m.person_id, m.measurement_datetime, diastolic
-      ) as meas
-  WHERE meas.person_id = sad.person_id
-      and meas.measurement_datetime = sad.entry_datetime
-      and sad.is_standard = 0
-      and sad.concept_id = 903118"
-
-  #####################################################################
-  #   update source systolic pressure data into cb_search_all_events
-  #####################################################################
-  echo "Updating diastolic pressure data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-  SET sad.systolic = meas.systolic
-  FROM
-      (
-          SELECT m.person_id,
-              m.measurement_datetime,
-              m.value_as_number as systolic
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-          WHERE m.measurement_source_concept_id = 903118
-          GROUP BY m.person_id, m.measurement_datetime, systolic
-      ) as meas
-  WHERE meas.person_id = sad.person_id
-      and meas.measurement_datetime = sad.entry_datetime
-      and sad.is_standard = 0
-      and sad.concept_id = 903115"
-
-  ################################################################
-  #   insert standard measurement data into cb_search_all_events
-  ################################################################
-  echo "Inserting measurement data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-      visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
-  SELECT p.person_id,
-      m.measurement_date as entry_date,
-      m.measurement_datetime as entry_datetime,
-      1 as is_standard,
-      m.measurement_concept_id as concept_id,
-      'Measurement' as domain,
-      cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id,
-      m.value_as_number,
-      m.value_as_concept_id,
-      case when measurement_concept_id = 903118 then m.value_as_number end as systolic,
-      case when measurement_concept_id = 903115 then m.value_as_number end as diastolic
-  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
-  WHERE m.measurement_concept_id is not null
-      and m.measurement_concept_id != 0"
-
-  #####################################################################
-  #   update standard diastolic pressure data into cb_search_all_events
-  #######################################################################
-  echo "Updating diastolic pressure data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-  SET sad.diastolic = meas.diastolic
-  FROM
-      (
-          SELECT m.person_id,
-              m.measurement_datetime,
-              m.value_as_number as diastolic
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-          WHERE m.measurement_concept_id = 903115
-          GROUP BY m.person_id, m.measurement_datetime, diastolic
-      ) as meas
-  WHERE meas.person_id = sad.person_id
-      and meas.measurement_datetime = sad.entry_datetime
-      and sad.is_standard = 1
-      and sad.concept_id = 903118"
-
-  #######################################################################
-  #   update standard diastolic pressure data into cb_search_all_events
-  #######################################################################
-  echo "Updating diastolic pressure data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-  SET sad.systolic = meas.systolic
-  FROM
-      (
-          SELECT m.person_id,
-              m.measurement_datetime,
-              m.value_as_number as systolic
-          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-          WHERE m.measurement_concept_id = 903118
-          GROUP BY m.person_id, m.measurement_datetime, systolic
-      ) as meas
-  WHERE meas.person_id = sad.person_id
-      and meas.measurement_datetime = sad.entry_datetime
-      and sad.is_standard = 1
-      and sad.concept_id = 903115"
-
-  ##############################################################
-  #   insert source observation data into cb_search_all_events
-  ##############################################################
-  echo "Inserting observation data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-      visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
-  SELECT p.person_id,
-      o.observation_date as entry_date,
-      o.observation_datetime as entry_datetime,
-      0 as is_standard,
-      o.observation_source_concept_id as concept_id,
-      'Observation' as domain,
-      cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id,
-      o.value_as_number,
-      o.value_as_concept_id,
-      o.value_source_concept_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_source_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
-  WHERE o.observation_source_concept_id is not null
-      and o.observation_source_concept_id != 0"
-
-  ################################################################
-  #   insert standard observation data into cb_search_all_events
-  ################################################################
-  echo "Inserting observation data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-      visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
-  SELECT p.person_id,
-      o.observation_date as entry_date,
-      o.observation_datetime as entry_datetime,
-      1 as is_standard,
-      o.observation_concept_id as concept_id,
-      'Observation' as domain,
-      cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id,
-      o.value_as_number,
-      o.value_as_concept_id,
-      o.value_source_concept_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
-  WHERE o.observation_concept_id is not null
-      and o.observation_concept_id != 0"
-
-  #######################################################
-  #   insert source drug data into cb_search_all_events
-  #######################################################
-  echo "Inserting drug data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      d.drug_exposure_start_date as entry_date,
-      d.drug_exposure_start_datetime as entry_datetime,
-      0 as is_standard,
-      d.drug_source_concept_id as concept_id,
-      'Drug' as domain,
-      cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_source_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
-  WHERE d.drug_source_concept_id is not null
-      and d.drug_source_concept_id != 0"
-
-  #########################################################
-  #   insert standard drug data into cb_search_all_events
-  #########################################################
-  echo "Inserting drug data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      d.drug_exposure_start_date as entry_date,
-      d.drug_exposure_start_datetime as entry_datetime,
-      1 as is_standard,
-      d.drug_concept_id as concept_id,
-      'Drug' as domain,
-      cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      vo.visit_concept_id,
-      vo.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
-  WHERE d.drug_concept_id is not null
-      and d.drug_concept_id != 0"
-
-  ##########################################################
-  #   insert standard visit data into cb_search_all_events
-  ##########################################################
-  echo "Inserting visit data into cb_search_all_events"
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-  SELECT p.person_id,
-      v.visit_start_date as entry_date,
-      v.visit_start_datetime as entry_datetime,
-      1 as is_standard,
-      v.visit_concept_id as concept_id,
-      'Visit' as domain,
-      cast(floor(date_diff(v.visit_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-      v.visit_concept_id,
-      v.visit_occurrence_id
-  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = v.person_id
-  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = v.visit_concept_id)
-  WHERE v.visit_concept_id is not null
-      and v.visit_concept_id != 0"
+  exit 0
 fi
+
+# Check that bq_dataset exists and exit if not
+datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+if [ -z "$datasets" ]
+then
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+else
+  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+  exit 1
+fi
+
+# Create bq tables we have json schema for
+schema_path=generate-cdr/bq-schemas
+
+bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_person
+bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_person.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_search_person
+
+bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_all_events
+bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_all_events.json --time_partitioning_type=DAY --clustering_fields concept_id $BQ_DATASET.cb_search_all_events
+
+################################################
+# insert person data into cb_search_person
+################################################
+echo "Inserting person data into cb_search_person"
+if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ]
+then
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+    (person_id, gender, sex_at_birth, race, ethnicity, dob)
+  SELECT p.person_id,
+    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
+    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as sex_at_birth,
+    case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
+    case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
+    date(birth_datetime) as dob
+  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+else
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+    (person_id, gender, sex_at_birth, race, ethnicity, dob)
+  SELECT p.person_id,
+    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
+    case when p.sex_at_birth_concept_id = 0 then 'Unknown' else s.concept_name end as sex_at_birth,
+    case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
+    case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
+    date(birth_datetime) as dob
+  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+fi
+
+################################################
+# set age_at_consent and age_at_cdr to each subject
+################################################
+# To get date_of_consent, we first try to find a consent date, if none, we fall back to Street Address: PII State
+# If that does not exist, we fall back to the MINIMUM date of The Basics Survey
+echo "adding age data to cb_search_person"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+SET x.age_at_consent = y.age_at_consent,
+    x.age_at_cdr = y.age_at_cdr
+FROM
+    (
+        SELECT person_id
+            ,date_of_birth
+            ,CAST(FLOOR(DATE_DIFF(date_of_consent, date_of_birth, month)/12) as INT64) as age_at_consent
+            ,CAST(FLOOR(DATE_DIFF(date_of_cdr, date_of_birth, month)/12) as INT64) as age_at_cdr
+        FROM
+        (
+            SELECT a.person_id
+                , date(a.birth_datetime) as date_of_birth
+                , coalesce(b.observation_date, c.observation_date, d.observation_date) as date_of_consent
+                , date('$CDR_DATE') as date_of_cdr
+            FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+            LEFT JOIN
+            (
+                -- Consent Date
+                SELECT *
+                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                WHERE observation_source_concept_id = 1585482
+            ) b on a.person_id = b.person_id
+            LEFT JOIN
+            (
+                -- Street Address: PII State
+                SELECT *
+                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                WHERE observation_source_concept_id = 1585249
+            ) c on a.person_id = c.person_id
+            LEFT JOIN
+            (
+                -- The Basics
+                SELECT person_id, MIN(observation_date) as observation_date
+                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                WHERE observation_source_concept_id in
+                    (
+                        SELECT descendant_concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                        WHERE ancestor_concept_id = 1586134
+                    )
+                GROUP BY 1
+            ) d on a.person_id = d.person_id
+        )
+    ) y
+WHERE x.person_id = y.person_id"
+
+################################################
+# set has physical measurement data flag
+################################################
+echo "set has physical measurement data flag in cb_search_person"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+SET x.has_physical_measurement_data = y.has_data
+FROM
+    (
+        SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+        LEFT JOIN
+            (
+                SELECT DISTINCT person_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+                WHERE measurement_source_concept_id in
+                    (
+                        SELECT concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+                        WHERE vocabulary_id = 'PPI'
+                            and concept_class_id = 'Clinical Observation'
+                            and domain_id = 'Measurement'
+                    )
+            ) b on a.person_id = b.person_id
+    ) y
+WHERE x.person_id = y.person_id"
+
+################################################
+# set has ppi survey data flag
+################################################
+echo "set has ppi survey data flag in cb_search_person"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+SET x.has_ppi_survey_data = y.has_data
+FROM
+    (
+        SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+        LEFT JOIN
+            (
+                SELECT DISTINCT person_id
+                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                WHERE observation_source_concept_id in
+                    (
+                        SELECT descendant_concept_id
+                        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                        WHERE ancestor_concept_id in
+                            (
+                                SELECT concept_id
+                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                WHERE domain_id = 'SURVEY'
+                                    and parent_id = 0
+                            )
+                    )
+            ) b on a.person_id = b.person_id
+    ) y
+WHERE x.person_id = y.person_id"
+
+################################################
+# set has EHR data flag
+################################################
+echo "set has EHR data flag in cb_search_person"
+if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ]
+then
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+  SET x.has_ehr_data = y.has_data
+  FROM
+      (
+          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+          LEFT JOIN
+              (
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.measurement_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.condition_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.device_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.drug_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.observation_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.procedure_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.visit_source_concept_id = b.concept_id
+                  WHERE b.vocabulary_id != 'PPI'
+              ) b on a.person_id = b.person_id
+      ) y
+  WHERE x.person_id = y.person_id"
+else
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+  SET x.has_ehr_data = y.has_data
+  FROM
+      (
+          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+          LEFT JOIN
+              (
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.measurement_ext\` as b on a.measurement_id = b.measurement_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence_ext\` as b on a.condition_occurrence_id = b.condition_occurrence_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.device_exposure_ext\` as b on a.device_exposure_id = b.device_exposure_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.drug_exposure_ext\` as b on a.drug_exposure_id = b.drug_exposure_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.observation_ext\` as b on a.observation_id = b.observation_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence_ext\` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+                  UNION DISTINCT
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
+                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence_ext\` as b on a.visit_occurrence_id = b.visit_occurrence_id
+                  WHERE lower(b.src_id) like 'ehr site%'
+              ) b on a.person_id = b.person_id
+      ) y
+  WHERE x.person_id = y.person_id"
+fi
+
+############################################################
+# insert source condition data into cb_search_all_events
+############################################################
+echo "Inserting source conditions data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    co.condition_start_date as entry_date,
+    co.condition_start_datetime as entry_datetime,
+    0 as is_standard,
+    co.condition_source_concept_id as concept_id,
+    'Condition' as domain,
+    cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_source_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
+where co.condition_source_concept_id is not null
+    and co.condition_source_concept_id != 0"
+
+##############################################################
+# insert standard condition data into cb_search_all_events
+##############################################################
+echo "Inserting standard conditions data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    co.condition_start_date as entry_date,
+    co.condition_start_datetime as entry_datetime,
+    1 as is_standard,
+    co.condition_concept_id as concept_id,
+    'Condition' as domain,
+    cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
+WHERE co.condition_concept_id is not null
+    and co.condition_concept_id != 0"
+
+############################################################
+#   insert source procedure data into cb_search_all_events
+############################################################
+echo "Inserting source procedures data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    po.procedure_date as entry_date,
+    po.procedure_datetime as entry_datetime,
+    0 as is_standard,
+    po.procedure_source_concept_id as concept_id,
+    'Procedure' as domain,
+    cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_source_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
+WHERE po.procedure_source_concept_id is not null
+    and po.procedure_source_concept_id != 0"
+
+##############################################################
+#   insert standard procedure data into cb_search_all_events
+##############################################################
+echo "Inserting standard procedures data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    po.procedure_date as entry_date,
+    po.procedure_datetime as entry_datetime,
+    1 as is_standard,
+    po.procedure_concept_id as concept_id,
+    'Procedure' as domain,
+    cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
+WHERE po.procedure_concept_id is not null
+    and po.procedure_concept_id != 0"
+
+##############################################################
+# insert source measurement data into cb_search_all_events
+##############################################################
+echo "Inserting source measurement data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+    visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
+SELECT p.person_id,
+    m.measurement_date as entry_date,
+    m.measurement_datetime as entry_datetime,
+    0 as is_standard,
+    m.measurement_source_concept_id as concept_id,
+    'Measurement' as domain,
+    cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id,
+    m.value_as_number,
+    m.value_as_concept_id,
+    case when measurement_source_concept_id = 903118 then m.value_as_number end as systolic,
+    case when measurement_source_concept_id = 903115 then m.value_as_number end as diastolic
+FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_source_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
+WHERE m.measurement_source_concept_id is not null
+    and m.measurement_source_concept_id != 0"
+
+#####################################################################
+# update source diastolic pressure data into cb_search_all_events
+#####################################################################
+echo "Updating diastolic pressure data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+SET sad.diastolic = meas.diastolic
+FROM
+    (
+        SELECT m.person_id,
+            m.measurement_datetime,
+            m.value_as_number as diastolic
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+        WHERE m.measurement_source_concept_id = 903115
+        GROUP BY m.person_id, m.measurement_datetime, diastolic
+    ) as meas
+WHERE meas.person_id = sad.person_id
+    and meas.measurement_datetime = sad.entry_datetime
+    and sad.is_standard = 0
+    and sad.concept_id = 903118"
+
+#####################################################################
+#   update source systolic pressure data into cb_search_all_events
+#####################################################################
+echo "Updating diastolic pressure data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+SET sad.systolic = meas.systolic
+FROM
+    (
+        SELECT m.person_id,
+            m.measurement_datetime,
+            m.value_as_number as systolic
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+        WHERE m.measurement_source_concept_id = 903118
+        GROUP BY m.person_id, m.measurement_datetime, systolic
+    ) as meas
+WHERE meas.person_id = sad.person_id
+    and meas.measurement_datetime = sad.entry_datetime
+    and sad.is_standard = 0
+    and sad.concept_id = 903115"
+
+################################################################
+#   insert standard measurement data into cb_search_all_events
+################################################################
+echo "Inserting measurement data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+    visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
+SELECT p.person_id,
+    m.measurement_date as entry_date,
+    m.measurement_datetime as entry_datetime,
+    1 as is_standard,
+    m.measurement_concept_id as concept_id,
+    'Measurement' as domain,
+    cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id,
+    m.value_as_number,
+    m.value_as_concept_id,
+    case when measurement_concept_id = 903118 then m.value_as_number end as systolic,
+    case when measurement_concept_id = 903115 then m.value_as_number end as diastolic
+FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
+WHERE m.measurement_concept_id is not null
+    and m.measurement_concept_id != 0"
+
+#####################################################################
+#   update standard diastolic pressure data into cb_search_all_events
+#######################################################################
+echo "Updating diastolic pressure data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+SET sad.diastolic = meas.diastolic
+FROM
+    (
+        SELECT m.person_id,
+            m.measurement_datetime,
+            m.value_as_number as diastolic
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+        WHERE m.measurement_concept_id = 903115
+        GROUP BY m.person_id, m.measurement_datetime, diastolic
+    ) as meas
+WHERE meas.person_id = sad.person_id
+    and meas.measurement_datetime = sad.entry_datetime
+    and sad.is_standard = 1
+    and sad.concept_id = 903118"
+
+#######################################################################
+#   update standard diastolic pressure data into cb_search_all_events
+#######################################################################
+echo "Updating diastolic pressure data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+SET sad.systolic = meas.systolic
+FROM
+    (
+        SELECT m.person_id,
+            m.measurement_datetime,
+            m.value_as_number as systolic
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+        WHERE m.measurement_concept_id = 903118
+        GROUP BY m.person_id, m.measurement_datetime, systolic
+    ) as meas
+WHERE meas.person_id = sad.person_id
+    and meas.measurement_datetime = sad.entry_datetime
+    and sad.is_standard = 1
+    and sad.concept_id = 903115"
+
+##############################################################
+#   insert source observation data into cb_search_all_events
+##############################################################
+echo "Inserting observation data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+    visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
+SELECT p.person_id,
+    o.observation_date as entry_date,
+    o.observation_datetime as entry_datetime,
+    0 as is_standard,
+    o.observation_source_concept_id as concept_id,
+    'Observation' as domain,
+    cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id,
+    o.value_as_number,
+    o.value_as_concept_id,
+    o.value_source_concept_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_source_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
+WHERE o.observation_source_concept_id is not null
+    and o.observation_source_concept_id != 0"
+
+################################################################
+#   insert standard observation data into cb_search_all_events
+################################################################
+echo "Inserting observation data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+    visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
+SELECT p.person_id,
+    o.observation_date as entry_date,
+    o.observation_datetime as entry_datetime,
+    1 as is_standard,
+    o.observation_concept_id as concept_id,
+    'Observation' as domain,
+    cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id,
+    o.value_as_number,
+    o.value_as_concept_id,
+    o.value_source_concept_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
+WHERE o.observation_concept_id is not null
+    and o.observation_concept_id != 0"
+
+#######################################################
+#   insert source drug data into cb_search_all_events
+#######################################################
+echo "Inserting drug data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    d.drug_exposure_start_date as entry_date,
+    d.drug_exposure_start_datetime as entry_datetime,
+    0 as is_standard,
+    d.drug_source_concept_id as concept_id,
+    'Drug' as domain,
+    cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_source_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
+WHERE d.drug_source_concept_id is not null
+    and d.drug_source_concept_id != 0"
+
+#########################################################
+#   insert standard drug data into cb_search_all_events
+#########################################################
+echo "Inserting drug data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    d.drug_exposure_start_date as entry_date,
+    d.drug_exposure_start_datetime as entry_datetime,
+    1 as is_standard,
+    d.drug_concept_id as concept_id,
+    'Drug' as domain,
+    cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    vo.visit_concept_id,
+    vo.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_concept_id)
+LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
+WHERE d.drug_concept_id is not null
+    and d.drug_concept_id != 0"
+
+##########################################################
+#   insert standard visit data into cb_search_all_events
+##########################################################
+echo "Inserting visit data into cb_search_all_events"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+SELECT p.person_id,
+    v.visit_start_date as entry_date,
+    v.visit_start_datetime as entry_datetime,
+    1 as is_standard,
+    v.visit_concept_id as concept_id,
+    'Visit' as domain,
+    cast(floor(date_diff(v.visit_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+    v.visit_concept_id,
+    v.visit_occurrence_id
+FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v
+JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = v.person_id
+JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = v.visit_concept_id)
+WHERE v.visit_concept_id is not null
+    and v.visit_concept_id != 0"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
@@ -4,632 +4,636 @@
 
 set -ex
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
-export CDR_DATE=$3 # cdr date
+export BQ_PROJECT=$1        # project
+export BQ_DATASET=$2        # dataset
+export CDR_DATE=$3          # cdr date
 export DATA_BROWSER_FLAG=$4 # data browser flag
+export DRY_RUN=$5           # dry run
 
-# Check that bq_dataset exists and exit if not
-datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
-if [ -z "$datasets" ]
+if [ "$DRY_RUN" == false ]
 then
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
-if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
-  echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
-else
-  echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
-  exit 1
-fi
+  # Check that bq_dataset exists and exit if not
+  datasets=$(bq --project=$BQ_PROJECT ls --max_results=1000)
+  if [ -z "$datasets" ]
+  then
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
+  if [[ $datasets =~ .*$BQ_DATASET.* ]]; then
+    echo "$BQ_PROJECT.$BQ_DATASET exists. Good. Carrying on."
+  else
+    echo "$BQ_PROJECT.$BQ_DATASET does not exist. Please specify a valid project and dataset."
+    exit 1
+  fi
 
-# Create bq tables we have json schema for
-schema_path=generate-cdr/bq-schemas
+  # Create bq tables we have json schema for
+  schema_path=generate-cdr/bq-schemas
 
-bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_person
-bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_person.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_search_person
+  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_person
+  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_person.json --time_partitioning_type=DAY --clustering_fields person_id $BQ_DATASET.cb_search_person
 
-bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_all_events
-bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_all_events.json --time_partitioning_type=DAY --clustering_fields concept_id $BQ_DATASET.cb_search_all_events
+  bq --project=$BQ_PROJECT rm -f $BQ_DATASET.cb_search_all_events
+  bq --quiet --project=$BQ_PROJECT mk --schema=$schema_path/cb_search_all_events.json --time_partitioning_type=DAY --clustering_fields concept_id $BQ_DATASET.cb_search_all_events
 
-################################################
-# insert person data into cb_search_person
-################################################
-echo "Inserting person data into cb_search_person"
-if [ "$DATA_BROWSER_FLAG" == true ]
-then
+  ################################################
+  # insert person data into cb_search_person
+  ################################################
+  echo "Inserting person data into cb_search_person"
+  if [ "$DATA_BROWSER_FLAG" == true ]
+  then
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+      (person_id, gender, race, ethnicity, dob)
+    SELECT p.person_id,
+      case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
+      case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
+      case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
+      date(birth_datetime) as dob
+    FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+  else
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+      (person_id, gender, sex_at_birth, race, ethnicity, dob)
+    SELECT p.person_id,
+      case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
+      case when p.sex_at_birth_concept_id = 0 then 'Unknown' else s.concept_name end as sex_at_birth,
+      case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
+      case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
+      date(birth_datetime) as dob
+    FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
+    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
+  fi
+
+  ################################################
+  # set age_at_consent and age_at_cdr to each subject
+  ################################################
+  # To get date_of_consent, we first try to find a consent date, if none, we fall back to Street Address: PII State
+  # If that does not exist, we fall back to the MINIMUM date of The Basics Survey
+  echo "adding age data to cb_search_person"
   bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
-    (person_id, gender, race, ethnicity, dob)
-  SELECT p.person_id,
-    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
-    case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
-    case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
-    date(birth_datetime) as dob
-  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
-else
-  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
-    (person_id, gender, sex_at_birth, race, ethnicity, dob)
-  SELECT p.person_id,
-    case when p.gender_concept_id = 0 then 'Unknown' else g.concept_name end as gender,
-    case when p.sex_at_birth_concept_id = 0 then 'Unknown' else s.concept_name end as sex_at_birth,
-    case when p.race_concept_id = 0 then 'Unknown' else regexp_replace(r.concept_name, r'^.+:\s', '') end as race,
-    case when e.concept_name is null then 'Unknown' else regexp_replace(e.concept_name, r'^.+:\s', '') end as ethnicity,
-    date(birth_datetime) as dob
-  FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` g on (p.gender_concept_id = g.concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` s on (p.sex_at_birth_concept_id = s.concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` r on (p.race_concept_id = r.concept_id)
-  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` e on (p.ethnicity_concept_id = e.concept_id)"
-fi
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+  SET x.age_at_consent = y.age_at_consent,
+      x.age_at_cdr = y.age_at_cdr
+  FROM
+      (
+          SELECT person_id
+              ,date_of_birth
+              ,CAST(FLOOR(DATE_DIFF(date_of_consent, date_of_birth, month)/12) as INT64) as age_at_consent
+              ,CAST(FLOOR(DATE_DIFF(date_of_cdr, date_of_birth, month)/12) as INT64) as age_at_cdr
+          FROM
+          (
+              SELECT a.person_id
+                  , date(a.birth_datetime) as date_of_birth
+                  , coalesce(b.observation_date, c.observation_date, d.observation_date) as date_of_consent
+                  , date('$CDR_DATE') as date_of_cdr
+              FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+              LEFT JOIN
+              (
+                  -- Consent Date
+                  SELECT *
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                  WHERE observation_source_concept_id = 1585482
+              ) b on a.person_id = b.person_id
+              LEFT JOIN
+              (
+                  -- Street Address: PII State
+                  SELECT *
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                  WHERE observation_source_concept_id = 1585249
+              ) c on a.person_id = c.person_id
+              LEFT JOIN
+              (
+                  -- The Basics
+                  SELECT person_id, MIN(observation_date) as observation_date
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                  WHERE observation_source_concept_id in
+                      (
+                          SELECT descendant_concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                          WHERE ancestor_concept_id = 1586134
+                      )
+                  GROUP BY 1
+              ) d on a.person_id = d.person_id
+          )
+      ) y
+  WHERE x.person_id = y.person_id"
 
-################################################
-# set age_at_consent and age_at_cdr to each subject
-################################################
-# To get date_of_consent, we first try to find a consent date, if none, we fall back to Street Address: PII State
-# If that does not exist, we fall back to the MINIMUM date of The Basics Survey
-echo "adding age data to cb_search_person"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-SET x.age_at_consent = y.age_at_consent,
-    x.age_at_cdr = y.age_at_cdr
-FROM
-    (
-        SELECT person_id
-            ,date_of_birth
-            ,CAST(FLOOR(DATE_DIFF(date_of_consent, date_of_birth, month)/12) as INT64) as age_at_consent
-            ,CAST(FLOOR(DATE_DIFF(date_of_cdr, date_of_birth, month)/12) as INT64) as age_at_cdr
-        FROM
+  ################################################
+  # set has physical measurement data flag
+  ################################################
+  echo "set has physical measurement data flag in cb_search_person"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+  SET x.has_physical_measurement_data = y.has_data
+  FROM
+      (
+          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+          LEFT JOIN
+              (
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
+                  WHERE measurement_source_concept_id in
+                      (
+                          SELECT concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
+                          WHERE vocabulary_id = 'PPI'
+                              and concept_class_id = 'Clinical Observation'
+                              and domain_id = 'Measurement'
+                      )
+              ) b on a.person_id = b.person_id
+      ) y
+  WHERE x.person_id = y.person_id"
+
+  ################################################
+  # set has ppi survey data flag
+  ################################################
+  echo "set has ppi survey data flag in cb_search_person"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+  SET x.has_ppi_survey_data = y.has_data
+  FROM
+      (
+          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
+          LEFT JOIN
+              (
+                  SELECT DISTINCT person_id
+                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
+                  WHERE observation_source_concept_id in
+                      (
+                          SELECT descendant_concept_id
+                          FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
+                          WHERE ancestor_concept_id in
+                              (
+                                  SELECT concept_id
+                                  FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                                  WHERE domain_id = 'SURVEY'
+                                      and parent_id = 0
+                              )
+                      )
+              ) b on a.person_id = b.person_id
+      ) y
+  WHERE x.person_id = y.person_id"
+
+  ################################################
+  # set has EHR data flag
+  ################################################
+  echo "set has EHR data flag in cb_search_person"
+  if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ] || [ "$DATA_BROWSER_FLAG" == true ]
+  then
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+    SET x.has_ehr_data = y.has_data
+    FROM
         (
-            SELECT a.person_id
-                , date(a.birth_datetime) as date_of_birth
-                , coalesce(b.observation_date, c.observation_date, d.observation_date) as date_of_consent
-                , date('$CDR_DATE') as date_of_cdr
+            SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
             FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
             LEFT JOIN
-            (
-                -- Consent Date
-                SELECT *
-                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                WHERE observation_source_concept_id = 1585482
-            ) b on a.person_id = b.person_id
+                (
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.measurement_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.condition_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.device_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.drug_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.observation_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.procedure_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.visit_source_concept_id = b.concept_id
+                    WHERE b.vocabulary_id != 'PPI'
+                ) b on a.person_id = b.person_id
+        ) y
+    WHERE x.person_id = y.person_id"
+  else
+    bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+    "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+    SET x.has_ehr_data = y.has_data
+    FROM
+        (
+            SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
+            FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
             LEFT JOIN
-            (
-                -- Street Address: PII State
-                SELECT *
-                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                WHERE observation_source_concept_id = 1585249
-            ) c on a.person_id = c.person_id
-            LEFT JOIN
-            (
-                -- The Basics
-                SELECT person_id, MIN(observation_date) as observation_date
-                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                WHERE observation_source_concept_id in
-                    (
-                        SELECT descendant_concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                        WHERE ancestor_concept_id = 1586134
-                    )
-                GROUP BY 1
-            ) d on a.person_id = d.person_id
-        )
-    ) y
-WHERE x.person_id = y.person_id"
+                (
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.measurement_ext\` as b on a.measurement_id = b.measurement_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence_ext\` as b on a.condition_occurrence_id = b.condition_occurrence_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.device_exposure_ext\` as b on a.device_exposure_id = b.device_exposure_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.drug_exposure_ext\` as b on a.drug_exposure_id = b.drug_exposure_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.observation_ext\` as b on a.observation_id = b.observation_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence_ext\` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                    UNION DISTINCT
+                    SELECT DISTINCT person_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
+                    LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence_ext\` as b on a.visit_occurrence_id = b.visit_occurrence_id
+                    WHERE lower(b.src_id) like 'ehr site%'
+                ) b on a.person_id = b.person_id
+        ) y
+    WHERE x.person_id = y.person_id"
+  fi
 
-################################################
-# set has physical measurement data flag
-################################################
-echo "set has physical measurement data flag in cb_search_person"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-SET x.has_physical_measurement_data = y.has_data
-FROM
-    (
-        SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-        LEFT JOIN
-            (
-                SELECT DISTINCT person_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\`
-                WHERE measurement_source_concept_id in
-                    (
-                        SELECT concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.concept\`
-                        WHERE vocabulary_id = 'PPI'
-                            and concept_class_id = 'Clinical Observation'
-                            and domain_id = 'Measurement'
-                    )
-            ) b on a.person_id = b.person_id
-    ) y
-WHERE x.person_id = y.person_id"
-
-################################################
-# set has ppi survey data flag
-################################################
-echo "set has ppi survey data flag in cb_search_person"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-SET x.has_ppi_survey_data = y.has_data
-FROM
-    (
-        SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-        FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-        LEFT JOIN
-            (
-                SELECT DISTINCT person_id
-                FROM \`$BQ_PROJECT.$BQ_DATASET.observation\`
-                WHERE observation_source_concept_id in
-                    (
-                        SELECT descendant_concept_id
-                        FROM \`$BQ_PROJECT.$BQ_DATASET.prep_concept_ancestor\`
-                        WHERE ancestor_concept_id in
-                            (
-                                SELECT concept_id
-                                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
-                                WHERE domain_id = 'SURVEY'
-                                    and parent_id = 0
-                            )
-                    )
-            ) b on a.person_id = b.person_id
-    ) y
-WHERE x.person_id = y.person_id"
-
-################################################
-# set has EHR data flag
-################################################
-echo "set has EHR data flag in cb_search_person"
-if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ] || [ "$DATA_BROWSER_FLAG" == true ]
-then
+  ############################################################
+  # insert source condition data into cb_search_all_events
+  ############################################################
+  echo "Inserting source conditions data into cb_search_all_events"
   bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-  SET x.has_ehr_data = y.has_data
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      co.condition_start_date as entry_date,
+      co.condition_start_datetime as entry_datetime,
+      0 as is_standard,
+      co.condition_source_concept_id as concept_id,
+      'Condition' as domain,
+      cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_source_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
+  where co.condition_source_concept_id is not null
+      and co.condition_source_concept_id != 0"
+
+  ##############################################################
+  # insert standard condition data into cb_search_all_events
+  ##############################################################
+  echo "Inserting standard conditions data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      co.condition_start_date as entry_date,
+      co.condition_start_datetime as entry_datetime,
+      1 as is_standard,
+      co.condition_concept_id as concept_id,
+      'Condition' as domain,
+      cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
+  WHERE co.condition_concept_id is not null
+      and co.condition_concept_id != 0"
+
+  ############################################################
+  #   insert source procedure data into cb_search_all_events
+  ############################################################
+  echo "Inserting source procedures data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      po.procedure_date as entry_date,
+      po.procedure_datetime as entry_datetime,
+      0 as is_standard,
+      po.procedure_source_concept_id as concept_id,
+      'Procedure' as domain,
+      cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_source_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
+  WHERE po.procedure_source_concept_id is not null
+      and po.procedure_source_concept_id != 0"
+
+  ##############################################################
+  #   insert standard procedure data into cb_search_all_events
+  ##############################################################
+  echo "Inserting standard procedures data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      po.procedure_date as entry_date,
+      po.procedure_datetime as entry_datetime,
+      1 as is_standard,
+      po.procedure_concept_id as concept_id,
+      'Procedure' as domain,
+      cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
+  WHERE po.procedure_concept_id is not null
+      and po.procedure_concept_id != 0"
+
+  ##############################################################
+  # insert source measurement data into cb_search_all_events
+  ##############################################################
+  echo "Inserting source measurement data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+      visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
+  SELECT p.person_id,
+      m.measurement_date as entry_date,
+      m.measurement_datetime as entry_datetime,
+      0 as is_standard,
+      m.measurement_source_concept_id as concept_id,
+      'Measurement' as domain,
+      cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id,
+      m.value_as_number,
+      m.value_as_concept_id,
+      case when measurement_source_concept_id = 903118 then m.value_as_number end as systolic,
+      case when measurement_source_concept_id = 903115 then m.value_as_number end as diastolic
+  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_source_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
+  WHERE m.measurement_source_concept_id is not null
+      and m.measurement_source_concept_id != 0"
+
+  #####################################################################
+  # update source diastolic pressure data into cb_search_all_events
+  #####################################################################
+  echo "Updating diastolic pressure data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+  SET sad.diastolic = meas.diastolic
   FROM
       (
-          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-          LEFT JOIN
-              (
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.measurement_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.condition_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.device_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.drug_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.observation_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.procedure_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` as b on a.visit_source_concept_id = b.concept_id
-                  WHERE b.vocabulary_id != 'PPI'
-              ) b on a.person_id = b.person_id
-      ) y
-  WHERE x.person_id = y.person_id"
-else
+          SELECT m.person_id,
+              m.measurement_datetime,
+              m.value_as_number as diastolic
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+          WHERE m.measurement_source_concept_id = 903115
+          GROUP BY m.person_id, m.measurement_datetime, diastolic
+      ) as meas
+  WHERE meas.person_id = sad.person_id
+      and meas.measurement_datetime = sad.entry_datetime
+      and sad.is_standard = 0
+      and sad.concept_id = 903118"
+
+  #####################################################################
+  #   update source systolic pressure data into cb_search_all_events
+  #####################################################################
+  echo "Updating diastolic pressure data into cb_search_all_events"
   bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
-  SET x.has_ehr_data = y.has_data
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+  SET sad.systolic = meas.systolic
   FROM
       (
-          SELECT a.person_id, CASE WHEN b.person_id is not null THEN 1 ELSE 0 END AS has_data
-          FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
-          LEFT JOIN
-              (
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.measurement_ext\` as b on a.measurement_id = b.measurement_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence_ext\` as b on a.condition_occurrence_id = b.condition_occurrence_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.device_exposure\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.device_exposure_ext\` as b on a.device_exposure_id = b.device_exposure_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.drug_exposure_ext\` as b on a.drug_exposure_id = b.drug_exposure_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.observation_ext\` as b on a.observation_id = b.observation_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence_ext\` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-                  UNION DISTINCT
-                  SELECT DISTINCT person_id
-                  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` as a
-                  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence_ext\` as b on a.visit_occurrence_id = b.visit_occurrence_id
-                  WHERE lower(b.src_id) like 'ehr site%'
-              ) b on a.person_id = b.person_id
-      ) y
-  WHERE x.person_id = y.person_id"
+          SELECT m.person_id,
+              m.measurement_datetime,
+              m.value_as_number as systolic
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+          WHERE m.measurement_source_concept_id = 903118
+          GROUP BY m.person_id, m.measurement_datetime, systolic
+      ) as meas
+  WHERE meas.person_id = sad.person_id
+      and meas.measurement_datetime = sad.entry_datetime
+      and sad.is_standard = 0
+      and sad.concept_id = 903115"
+
+  ################################################################
+  #   insert standard measurement data into cb_search_all_events
+  ################################################################
+  echo "Inserting measurement data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+      visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
+  SELECT p.person_id,
+      m.measurement_date as entry_date,
+      m.measurement_datetime as entry_datetime,
+      1 as is_standard,
+      m.measurement_concept_id as concept_id,
+      'Measurement' as domain,
+      cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id,
+      m.value_as_number,
+      m.value_as_concept_id,
+      case when measurement_concept_id = 903118 then m.value_as_number end as systolic,
+      case when measurement_concept_id = 903115 then m.value_as_number end as diastolic
+  FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
+  WHERE m.measurement_concept_id is not null
+      and m.measurement_concept_id != 0"
+
+  #####################################################################
+  #   update standard diastolic pressure data into cb_search_all_events
+  #######################################################################
+  echo "Updating diastolic pressure data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+  SET sad.diastolic = meas.diastolic
+  FROM
+      (
+          SELECT m.person_id,
+              m.measurement_datetime,
+              m.value_as_number as diastolic
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+          WHERE m.measurement_concept_id = 903115
+          GROUP BY m.person_id, m.measurement_datetime, diastolic
+      ) as meas
+  WHERE meas.person_id = sad.person_id
+      and meas.measurement_datetime = sad.entry_datetime
+      and sad.is_standard = 1
+      and sad.concept_id = 903118"
+
+  #######################################################################
+  #   update standard diastolic pressure data into cb_search_all_events
+  #######################################################################
+  echo "Updating diastolic pressure data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
+  SET sad.systolic = meas.systolic
+  FROM
+      (
+          SELECT m.person_id,
+              m.measurement_datetime,
+              m.value_as_number as systolic
+          FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
+          WHERE m.measurement_concept_id = 903118
+          GROUP BY m.person_id, m.measurement_datetime, systolic
+      ) as meas
+  WHERE meas.person_id = sad.person_id
+      and meas.measurement_datetime = sad.entry_datetime
+      and sad.is_standard = 1
+      and sad.concept_id = 903115"
+
+  ##############################################################
+  #   insert source observation data into cb_search_all_events
+  ##############################################################
+  echo "Inserting observation data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+      visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
+  SELECT p.person_id,
+      o.observation_date as entry_date,
+      o.observation_datetime as entry_datetime,
+      0 as is_standard,
+      o.observation_source_concept_id as concept_id,
+      'Observation' as domain,
+      cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id,
+      o.value_as_number,
+      o.value_as_concept_id,
+      o.value_source_concept_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_source_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
+  WHERE o.observation_source_concept_id is not null
+      and o.observation_source_concept_id != 0"
+
+  ################################################################
+  #   insert standard observation data into cb_search_all_events
+  ################################################################
+  echo "Inserting observation data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
+      visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
+  SELECT p.person_id,
+      o.observation_date as entry_date,
+      o.observation_datetime as entry_datetime,
+      1 as is_standard,
+      o.observation_concept_id as concept_id,
+      'Observation' as domain,
+      cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id,
+      o.value_as_number,
+      o.value_as_concept_id,
+      o.value_source_concept_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
+  WHERE o.observation_concept_id is not null
+      and o.observation_concept_id != 0"
+
+  #######################################################
+  #   insert source drug data into cb_search_all_events
+  #######################################################
+  echo "Inserting drug data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      d.drug_exposure_start_date as entry_date,
+      d.drug_exposure_start_datetime as entry_datetime,
+      0 as is_standard,
+      d.drug_source_concept_id as concept_id,
+      'Drug' as domain,
+      cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_source_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
+  WHERE d.drug_source_concept_id is not null
+      and d.drug_source_concept_id != 0"
+
+  #########################################################
+  #   insert standard drug data into cb_search_all_events
+  #########################################################
+  echo "Inserting drug data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      d.drug_exposure_start_date as entry_date,
+      d.drug_exposure_start_datetime as entry_datetime,
+      1 as is_standard,
+      d.drug_concept_id as concept_id,
+      'Drug' as domain,
+      cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      vo.visit_concept_id,
+      vo.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_concept_id)
+  LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
+  WHERE d.drug_concept_id is not null
+      and d.drug_concept_id != 0"
+
+  ##########################################################
+  #   insert standard visit data into cb_search_all_events
+  ##########################################################
+  echo "Inserting visit data into cb_search_all_events"
+  bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+  "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
+      (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
+  SELECT p.person_id,
+      v.visit_start_date as entry_date,
+      v.visit_start_datetime as entry_datetime,
+      1 as is_standard,
+      v.visit_concept_id as concept_id,
+      'Visit' as domain,
+      cast(floor(date_diff(v.visit_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
+      v.visit_concept_id,
+      v.visit_occurrence_id
+  FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = v.person_id
+  JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = v.visit_concept_id)
+  WHERE v.visit_concept_id is not null
+      and v.visit_concept_id != 0"
 fi
-
-############################################################
-# insert source condition data into cb_search_all_events
-############################################################
-echo "Inserting source conditions data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    co.condition_start_date as entry_date,
-    co.condition_start_datetime as entry_datetime,
-    0 as is_standard,
-    co.condition_source_concept_id as concept_id,
-    'Condition' as domain,
-    cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
-where co.condition_source_concept_id is not null
-    and co.condition_source_concept_id != 0"
-
-##############################################################
-# insert standard condition data into cb_search_all_events
-##############################################################
-echo "Inserting standard conditions data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    co.condition_start_date as entry_date,
-    co.condition_start_datetime as entry_datetime,
-    1 as is_standard,
-    co.condition_concept_id as concept_id,
-    'Condition' as domain,
-    cast(floor(date_diff(co.condition_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.condition_occurrence\` co
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = co.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = co.condition_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = co.visit_occurrence_id)
-WHERE co.condition_concept_id is not null
-    and co.condition_concept_id != 0"
-
-############################################################
-#   insert source procedure data into cb_search_all_events
-############################################################
-echo "Inserting source procedures data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    po.procedure_date as entry_date,
-    po.procedure_datetime as entry_datetime,
-    0 as is_standard,
-    po.procedure_source_concept_id as concept_id,
-    'Procedure' as domain,
-    cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
-WHERE po.procedure_source_concept_id is not null
-    and po.procedure_source_concept_id != 0"
-
-##############################################################
-#   insert standard procedure data into cb_search_all_events
-##############################################################
-echo "Inserting standard procedures data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    po.procedure_date as entry_date,
-    po.procedure_datetime as entry_datetime,
-    1 as is_standard,
-    po.procedure_concept_id as concept_id,
-    'Procedure' as domain,
-    cast(floor(date_diff(po.procedure_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.procedure_occurrence\` po
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
-WHERE po.procedure_concept_id is not null
-    and po.procedure_concept_id != 0"
-
-##############################################################
-# insert source measurement data into cb_search_all_events
-##############################################################
-echo "Inserting source measurement data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-    visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
-SELECT p.person_id,
-    m.measurement_date as entry_date,
-    m.measurement_datetime as entry_datetime,
-    0 as is_standard,
-    m.measurement_source_concept_id as concept_id,
-    'Measurement' as domain,
-    cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id,
-    m.value_as_number,
-    m.value_as_concept_id,
-    case when measurement_source_concept_id = 903118 then m.value_as_number end as systolic,
-    case when measurement_source_concept_id = 903115 then m.value_as_number end as diastolic
-FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
-WHERE m.measurement_source_concept_id is not null
-    and m.measurement_source_concept_id != 0"
-
-#####################################################################
-# update source diastolic pressure data into cb_search_all_events
-#####################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-SET sad.diastolic = meas.diastolic
-FROM
-    (
-        SELECT m.person_id,
-            m.measurement_datetime,
-            m.value_as_number as diastolic
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-        WHERE m.measurement_source_concept_id = 903115
-        GROUP BY m.person_id, m.measurement_datetime, diastolic
-    ) as meas
-WHERE meas.person_id = sad.person_id
-    and meas.measurement_datetime = sad.entry_datetime
-    and sad.is_standard = 0
-    and sad.concept_id = 903118"
-
-#####################################################################
-#   update source systolic pressure data into cb_search_all_events
-#####################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-SET sad.systolic = meas.systolic
-FROM
-    (
-        SELECT m.person_id,
-            m.measurement_datetime,
-            m.value_as_number as systolic
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-        WHERE m.measurement_source_concept_id = 903118
-        GROUP BY m.person_id, m.measurement_datetime, systolic
-    ) as meas
-WHERE meas.person_id = sad.person_id
-    and meas.measurement_datetime = sad.entry_datetime
-    and sad.is_standard = 0
-    and sad.concept_id = 903115"
-
-################################################################
-#   insert standard measurement data into cb_search_all_events
-################################################################
-echo "Inserting measurement data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-    visit_occurrence_id, value_as_number, value_as_concept_id, systolic, diastolic)
-SELECT p.person_id,
-    m.measurement_date as entry_date,
-    m.measurement_datetime as entry_datetime,
-    1 as is_standard,
-    m.measurement_concept_id as concept_id,
-    'Measurement' as domain,
-    cast(floor(date_diff(m.measurement_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id,
-    m.value_as_number,
-    m.value_as_concept_id,
-    case when measurement_concept_id = 903118 then m.value_as_number end as systolic,
-    case when measurement_concept_id = 903115 then m.value_as_number end as diastolic
-FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
-WHERE m.measurement_concept_id is not null
-    and m.measurement_concept_id != 0"
-
-#####################################################################
-#   update standard diastolic pressure data into cb_search_all_events
-#######################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-SET sad.diastolic = meas.diastolic
-FROM
-    (
-        SELECT m.person_id,
-            m.measurement_datetime,
-            m.value_as_number as diastolic
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-        WHERE m.measurement_concept_id = 903115
-        GROUP BY m.person_id, m.measurement_datetime, diastolic
-    ) as meas
-WHERE meas.person_id = sad.person_id
-    and meas.measurement_datetime = sad.entry_datetime
-    and sad.is_standard = 1
-    and sad.concept_id = 903118"
-
-#######################################################################
-#   update standard diastolic pressure data into cb_search_all_events
-#######################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
-SET sad.systolic = meas.systolic
-FROM
-    (
-        SELECT m.person_id,
-            m.measurement_datetime,
-            m.value_as_number as systolic
-        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` m
-        WHERE m.measurement_concept_id = 903118
-        GROUP BY m.person_id, m.measurement_datetime, systolic
-    ) as meas
-WHERE meas.person_id = sad.person_id
-    and meas.measurement_datetime = sad.entry_datetime
-    and sad.is_standard = 1
-    and sad.concept_id = 903115"
-
-##############################################################
-#   insert source observation data into cb_search_all_events
-##############################################################
-echo "Inserting observation data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-    visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
-SELECT p.person_id,
-    o.observation_date as entry_date,
-    o.observation_datetime as entry_datetime,
-    0 as is_standard,
-    o.observation_source_concept_id as concept_id,
-    'Observation' as domain,
-    cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id,
-    o.value_as_number,
-    o.value_as_concept_id,
-    o.value_source_concept_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
-WHERE o.observation_source_concept_id is not null
-    and o.observation_source_concept_id != 0"
-
-################################################################
-#   insert standard observation data into cb_search_all_events
-################################################################
-echo "Inserting observation data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id,
-    visit_occurrence_id, value_as_number, value_as_concept_id, value_source_concept_id)
-SELECT p.person_id,
-    o.observation_date as entry_date,
-    o.observation_datetime as entry_datetime,
-    1 as is_standard,
-    o.observation_concept_id as concept_id,
-    'Observation' as domain,
-    cast(floor(date_diff(o.observation_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id,
-    o.value_as_number,
-    o.value_as_concept_id,
-    o.value_source_concept_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` o
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
-WHERE o.observation_concept_id is not null
-    and o.observation_concept_id != 0"
-
-#######################################################
-#   insert source drug data into cb_search_all_events
-#######################################################
-echo "Inserting drug data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    d.drug_exposure_start_date as entry_date,
-    d.drug_exposure_start_datetime as entry_datetime,
-    0 as is_standard,
-    d.drug_source_concept_id as concept_id,
-    'Drug' as domain,
-    cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
-WHERE d.drug_source_concept_id is not null
-    and d.drug_source_concept_id != 0"
-
-#########################################################
-#   insert standard drug data into cb_search_all_events
-#########################################################
-echo "Inserting drug data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    d.drug_exposure_start_date as entry_date,
-    d.drug_exposure_start_datetime as entry_datetime,
-    1 as is_standard,
-    d.drug_concept_id as concept_id,
-    'Drug' as domain,
-    cast(floor(date_diff(d.drug_exposure_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
-WHERE d.drug_concept_id is not null
-    and d.drug_concept_id != 0"
-
-##########################################################
-#   insert standard visit data into cb_search_all_events
-##########################################################
-echo "Inserting visit data into cb_search_all_events"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    v.visit_start_date as entry_date,
-    v.visit_start_datetime as entry_datetime,
-    1 as is_standard,
-    v.visit_concept_id as concept_id,
-    'Visit' as domain,
-    cast(floor(date_diff(v.visit_start_date, date(p.year_of_birth, p.month_of_birth, p.day_of_birth), month)/12) as int64) as age_at_event,
-    v.visit_concept_id,
-    v.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` v
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = v.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = v.visit_concept_id)
-WHERE v.visit_concept_id is not null
-    and v.visit_concept_id != 0"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search.sh
@@ -7,7 +7,7 @@ set -ex
 export BQ_PROJECT=$1        # project
 export BQ_DATASET=$2        # dataset
 export CDR_DATE=$3          # cdr date
-export DATA_BROWSER_FLAG=$4 # data browser flag
+export DATA_BROWSER=$4      # data browser flag
 export DRY_RUN=$5           # dry run
 
 if [ "$DRY_RUN" == false ]
@@ -39,7 +39,7 @@ then
   # insert person data into cb_search_person
   ################################################
   echo "Inserting person data into cb_search_person"
-  if [ "$DATA_BROWSER_FLAG" == true ]
+  if [ "$DATA_BROWSER" == true ]
   then
     bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
     "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
@@ -186,7 +186,7 @@ then
   # set has EHR data flag
   ################################################
   echo "set has EHR data flag in cb_search_person"
-  if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ] || [ "$DATA_BROWSER_FLAG" == true ]
+  if [ "$BQ_PROJECT:$BQ_DATASET" == "all-of-us-ehr-dev:synthetic_cdr20180606" ] || [ "$DATA_BROWSER" == true ]
   then
     bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
     "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -4,12 +4,14 @@
 
 set -ex
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
-export CDR_DATE=$3 # cdr date
+export BQ_PROJECT=$1          # project
+export BQ_DATASET=$2          # dataset
+export CDR_DATE=$3            # cdr date
+export DATA_BROWSER_FLAG=$4   # data browser flag
+export DRY_RUN=$5             # dry run
 
 echo "Making denormalized search tables"
-if ./generate-cdr/make-bq-denormalized-search.sh $BQ_PROJECT $BQ_DATASET $CDR_DATE
+if ./generate-cdr/make-bq-denormalized-search.sh $BQ_PROJECT $BQ_DATASET $CDR_DATE $DATA_BROWSER_FLAG $DRY_RUN
 then
     echo "Denormalized search tables generated"
 else
@@ -18,7 +20,7 @@ else
 fi
 
 echo "Making criteria tables"
-if ./generate-cdr/generate-cb-criteria-tables.sh $BQ_PROJECT $BQ_DATASET
+if ./generate-cdr/generate-cb-criteria-tables.sh $BQ_PROJECT $BQ_DATASET $DATA_BROWSER_FLAG $DRY_RUN
 then
     echo "criteria tables generated"
 else
@@ -27,7 +29,7 @@ else
 fi
 
 echo "Making denormalized review tables"
-if ./generate-cdr/make-bq-denormalized-review.sh $BQ_PROJECT $BQ_DATASET
+if ./generate-cdr/make-bq-denormalized-review.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
 then
     echo "Denormalized review tables generated"
 else
@@ -36,7 +38,7 @@ else
 fi
 
 echo "Making denormalized dataset tables"
-if ./generate-cdr/make-bq-denormalized-dataset.sh $BQ_PROJECT $BQ_DATASET
+if ./generate-cdr/make-bq-denormalized-dataset.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
 then
     echo "Denormalized dataset tables generated"
 else
@@ -45,7 +47,7 @@ else
 fi
 
 echo "Making dataset linking tables"
-if ./generate-cdr/make-bq-dataset-linking.sh $BQ_PROJECT $BQ_DATASET
+if ./generate-cdr/make-bq-dataset-linking.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
 then
     echo "dataset linking tables generated"
 else

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -7,12 +7,12 @@ set -e
 export BQ_PROJECT=$1          # project
 export BQ_DATASET=$2          # dataset
 export CDR_DATE=$3            # cdr date
-export DATA_BROWSER_FLAG=$4   # data browser flag
+export DATA_BROWSER=$4        # data browser flag
 export DRY_RUN=$5             # dry run
 
 echo ""
 echo 'Making denormalized search tables'
-if ./generate-cdr/make-bq-denormalized-search.sh $BQ_PROJECT $BQ_DATASET $CDR_DATE $DATA_BROWSER_FLAG $DRY_RUN
+if ./generate-cdr/make-bq-denormalized-search.sh $BQ_PROJECT $BQ_DATASET $CDR_DATE $DATA_BROWSER $DRY_RUN
 then
     echo "Making denormalized search tables complete"
 else
@@ -22,7 +22,7 @@ fi
 
 echo ""
 echo "Making criteria tables"
-if ./generate-cdr/generate-cb-criteria-tables.sh $BQ_PROJECT $BQ_DATASET $DATA_BROWSER_FLAG $DRY_RUN
+if ./generate-cdr/generate-cb-criteria-tables.sh $BQ_PROJECT $BQ_DATASET $DATA_BROWSER $DRY_RUN
 then
     echo "Making criteria tables complete"
 else
@@ -30,7 +30,7 @@ else
     exit 1
 fi
 
-if [ "$DATA_BROWSER_FLAG" == false ]
+if [ "$DATA_BROWSER" == false ]
 then
   echo ""
   echo "Making denormalized review tables"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -2,7 +2,7 @@
 
 # This generates big query denormalized tables for search, review and datasets.
 
-set -ex
+set -e
 
 export BQ_PROJECT=$1          # project
 export BQ_DATASET=$2          # dataset
@@ -10,50 +10,55 @@ export CDR_DATE=$3            # cdr date
 export DATA_BROWSER_FLAG=$4   # data browser flag
 export DRY_RUN=$5             # dry run
 
-echo "Making denormalized search tables"
+echo ""
+echo 'Making denormalized search tables'
 if ./generate-cdr/make-bq-denormalized-search.sh $BQ_PROJECT $BQ_DATASET $CDR_DATE $DATA_BROWSER_FLAG $DRY_RUN
 then
-    echo "Denormalized search tables generated"
+    echo "Making denormalized search tables complete"
 else
-    echo "FAILED To generate denormalized search tables"
+    echo "Making denormalized search tables failed!"
     exit 1
 fi
 
+echo ""
 echo "Making criteria tables"
 if ./generate-cdr/generate-cb-criteria-tables.sh $BQ_PROJECT $BQ_DATASET $DATA_BROWSER_FLAG $DRY_RUN
 then
-    echo "criteria tables generated"
+    echo "Making criteria tables complete"
 else
-    echo "FAILED To generate criteria tables"
+    echo "Making criteria tables failed!"
     exit 1
 fi
 
-echo "Making denormalized review tables"
-if ./generate-cdr/make-bq-denormalized-review.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
+if [ "$DATA_BROWSER_FLAG" == false ]
 then
-    echo "Denormalized review tables generated"
-else
-    echo "FAILED To generate denormalized review tables"
-    exit 1
+  echo ""
+  echo "Making denormalized review tables"
+  if ./generate-cdr/make-bq-denormalized-review.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
+  then
+      echo "Making denormalized review tables complete"
+  else
+      echo "Making denormalized review tables failed!"
+      exit 1
+  fi
+
+  echo ""
+  echo "Making denormalized dataset tables"
+  if ./generate-cdr/make-bq-denormalized-dataset.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
+  then
+      echo "Making denormalized dataset tables complete"
+  else
+      echo "Making denormalized dataset tables failed"
+      exit 1
+  fi
+
+  echo ""
+  echo "Making dataset linking tables"
+  if ./generate-cdr/make-bq-dataset-linking.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
+  then
+      echo "Making dataset linking tables complete"
+  else
+      echo "Making dataset linking tables failed!"
+      exit 1
+  fi
 fi
-
-echo "Making denormalized dataset tables"
-if ./generate-cdr/make-bq-denormalized-dataset.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
-then
-    echo "Denormalized dataset tables generated"
-else
-    echo "FAILED To generate denormalized dataset tables"
-    exit 1
-fi
-
-echo "Making dataset linking tables"
-if ./generate-cdr/make-bq-dataset-linking.sh $BQ_PROJECT $BQ_DATASET $DRY_RUN
-then
-    echo "dataset linking tables generated"
-else
-    echo "FAILED To generate dataset linking tables"
-    exit 1
-fi
-
-echo " Finished make-bq-denormalized-tables"
-

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -773,7 +773,7 @@ Common.register_command({
 
 def make_bq_denormalized_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser_flag = false
+  op.opts.data_browser = false
   op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
@@ -791,8 +791,8 @@ def make_bq_denormalized_tables(cmd_name, *args)
     "CDR date is Required. Please use the date from the source CDR. <YYYY-mm-dd>"
   )
   op.add_option(
-    "--data-browser-flag [data-browser-flag]",
-    ->(opts, v) { opts.data_browser_flag = v},
+    "--data-browser [data-browser]",
+    ->(opts, v) { opts.data_browser = v},
     "Is this run for data browser. Default is false"
   )
   op.add_option(
@@ -804,7 +804,7 @@ def make_bq_denormalized_tables(cmd_name, *args)
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -848,7 +848,7 @@ Generates big query denormalized tables for review. Used by cohort builder. Must
 
 def make_bq_denormalized_search(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser_flag = false
+  op.opts.data_browser = false
   op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
@@ -866,8 +866,8 @@ def make_bq_denormalized_search(cmd_name, *args)
     "CDR date is Required. Please use the date from the source CDR. <YYYY-mm-dd>"
   )
   op.add_option(
-    "--data-browser-flag [data-browser-flag]",
-    ->(opts, v) { opts.data_browser_flag = v},
+    "--data-browser [data-browser]",
+    ->(opts, v) { opts.data_browser = v},
     "Is this run for data browser. Default is false"
   )
   op.add_option(
@@ -879,7 +879,7 @@ def make_bq_denormalized_search(cmd_name, *args)
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -956,7 +956,7 @@ Must be run once when a new cdr is released",
 
 def generate_cb_criteria_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser_flag = false
+  op.opts.data_browser = false
   op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
@@ -969,8 +969,8 @@ def generate_cb_criteria_tables(cmd_name, *args)
     "BQ dataset. Required."
   )
   op.add_option(
-    "--data-browser-flag [data-browser-flag]",
-    ->(opts, v) { opts.data_browser_flag = v},
+    "--data-browser [data-browser]",
+    ->(opts, v) { opts.data_browser = v},
     "Is this run for data browser. Default is false"
   )
   op.add_option(
@@ -982,7 +982,7 @@ def generate_cb_criteria_tables(cmd_name, *args)
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser} #{op.opts.dry_run}}
 end
 
 Common.register_command({

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -804,7 +804,7 @@ def make_bq_denormalized_tables(cmd_name, *args)
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag}  #{op.opts.dry_run}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -816,6 +816,7 @@ Generates big query denormalized tables for search and review. Used by cohort bu
 
 def make_bq_denormalized_review(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -826,11 +827,16 @@ def make_bq_denormalized_review(cmd_name, *args)
     ->(opts, v) { opts.bq_dataset = v},
     "BQ dataset. Required."
   )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-review.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-review.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -843,6 +849,7 @@ Generates big query denormalized tables for review. Used by cohort builder. Must
 def make_bq_denormalized_search(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.data_browser_flag = false
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -863,11 +870,16 @@ def make_bq_denormalized_search(cmd_name, *args)
     ->(opts, v) { opts.data_browser_flag = v},
     "Is this run for data browser. Default is false"
   )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_date }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -879,6 +891,7 @@ Generates big query denormalized search. Used by cohort builder. Must be run onc
 
 def make_bq_denormalized_dataset(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -889,11 +902,16 @@ def make_bq_denormalized_dataset(cmd_name, *args)
     ->(opts, v) { opts.bq_dataset = v},
     "BQ dataset. Required."
   )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-dataset.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-dataset.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -905,6 +923,7 @@ Generates big query denormalized dataset tables. Used by Data Set Builder. Must 
 
 def make_bq_dataset_linking(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -915,11 +934,16 @@ def make_bq_dataset_linking(cmd_name, *args)
     ->(opts, v) { opts.bq_dataset = v},
     "BQ dataset. Required."
   )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-dataset-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-dataset-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -933,6 +957,7 @@ Must be run once when a new cdr is released",
 def generate_cb_criteria_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.data_browser_flag = false
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -948,11 +973,16 @@ def generate_cb_criteria_tables(cmd_name, *args)
     ->(opts, v) { opts.data_browser_flag = v},
     "Is this run for data browser. Default is false"
   )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser_flag}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser_flag} #{op.opts.dry_run}}
 end
 
 Common.register_command({

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -773,6 +773,8 @@ Common.register_command({
 
 def make_bq_denormalized_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser_flag = false
+  op.opts.dry_run = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -788,11 +790,21 @@ def make_bq_denormalized_tables(cmd_name, *args)
     ->(opts, v) { opts.cdr_date = v},
     "CDR date is Required. Please use the date from the source CDR. <YYYY-mm-dd>"
   )
+  op.add_option(
+    "--data-browser-flag [data-browser-flag]",
+    ->(opts, v) { opts.data_browser_flag = v},
+    "Is this run for data browser. Default is false"
+  )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_date }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag}  #{op.opts.dry_run}}
 end
 
 Common.register_command({
@@ -847,10 +859,10 @@ def make_bq_denormalized_search(cmd_name, *args)
     "CDR date is Required. Please use the date from the source CDR. <YYYY-mm-dd>"
   )
   op.add_option(
-      "--data-browser-flag [data-browser-flag]",
-      ->(opts, v) { opts.data_browser_flag = v},
-      "Is this run for data browser. Default is false"
-    )
+    "--data-browser-flag [data-browser-flag]",
+    ->(opts, v) { opts.data_browser_flag = v},
+    "Is this run for data browser. Default is false"
+  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_date }
   op.parse.validate
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -798,7 +798,7 @@ def make_bq_denormalized_tables(cmd_name, *args)
   op.add_option(
     "--dry-run [dry-run]",
     ->(opts, v) { opts.dry_run = v},
-    "Is this dry run. Default is false"
+    "Is this dry a run. Default is false"
   )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_date }
   op.parse.validate

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -830,6 +830,7 @@ Generates big query denormalized tables for review. Used by cohort builder. Must
 
 def make_bq_denormalized_search(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser_flag = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -845,11 +846,16 @@ def make_bq_denormalized_search(cmd_name, *args)
     ->(opts, v) { opts.cdr_date = v},
     "CDR date is Required. Please use the date from the source CDR. <YYYY-mm-dd>"
   )
+  op.add_option(
+      "--data-browser-flag [data-browser-flag]",
+      ->(opts, v) { opts.data_browser_flag = v},
+      "Is this run for data browser. Default is false"
+    )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_date }
   op.parse.validate
 
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date}}
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/make-bq-denormalized-search.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_date} #{op.opts.data_browser_flag}}
 end
 
 Common.register_command({

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -885,11 +885,11 @@ def make_bq_denormalized_dataset(cmd_name, *args)
 end
 
 Common.register_command({
-                            :invocation => "make-bq-denormalized-dataset",
-                            :description => "make-bq-denormalized-dataset --bq-project <PROJECT> --bq-dataset <DATASET>
+  :invocation => "make-bq-denormalized-dataset",
+  :description => "make-bq-denormalized-dataset --bq-project <PROJECT> --bq-dataset <DATASET>
 Generates big query denormalized dataset tables. Used by Data Set Builder. Must be run once when a new cdr is released",
-                            :fn => ->(*args) { make_bq_denormalized_dataset("make-bq-denormalized-dataset", *args) }
-                        })
+  :fn => ->(*args) { make_bq_denormalized_dataset("make-bq-denormalized-dataset", *args) }
+})
 
 def make_bq_dataset_linking(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
@@ -911,35 +911,43 @@ def make_bq_dataset_linking(cmd_name, *args)
 end
 
 Common.register_command({
-                            :invocation => "make-bq-dataset-linking",
-                            :description => "make-bq-dataset-linking --bq-project <PROJECT> --bq-dataset <DATASET>
+  :invocation => "make-bq-dataset-linking",
+  :description => "make-bq-dataset-linking --bq-project <PROJECT> --bq-dataset <DATASET>
 Generates big query dataset linking tables. Used by Data Set Builder to show users values information.
 Must be run once when a new cdr is released",
-                            :fn => ->(*args) { make_bq_dataset_linking("make-bq-dataset-linking", *args) }
-                        })
-
-def generate_criteria_table(*args)
-  common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-criteria-table.sh} + args
-end
-
-Common.register_command({
-  :invocation => "generate-criteria-table",
-  :description => "generate-criteria-table --bq-project <PROJECT> --bq-dataset <DATASET>
-Generates the criteria table in big query. Used by cohort builder. Must be run once when a new cdr is released",
-  :fn => ->(*args) { generate_criteria_table(*args) }
+  :fn => ->(*args) { make_bq_dataset_linking("make-bq-dataset-linking", *args) }
 })
 
-def generate_cb_criteria_tables(*args)
+def generate_cb_criteria_tables(cmd_name, *args)
+  op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser_flag = false
+  op.add_option(
+    "--bq-project [bq-project]",
+    ->(opts, v) { opts.bq_project = v},
+    "BQ Project. Required."
+  )
+  op.add_option(
+    "--bq-dataset [bq-dataset]",
+    ->(opts, v) { opts.bq_dataset = v},
+    "BQ dataset. Required."
+  )
+  op.add_option(
+    "--data-browser-flag [data-browser-flag]",
+    ->(opts, v) { opts.data_browser_flag = v},
+    "Is this run for data browser. Default is false"
+  )
+  op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
+  op.parse.validate
+
   common = Common.new
-  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh} + args
+  common.run_inline %W{docker-compose run db-make-bq-tables ./generate-cdr/generate-cb-criteria-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser_flag}}
 end
 
 Common.register_command({
   :invocation => "generate-cb-criteria-tables",
   :description => "generate-cb-criteria-tables --bq-project <PROJECT> --bq-dataset <DATASET>
 Generates the criteria table in big query. Used by cohort builder. Must be run once when a new cdr is released",
-  :fn => ->(*args) { generate_cb_criteria_tables(*args) }
+  :fn => ->(*args) { generate_cb_criteria_tables("generate_cb_criteria_tables", *args) }
 })
 
 def generate_private_cdr_counts(cmd_name, *args)


### PR DESCRIPTION
This PR adds the following flags to the denormalized CDR table builds
1. --data-browswer indicates of were building denormalized search and criteria tables for DB. **NOTE: --data-browswer flag is false by default**
2. --dry-run when false the denormalized CDR table build scripts will echo out all provided args for validity(this helps validate that all args are being passed to child script correctly). **NOTE: --dry-run flag is false by default**

**Example CohortBuilder run:** 
`./project.rb make-bq-denormalized-tables --bq-project all-of-us-ehr-dev --bq-dataset synpuf_100 --cdr-date 2020-10-04`

**Example CohortBuilder dry run:** 
`./project.rb make-bq-denormalized-tables --bq-project all-of-us-ehr-dev --bq-dataset synpuf_100 --cdr-date 2020-10-04 --dry-run true`
**Output**
![Screen Shot 2020-04-28 at 10 41 05 AM](https://user-images.githubusercontent.com/3904919/80507762-cf77cf00-893c-11ea-9208-25435d4f2112.png)

**Example DataBrowser run:** 
`./project.rb make-bq-denormalized-tables --bq-project all-of-us-ehr-dev --bq-dataset synpuf_100 --cdr-date 2020-10-04 --data-browser true`

**Example DataBrowser dry run:(notice that it only generates denormalized search and criteria tables** 
`./project.rb make-bq-denormalized-tables --bq-project all-of-us-ehr-dev --bq-dataset synpuf_100 --cdr-date 2020-10-04 --data-browser true --dry-run true`
**Output**
![Screen Shot 2020-04-28 at 10 36 30 AM](https://user-images.githubusercontent.com/3904919/80507189-2e891400-893c-11ea-89e2-d75e4cc2e56c.png)
