### PR TITLE
[risk=low] Add or update equals() and hashCode() for Institution* DB models

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
@@ -172,6 +172,29 @@ public class DbInstitution {
     }
     DbInstitution that = (DbInstitution) o;
 
+    final boolean domainsEq = Objects.equal(emailDomains, that.emailDomains);
+    System.out.println("DBInst emailDomains eq=" + domainsEq);
+    if (!domainsEq) {
+      for (DbInstitutionEmailDomain domain : emailDomains) {
+        System.out.println("domain = " + domain);
+      }
+      for (DbInstitutionEmailDomain domain : that.emailDomains) {
+        System.out.println("that domain = " + domain);
+      }
+    }
+
+    final boolean addrsEq = Objects.equal(emailAddresses, that.emailAddresses);
+    System.out.println("DBInst emailAddresses eq=" + addrsEq);
+    if (!addrsEq) {
+      for (DbInstitutionEmailAddress addr : emailAddresses) {
+        System.out.println("addr = " + addr);
+      }
+
+      for (DbInstitutionEmailAddress addr : that.emailAddresses) {
+        System.out.println("that addr = " + addr);
+      }
+    }
+
     return Objects.equal(shortName, that.shortName)
         && Objects.equal(displayName, that.displayName)
         && Objects.equal(organizationTypeEnum, that.organizationTypeEnum)

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db.model;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Optional;
@@ -156,5 +157,79 @@ public class DbInstitution {
     this.emailAddresses.addAll(Sets.difference(attachedAddresses, this.emailAddresses));
 
     return this;
+  }
+
+  // omit ID field from equality so equivalent objects match regardless
+  // of whether they are actually present in the DB
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DbInstitution that = (DbInstitution) o;
+
+    return Objects.equal(shortName, that.shortName)
+        && Objects.equal(displayName, that.displayName)
+        && Objects.equal(organizationTypeEnum, that.organizationTypeEnum)
+        && Objects.equal(organizationTypeOtherText, that.organizationTypeOtherText)
+        && Objects.equal(duaTypeEnum, that.duaTypeEnum)
+        && Objects.equal(emailDomains, that.emailDomains)
+        && Objects.equal(emailAddresses, that.emailAddresses);
+  }
+
+  // to prevent cycles in the emails' equals() methods
+  public boolean equalsWithoutEmails(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DbInstitution that = (DbInstitution) o;
+
+    return Objects.equal(shortName, that.shortName)
+        && Objects.equal(displayName, that.displayName)
+        && Objects.equal(organizationTypeEnum, that.organizationTypeEnum)
+        && Objects.equal(organizationTypeOtherText, that.organizationTypeOtherText)
+        && Objects.equal(duaTypeEnum, that.duaTypeEnum);
+  }
+
+  public static boolean equalsWithoutEmails(final DbInstitution a, final DbInstitution b) {
+    if (a == null) {
+      return (b == null);
+    } else {
+      return a.equalsWithoutEmails(b);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        shortName,
+        displayName,
+        organizationTypeEnum,
+        organizationTypeOtherText,
+        duaTypeEnum,
+        emailDomains,
+        emailAddresses);
+  }
+
+  // to prevent cycles in the emails' hashCode() methods
+  public int hashCodeWithoutEmails() {
+    return Objects.hashCode(
+        shortName, displayName, organizationTypeEnum, organizationTypeOtherText, duaTypeEnum);
+  }
+
+  // to prevent cycles in the emails' hashCode() methods
+  public static Object hashCodeWithoutEmails(final DbInstitution institution) {
+    if (institution == null) {
+      return 0;
+    } else {
+      return institution.hashCodeWithoutEmails();
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitution.java
@@ -224,7 +224,6 @@ public class DbInstitution {
         shortName, displayName, organizationTypeEnum, organizationTypeOtherText, duaTypeEnum);
   }
 
-  // to prevent cycles in the emails' hashCode() methods
   public static Object hashCodeWithoutEmails(final DbInstitution institution) {
     if (institution == null) {
       return 0;

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailAddress.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailAddress.java
@@ -54,7 +54,8 @@ public class DbInstitutionEmailAddress {
     return this;
   }
 
-  // logical equality: data members without the ID field
+  // omit ID field from equality so equivalent objects match regardless
+  // of whether they are actually present in the DB
 
   @Override
   public boolean equals(Object o) {
@@ -67,12 +68,14 @@ public class DbInstitutionEmailAddress {
 
     DbInstitutionEmailAddress that = (DbInstitutionEmailAddress) o;
 
-    return Objects.equals(institution, that.institution)
-        && Objects.equals(emailAddress, that.emailAddress);
+    // calling institution.equals() would introduce a cycle here
+    return Objects.equals(emailAddress, that.emailAddress)
+        && DbInstitution.equalsWithoutEmails(institution, that.institution);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(institution, emailAddress);
+    // calling institution.hashCode() would introduce a cycle here
+    return Objects.hash(emailAddress, DbInstitution.hashCodeWithoutEmails(institution));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailAddress.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailAddress.java
@@ -68,6 +68,17 @@ public class DbInstitutionEmailAddress {
 
     DbInstitutionEmailAddress that = (DbInstitutionEmailAddress) o;
 
+    System.out.println("emailAddress=" + emailAddress);
+    System.out.println("emailAddress eq=" + Objects.equals(emailAddress, that.emailAddress));
+    System.out.println(
+        "institutionShortName eq="
+            + Objects.equals(institution.getShortName(), that.institution.getShortName()));
+    System.out.println(
+        "institutionShortName eq2="
+            + ((institution != null)
+                && (that.institution != null)
+                && Objects.equals(institution.getShortName(), that.institution.getShortName())));
+
     // calling institution.equals() would introduce a cycle here
     return Objects.equals(emailAddress, that.emailAddress)
         && DbInstitution.equalsWithoutEmails(institution, that.institution);
@@ -77,5 +88,18 @@ public class DbInstitutionEmailAddress {
   public int hashCode() {
     // calling institution.hashCode() would introduce a cycle here
     return Objects.hash(emailAddress, DbInstitution.hashCodeWithoutEmails(institution));
+  }
+
+  @Override
+  public String toString() {
+    return "DbInstitutionEmailAddress{"
+        + "institutionEmailAddressId="
+        + institutionEmailAddressId
+        + ", institution="
+        + institution
+        + ", emailAddress='"
+        + emailAddress
+        + '\''
+        + '}';
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailDomain.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailDomain.java
@@ -54,7 +54,8 @@ public class DbInstitutionEmailDomain {
     return this;
   }
 
-  // logical equality: data members without the ID field
+  // omit ID field from equality so equivalent objects match regardless
+  // of whether they are actually present in the DB
 
   @Override
   public boolean equals(Object o) {
@@ -67,12 +68,14 @@ public class DbInstitutionEmailDomain {
 
     DbInstitutionEmailDomain that = (DbInstitutionEmailDomain) o;
 
-    return Objects.equals(institution, that.institution)
-        && Objects.equals(emailDomain, that.emailDomain);
+    // calling institution.equals() would introduce a cycle here
+    return Objects.equals(emailDomain, that.emailDomain)
+        && DbInstitution.equalsWithoutEmails(institution, that.institution);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(institution, emailDomain);
+    // calling institution.hashCode() would introduce a cycle here
+    return Objects.hash(emailDomain, DbInstitution.hashCodeWithoutEmails(institution));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailDomain.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionEmailDomain.java
@@ -78,4 +78,17 @@ public class DbInstitutionEmailDomain {
     // calling institution.hashCode() would introduce a cycle here
     return Objects.hash(emailDomain, DbInstitution.hashCodeWithoutEmails(institution));
   }
+
+  @Override
+  public String toString() {
+    return "DbInstitutionEmailDomain{"
+        + "institutionEmailDomainId="
+        + institutionEmailDomainId
+        + ", institution="
+        + institution
+        + ", emailDomain='"
+        + emailDomain
+        + '\''
+        + '}';
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionUserInstructions.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionUserInstructions.java
@@ -54,7 +54,8 @@ public class DbInstitutionUserInstructions {
     return this;
   }
 
-  // logical equality: data members without the ID field
+  // omit ID field from equality so equivalent objects match regardless
+  // of whether they are actually present in the DB
 
   @Override
   public boolean equals(Object o) {
@@ -67,12 +68,12 @@ public class DbInstitutionUserInstructions {
 
     DbInstitutionUserInstructions that = (DbInstitutionUserInstructions) o;
 
-    return Objects.equals(institution.getInstitutionId(), that.institution.getInstitutionId())
-        && Objects.equals(userInstructions, that.userInstructions);
+    return Objects.equals(userInstructions, that.userInstructions)
+        && Objects.equals(institution, that.institution);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(institution.getInstitutionId(), userInstructions);
+    return Objects.hash(userInstructions, institution);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
@@ -106,8 +106,8 @@ public class DbVerifiedInstitutionalAffiliation {
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        user.getUsername(), institution, institutionalRoleEnum, institutionalRoleOtherText);
+    final int userHash = (user == null) ? 0 : Objects.hashCode(user.getUsername());
+    return Objects.hash(userHash, institution, institutionalRoleEnum, institutionalRoleOtherText);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
@@ -95,6 +95,15 @@ public class DbVerifiedInstitutionalAffiliation {
 
     DbVerifiedInstitutionalAffiliation that = (DbVerifiedInstitutionalAffiliation) o;
 
+    System.out.println("user eq=" + Objects.equals(user.getUsername(), that.user.getUsername()));
+    System.out.println("institution eq=" + Objects.equals(institution, that.institution));
+    System.out.println(
+        "institutionalRoleEnum eq="
+            + Objects.equals(institutionalRoleEnum, that.institutionalRoleEnum));
+    System.out.println(
+        "institutionalRoleOtherText eq="
+            + Objects.equals(institutionalRoleOtherText, that.institutionalRoleOtherText));
+
     // TODO: DbUser doesn't have a well-defined equals() so we use the username instead
     return Objects.equals(
             Optional.ofNullable(user).map(DbUser::getUsername),

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbVerifiedInstitutionalAffiliation.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.model;
 
 import java.util.Objects;
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -80,6 +81,9 @@ public class DbVerifiedInstitutionalAffiliation {
     return this;
   }
 
+  // omit ID field from equality so equivalent objects match regardless
+  // of whether they are actually present in the DB
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,7 +95,10 @@ public class DbVerifiedInstitutionalAffiliation {
 
     DbVerifiedInstitutionalAffiliation that = (DbVerifiedInstitutionalAffiliation) o;
 
-    return Objects.equals(user, that.user)
+    // TODO: DbUser doesn't have a well-defined equals() so we use the username instead
+    return Objects.equals(
+            Optional.ofNullable(user).map(DbUser::getUsername),
+            Optional.ofNullable(that.user).map(DbUser::getUsername))
         && Objects.equals(institution, that.institution)
         && Objects.equals(institutionalRoleEnum, that.institutionalRoleEnum)
         && Objects.equals(institutionalRoleOtherText, that.institutionalRoleOtherText);
@@ -99,7 +106,8 @@ public class DbVerifiedInstitutionalAffiliation {
 
   @Override
   public int hashCode() {
-    return Objects.hash(user, institution, institutionalRoleEnum, institutionalRoleOtherText);
+    return Objects.hash(
+        user.getUsername(), institution, institutionalRoleEnum, institutionalRoleOtherText);
   }
 
   @Override

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -181,7 +181,7 @@ public class InstitutionServiceTest {
             .emailDomains(ImmutableList.of("broad.org", "google.com"))
             .emailAddresses(ImmutableList.of("joel@broad.org", "joel@google.com"));
     final Institution instWithEmailsRoundTrip = service.createInstitution(instWithEmails);
-    assertEqualInstitutions(instWithEmailsRoundTrip, instWithEmails);
+    assertThat(instWithEmailsRoundTrip).isEqualTo(instWithEmails);
 
     // keep one and change one of each
 
@@ -191,7 +191,7 @@ public class InstitutionServiceTest {
             .emailAddresses(ImmutableList.of("joel@broad.org", "joel@verily.com"));
     final Institution instWithNewEmailsRoundTrip =
         service.updateInstitution(instWithEmails.getShortName(), instWithNewEmails).get();
-    assertEqualInstitutions(instWithNewEmailsRoundTrip, instWithNewEmails);
+    assertThat(instWithNewEmailsRoundTrip).isEqualTo(instWithNewEmails);
 
     // clear both
     final Institution instWithoutEmails =
@@ -507,15 +507,6 @@ public class InstitutionServiceTest {
   public void validate_OperationalUser_nullInstitution() {
     DbInstitution institution = null;
     assertThat(service.validateOperationalUser(institution)).isFalse();
-  }
-
-  // Institutions' email domains and addresses are Lists but have no inherent order,
-  // so they can't be directly compared for equality
-  private void assertEqualInstitutions(Institution actual, final Institution expected) {
-    assertThat(actual.getShortName()).isEqualTo(expected.getShortName());
-    assertThat(actual.getDisplayName()).isEqualTo(expected.getDisplayName());
-    assertThat(actual.getEmailDomains()).containsExactlyElementsIn(expected.getEmailDomains());
-    assertThat(actual.getEmailAddresses()).containsExactlyElementsIn(expected.getEmailAddresses());
   }
 
   private DbUser createUser(String contactEmail) {

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/institutions/User.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/institutions/User.java
@@ -100,7 +100,8 @@ public abstract class User {
       // will always execute since we checked it above
       existingAffil.ifPresent(
           existingAffiliation -> {
-            if (equivalent(existingAffiliation, newAffiliation)) {
+            //            if (equivalent(existingAffiliation, newAffiliation)) {
+            if (existingAffiliation.equals(newAffiliation)) {
               LOGGER.info("No action taken.  Affiliation exists: " + existingAffiliation);
             } else {
               throw new RuntimeException(


### PR DESCRIPTION
Description:

I need `DbVerifiedInstitutionalAffiliation.equals()` for the tool I'm building for RW-4911, and perhaps these could be more generally useful.

Local testing:
* Hitting a variety of API endpoints continues to work
* I can create a user with a verified institution in the UI
* I receive the User Instructions email for my institution

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
