### PR TITLE
[no ticket][risk=no] Use a bigger CircleCI vm for api-build-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ anchors:
 
   java_defaults: &java_defaults
     <<: *defaults
-    # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
-    # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
-    resource_class: medium+
     environment:
       # As best I can tell (dmohs, 7 Feb '17), this is the only way to set a memory limit that Java
       # processes executed within CircleCI's docker containers will respect. Very helpful resource:
@@ -211,6 +208,9 @@ commands:
 # -------------------------
 jobs:
   api-build-test:
+    # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
+    # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    resource_class: medium+
     <<: *java_defaults
     steps:
       - checkout_init_git


### PR DESCRIPTION
Since merge https://github.com/all-of-us/workbench/pull/3494, one job, `api-build-test` started to get OOM when running Java Unit tests in CircleCI. I don't know why at this time. To workaround it temporarily, using a bigger vm with 6GB of memory has resolved the issue. 
A previous PR changed `resource_class` to all CircleCI jobs. But that is not necessary because only `api-build-test` requires it.  
Ticket to investigate issue is https://precisionmedicineinitiative.atlassian.net/browse/RW-4874