### PR TITLE
[risk=no] Make capitalization consistent in CB operator dropdowns

### DIFF
--- a/e2e/app/component/create-criteria-modal.ts
+++ b/e2e/app/component/create-criteria-modal.ts
@@ -29,8 +29,8 @@ export enum PhysicalMeasurementsCriteria {
 export enum FilterSign {
   AnyValue = 'Any value',
   Equals = 'Equals',
-  GreaterThanOrEqualTo = 'Greater than or Equal to',
-  LessThanOrEqualTo = 'Less than or Equal to',
+  GreaterThanOrEqualTo = 'Greater Than or Equal To',
+  LessThanOrEqualTo = 'Less Than or Equal To',
   Between = 'Between',
 }
 

--- a/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
@@ -174,8 +174,8 @@ export const AttributesPage = withCurrentWorkspace() (
         loading: true,
         options: [
           {label: 'Equals', value: Operator.EQUAL},
-          {label: 'Greater than or Equal to', value: Operator.GREATERTHANOREQUALTO},
-          {label: 'Less than or Equal to', value: Operator.LESSTHANOREQUALTO},
+          {label: 'Greater Than or Equal To', value: Operator.GREATERTHANOREQUALTO},
+          {label: 'Less Than or Equal To', value: Operator.LESSTHANOREQUALTO},
           {label: 'Between', value: Operator.BETWEEN},
         ],
       };


### PR DESCRIPTION
Fix difference in modifiers and attributes pages.