### PR TITLE
[noTicket][RISK=LOW]While calling RDR api set status as INACTIVE for deleted Workspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -29,6 +29,7 @@ import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.RdrEntity;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.rdr.api.RdrApi;
 import org.pmiops.workbench.rdr.model.RdrResearcher;
 import org.pmiops.workbench.rdr.model.RdrWorkspace;
@@ -280,9 +281,13 @@ public class RdrExportServiceImpl implements RdrExportService {
     rdrWorkspace.setCreationTime(dbWorkspace.getCreationTime().toLocalDateTime().atOffset(offset));
     rdrWorkspace.setModifiedTime(
         dbWorkspace.getLastModifiedTime().toLocalDateTime().atOffset(offset));
-    rdrWorkspace.setStatus(
-        org.pmiops.workbench.rdr.model.RdrWorkspace.StatusEnum.fromValue(
-            dbWorkspace.getWorkspaceActiveStatusEnum().toString()));
+
+    RdrWorkspace.StatusEnum workspaceRDRStatus =
+        dbWorkspace.getWorkspaceActiveStatusEnum() == WorkspaceActiveStatus.ACTIVE
+            ? RdrWorkspace.StatusEnum.ACTIVE
+            : RdrWorkspace.StatusEnum.INACTIVE;
+
+    rdrWorkspace.setStatus(workspaceRDRStatus);
     setExcludeFromPublicDirectory(dbWorkspace.getCreator(), rdrWorkspace);
 
     rdrWorkspace.setDiseaseFocusedResearch(dbWorkspace.getDiseaseFocusedResearch());

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -97,7 +97,7 @@ definitions:
         format: date-time
       status:
         type: string
-        description: Workspace Status
+        description: INACTIVE Represents the workspace is deleted or Pending Deletion
         enum:
           - ACTIVE
           - INACTIVE
@@ -107,6 +107,7 @@ definitions:
           $ref: '#/definitions/RdrWorkspaceUser'
       excludeFromPublicDirectory:
         type: boolean
+        description: Set to true if the creator of the workspace is an Operational User
       diseaseFocusedResearch:
         type: boolean
       diseaseFocusedResearchName:

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -215,7 +215,6 @@ public class RdrExportServiceImplTest {
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
   }
 
-
   /**
    * For deleted workspace RDR should send the status as INACTIVE
    *
@@ -237,11 +236,10 @@ public class RdrExportServiceImplTest {
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace));
   }
 
-
   private RdrWorkspace toDefaultRdrWorkspace(DbWorkspace dbWorkspace) {
     ZoneOffset offset = OffsetDateTime.now().getOffset();
     RdrWorkspace rdrWorkspace = new RdrWorkspace();
-    rdrWorkspace.setWorkspaceId((int)dbWorkspace.getWorkspaceId());
+    rdrWorkspace.setWorkspaceId((int) dbWorkspace.getWorkspaceId());
     rdrWorkspace.setName(dbWorkspace.getName());
 
     rdrWorkspace.setCreationTime(dbWorkspace.getCreationTime().toLocalDateTime().atOffset(offset));


### PR DESCRIPTION
**Problem PR is trying to resolve**: In case of deleted workspaces or workspaces with Active_Status other than 0, the request to rdr was not able to set the status as it was doing a enum string match:
        RDR has ACTIVE ,INACTIVE while Workbench has ACTIVE, DELETED and PENDING_DELETE. 

Since there was a missing attribute (status) while exportWorkspace call to RDR, the api was throwing 400 Bad Request Error.

**Solution**: Rather than matching Enum string value, check and set rdrWorkspaceStatus as Active for workspaces with active_Status as ACTIVE, else set to INACTIVE in all other cases



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
