### PR TITLE
[risk=moderate] Flag consistency for enableRdrExport

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -95,7 +95,7 @@
     "unsafeAllowDeleteUser": true,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableRdrExport": false,
+    "enableRdrExport": true,
     "enableBillingLockout": true,
     "enableBillingUpgrade": true,
     "enableSumoLogicEventHandling": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -92,7 +92,7 @@
     "unsafeAllowDeleteUser": false,
     "enableVpcFlowLogs": true,
     "enableVpcServicePerimeter": true,
-    "enableRdrExport": false,
+    "enableRdrExport": true,
     "enableBillingLockout": true,
     "enableBillingUpgrade": false,
     "enableSumoLogicEventHandling": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": false,
+    "enableComplianceTraining": true,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": true,
+    "enableComplianceTraining": false,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": false,
+    "enableComplianceTraining": true,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -81,7 +81,7 @@
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
   "access": {
-    "enableComplianceTraining": true,
+    "enableComplianceTraining": false,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,


### PR DESCRIPTION
Description:

[edit] Following up on ~#3484 and~ #3547 where flags were not flipped in all environments, for release expediency.  This flips all envs to true for ~these two flags~ enableRdrExport.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
