### PR TITLE
[risk=no] Enforce unique display name for Institutions

### DIFF
--- a/api/db/changelog/db.changelog-135-institution-unique-display-name.xml
+++ b/api/db/changelog/db.changelog-135-institution-unique-display-name.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-135-institution-unique-display-name">
+    <addUniqueConstraint tableName="institution" columnNames="display_name"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -142,6 +142,7 @@
     <include file="changelog/db.changelog-132-non-null-contact-email.xml"/>
     <include file="changelog/db.changelog-133-institution-user-instructions.xml"/>
     <include file="changelog/db.changelog-134-institution-data-user-agreement.xml"/>
+    <include file="changelog/db.changelog-135-institution-unique-display-name.xml"/>
 
     <!--
      Note: to update the DB locally, do the following:

--- a/api/src/main/java/org/pmiops/workbench/db/dao/InstitutionDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/InstitutionDao.java
@@ -6,4 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface InstitutionDao extends CrudRepository<DbInstitution, Long> {
   Optional<DbInstitution> findOneByShortName(final String shortName);
+
+  Optional<DbInstitution> findOneByDisplayName(final String displayName);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
@@ -55,7 +55,7 @@ public class DbInstitution {
     return this;
   }
 
-  @Column(name = "display_name", nullable = false)
+  @Column(name = "display_name", nullable = false, unique = true)
   public String getDisplayName() {
     return displayName;
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionDaoTest.java
@@ -232,11 +232,11 @@ public class InstitutionDaoTest {
   @Test(expected = DataIntegrityViolationException.class)
   public void test_uniqueDisplayNameRequired() {
     final DbInstitution snowflake1 =
-            new DbInstitution().setShortName("Inst1").setDisplayName("Not Unique");
+        new DbInstitution().setShortName("Inst1").setDisplayName("Not Unique");
     institutionDao.save(snowflake1);
 
     final DbInstitution snowflake2 =
-            new DbInstitution().setShortName("Inst2").setDisplayName("Not Unique");
+        new DbInstitution().setShortName("Inst2").setDisplayName("Not Unique");
     institutionDao.save(snowflake2);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionDaoTest.java
@@ -43,8 +43,8 @@ public class InstitutionDaoTest {
     institutionWithEmailPatterns =
         institutionDao.save(
             new DbInstitution()
-                .setShortName("Broad1")
-                .setDisplayName("The Broad Institute")
+                .setShortName("NIH")
+                .setDisplayName("The National Institutes of Health")
                 .setEmailAddresses(emailAddresses)
                 .setEmailDomains(emailDomains));
   }
@@ -112,8 +112,17 @@ public class InstitutionDaoTest {
   public void test_findOneByShortName() {
     assertThat(institutionDao.findOneByShortName("Broad"))
         .hasValue(institutionWithoutEmailPatterns);
-    assertThat(institutionDao.findOneByShortName("Broad1")).hasValue(institutionWithEmailPatterns);
+    assertThat(institutionDao.findOneByShortName("NIH")).hasValue(institutionWithEmailPatterns);
     assertThat(institutionDao.findOneByShortName("Verily")).isEmpty();
+  }
+
+  @Test
+  public void test_findOneByDisplayName() {
+    assertThat(institutionDao.findOneByDisplayName("The Broad Institute"))
+        .hasValue(institutionWithoutEmailPatterns);
+    assertThat(institutionDao.findOneByDisplayName("The National Institutes of Health"))
+        .hasValue(institutionWithEmailPatterns);
+    assertThat(institutionDao.findOneByDisplayName("Verily, LLC")).isEmpty();
   }
 
   @Test
@@ -196,9 +205,16 @@ public class InstitutionDaoTest {
   }
 
   @Test(expected = DataIntegrityViolationException.class)
-  public void test_idRequired() {
+  public void test_shortNameRequired() {
     final DbInstitution testInst = new DbInstitution();
     testInst.setDisplayName("so long");
+    institutionDao.save(testInst);
+  }
+
+  @Test(expected = DataIntegrityViolationException.class)
+  public void test_displayNameRequired() {
+    final DbInstitution testInst = new DbInstitution();
+    testInst.setShortName("VUMC");
     institutionDao.save(testInst);
   }
 
@@ -214,9 +230,13 @@ public class InstitutionDaoTest {
   }
 
   @Test(expected = DataIntegrityViolationException.class)
-  public void test_displayNameRequired() {
-    final DbInstitution testInst = new DbInstitution();
-    testInst.setShortName("VUMC");
-    institutionDao.save(testInst);
+  public void test_uniqueDisplayNameRequired() {
+    final DbInstitution snowflake1 =
+            new DbInstitution().setShortName("Inst1").setDisplayName("Not Unique");
+    institutionDao.save(snowflake1);
+
+    final DbInstitution snowflake2 =
+            new DbInstitution().setShortName("Inst2").setDisplayName("Not Unique");
+    institutionDao.save(snowflake2);
   }
 }


### PR DESCRIPTION
Description:

Fixes an earlier oversight, and helps ensure correctness for the tool in RW-4911.

I confirmed that there are currently no display name duplicates in any environments.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
