### PR TITLE
[RW-4906][risk=low] bulkAuditProjectAccess improvements

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/google/CloudResourceManagerServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/CloudResourceManagerServiceImplIntegrationTest.java
@@ -27,7 +27,7 @@ public class CloudResourceManagerServiceImplIntegrationTest extends BaseIntegrat
       "cloud-resource-manager-integration-test@fake-research-aou.org";
 
   @Test
-  public void testGetAllProjectsForUser() {
+  public void testGetAllProjectsForUser() throws Exception {
     DbUser testUser = new DbUser();
     testUser.setUsername(CLOUD_RESOURCE_MANAGER_TEST_USER_EMAIL);
     List<Project> projectList = service.getAllProjectsForUser(testUser);

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.google.CloudResourceManagerService;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -255,31 +256,42 @@ public class OfflineUserController implements OfflineUserApiDelegate {
    */
   @Override
   public ResponseEntity<Void> bulkAuditProjectAccess() {
-    for (DbUser user : userService.getAllUsers()) {
+    int errorCount = 0;
+    List<DbUser> users = userService.getAllUsers();
+    for (DbUser user : users) {
       // TODO(RW-2062): Move to using the gcloud api for list all resources when it is available.
-      List<String> unauthorizedLogs =
-          cloudResourceManagerService.getAllProjectsForUser(user).stream()
-              .filter(
-                  project ->
-                      project.getParent() == null
-                          || !(WHITELISTED_ORG_IDS.contains(project.getParent().getId())))
-              .map(
-                  project ->
-                      project.getName()
-                          + " in organization "
-                          + Optional.ofNullable(project.getParent())
-                              .map(ResourceId::getId)
-                              .orElse("[none]"))
-              .collect(Collectors.toList());
-      if (unauthorizedLogs.size() > 0) {
-        log.log(
-            Level.WARNING,
-            "User "
-                + user.getUsername()
-                + " has access to projects: "
-                + String.join(", ", unauthorizedLogs));
+      try {
+        List<String> unauthorizedLogs =
+            cloudResourceManagerService.getAllProjectsForUser(user).stream()
+                .filter(
+                    project ->
+                        project.getParent() == null
+                            || !(WHITELISTED_ORG_IDS.contains(project.getParent().getId())))
+                .map(
+                    project ->
+                        project.getName()
+                            + " in organization "
+                            + Optional.ofNullable(project.getParent())
+                                .map(ResourceId::getId)
+                                .orElse("[none]"))
+                .collect(Collectors.toList());
+        if (unauthorizedLogs.size() > 0) {
+          log.warning(
+              "User "
+                  + user.getUsername()
+                  + " has access to projects: "
+                  + String.join(", ", unauthorizedLogs));
+        }
+      } catch (IOException e) {
+        log.log(Level.SEVERE, "failed to audit project access for user " + user.getUsername(), e);
+        errorCount++;
       }
     }
+    if (errorCount > 0) {
+      log.severe(String.format("encountered errors on %d/%d users", errorCount, users.size()));
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+    log.info(String.format("successfully audited %d users", users.size()));
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerService.java
@@ -1,10 +1,11 @@
 package org.pmiops.workbench.google;
 
 import com.google.api.services.cloudresourcemanager.model.Project;
+import java.io.IOException;
 import java.util.List;
 import org.pmiops.workbench.db.model.DbUser;
 
 /** Encapsulate Google APIs for interfacing with Google Cloud ResourceManager. */
 public interface CloudResourceManagerService {
-  List<Project> getAllProjectsForUser(DbUser user);
+  List<Project> getAllProjectsForUser(DbUser user) throws IOException;
 }

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -153,7 +153,7 @@ public class OfflineUserControllerTest {
   }
 
   @Test
-  public void testBulkProjectAudit() {
+  public void testBulkProjectAudit() throws Exception {
     List<Project> projectList = new ArrayList<>();
     doReturn(projectList).when(cloudResourceManagerService).getAllProjectsForUser(any());
     offlineUserController.bulkAuditProjectAccess();


### PR DESCRIPTION
- Bug fix: actually paginate the project results from CRM. Previous code only examined the first page..
- Bug fix: for default projects (no org/folder), project.parent is null. Handle this
- Behavior: continue after we hit an error. This will allow us to quantify whether we're having issues for all users, or just one.
- Logs: actually log which user we're having auth issues for. Swallowing the exception at a low level and throwing a runtime exception instead is not useful in this situation.