### PR TITLE
[RW-4877][risk=no] Configure RDR export to run at 9pm CT

### DIFF
--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -56,6 +56,9 @@ cron:
   target: api
 - description: 'Export user and workspace data to RDR'
   url: /v1/cron/exportToRdr
-  schedule: every 24 hours
-  timezone: UTC
+  # RDR export is hard-coded to 9pm CT, to align with VUMC expectations that the daily export is run at a time
+  # that is (1) after the close of normal business working hours, and (2) early enough in the evening that the
+  # entire export (and downstream data flows) can complete before start of the next business day.
+  schedule: every day 21:00
+  timezone: America/Chicago
   target: api


### PR DESCRIPTION
Per request from VUMC, who would like the RDR export to be hard-coded to a specific time of day. We're aiming for this to shift things on test/stable and give it a few days to burn in on stable before we eventually turn on the RDR export in prod.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review