### PR TITLE
[risk=no] Enable gradle output caching

### DIFF
--- a/api/gradle.properties
+++ b/api/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.console=plain


### PR DESCRIPTION
Output caching is apparently not enabled by default in Gradle. The only caching we currently do is for externally downloaded dependencies. For me, this shaved 10-30s on a cached dev-up.

Numbers to capture from the log before/after:
- Loading configs complete (52s)                                                                                                                                                                                     
- Total dev-env setup time: 67s 
- API server startup complete (39s)