### PR TITLE
[risk=no] Fix keyfile path for staging/perf deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
-              --key-file circle-sa-key.json \
+              --key-file ~/workbench/api/circle-sa-key.json \
               --promote
       - manage_api_cache:
           save: true
@@ -480,7 +480,7 @@ jobs:
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
-              --key-file circle-sa-key.json \
+              --key-file ~/workbench/api/circle-sa-key.json \
               --promote
       - manage_api_cache:
           save: true


### PR DESCRIPTION
The SA key activation was recently factored out. The refactored version writes the key in the `api` subdir, while the previous approach wrote the file to the `deploy` subdir.

https://github.com/all-of-us/workbench/pull/3479/files#diff-1d37e48f9ceff6d8030570cd36286a61L325