### PR TITLE
[RW-5017][risk=no] Fix dropdowns on CB modifiers page (#3635) NOT TO MERGE

### DIFF
--- a/ui/src/app/cohort-search/modal/modal.component.html
+++ b/ui/src/app/cohort-search/modal/modal.component.html
@@ -100,6 +100,7 @@
                   <div class="panel-left" [class.show]="mode === 'modifiers'">
                     <crit-list-modifier-page *ngIf="showModifiers"
                       [disabled]="modifiersFlag"
+                      [selections]="selections"
                       [wizard]="wizard"></crit-list-modifier-page>
                   </div>
                   <!-- Attributes Page -->

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -11,7 +11,7 @@ import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {CriteriaType, DomainType, ModifierType, Operator} from 'generated/fetch';
+import {Criteria, CriteriaType, DomainType, ModifierType, Operator} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as moment from 'moment';
 import {Dropdown} from 'primereact/dropdown';
@@ -182,8 +182,13 @@ const validatorFuncs = {
   }
 };
 
+interface Selection extends Criteria {
+  parameterId: string;
+}
+
 interface Props {
   disabled: Function;
+  selections: Array<Selection>;
   wizard: any;
   workspace: WorkspaceData;
 }
@@ -388,7 +393,8 @@ export const ListModifierPage = withCurrentWorkspace()(
 
     calculate = () => {
       const {
-        wizard: {domain, item: {modifiers, searchParameters}, role},
+        selections,
+        wizard: {domain, item: {modifiers}, role},
         workspace: {cdrVersionId}
       } = this.props;
       this.trackEvent('Calculate');
@@ -400,7 +406,7 @@ export const ListModifierPage = withCurrentWorkspace()(
           [role]: [{
             items: [{
               type: domain,
-              searchParameters: searchParameters.map(mapParameter),
+              searchParameters: selections.map(mapParameter),
               modifiers: modifiers
             }]
           }],
@@ -519,6 +525,7 @@ export const ListModifierPage = withCurrentWorkspace()(
                 style={styles.select}
                 onChange={(e) => this.selectChange(e.value, i)}
                 options={options}
+                optionValue='value'
                 itemTemplate={(e) => this.optionTemplate(e, name)}/>
               {operator && name !== ModifierType.ENCOUNTERS && <React.Fragment>
                 {this.renderInput(i, '0', mod.type)}
@@ -560,9 +567,10 @@ export const ListModifierPage = withCurrentWorkspace()(
 })
 export class ModifierPageComponent extends ReactWrapperBase {
   @Input('disabled') disabled: Props['disabled'];
+  @Input('selections') selections: Props['selections'];
   @Input('wizard') wizard: Props['wizard'];
 
   constructor() {
-    super(ListModifierPage, ['disabled', 'wizard']);
+    super(ListModifierPage, ['disabled', 'selections', 'wizard']);
   }
 }


### PR DESCRIPTION
* RW-5017 fix dropdowns in modifiers after primereact update

* RW-5017 move selections to separate prop to fix calculate issue

* RW-5017 revert capitalization change

Co-authored-by: Will Dolbeer <WillDolbeer@VICTRs-MacBook-Pro.local>

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
