### PR TITLE
[RW-3942][risk=low] Leverage new readonly user in developer CLI tooling (2/2)

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2079,11 +2079,10 @@ def connect_to_cloud_db_binlog(cmd_name, *args)
     common.status "\n" + "*" * 80
     common.status "Listing available journal files: "
 
-    # "root" is required for binlog access.
-    password = env["MYSQL_ROOT_PASSWORD"]
+    password = env["DEV_READONLY_DB_PASSWORD"]
     run_with_redirects(
       "echo 'SHOW BINARY LOGS;' | " +
-      "mysql --host=127.0.0.1 --port=3307 --user=root " +
+      "mysql --host=127.0.0.1 --port=3307 --user=dev-readonly " +
       "--database=#{env['DB_NAME']} --password=#{password}", password)
     common.status "*" * 80
 
@@ -2097,7 +2096,7 @@ def connect_to_cloud_db_binlog(cmd_name, *args)
     # Work out of /tmp for easy local file redirection. We don't want binlogs
     # winding up back in Workbench source control accidentally.
     run_with_redirects(
-      "export MYSQL_HOME=$(with-mysql-login.sh root #{password}); " +
+      "export MYSQL_HOME=$(with-mysql-login.sh dev-readonly #{password}); " +
       "cd /tmp; /bin/bash", password)
   end
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2031,7 +2031,7 @@ def connect_to_cloud_db(cmd_name, *args)
   op.parse.validate
   gcc.validate
 
-  if op.opts.db_user.nil?
+  if op.opts.db_user.nil? || op.opts.db_user.empty?
     op.opts.db_user = "dev-readonly"
   end
 
@@ -2041,7 +2041,7 @@ def connect_to_cloud_db(cmd_name, *args)
     "workbench" => env["WORKBENCH_DB_PASSWORD"],
     "root" => env["MYSQL_ROOT_PASSWORD"]
   }
-  unless user_to_password.has_key? op.opts.db_user
+  unless user_to_password.has_key?(op.opts.db_user)
     Common.new.error(
       "invalid --db-user provided, wanted one of #{user_to_password.keys}, got '#{op.opts.db_user}'")
     exit 1

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2024,7 +2024,9 @@ def connect_to_cloud_db(cmd_name, *args)
   op.add_option(
     "--db-user [user]",
     ->(opts, v) { opts.db_user = v },
-    "Optional database user to connect as, defaults to 'dev-readonly'")
+    "Optional database user to connect as, defaults to 'dev-readonly'. " +
+    "To perform mutations use 'workbench'. Avoid using 'root' unless " +
+    "absolutely necessary.")
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate
@@ -2034,20 +2036,24 @@ def connect_to_cloud_db(cmd_name, *args)
   end
 
   env = read_db_vars(gcc)
-  db_password = nil
-  case op.opts.db_user
-  when "dev-readonly"
-    db_password = env["DEV_READONLY_DB_PASSWORD"]
-  when "workbench"
-    db_password = env["WORKBENCH_DB_PASSWORD"]
-  when "root"
-    db_password = env["MYSQL_ROOT_PASSWORD"]
-  else
-    raise ArgumentError.new(
-            "invalid --db-user provided, wanted 'workbench', 'dev-readonly', or 'root', got '#{op.opts.db_user}'")
+  user_to_password = {
+    "dev-readonly" => env["DEV_READONLY_DB_PASSWORD"],
+    "workbench" => env["WORKBENCH_DB_PASSWORD"],
+    "root" => env["MYSQL_ROOT_PASSWORD"]
+  }
+  unless user_to_password.has_key? op.opts.db_user
+    Common.new.error(
+      "invalid --db-user provided, wanted one of #{user_to_password.keys}, got '#{op.opts.db_user}'")
+    exit 1
   end
+  db_password = user_to_password[op.opts.db_user]
 
   CloudSqlProxyContext.new(gcc.project).run do
+    if op.opts.db_user == "dev-readonly"
+      common.status ""
+      common.status "Database session will be read-only; use --db-user to change this"
+      common.status ""
+    end
     common.run_inline %W{
       mysql --host=127.0.0.1 --port=3307 --user=#{op.opts.db_user}
       --database=#{env["DB_NAME"]} --password=#{db_password}},


### PR DESCRIPTION
This was already reviewed/approved during https://github.com/all-of-us/workbench/pull/3550, which was partially reverted. Adds a new flag to `./project.rb connect-to-cloud-db of --db-user.` Defaults to the new readonly user.

**Blocked on**: https://precisionmedicineinitiative.atlassian.net/browse/PD-5108