### PR TITLE
[RW-4933][risk=no] Revert docker_run change

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -130,7 +130,7 @@ def ensure_docker(cmd_name, args=nil)
   args = (args or [])
   unless Workbench.in_docker?
     ensure_docker_sync()
-    docker_run(%W{./project.rb #{cmd_name}} + args)
+    exec(*(%W{docker-compose run --rm scripts ./project.rb #{cmd_name}} + args))
   end
 end
 


### PR DESCRIPTION
Regression: `run_inline` executes and then continues, `exec` replaces the current process. Revert this change from https://github.com/all-of-us/workbench/pull/3548/files