### PR TITLE
[risk=no][RW-4914] Disable profile in sidenav when unregistered

### DIFF
--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -27,8 +27,9 @@ describe('SideNav', () => {
   it('disables options when user not registered', () => {
     const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB,
       dataAccessLevel: DataAccessLevel.Unregistered}}/>);
+    wrapper.setState({showUserOptions: true});
     // These are our expected items to be disabled when you are not registered
-    let disabledItemText = ['Your Workspaces', 'Featured Workspaces', 'User Support'];
+    let disabledItemText = ['Profile', 'Your Workspaces', 'Featured Workspaces', 'User Support'];
     const sideNavItems = wrapper.find(SideNavItem);
     let disabledItems = sideNavItems.filterWhere(sideNavItem => sideNavItem.props().disabled);
     sideNavItems.forEach(sideNavItem => {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -270,6 +270,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
           onToggleSideNav={() => this.props.onToggleSideNav()}
           href='/profile'
           active={this.props.profileActive}
+          disabled={!hasRegisteredAccessFetch(profile.dataAccessLevel)}
         />
       }
       {


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
