### PR TITLE
[RW-3942][risk=low] Add a new standalone command to create/update the DB (1.5/2)

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2230,7 +2230,13 @@ end
 
 Common.register_command({
   :invocation => "create-or-update-workbench-db",
-  :description => "Creates or updates the Workbench database and users",
+  :description => "Creates or updates the Workbench database and users.\n" \
+                  "This can be used in the event that new users or permissions " \
+                  "are added to create_db.sql, as this is not currently rerun " \
+                  "during deployment. This process is separate from Liquibase " \
+                  "migrations as these changes may require root, be necessary " \
+                  "to bootstrap Liquibase, or require sensitive variables such " \
+                  "as passwords which are unavailable to Liquibase.",
   :fn => ->(*args) { create_or_update_workbench_db("create-or-update-workbench-db", args) }
 })
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2216,7 +2216,7 @@ Common.register_command({
 def create_workbench_db()
   run_with_redirects(
     "cat db/create_db.sql | envsubst | " \
-    "mysql -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
+    "mysql -v -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
     ENV["MYSQL_ROOT_PASSWORD"]
   )
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2221,6 +2221,19 @@ def create_workbench_db()
   )
 end
 
+def create_or_update_workbench_db(cmd_name, args)
+  ensure_docker cmd_name, args
+  with_cloud_proxy_and_db_env(cmd_name, args) do |ctx|
+    create_workbench_db
+  end
+end
+
+Common.register_command({
+  :invocation => "create-or-update-workbench-db",
+  :description => "Creates or updates the Workbench database and users",
+  :fn => ->(*args) { create_or_update_workbench_db("create-or-update-workbench-db", args) }
+})
+
 def migrate_database(dry_run = false)
   common = Common.new
   common.status "Migrating main database..."

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2214,6 +2214,8 @@ Common.register_command({
 })
 
 def create_or_update_workbench_db()
+  # This method assumes that a cloud SQL proxy is active, and that appropriate
+  # env variables are exported to correspond to the target environment.
   run_with_redirects(
     "cat db/create_db.sql | envsubst | " \
     "mysql -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
@@ -2224,6 +2226,7 @@ end
 def create_or_update_workbench_db_cmd(cmd_name, args)
   ensure_docker cmd_name, args
   with_cloud_proxy_and_db_env(cmd_name, args) do |ctx|
+    # with_cloud_proxy_and_db_env loads env vars into scope which parameterize this call
     create_or_update_workbench_db
   end
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2213,7 +2213,7 @@ Common.register_command({
   :fn => ->(*args) { deploy_api("deploy-api", args) }
 })
 
-def create_workbench_db()
+def create_or_update_workbench_db()
   run_with_redirects(
     "cat db/create_db.sql | envsubst | " \
     "mysql -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
@@ -2221,10 +2221,10 @@ def create_workbench_db()
   )
 end
 
-def create_or_update_workbench_db(cmd_name, args)
+def create_or_update_workbench_db_cmd(cmd_name, args)
   ensure_docker cmd_name, args
   with_cloud_proxy_and_db_env(cmd_name, args) do |ctx|
-    create_workbench_db
+    create_or_update_workbench_db
   end
 end
 
@@ -2237,7 +2237,7 @@ Common.register_command({
                   "migrations as these changes may require root, be necessary " \
                   "to bootstrap Liquibase, or require sensitive variables such " \
                   "as passwords which are unavailable to Liquibase.",
-  :fn => ->(*args) { create_or_update_workbench_db("create-or-update-workbench-db", args) }
+  :fn => ->(*args) { create_or_update_workbench_db_cmd("create-or-update-workbench-db", args) }
 })
 
 def migrate_database(dry_run = false)
@@ -2540,7 +2540,7 @@ def setup_project_data(gcc, cdr_db_name)
 
 
     common.status "Setting up databases and users..."
-    create_workbench_db
+    create_or_update_workbench_db
 
     common.status "Running schema migrations..."
     migrate_database

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2216,7 +2216,7 @@ Common.register_command({
 def create_workbench_db()
   run_with_redirects(
     "cat db/create_db.sql | envsubst | " \
-    "mysql -v -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
+    "mysql -u \"root\" -p\"#{ENV["MYSQL_ROOT_PASSWORD"]}\" --host 127.0.0.1 --port 3307",
     ENV["MYSQL_ROOT_PASSWORD"]
   )
 end


### PR DESCRIPTION
On further review, create_db.sql isn't run during deployments. Add a standalone command to apply this per environment as needed. This would only be needed when user creation, grants, or passwords need updating.

```
./project.rb create-or-update-workbench-db --project ...
```