### PR TITLE
[RW-3942][risk=moderate] Add readonly database user (1/2)

### DIFF
--- a/api/db/create_db.sql
+++ b/api/db/create_db.sql
@@ -1,16 +1,20 @@
 CREATE DATABASE IF NOT EXISTS ${DB_NAME} CHARACTER SET utf8 COLLATE utf8_general_ci;
 
+CREATE USER IF NOT EXISTS '${DEV_READONLY_DB_USER}'@'%' IDENTIFIED BY '${DEV_READONLY_DB_PASSWORD}';
 CREATE USER IF NOT EXISTS '${WORKBENCH_DB_USER}'@'%' IDENTIFIED BY '${WORKBENCH_DB_PASSWORD}';
 CREATE USER IF NOT EXISTS '${LIQUIBASE_DB_USER}'@'%' IDENTIFIED BY '${LIQUIBASE_DB_PASSWORD}';
 -- In case the users already exist, change their passwords.
+SET PASSWORD FOR '${DEV_READONLY_DB_USER}'@'%' = '${DEV_READONLY_DB_PASSWORD}';
 SET PASSWORD FOR '${WORKBENCH_DB_USER}'@'%' = '${WORKBENCH_DB_PASSWORD}';
 SET PASSWORD FOR '${LIQUIBASE_DB_USER}'@'%' = '${LIQUIBASE_DB_PASSWORD}';
+
+-- Grant readonly access to all tables, captures Workbench, CDR, and Liquibase.
+GRANT SELECT, CREATE TEMPORARY TABLES ON * TO '${DEV_READONLY_DB_USER}'@'%';
 
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON ${DB_NAME}.* TO '${WORKBENCH_DB_USER}'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, INDEX, REFERENCES, CREATE TEMPORARY TABLES, CREATE VIEW ON ${DB_NAME}.* TO '${LIQUIBASE_DB_USER}'@'%';
 
--- Give wildcard permission to cdr databases for workbench
--- cdr* is the older and/or local naming convention, synth_r_*, r_* is new
-GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `cdr%`.* TO '${WORKBENCH_DB_USER}'@'%';
+-- Give wildcard permission to cdr databases for workbench/readonly
+-- synth_r_*, r_* is the CDR database naming convention for synthetic and prod respectively
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `r_%`.* TO '${WORKBENCH_DB_USER}'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `synth_r_%`.* TO '${WORKBENCH_DB_USER}'@'%';

--- a/api/db/create_db.sql
+++ b/api/db/create_db.sql
@@ -11,10 +11,12 @@ SET PASSWORD FOR '${LIQUIBASE_DB_USER}'@'%' = '${LIQUIBASE_DB_PASSWORD}';
 -- Grant readonly access to all tables, captures Workbench, CDR, and Liquibase.
 GRANT SELECT, CREATE TEMPORARY TABLES ON * TO '${DEV_READONLY_DB_USER}'@'%';
 
+-- Give main db access and wildcard permission to cdr databases for workbench
+-- cdr* is the older and/or local naming convention, synth_r_*, r_* is new
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON ${DB_NAME}.* TO '${WORKBENCH_DB_USER}'@'%';
-GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, INDEX, REFERENCES, CREATE TEMPORARY TABLES, CREATE VIEW ON ${DB_NAME}.* TO '${LIQUIBASE_DB_USER}'@'%';
-
--- Give wildcard permission to cdr databases for workbench/readonly
--- synth_r_*, r_* is the CDR database naming convention for synthetic and prod respectively
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `cdr%`.* TO '${WORKBENCH_DB_USER}'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `r_%`.* TO '${WORKBENCH_DB_USER}'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES ON `synth_r_%`.* TO '${WORKBENCH_DB_USER}'@'%';
+
+-- Liquibase needs to perform schema changes on the main database.
+GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, INDEX, REFERENCES, CREATE TEMPORARY TABLES, CREATE VIEW ON ${DB_NAME}.* TO '${LIQUIBASE_DB_USER}'@'%';

--- a/api/db/create_db.sql
+++ b/api/db/create_db.sql
@@ -9,7 +9,7 @@ SET PASSWORD FOR '${WORKBENCH_DB_USER}'@'%' = '${WORKBENCH_DB_PASSWORD}';
 SET PASSWORD FOR '${LIQUIBASE_DB_USER}'@'%' = '${LIQUIBASE_DB_PASSWORD}';
 
 -- Grant readonly access to all tables, captures Workbench, CDR, and Liquibase.
-GRANT SELECT, CREATE TEMPORARY TABLES ON * TO '${DEV_READONLY_DB_USER}'@'%';
+GRANT SELECT, CREATE TEMPORARY TABLES ON *.* TO '${DEV_READONLY_DB_USER}'@'%';
 
 -- Give main db access and wildcard permission to cdr databases for workbench
 -- cdr* is the older and/or local naming convention, synth_r_*, r_* is new

--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -12,6 +12,8 @@ LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench
 WORKBENCH_DB_PASSWORD=wb-notasecret
+DEV_READONLY_DB_USER=dev-readonly
+DEV_READONLY_DB_PASSWORD=dev-readonly-notasecret
 CDR_DB_USER=workbench
 CDR_DB_PASSWORD=wb-notasecret
 


### PR DESCRIPTION
- Adds a new database user: `dev-readonly`, intended for developer readonly access. Our other usernames are: `workbench` (i.e. the application), `root`, and `liquibase`.
- Adds a new flag to `./project.rb connect-to-cloud-db` of `--db-user`. Defaults to the new readonly user.

If this looks good, I will need to execute the following:

- Apply a manual process to backfill the new username and generated passwords into all vars.env files in all environments
- ~~Manually run the create_db script in all environments to backfill the new user. Alternatively may issue this as manual SQL commands, will figure this out on the ticket.~~
--> **TIL**: create_db.sql gets applied on all migrations