### PR TITLE
[risk=no] wait-for-it on cloud sql proxy, instead of waiting 1s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
 anchors:
   defaults: &defaults
     docker:
-      - image: allofustest/workbench:buildimage-0.0.16
+      - image: allofustest/workbench:buildimage-0.0.17
     working_directory: ~/workbench
 
   java_defaults: &java_defaults
@@ -243,7 +243,7 @@ jobs:
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     resource_class: medium+
     docker:
-      - image: allofustest/workbench:buildimage-0.0.16
+      - image: allofustest/workbench:buildimage-0.0.17
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu

--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -1,4 +1,5 @@
 require_relative "../../aou-utils/serviceaccounts"
+require_relative "../../aou-utils/utils/common"
 require_relative "../../aou-utils/workbench"
 
 class CloudSqlProxyContext < ServiceAccountContext
@@ -14,7 +15,7 @@ class CloudSqlProxyContext < ServiceAccountContext
         })
       end
       begin
-        sleep 1 # TODO(dmohs): Detect running better.
+        Common.new.run_inline(%W{wait-for-it 0.0.0.0:3307 -t 120})
         yield
       ensure
         Process.kill "HUP", @ps

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -27,7 +27,7 @@ RUN cd && \
   rm -rf gcloud.tgz
 
 RUN sudo apt-get update
-RUN sudo apt-get install gettext ruby default-mysql-client python-pip
+RUN sudo apt-get install gettext ruby default-mysql-client python-pip wait-for-it
 RUN sudo pip install --upgrade pip pylint
 
 ENV PATH=/home/circleci/node/bin:/home/circleci/google-cloud-sdk/bin:$PATH

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   deploy:
-    image: allofustest/workbench:buildimage-0.0.16
+    image: allofustest/workbench:buildimage-0.0.17
     entrypoint: /bootstrap-docker.sh
     user: circleci
     environment:


### PR DESCRIPTION
Appears to work on slower starts (verified by Joel).

Simulated timeout (wrong port):

```
+ wait-for-it 0.0.0.0:3308 -t 5
wait-for-it: waiting 5 seconds for 0.0.0.0:3308
2020/05/12 18:17:04 current FDs rlimit set to 1048576, wanted limit is 8500. Nothing to do here.
2020/05/12 18:17:04 using credential file for authentication; email=all-of-us-workbench-test@appspot.gserviceaccount.com
2020/05/12 18:17:04 Listening on 0.0.0.0:3307 for all-of-us-workbench-test:us-central1:workbenchmaindb
2020/05/12 18:17:04 Ready for new connections
wait-for-it: timeout occurred after waiting 5 seconds for 0.0.0.0:3308
```

Exits as expected