### PR TITLE
[no ticket][risk=no] Allow RDR export cron failures to throw a server error

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
@@ -19,7 +19,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.rdr.RdrExportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
  * This offline process is responsible to daily sync up with RDR by creating/pushing multiple Cloud
  * Task tasks with eligible user Ids and workspace Ids to cloud task queue.
  *
- * None of the actual RDR communication occurs from within this cron job handler, so this cron
+ * <p>None of the actual RDR communication occurs from within this cron job handler, so this cron
  * may succeed even though the actual export tasks to RDR are failing. See
  * CloudTaskRdrExportController for the handlers which do the actual RDR export work.
  *
@@ -76,7 +75,8 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
         groupIdsAndPushTask(rdrExportService.findAllWorkspacesIdsToExport(), EXPORT_USER_PATH);
       } catch (Exception ex) {
         throw new ServerErrorException(
-            String.format("Error creating RDR export Cloud Tasks for workspaces: %s", ex.getMessage()));
+            String.format(
+                "Error creating RDR export Cloud Tasks for workspaces: %s", ex.getMessage()));
       }
     }
     return ResponseEntity.noContent().build();
@@ -113,7 +113,8 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
     }
   }
 
-  private void createAndPushTask(List<Long> ids, String queuePath, String taskUri) throws IOException {
+  private void createAndPushTask(List<Long> ids, String queuePath, String taskUri)
+      throws IOException {
     List<String> idsAsString = ids.stream().map(id -> id.toString()).collect(Collectors.toList());
     Gson gson = new Gson();
     String daysJson = gson.toJson(ids);
@@ -133,8 +134,8 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
     } catch (IOException ex) {
       log.severe(
           String.format(
-              "Error while creating task to push to queue for IDS %s and path %s. " +
-                  "Re-throwing error",
+              "Error while creating task to push to queue for IDS %s and path %s. "
+                  + "Re-throwing error",
               idsAsString, taskUri));
       throw ex;
     }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
@@ -19,12 +19,17 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.rdr.RdrExportService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * This offline process is responsible to daily sync up with RDR by creating/pushing multiple task
- * with eligible user Ids and workspace Ids to cloud task queue
+ * This offline process is responsible to daily sync up with RDR by creating/pushing multiple Cloud
+ * Task tasks with eligible user Ids and workspace Ids to cloud task queue.
+ *
+ * None of the actual RDR communication occurs from within this cron job handler, so this cron
+ * may succeed even though the actual export tasks to RDR are failing. See
+ * CloudTaskRdrExportController for the handlers which do the actual RDR export work.
  *
  * @author nsaxena
  */

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRdrExportController.java
@@ -68,15 +68,12 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
       try {
         groupIdsAndPushTask(rdrExportService.findAllUserIdsToExport(), EXPORT_RESEARCHER_PATH);
       } catch (Exception ex) {
-        throw new ServerErrorException(
-            String.format("Error creating RDR export Cloud Tasks for users: %s", ex.getMessage()));
+        throw new ServerErrorException("Error creating RDR export Cloud Tasks for users", ex);
       }
       try {
         groupIdsAndPushTask(rdrExportService.findAllWorkspacesIdsToExport(), EXPORT_USER_PATH);
       } catch (Exception ex) {
-        throw new ServerErrorException(
-            String.format(
-                "Error creating RDR export Cloud Tasks for workspaces: %s", ex.getMessage()));
+        throw new ServerErrorException("Error creating RDR export Cloud Tasks for workspaces", ex);
       }
     }
     return ResponseEntity.noContent().build();
@@ -127,10 +124,7 @@ public class OfflineRdrExportController implements OfflineRdrExportApiDelegate {
               .setHttpMethod(HttpMethod.POST)
               .putHeaders("Content-type", "application/json")
               .build();
-
-      Task taskBuilder = Task.newBuilder().setAppEngineHttpRequest(req).build();
-      Task task = client.createTask(queuePath, taskBuilder);
-
+      client.createTask(queuePath, Task.newBuilder().setAppEngineHttpRequest(req).build());
     } catch (IOException ex) {
       log.severe(
           String.format(


### PR DESCRIPTION
This is a small follow-up based on Jay's observation that exceptions in the RDR export cronjob handler aren't causing the service to return a 500 response.

Screenshot demonstrating this issue (see the line with a severe error log but a 204 response):

<img width="826" alt="Screen Shot 2020-05-11 at 10 14 00 AM" src="https://user-images.githubusercontent.com/51842/81571589-26839800-9370-11ea-943e-186f607fe306.png">

TESTING: I haven't tested locally. I'm willing to try and set up some unit tests for RDR export controller (no test file exists yet), but it will take some DI finagling to get working correctly, so I've punted on this for a first cut of this PR.