### PR TITLE
[RW-4908][risk=no] More aggressively clear ?workbenchAccessTasks=true

### DIFF
--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -402,7 +402,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
              data-test-id='success-message'>
           You successfully completed all the required steps to access the Researcher Workbench.
           <Button style={{marginLeft: '0.5rem'}}
-                  onClick={() => window.location.reload()}>Get Started</Button>
+                  onClick={() => navigate([''])}>Get Started</Button>
         </div>
       }
       {this.state.twoFactorAuthModalOpen && <Modal width={500}>

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -402,7 +402,15 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
              data-test-id='success-message'>
           You successfully completed all the required steps to access the Researcher Workbench.
           <Button style={{marginLeft: '0.5rem'}}
-                  onClick={() => navigate([''])}>Get Started</Button>
+                  onClick={() => {
+                    // Quirk / hack note: the goal here is to send the user to the homepage once they've completed
+                    // all access modules. Normally we would just navigate(['']) to do this. However, because
+                    // of the way this dashboard is rendered *within* the homepage component, a call to
+                    // navigate is not enough to trigger the normal homepage to load. As a workaround, we
+                    // explicitly clear the search query and redirect to the root path.
+                    window.location.pathname = '/';
+                    window.location.search = '';
+                  }}>Get Started</Button>
         </div>
       }
       {this.state.twoFactorAuthModalOpen && <Modal width={500}>

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -16,7 +16,7 @@ import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {getLiveDataUseAgreementVersion} from 'app/utils/code-of-conduct';
-import {serverConfigStore} from 'app/utils/navigation';
+import {navigate, serverConfigStore} from 'app/utils/navigation';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
 import {validate} from 'validate.js';
@@ -93,7 +93,7 @@ export const DataUserCodeOfConduct = withUserProfile()(
       const dataUseAgreementVersion = getLiveDataUseAgreementVersion(serverConfigStore.getValue());
       profileApi().submitDataUseAgreement(dataUseAgreementVersion, initials).then((profile) => {
         this.props.profileState.updateCache(profile);
-        window.history.back();
+        navigate(['']);
       });
     }
 

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -93,7 +93,7 @@ export const DataUserCodeOfConduct = withUserProfile()(
       const dataUseAgreementVersion = getLiveDataUseAgreementVersion(serverConfigStore.getValue());
       profileApi().submitDataUseAgreement(dataUseAgreementVersion, initials).then((profile) => {
         this.props.profileState.updateCache(profile);
-        navigate(['']);
+        navigate(['/']);
       });
     }
 


### PR DESCRIPTION
This PR attempts to clean up some of our user registration navigation endpoints, to clear out the `?workbenchAccessTasks=true` query param if it has ever been set. Some users encountered this issue when walking through registration, where the "access tasks" dashboard never went away.

Unfortunately, the way the registration tasks component is loaded & shown as part of the homepage components makes the fix here quite ugly. (I'd attempted to motivate these two components to be entirely different routes during its original implementation, but didn't succeed.)

While walking through the registration flow, I also noticed that DUCC uses browser.back() instead of navigating to the homepage component. I think the latter is more appropriate, and also would have fixed the issue in RW-4908.

I'm not 100% sure this PR is even worth merging – it could provide us defense in depth against RW-4908 regressions, but it may be introducing too much add'l complexity.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [NO SORRY] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [NO] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`