### PR TITLE
[No Ticket][Risk=no] Fix the width on account creation to resize based on page.

### DIFF
--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -63,6 +63,25 @@ export const styles = {
     // Without explicit vertical align, this div is top-aligned when empty, which can cause some
     // excess space above the input element and layout jitter when an icon becomes shown.
     verticalAlign: 'middle',
+  },
+
+  textBoxWithLengthValidationTextBoxStyle: {
+    height: '15rem',
+    resize: 'none',
+    width: '48rem',
+    borderRadius: '3px 3px 0 0',
+    borderColor: colorWithWhiteness(colors.dark, 0.5)
+  },
+
+  textBoxWithLengthValidationValidationStyle: {
+    justifyContent: 'space-between',
+    width: '48rem',
+    backgroundColor: colorWithWhiteness(colors.primary, 0.95),
+    fontSize: 12,
+    colors: colors.primary,
+    padding: '0.25rem',
+    borderRadius: '0 0 3px 3px', marginTop: '-0.5rem',
+    border: `1px solid ${colorWithWhiteness(colors.dark, 0.5)}`
   }
 };
 
@@ -105,6 +124,7 @@ interface TextAreaWithLengthValidationMessageProps {
   onChange: (s: string) => void;
   tooShortWarningCharacters?: number;
   tooShortWarning?: string;
+  textBoxStyleOverrides?: {};
 }
 
 interface TextAreaWithLengthValidationMessageState {
@@ -160,29 +180,14 @@ export class TextAreaWithLengthValidationMessage extends React.Component<
 
     return <React.Fragment>
       <TextArea
-          style={{
-            height: '15rem',
-            resize: 'none',
-            width: '48rem',
-            borderRadius: '3px 3px 0 0',
-            boderColor: colorWithWhiteness(colors.dark, 0.5)
-          }}
+          style={{...styles.textBoxWithLengthValidationTextBoxStyle, ...this.props.textBoxStyleOverrides}}
           id={id}
           value={text}
           onBlur={() => this.updateShowTooShortWarning()}
           onChange={v => this.onTextUpdate(v)}
       />
       <FlexRow
-          style={{
-            justifyContent: 'space-between',
-            width: '48rem',
-            backgroundColor: colorWithWhiteness(colors.primary, 0.95),
-            fontSize: 12,
-            colors: colors.primary,
-            padding: '0.25rem',
-            borderRadius: '0 0 3px 3px', marginTop: '-0.5rem',
-            border: `1px solid ${colorWithWhiteness(colors.dark, 0.5)}`
-          }}
+          style={{...styles.textBoxWithLengthValidationValidationStyle, ...this.props.textBoxStyleOverrides}}
       >
         {showTooShortWarning &&
           <label

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -51,6 +51,10 @@ const styles = reactStyles({
     fontSize: 12,
     fontWeight: 400
   },
+  textAreaStyleOverride: {
+    width: '100%',
+    minWidth: '30rem'
+  }
 });
 
 const researchPurposeList = [
@@ -623,6 +627,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
               initialText={areaOfResearch}
               maxCharacters={2000}
               onChange={(s: string) => this.updateProfileObject('areaOfResearch', s)}
+              textBoxStyleOverrides={styles.textAreaStyleOverride}
               tooLongWarningCharacters={1900}
             />
           </Section>


### PR DESCRIPTION
The fixed width is too big for the account creation page, because we have the text-box on the side. This adds the ability to mess with the styling so that we can override the width on the validated text box, so that we can fix that problem.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
