### PR TITLE
[risk=no] Fix welcome email text

### DIFF
--- a/api/src/main/resources/emails/welcomeemail/content.html
+++ b/api/src/main/resources/emails/welcomeemail/content.html
@@ -139,7 +139,7 @@
         <h2 style="text-decoration: underline">About your Researcher Workbench account</h2>
         <div class="text"> Your Researcher Workbench account is hosted by Google. This is
           <div class="text bold-user-label"> different and isolated</div> from your personal and
-           professional Google accounts. There are three places during the registration process where
+           professional Google accounts. There are two places during the registration process where
            you will interface directly with Google:
         </div>
         <ul>


### PR DESCRIPTION
Change 'three' to 'two' after dropping one of the bullets.
<img width="897" alt="Screen Shot 2020-05-07 at 1 25 24 PM" src="https://user-images.githubusercontent.com/40036095/81326753-e1095700-905f-11ea-8bef-40ae2c3e0b6b.png">
