### PR TITLE
[RW-3955][risk=no] Update database ACLs to capture prod CDR convention

### DIFF
--- a/api/db/create_db.sql
+++ b/api/db/create_db.sql
@@ -10,6 +10,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON ${DB_NAME}.* TO
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, INDEX, REFERENCES, CREATE TEMPORARY TABLES, CREATE VIEW ON ${DB_NAME}.* TO '${LIQUIBASE_DB_USER}'@'%';
 
 -- Give wildcard permission to cdr databases for workbench
--- cdr* is the older and/or local naming convention, synth_r_* is new
+-- cdr* is the older and/or local naming convention, synth_r_*, r_* is new
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `cdr%`.* TO '${WORKBENCH_DB_USER}'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `r_%`.* TO '${WORKBENCH_DB_USER}'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `synth_r_%`.* TO '${WORKBENCH_DB_USER}'@'%';


### PR DESCRIPTION
This caused an issue with the preprod CDR. May as well apply this in all new environments.