### PR TITLE
[RW-4854][risk=low] Drop beta access requirement in stable

### DIFF
--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -84,7 +84,7 @@
     "enableComplianceTraining": true,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
-    "enableBetaAccess": true,
+    "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
     "requireInvitationKey": true
   },


### PR DESCRIPTION
Account creation is still restricted by invite key and institutional affiliation.

