### PR TITLE
[RW-4877][RISK=NO]Run RDR export at a specific time

### DIFF
--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -56,6 +56,6 @@ cron:
   target: api
 - description: 'Export user and workspace data to RDR'
   url: /v1/cron/exportToRdr
-  schedule: every 24 hours
+  schedule: every 24 hours 13:00
   timezone: UTC
   target: api


### PR DESCRIPTION
Since i cannot test this on local i want to verify on TEST env that by following https://cloud.google.com/appengine/docs/flexible/nodejs/scheduling-jobs-with-cron-yaml

cron job will run at a specified time every day (right now at 1:00pm)
If this will work i will push another PR to correct the time (10:00pm EST)