### PR TITLE
[RW-4860][risk=low] Show "all tasks completed" dialog correctly when enableBetaAccess is false

### DIFF
--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -18,6 +18,7 @@ describe('RegistrationDashboard', () => {
   beforeEach(() => {
     registerApiClient(ProfileApi, new ProfileApiStub());
     serverConfigStore.next({
+      enableBetaAccess: true,
       enableDataUseAgreement: true,
       gsuiteDomain: 'fake-research-aou.org',
       projectId: 'aaa',
@@ -25,13 +26,13 @@ describe('RegistrationDashboard', () => {
       enableEraCommons: true,
       enableV3DataUserCodeOfConduct: true
     });
-    props  = {
+    props = {
       eraCommonsLinked: false,
       eraCommonsLoading: false,
       eraCommonsError: '',
       trainingCompleted: false,
       firstVisitTraining: true,
-      betaAccessGranted: true,
+      betaAccessGranted: false,
       twoFactorAuthCompleted: false,
       dataUserCodeOfConductCompleted: false
     };
@@ -85,11 +86,25 @@ describe('RegistrationDashboard', () => {
 
   it('should not display a warning when enableBetaAccess is false', () => {
     serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: false});
+    props.betaAccessGranted = false;
     const wrapper = component();
     expect(wrapper.find('[data-test-id="beta-access-warning"]').length).toBe(0);
   });
 
   it('should display a success message when all tasks have been completed', () => {
+    props.betaAccessGranted = true;
+    props.eraCommonsLinked = true;
+    props.trainingCompleted = true;
+    props.twoFactorAuthCompleted = true;
+    props.dataUserCodeOfConductCompleted = true;
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="success-message"]').length).toBe(1);
+  });
+
+  it('should display a success message when complete and enableBetaAccess is false', () => {
+    serverConfigStore.next({...serverConfigStore.getValue(), enableBetaAccess: false});
+    // When enableBetaAccess is false, we shouldn't need to have been granted beta access.
+    props.betaAccessGranted = false;
     props.eraCommonsLinked = true;
     props.trainingCompleted = true;
     props.twoFactorAuthCompleted = true;

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -237,7 +237,14 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
   }
 
   allTasksCompleted(): boolean {
-    return this.taskCompletionList.every(v => v);
+    const {betaAccessGranted} = this.props;
+    const {enableBetaAccess} = serverConfigStore.getValue();
+
+    // Beta access is awkwardly not treated as a task in the completion list. So we manually
+    // check whether (1) beta access requirement is turned off for this env, or (2) the user
+    // has been granted beta access.
+    return this.taskCompletionList.every(v => v) &&
+      (!enableBetaAccess || betaAccessGranted);
   }
 
   isEnabled(i: number): boolean {
@@ -386,13 +393,14 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
         </div>
         <AlertClose onClick={() => this.setState({trainingWarningOpen: false})}/>
       </AlertWarning>}
-      {(this.allTasksCompleted() && betaAccessGranted) &&
-      <div style={{...baseStyles.card, ...styles.warningModal, marginRight: 0}}
-           data-test-id='success-message'>
-        You successfully completed all the required steps to access the Researcher Workbench.
-        <Button style={{marginLeft: '0.5rem'}}
-                onClick={() => window.location.reload()}>Get Started</Button>
-      </div>}
+      {this.allTasksCompleted() &&
+        <div style={{...baseStyles.card, ...styles.warningModal, marginRight: 0}}
+             data-test-id='success-message'>
+          You successfully completed all the required steps to access the Researcher Workbench.
+          <Button style={{marginLeft: '0.5rem'}}
+                  onClick={() => window.location.reload()}>Get Started</Button>
+        </div>
+      }
       {this.state.twoFactorAuthModalOpen && <Modal width={500}>
           <ModalTitle style={styles.twoFactorAuthModalHeader}>Redirecting to turn on Google 2-step Verification</ModalTitle>
           <ModalBody>


### PR DESCRIPTION
This was arguably something I missed in the prior PR for RW-4860; the logic needed to be updated elsewhere in the UI to correctly show the "you're all set" banner once all access tasks have been completed.

TESTING: I will plan to manually validate the change post-merge on the test environment. Results will be noted in a comment on RW-4860.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally