### PR TITLE
[risk=low][no ticket] Return email addresses and domains in sorted order for Institutions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionMapper.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -22,15 +21,17 @@ public interface InstitutionMapper {
 
   Institution dbToModel(DbInstitution dbObject);
 
-  default List<String> toModelDomains(@NotNull Set<DbInstitutionEmailDomain> dbDomains) {
-    return dbDomains.stream()
+  default List<String> toModelDomains(Set<DbInstitutionEmailDomain> dbDomains) {
+    return Optional.ofNullable(dbDomains).orElse(Collections.emptySet()).stream()
         .map(DbInstitutionEmailDomain::getEmailDomain)
+        .sorted()
         .collect(Collectors.toList());
   }
 
-  default List<String> toModelAddresses(@NotNull Set<DbInstitutionEmailAddress> dbAddresses) {
-    return dbAddresses.stream()
+  default List<String> toModelAddresses(Set<DbInstitutionEmailAddress> dbAddresses) {
+    return Optional.ofNullable(dbAddresses).orElse(Collections.emptySet()).stream()
         .map(DbInstitutionEmailAddress::getEmailAddress)
+        .sorted()
         .collect(Collectors.toList());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
@@ -26,32 +26,34 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class InstitutionMapperTest {
   @Autowired InstitutionMapper mapper;
 
-  private List<String> modelDomains;
-  private List<String> modelAddresses;
+  private List<String> sortedModelDomains;
+  private List<String> sortedModelAddresses;
   private Set<DbInstitutionEmailDomain> dbDomains;
   private Set<DbInstitutionEmailAddress> dbAddresses;
 
   @Before
   public void setup() {
-    modelDomains = Lists.newArrayList("broad.org", "broadinst.org");
-    modelAddresses = Lists.newArrayList("joel@other-univ.org");
+    sortedModelDomains = Lists.newArrayList("broad.org", "verily.com");
+    sortedModelAddresses = Lists.newArrayList("alice@nih.gov", "joel@other-inst.org");
 
     // note: these do NOT have their institutions set
     // so they will match the withoutInstitution tests
 
     dbDomains =
         Sets.newHashSet(
-            new DbInstitutionEmailDomain().setEmailDomain("broad.org"),
-            new DbInstitutionEmailDomain().setEmailDomain("broadinst.org"));
+            new DbInstitutionEmailDomain().setEmailDomain("verily.com"),
+            new DbInstitutionEmailDomain().setEmailDomain("broad.org"));
 
     dbAddresses =
-        Sets.newHashSet(new DbInstitutionEmailAddress().setEmailAddress("joel@other-univ.org"));
+        Sets.newHashSet(
+            new DbInstitutionEmailAddress().setEmailAddress("joel@other-inst.org"),
+            new DbInstitutionEmailAddress().setEmailAddress("alice@nih.gov"));
   }
 
   @Test
   public void test_toModelDomains() {
     final List<String> testModelDomains = mapper.toModelDomains(dbDomains);
-    assertThat(testModelDomains).containsExactlyElementsIn(modelDomains);
+    assertThat(testModelDomains).isEqualTo(sortedModelDomains);
 
     // round trip
     assertThat(mapper.toDbDomainsWithoutInstitution(testModelDomains)).isEqualTo(dbDomains);
@@ -60,11 +62,11 @@ public class InstitutionMapperTest {
   @Test
   public void test_toDbDomainsWithoutInstitution() {
     final Set<DbInstitutionEmailDomain> testDbDomains =
-        mapper.toDbDomainsWithoutInstitution(modelDomains);
+        mapper.toDbDomainsWithoutInstitution(sortedModelDomains);
     assertThat(testDbDomains).containsExactlyElementsIn(dbDomains);
 
     // round trip
-    assertThat(mapper.toModelDomains(testDbDomains)).isEqualTo(modelDomains);
+    assertThat(mapper.toModelDomains(testDbDomains)).isEqualTo(sortedModelDomains);
   }
 
   @Test
@@ -75,7 +77,7 @@ public class InstitutionMapperTest {
   @Test
   public void test_toModelAddresses() {
     final List<String> testModelAddresses = mapper.toModelAddresses(dbAddresses);
-    assertThat(testModelAddresses).containsExactlyElementsIn(modelAddresses);
+    assertThat(testModelAddresses).isEqualTo(sortedModelAddresses);
 
     // round trip
     assertThat(mapper.toDbAddressesWithoutInstitution(testModelAddresses)).isEqualTo(dbAddresses);
@@ -84,11 +86,11 @@ public class InstitutionMapperTest {
   @Test
   public void test_toDbAddressesWithoutInstitution() {
     final Set<DbInstitutionEmailAddress> testDbAddresses =
-        mapper.toDbAddressesWithoutInstitution(modelAddresses);
+        mapper.toDbAddressesWithoutInstitution(sortedModelAddresses);
     assertThat(testDbAddresses).containsExactlyElementsIn(dbAddresses);
 
     // round trip
-    assertThat(mapper.toModelAddresses(testDbAddresses)).isEqualTo(modelAddresses);
+    assertThat(mapper.toModelAddresses(testDbAddresses)).isEqualTo(sortedModelAddresses);
   }
 
   @Test
@@ -102,8 +104,8 @@ public class InstitutionMapperTest {
         new Institution()
             .shortName("Test")
             .displayName("Test State University")
-            .emailDomains(modelDomains)
-            .emailAddresses(modelAddresses);
+            .emailDomains(sortedModelDomains)
+            .emailAddresses(sortedModelAddresses);
 
     final DbInstitution dbInst = mapper.modelToDb(inst);
 
@@ -120,8 +122,8 @@ public class InstitutionMapperTest {
 
     assertThat(roundTrip.getShortName()).isEqualTo(inst.getShortName());
     assertThat(roundTrip.getDisplayName()).isEqualTo(inst.getDisplayName());
-    assertThat(roundTrip.getEmailDomains()).containsExactlyElementsIn(inst.getEmailDomains());
-    assertThat(roundTrip.getEmailAddresses()).containsExactlyElementsIn(inst.getEmailAddresses());
+    assertThat(roundTrip.getEmailDomains()).isEqualTo(inst.getEmailDomains());
+    assertThat(roundTrip.getEmailAddresses()).isEqualTo(inst.getEmailAddresses());
   }
 
   @Test
@@ -137,8 +139,8 @@ public class InstitutionMapperTest {
 
     assertThat(inst.getShortName()).isEqualTo(dbInst.getShortName());
     assertThat(inst.getDisplayName()).isEqualTo(dbInst.getDisplayName());
-    assertThat(inst.getEmailDomains()).containsExactlyElementsIn(modelDomains);
-    assertThat(inst.getEmailAddresses()).containsExactlyElementsIn(modelAddresses);
+    assertThat(inst.getEmailDomains()).isEqualTo(sortedModelDomains);
+    assertThat(inst.getEmailAddresses()).isEqualTo(sortedModelAddresses);
 
     final DbInstitution roundTrip = mapper.modelToDb(inst);
 


### PR DESCRIPTION
Description:

It would be nice to have a consistent order for email addresses and domains when working with Institutions.  The existing API does not imply any order, and they remain unordered sets in the DB.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
