### PR TITLE
[RW-4913][risk=no] Improve reliability of 2FA redirects

### DIFF
--- a/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {serverConfigStore} from 'app/utils/navigation';
-import {RegistrationDashboard, RegistrationDashboardProps} from 'app/pages/homepage/registration-dashboard';
+import {getGoogleSecurityUrlWithAccountChooser, RegistrationDashboard, RegistrationDashboardProps} from 'app/pages/homepage/registration-dashboard';
 import {ProfileApi} from 'generated/fetch';
 import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
 
@@ -123,6 +123,12 @@ describe('RegistrationDashboard', () => {
     serverConfigStore.next({...serverConfigStore.getValue(), unsafeAllowSelfBypass: true});
     const wrapper = component();
     expect(wrapper.find('[data-test-id="self-bypass"]').length).toBe(1);
+  });
+
+  it('should generate expected account switcher URL', () => {
+    serverConfigStore.next({...serverConfigStore.getValue(), gsuiteDomain: 'fake-research-aou.org'});
+    expect(getGoogleSecurityUrlWithAccountChooser()).toMatch(
+      /https:\/\/accounts.google.com\/AccountChooser\?continue=(.*?)\&hd=fake-research-aou\.org/);
   });
 
 });

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -71,18 +71,21 @@ const styles = reactStyles({
   },
 });
 
+export function getGoogleSecurityUrlWithAccountChooser(): string {
+  const accountChooserBase = 'https://accounts.google.com/AccountChooser';
+  const url = new URL(accountChooserBase);
+  url.searchParams.set('continue', 'https://myaccount.google.com/signinoptions/two-step-verification/enroll');
+  // If available, set the 'hd' param to give Google a hint that we want to force login to this
+  // specific G Suite domain.
+  if (serverConfigStore.getValue()) {
+    url.searchParams.set('hd', serverConfigStore.getValue().gsuiteDomain);
+  }
+  return url.toString();
+}
+
 function redirectToGoogleSecurity(): void {
   AnalyticsTracker.Registration.TwoFactorAuth();
-  let url = 'https://myaccount.google.com/signinoptions/two-step-verification/enroll';
-  const {profile} = userProfileStore.getValue();
-  // The profile should always be available at this point, but avoid making an
-  // implicit hard dependency on that, since the authuser'less URL is still useful.
-  if (profile.username) {
-    // Attach the authuser, in case users are using Google multilogin - their
-    // AoU researcher account is unlikely to be their primary Google login.
-    url += `?authuser=${profile.username}`;
-  }
-  window.open(url, '_blank');
+  window.open(getGoogleSecurityUrlWithAccountChooser(), '_blank');
 }
 
 function redirectToNiH(): void {

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -73,7 +73,7 @@ const styles = reactStyles({
 
 function redirectToGoogleSecurity(): void {
   AnalyticsTracker.Registration.TwoFactorAuth();
-  let url = 'https://myaccount.google.com/u/2/signinoptions/two-step-verification/enroll';
+  let url = 'https://myaccount.google.com/signinoptions/two-step-verification/enroll';
   const {profile} = userProfileStore.getValue();
   // The profile should always be available at this point, but avoid making an
   // implicit hard dependency on that, since the authuser'less URL is still useful.

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -71,21 +71,21 @@ const styles = reactStyles({
   },
 });
 
-export function getGoogleSecurityUrlWithAccountChooser(): string {
+export function getTwoFactorSetupUrl(): string {
   const accountChooserBase = 'https://accounts.google.com/AccountChooser';
   const url = new URL(accountChooserBase);
-  url.searchParams.set('continue', 'https://myaccount.google.com/signinoptions/two-step-verification/enroll');
-  // If available, set the 'hd' param to give Google a hint that we want to force login to this
-  // specific G Suite domain.
-  if (serverConfigStore.getValue()) {
-    url.searchParams.set('hd', serverConfigStore.getValue().gsuiteDomain);
+  // If available, set the 'Email' param to give Google a hint that we want to access the
+  // target URL as this specific G Suite user. This helps guide users when multi-login is in use.
+  if (userProfileStore.getValue()) {
+    url.searchParams.set('Email', userProfileStore.getValue().profile.username);
   }
+  url.searchParams.set('continue', 'https://myaccount.google.com/signinoptions/two-step-verification/enroll');
   return url.toString();
 }
 
-function redirectToGoogleSecurity(): void {
+function redirectToTwoFactorSetup(): void {
   AnalyticsTracker.Registration.TwoFactorAuth();
-  window.open(getGoogleSecurityUrlWithAccountChooser(), '_blank');
+  window.open(getTwoFactorSetupUrl(), '_blank');
 }
 
 function redirectToNiH(): void {
@@ -134,7 +134,7 @@ export const getRegistrationTasks = () => serverConfigStore.getValue() ? ([
     completionTimestamp: (profile: Profile) => {
       return profile.twoFactorAuthCompletionTime || profile.twoFactorAuthBypassTime;
     },
-    onClick: redirectToGoogleSecurity
+    onClick: redirectToTwoFactorSetup
   }, {
     key: 'eraCommons',
     completionPropsKey: 'eraCommonsLinked',
@@ -417,7 +417,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
               <Button onClick = {() => this.setState({twoFactorAuthModalOpen: false})}
                       type='secondary' style={styles.twoFactorAuthModalCancelButton}>Cancel</Button>
               <Button onClick = {() => {
-                redirectToGoogleSecurity();
+                redirectToTwoFactorSetup();
                 this.setState((state) => ({
                   accessTaskKeyToButtonAsRefresh: state.accessTaskKeyToButtonAsRefresh.set('twoFactorAuth', true),
                   twoFactorAuthModalOpen: false

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -13,7 +13,7 @@ import {EmptyResponse} from 'generated/fetch/api';
 
 export class ProfileStubVariables {
   static PROFILE_STUB = <Profile>{
-    username: 'testers',
+    username: 'tester@fake-research-aou.org',
     contactEmail: 'tester@mactesterson.edu><script>alert("hello");</script>',
     dataAccessLevel: DataAccessLevel.Registered,
     givenName: 'Tester!@#$%^&*()><script>alert("hello");</script>',


### PR DESCRIPTION
Based on discussion in RW-4913, this seems like the most straightforward fix to the issue encountered in the bug.

Request to reviewers: please test in your own Chrome profile by replicating the 2FA URL, including the authuser param, and trying it out in various scenarios (e.g. Gmail account is primary, G Suite is primary, etc.)

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review