### PR TITLE
[RW-4864][risk=no] Fix dua completion logic for registration tasks

### DIFF
--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -49,6 +49,7 @@ describe('HomepageComponent', () => {
       projectId: 'aaa',
       publicApiKeyForErrorReports: 'aaa',
       enableEraCommons: true,
+      enableV3DataUserCodeOfConduct: true
     });
   });
 
@@ -94,6 +95,40 @@ describe('HomepageComponent', () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="registration-dashboard"]').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should show DUCC task as incomplete for user who has signed old version', async () => {
+    const newProfile = {
+      ...profile,
+      dataUseAgreementBypassTime: null,
+      dataUseAgreementCompletionTime: 1000,
+      dataUseAgreementSignedVersion: 2, // Old version
+      dataAccessLevel: DataAccessLevel.Unregistered
+    };
+    serverConfigStore.next({...serverConfigStore.getValue()});
+    userProfileStore.next({profile: newProfile, reload, updateCache});
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    const duccTask = wrapper.find('[data-test-id="registration-task-dataUserCodeOfConduct"]');
+    expect(duccTask.find('[data-test-id="registration-task-link"]').exists()).toBeTruthy();
+    expect(duccTask.find('[data-test-id="completed-button"]').exists()).toBeFalsy();
+  });
+
+  it('should show DUCC task as completed for user who has signed current version', async () => {
+    const newProfile = {
+      ...profile,
+      dataUseAgreementBypassTime: null,
+      dataUseAgreementCompletionTime: 1000,
+      dataUseAgreementSignedVersion: 3, // Live version
+      dataAccessLevel: DataAccessLevel.Unregistered
+    };
+    serverConfigStore.next({...serverConfigStore.getValue()});
+    userProfileStore.next({profile: newProfile, reload, updateCache});
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    const duccTask = wrapper.find('[data-test-id="registration-task-dataUserCodeOfConduct"]');
+    expect(duccTask.find('[data-test-id="registration-task-link"]').exists()).toBeFalsy();
+    expect(duccTask.find('[data-test-id="completed-button"]').exists()).toBeTruthy();
   });
 
   it('should not display the quick tour if registration dashboard is open', async () => {

--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -23,6 +23,7 @@ describe('RegistrationDashboard', () => {
       projectId: 'aaa',
       publicApiKeyForErrorReports: 'aaa',
       enableEraCommons: true,
+      enableV3DataUserCodeOfConduct: true
     });
     props  = {
       eraCommonsLinked: false,
@@ -53,17 +54,17 @@ describe('RegistrationDashboard', () => {
     let wrapper = component();
 
     // initially, first tile should be enabled and second tile should be disabled
-    expect(wrapper.find('[data-test-id="registration-task-0"]')
+    expect(wrapper.find('[data-test-id="registration-task-twoFactorAuth"]')
       .find('[data-test-id="registration-task-link"]').first().prop('disabled')).toBeFalsy();
-    expect(wrapper.find('[data-test-id="registration-task-1"]')
+    expect(wrapper.find('[data-test-id="registration-task-eraCommons"]')
       .find('[data-test-id="registration-task-link"]').first().prop('disabled')).toBeTruthy();
 
     props.twoFactorAuthCompleted = true;
     wrapper = component();
     // now, first tile should be disabled but completed and second tile should be enabled
-    expect(wrapper.find('[data-test-id="registration-task-0"]')
+    expect(wrapper.find('[data-test-id="registration-task-twoFactorAuth"]')
       .find('[data-test-id="completed-button"]').length).toBeGreaterThanOrEqual(1);
-    expect(wrapper.find('[data-test-id="registration-task-1"]')
+    expect(wrapper.find('[data-test-id="registration-task-eraCommons"]')
       .find('[data-test-id="registration-task-link"]').first().prop('disabled')).toBeFalsy();
 
   });

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -12,6 +12,7 @@ import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
+import {getLiveDataUseAgreementVersion} from 'app/utils/code-of-conduct';
 import {navigate, serverConfigStore, userProfileStore} from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {AccessModule, Profile} from 'generated/fetch';
@@ -114,6 +115,11 @@ interface RegistrationTask {
 // This needs to be a function, because we want it to evaluate at call time,
 // not at compile time, to ensure that we make use of the server config store.
 // This is important so that we can feature flag off registration tasks.
+//
+// Important: The completion criteria here needs to be kept synchronized with
+// the server-side logic, else users can get stuck on the registration dashboard
+// without a next step:
+// https://github.com/all-of-us/workbench/blob/f3c5ba23219242b6e57166c30cbd2fc863f4188b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java#L240-L272
 export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
   {
     key: 'twoFactorAuth',
@@ -160,7 +166,16 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     featureFlag: serverConfigStore.getValue().enableDataUseAgreement,
     completedText: 'Signed',
     completionTimestamp: (profile: Profile) => {
-      return profile.dataUseAgreementCompletionTime || profile.dataUseAgreementBypassTime;
+      if (profile.dataUseAgreementBypassTime) {
+        return profile.dataUseAgreementBypassTime;
+      }
+      // The DUA completion time field tracks the most recent DUA completion
+      // timestamp, but doesn't specify whether that DUA is currently active.
+      const requiredDuaVersion = getLiveDataUseAgreementVersion(serverConfigStore.getValue());
+      if (profile.dataUseAgreementSignedVersion === requiredDuaVersion) {
+        return profile.dataUseAgreementCompletionTime;
+      }
+      return null;
     },
     onClick: () => {
       AnalyticsTracker.Registration.EnterDUCC();
@@ -323,7 +338,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
         </div>}
       <FlexRow style={{marginTop: '0.85rem'}}>
         {registrationTasksToRender.map((card, i) => {
-          return <ResourceCardBase key={i} data-test-id={'registration-task-' + i.toString()}
+          return <ResourceCardBase key={i} data-test-id={'registration-task-' + card.key}
             style={this.isEnabled(i) ? styles.cardStyle : {...styles.cardStyle,
               opacity: '0.6', maxHeight: this.allTasksCompleted() ? '190px' : '305px',
               minHeight: this.allTasksCompleted() ? '190px' : '305px'}}>

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -119,7 +119,7 @@ interface RegistrationTask {
 // Important: The completion criteria here needs to be kept synchronized with
 // the server-side logic, else users can get stuck on the registration dashboard
 // without a next step:
-// https://github.com/all-of-us/workbench/blob/f3c5ba23219242b6e57166c30cbd2fc863f4188b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java#L240-L272
+// https://github.com/all-of-us/workbench/blob/master/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java#L240-L272
 export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
   {
     key: 'twoFactorAuth',

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -15,6 +15,7 @@ import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
+import {getLiveDataUseAgreementVersion} from 'app/utils/code-of-conduct';
 import {serverConfigStore} from 'app/utils/navigation';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
@@ -87,7 +88,7 @@ export const DataUserCodeOfConduct = withUserProfile()(
 
     submitDataUserCodeOfConduct(initials) {
       this.setState({submitting: true});
-      const dataUseAgreementVersion = serverConfigStore.getValue().enableV3DataUserCodeOfConduct ? 3 : 2;
+      const dataUseAgreementVersion = getLiveDataUseAgreementVersion(serverConfigStore.getValue());
       profileApi().submitDataUseAgreement(dataUseAgreementVersion, initials).then((profile) => {
         this.props.profileState.updateCache(profile);
         window.history.back();

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -1,0 +1,14 @@
+import {ConfigResponse} from 'generated';
+
+/**
+ * Returns the currently live DUA version. This version should be displayed when
+ * completing the DUA and this exact version must be signed in order to receive
+ * registered data access.
+ *
+ * Note: If we instead returned a live DUA version in the server config, we
+ * could likely eliminate this helper function. This needs further design
+ * thinking though. For now just consolidate DUA logic through this package.
+ */
+export function getLiveDataUseAgreementVersion(config: ConfigResponse): number {
+  return config.enableV3DataUserCodeOfConduct ? 3 : 2;
+}


### PR DESCRIPTION
Switch the registration dashboard to look at the signed DUA version instead of just the DUA completion time. This brings the UI up to date with the API's behavior on this access module. Without this, users who have completed an old DUA will be stuck on the registration homepage with no actions.

- Pull out logic for determining current DUA version, since it's now in two spots. Notes about how we could refactor in comments.
- Add regression test for this situation.

To test this, I put a user into a state where they've completed DUA v2 with no bypass in test.

Currently on test:
![image](https://user-images.githubusercontent.com/822298/80657403-5a89bf80-8a38-11ea-96d3-5eaf74ba2274.png)

With this PR:
![image](https://user-images.githubusercontent.com/822298/80657470-86a54080-8a38-11ea-9706-2c079e29b9d5.png)
