### PR TITLE
[risk=no][RW-4928] Don't check Inst Affil on Profile Edit

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -38,8 +38,7 @@ public interface UserService {
       List<DbInstitutionalAffiliation> dbAffiliations,
       DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation);
 
-  DbUser updateUserWithConflictHandling(
-      DbUser user, DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation);
+  DbUser updateUserWithConflictHandling(DbUser user);
 
   DbUser submitDataUseAgreement(
       DbUser user, Integer dataUseAgreementSignedVersion, String initials);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -47,7 +47,6 @@ import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.EmailVerificationStatus;
-import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.monitoring.GaugeDataCollector;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.labels.MetricLabel;
@@ -412,29 +411,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
    * dbExistingVerifiedInstitutionalAffiliation and update it with Institution role and other text
    *
    * @param dbUser
-   * @param dbVerifiedAffiliation
    * @return
    */
   @Override
-  public DbUser updateUserWithConflictHandling(
-      DbUser dbUser, DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation) {
+  public DbUser updateUserWithConflictHandling(DbUser dbUser) {
     try {
       dbUser = userDao.save(dbUser);
-      boolean requireInstitutionalVerification =
-          configProvider.get().featureFlags.requireInstitutionalVerification;
-      if (requireInstitutionalVerification) {
-        DbVerifiedInstitutionalAffiliation dbExistingVerifiedInstitutionalAffiliation =
-            verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).get();
-        dbExistingVerifiedInstitutionalAffiliation.setInstitutionalRoleEnum(
-            dbVerifiedAffiliation.getInstitutionalRoleEnum());
-        if (dbVerifiedAffiliation.getInstitutionalRoleEnum().equals(InstitutionalRole.OTHER)) {
-          dbExistingVerifiedInstitutionalAffiliation.setInstitutionalRoleOtherText(
-              dbVerifiedAffiliation.getInstitutionalRoleOtherText());
-        } else {
-          dbExistingVerifiedInstitutionalAffiliation.setInstitutionalRoleOtherText("");
-        }
-        this.verifiedInstitutionalAffiliationDao.save(dbExistingVerifiedInstitutionalAffiliation);
-      }
     } catch (ObjectOptimisticLockingFailureException e) {
       log.log(Level.WARNING, "version conflict for user update", e);
       throw new ConflictException("Failed due to concurrent modification");

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -756,6 +756,63 @@ public class ProfileControllerTest extends BaseControllerTest {
     createUser();
   }
 
+  @Test(expected = BadRequestException.class)
+  public void updateVerifiedInstitutionalAffiliation_change_forbidden() {
+    config.featureFlags.requireInstitutionalVerification = true;
+
+    final VerifiedInstitutionalAffiliation original = createVerifiedInstitutionalAffiliation();
+
+    createAccountRequest.getProfile().setVerifiedInstitutionalAffiliation(original);
+
+    createUser();
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getVerifiedInstitutionalAffiliation()).isEqualTo(original);
+
+    final VerifiedInstitutionalAffiliation newAffil =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName("NotTheBroad")
+            .institutionDisplayName("The Narrow Institute?")
+            .institutionalRoleEnum(InstitutionalRole.PRE_DOCTORAL);
+
+    profile.setVerifiedInstitutionalAffiliation(newAffil);
+    profileController.updateProfile(profile);
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void updateVerifiedInstitutionalAffiliation_add_forbidden() {
+    // necessary to create a user without one
+    config.featureFlags.requireInstitutionalVerification = false;
+    createUser();
+
+    config.featureFlags.requireInstitutionalVerification = true;
+
+    Profile profile = profileController.getMe().getBody();
+    final VerifiedInstitutionalAffiliation original = profile.getVerifiedInstitutionalAffiliation();
+    assertThat(original).isNull();
+
+    final VerifiedInstitutionalAffiliation toAdd = createVerifiedInstitutionalAffiliation();
+    profile.setVerifiedInstitutionalAffiliation(toAdd);
+    profileController.updateProfile(profile);
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void updateVerifiedInstitutionalAffiliation_remove_forbidden() {
+    config.featureFlags.requireInstitutionalVerification = true;
+
+    final VerifiedInstitutionalAffiliation original = createVerifiedInstitutionalAffiliation();
+
+    createAccountRequest.getProfile().setVerifiedInstitutionalAffiliation(original);
+
+    createUser();
+
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getVerifiedInstitutionalAffiliation()).isEqualTo(original);
+
+    profile.setVerifiedInstitutionalAffiliation(null);
+    profileController.updateProfile(profile);
+  }
+
   @Test
   public void updateContactEmail_forbidden() {
     createUser();

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -757,17 +757,15 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test(expected = BadRequestException.class)
-  public void updateVerifiedInstitutionalAffiliation_change_forbidden() {
+  public void updateVerifiedInstitutionalAffiliation_changeForbidden() {
     config.featureFlags.requireInstitutionalVerification = true;
 
     final VerifiedInstitutionalAffiliation original = createVerifiedInstitutionalAffiliation();
 
     createAccountRequest.getProfile().setVerifiedInstitutionalAffiliation(original);
-
     createUser();
 
-    Profile profile = profileController.getMe().getBody();
-    assertThat(profile.getVerifiedInstitutionalAffiliation()).isEqualTo(original);
+    final Profile profile = profileController.getMe().getBody();
 
     final VerifiedInstitutionalAffiliation newAffil =
         new VerifiedInstitutionalAffiliation()
@@ -780,35 +778,29 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test(expected = BadRequestException.class)
-  public void updateVerifiedInstitutionalAffiliation_add_forbidden() {
+  public void updateVerifiedInstitutionalAffiliation_addForbidden() {
     // necessary to create a user without one
     config.featureFlags.requireInstitutionalVerification = false;
     createUser();
 
     config.featureFlags.requireInstitutionalVerification = true;
 
-    Profile profile = profileController.getMe().getBody();
-    final VerifiedInstitutionalAffiliation original = profile.getVerifiedInstitutionalAffiliation();
-    assertThat(original).isNull();
-
+    final Profile profile = profileController.getMe().getBody();
     final VerifiedInstitutionalAffiliation toAdd = createVerifiedInstitutionalAffiliation();
     profile.setVerifiedInstitutionalAffiliation(toAdd);
     profileController.updateProfile(profile);
   }
 
   @Test(expected = BadRequestException.class)
-  public void updateVerifiedInstitutionalAffiliation_remove_forbidden() {
+  public void updateVerifiedInstitutionalAffiliation_removeForbidden() {
     config.featureFlags.requireInstitutionalVerification = true;
 
     final VerifiedInstitutionalAffiliation original = createVerifiedInstitutionalAffiliation();
 
     createAccountRequest.getProfile().setVerifiedInstitutionalAffiliation(original);
-
     createUser();
 
-    Profile profile = profileController.getMe().getBody();
-    assertThat(profile.getVerifiedInstitutionalAffiliation()).isEqualTo(original);
-
+    final Profile profile = profileController.getMe().getBody();
     profile.setVerifiedInstitutionalAffiliation(null);
     profileController.updateProfile(profile);
   }

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -235,15 +235,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
     }
   }
 
-  setVerifiedInstitutionRole(newRole) {
-    this.setState(fp.set(['currentProfile', 'verifiedInstitutionalAffiliation', 'institutionalRoleEnum'], newRole));
-
-  }
-
   get saveProfileErrorMessage() {
-    if (this.props.profileState.profile && !this.props.profileState.profile.verifiedInstitutionalAffiliation) {
-      return 'Institution cannot be empty contact admin';
-    }
     return 'You must correct errors before saving.';
   }
 
@@ -363,7 +355,7 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
   render() {
     const {profileState: {profile}} = this.props;
     const {currentProfile, saveProfileErrorResponse, updating, showDemographicSurveyModal} = this.state;
-    const {enableComplianceTraining, enableEraCommons, enableDataUseAgreement} =
+    const {enableComplianceTraining, enableEraCommons, enableDataUseAgreement, requireInstitutionalVerification} =
       serverConfigStore.getValue();
     const {
       givenName, familyName, areaOfResearch,
@@ -455,25 +447,29 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
                   valueKey: 'verifiedInstitutionalAffiliation.institutionDisplayName',
                   disabled: true
                 })}
-                {!profile.verifiedInstitutionalAffiliation && <div style={{color: colors.danger}}>
-                    Institution cannot be empty. Please contact admin
-                </div>}
+                {requireInstitutionalVerification && !profile.verifiedInstitutionalAffiliation &&
+                  <div style={{color: colors.danger}}>
+                    Institution cannot be empty. Please contact admin.
+                  </div>}
               </FlexColumn>
               <FlexColumn>
                 <div style={styles.inputLabel}>Your Role</div>
                 {profile.verifiedInstitutionalAffiliation &&
-                <Dropdown style={{width: '12.5rem'}} data-test-id='role-dropdown'
-                          placeholder='Your Role'
-                          options={this.getRoleOptions()}
-                          onChange={(v) => this.setVerifiedInstitutionRole(v.value)}
-                          value={currentProfile.verifiedInstitutionalAffiliation.institutionalRoleEnum}/>}
+                  <Dropdown style={{width: '12.5rem'}}
+                            data-test-id='role-dropdown'
+                            placeholder='Your Role'
+                            options={this.getRoleOptions()}
+                            disabled={true}
+                            value={currentProfile.verifiedInstitutionalAffiliation.institutionalRoleEnum}/>}
+
                 {currentProfile.verifiedInstitutionalAffiliation &&
                 currentProfile.verifiedInstitutionalAffiliation.institutionalRoleEnum &&
                 currentProfile.verifiedInstitutionalAffiliation.institutionalRoleEnum ===
                 InstitutionalRole.OTHER && <div>{makeProfileInput({
                   title: '',
                   valueKey: ['verifiedInstitutionalAffiliation', 'institutionalRoleOtherText'],
-                  style: {marginTop: '1rem'}
+                  style: {marginTop: '1rem'},
+                  disabled: true
                 })}
                 </div>}
               </FlexColumn>
@@ -653,14 +649,14 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
               Cancel
             </Button>
             <TooltipTrigger
-              side='top'
-              content={(!!errors || !profile.verifiedInstitutionalAffiliation) && this.saveProfileErrorMessage}>
+                side='top'
+                content={!!errors && this.saveProfileErrorMessage}>
               <Button
-                data-test-id='save_profile'
-                type='purplePrimary'
-                style={{marginLeft: 40}}
-                onClick={() => this.saveProfile(currentProfile)}
-                disabled={!!errors || fp.isEqual(profile, currentProfile) || !profile.verifiedInstitutionalAffiliation}
+                  data-test-id='save_profile'
+                  type='purplePrimary'
+                  style={{marginLeft: 40}}
+                  onClick={() => this.saveProfile(currentProfile)}
+                  disabled={!!errors || fp.isEqual(profile, currentProfile)}
               >
                 Save Profile
               </Button>

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -649,14 +649,14 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
               Cancel
             </Button>
             <TooltipTrigger
-                side='top'
-                content={!!errors && this.saveProfileErrorMessage}>
+              side='top'
+              content={!!errors && this.saveProfileErrorMessage}>
               <Button
-                  data-test-id='save_profile'
-                  type='purplePrimary'
-                  style={{marginLeft: 40}}
-                  onClick={() => this.saveProfile(currentProfile)}
-                  disabled={!!errors || fp.isEqual(profile, currentProfile)}
+                data-test-id='save_profile'
+                type='purplePrimary'
+                style={{marginLeft: 40}}
+                onClick={() => this.saveProfile(currentProfile)}
+                disabled={!!errors || fp.isEqual(profile, currentProfile)}
               >
                 Save Profile
               </Button>


### PR DESCRIPTION
Scout noticed a problem on Local: because their user didn't have a Verified Institutional Affiliation associated with it, they couldn't update the user's profile.

It's not necessary to check here, because the control for updating is disabled.  The back end should also be updated to prevent modifying the affiliation.

Tested locally:
[x] A user without Affiliation can edit their profile
[x] User creation still requires Affiliation
[x] A user with Affiliation can edit their profile but not Affiliation

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later

---
Before this change, users without Affiliation see this warning label:
<img width="446" alt="before-label" src="https://user-images.githubusercontent.com/2701406/81414545-23d93680-9115-11ea-8250-ada012f55bf5.png">

And they are prevented from editing their profile:
<img width="480" alt="before-cant-save" src="https://user-images.githubusercontent.com/2701406/81414586-318ebc00-9115-11ea-85e3-12e0275c8b71.png">

After the change, the label remains (because it does indeed describe a wrong state):
<img width="448" alt="after-label" src="https://user-images.githubusercontent.com/2701406/81414624-4408f580-9115-11ea-89e9-6b39f056e408.png">

But the user can edit their profile:
<img width="247" alt="after-can-save" src="https://user-images.githubusercontent.com/2701406/81414654-4ff4b780-9115-11ea-90c1-e0d3daedc4f6.png">

New user creation still requires an Affiliation:
<img width="441" alt="cant-create-wo" src="https://user-images.githubusercontent.com/2701406/81414682-5a16b600-9115-11ea-8ed9-42fa4c26a8fd.png">

Users with Affiliation cannot change Affiliation:
<img width="319" alt="cant-edit-profile" src="https://user-images.githubusercontent.com/2701406/81414736-6a2e9580-9115-11ea-8eb7-85591edf0e73.png">
