### PR TITLE
[no ticket][risk=no] write build results to a file and consume that in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,8 @@ jobs:
           name: Java linting
           working_directory: ~/workbench/api
           command: ./gradlew spotlessCheck
+      - store_test_results:
+           path: ~/workbench/api/build/test-results/test
       - manage_api_cache:
           save: true
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -624,6 +624,12 @@ tasks.withType(Test) {
     testLogging {
       events "passed", "skipped", "failed"
     }
+    reports {
+      // Write XML file (used by CircleCI, Jenkins, etc) to api/build/test-results/test
+      junitXml.enabled = true
+      // Write human-readable test report to api/build/reports/
+      html.enabled = true
+    }
   }
 }
 


### PR DESCRIPTION
This turns on html and xml build reporting for JUnit tests. The XML file is used to populate the TESTS tab, which prevents users from having to Ctrl+F "FAILED" in the output.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
