### PR TITLE
[RW-4856][risk=no] Hide beta access banner when the module is turned off

### DIFF
--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -70,9 +70,23 @@ describe('RegistrationDashboard', () => {
   });
 
   it('should display a warning when beta access has not been granted', () => {
+    serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: true});
     props.betaAccessGranted = false;
     const wrapper = component();
     expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(1);
+  });
+
+  it('should clear warning when user has been granted beta access', () => {
+    serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: true});
+    props.betaAccessGranted = true;
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(1);
+  });
+
+  it('should not display a warning when enableBetaAccess is false', () => {
+    serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: false});
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(0);
   });
 
   it('should display a success message when all tasks have been completed', () => {

--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -80,7 +80,7 @@ describe('RegistrationDashboard', () => {
     serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: true});
     props.betaAccessGranted = true;
     const wrapper = component();
-    expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(1);
+    expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(0);
   });
 
   it('should not display a warning when enableBetaAccess is false', () => {

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -295,7 +295,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
   render() {
     const {bypassActionComplete, bypassInProgress, trainingWarningOpen} = this.state;
     const {betaAccessGranted, eraCommonsError, trainingCompleted} = this.props;
-    const canUnsafeSelfBypass = serverConfigStore.getValue().unsafeAllowSelfBypass;
+    const {enableBetaAccess, unsafeAllowSelfBypass} = serverConfigStore.getValue();
 
     const anyBypassActionsRemaining = !(this.allTasksCompleted() && betaAccessGranted);
 
@@ -310,7 +310,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
     return <FlexColumn style={{position: 'relative'}} data-test-id='registration-dashboard'>
       {bypassInProgress && <SpinnerOverlay />}
       <div style={styles.mainHeader}>Complete Registration</div>
-      {canUnsafeSelfBypass &&
+      {unsafeAllowSelfBypass &&
         <div data-test-id='self-bypass'
              style={{...baseStyles.card, ...styles.warningModal, margin: '0.85rem 0 0'}}>
           {bypassActionComplete &&
@@ -329,7 +329,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
           }
         </div>
       }
-      {!betaAccessGranted &&
+      {enableBetaAccess && !betaAccessGranted &&
         <div data-test-id='beta-access-warning'
              style={{...baseStyles.card, ...styles.warningModal, margin: '1rem 0 0'}}>
           <ClrIcon shape='warning-standard' class='is-solid'


### PR DESCRIPTION
Pretty straightforward change to hide the beta banner in environments where we're not using the beta access module.

Before:

<img width="500" alt="Screen Shot 2020-04-30 at 11 27 56 PM" src="https://user-images.githubusercontent.com/51842/80779879-fd2a6700-8b3a-11ea-9385-28f7d37d2ac9.png">

After:

<img width="500" alt="Screen Shot 2020-04-30 at 11 23 33 PM" src="https://user-images.githubusercontent.com/51842/80779890-0582a200-8b3b-11ea-89d2-b0f70c44f64d.png">


---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
