### PR TITLE
[risk=no] Delete the ephemeral ingest dataset on publish-cdr

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -123,13 +123,16 @@ def publish_cdr(cmd_name, args)
     # hit enter.
     # TODO(RW-3768): Figure out how to prepopulate this value or disable interactivity.
 
-    # Copy through an intermediate project and delete after (2h TTL), per
-    # https://docs.google.com/document/d/1EHw5nisXspJjA9yeZput3W4-vSIcuLBU5dPizTnk1i0/edit
+    # Copy through an intermediate project and delete after (include TTL in case later steps fail).
+    # See https://docs.google.com/document/d/1EHw5nisXspJjA9yeZput3W4-vSIcuLBU5dPizTnk1i0/edit
     common.run_inline %W{bq mk -f --default_table_expiration 7200 --dataset #{ingest_dataset}}
     common.run_inline %W{./copy-bq-dataset.sh #{source_dataset} #{ingest_dataset} #{env.fetch(:source_cdr_project)} #{table_filter}}
 
     common.run_inline %W{bq mk -f --dataset #{dest_dataset}}
     common.run_inline %W{./copy-bq-dataset.sh #{ingest_dataset} #{dest_dataset} #{env.fetch(:ingest_cdr_project)} #{table_filter}}
+
+    # Delete the intermediate dataset.
+    common.run_inline %W{bq rm -rf --dataset #{ingest_dataset}}
 
     auth_domain_group = get_auth_domain_group(op.opts.project)
 


### PR DESCRIPTION
I previously thought this wasn't possible, but I was just misunderstanding the error message. `bq rm -rf` is needed to kill datasets which still contain child tables. Leave the TTL setting in case there's a partial cancel/failure.