### PR TITLE
[RW-4888][risk=no] Add helptext to notebooks

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -142,9 +142,12 @@ const routes: Routes = [
                       // use the (urldecoded) captured value nbName
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
+                      // The iframe we use to display the Jupyter notebook does something strange
+                      // to the height calculation of the container, which is normally set to auto.
+                      // Setting this flag sets the container to 100% so that no content is clipped.
+                      contentFullHeightOverride: true,
                       helpContent: 'notebookStorage',
                       notebookHelpSidebarStyles: true,
-                      notebookRouterOutletContainerStyles: true,
                       minimizeChrome: true
                     }
                   }, {

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -142,6 +142,9 @@ const routes: Routes = [
                       // use the (urldecoded) captured value nbName
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
+                      helpContent: 'notebookStorage',
+                      notebookHelpSidebarStyles: true,
+                      notebookRouterOutletContainerStyles: true,
                       minimizeChrome: true
                     }
                   }, {
@@ -150,7 +153,7 @@ const routes: Routes = [
                     data: {
                       pathElementForTitle: 'nbName',
                       breadcrumb: BreadcrumbType.Notebook,
-                      helpContent: 'preview',
+                      helpContent: 'notebookStorage',
                       notebookHelpSidebarStyles: true,
                       minimizeChrome: true
                     }

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -29,7 +29,7 @@
                     [shareFunction]="handleShareAction"
                     [sidebarOpen]="sidebarOpen"
                     [notebookStyles]="notebookStyles"></app-help-sidebar>
-  <div [style.margin-right]="helpContent ? '45px' : 0" [style.height]="helpContent ? 'auto': '100%'">
+  <div [style.margin-right]="helpContent ? '45px' : 0" [style.height]="helpContent && !notebookRouterOutletContainerStyles ? 'auto': '100%'">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>
 </ng-container>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -29,7 +29,7 @@
                     [shareFunction]="handleShareAction"
                     [sidebarOpen]="sidebarOpen"
                     [notebookStyles]="notebookStyles"></app-help-sidebar>
-  <div [style.margin-right]="helpContent ? '45px' : 0" [style.height]="helpContent && !notebookRouterOutletContainerStyles ? 'auto': '100%'">
+  <div [style.margin-right]="helpContent ? '45px' : 0" [style.height]="helpContent && !contentFullHeightOverride ? 'auto': '100%'">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>
 </ng-container>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -42,7 +42,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   helpContent = 'data';
   sidebarOpen = false;
   notebookStyles = false;
-  notebookRouterOutletContainerStyles = false;
+  contentFullHeightOverride = false;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -221,8 +221,8 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         this.notebookStyles = true;
       }
 
-      if (child.snapshot.data.notebookRouterOutletContainerStyles) {
-        this.notebookRouterOutletContainerStyles = true;
+      if (child.snapshot.data.contentFullHeightOverride) {
+        this.contentFullHeightOverride = true;
       }
 
       if (child.firstChild) {

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -42,6 +42,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   helpContent = 'data';
   sidebarOpen = false;
   notebookStyles = false;
+  notebookRouterOutletContainerStyles = false;
 
   bugReportOpen: boolean;
   bugReportDescription = '';
@@ -218,6 +219,10 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
     while (child) {
       if (child.snapshot.data.notebookHelpSidebarStyles) {
         this.notebookStyles = true;
+      }
+
+      if (child.snapshot.data.notebookRouterOutletContainerStyles) {
+        this.notebookRouterOutletContainerStyles = true;
       }
 
       if (child.firstChild) {

--- a/ui/src/assets/json/help-sidebar.json
+++ b/ui/src/assets/json/help-sidebar.json
@@ -409,7 +409,7 @@
       ]
     }
   ],
-  "preview": [
+  "notebookStorage": [
     {
       "title": "What is a workspace bucket?",
       "content": [


### PR DESCRIPTION
This text is now on both the notebook preview page and the actual notebook page.
<img width="1680" alt="Screen Shot 2020-05-04 at 3 38 21 PM" src="https://user-images.githubusercontent.com/1847690/81006311-4e797580-8e1d-11ea-9eff-d99e6d0840c9.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally