### PR TITLE
parallelism for api-build-test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ anchors:
     # In Feb 2017, this was set to 3G. But in Feb 2019 (RW-2194) we started seeing OOM errors,
     # so we bumped this down further to 2G.
     JAVA_TOOL_OPTIONS: -Xmx2g
-    # https://docs.gradle.org/6.3/userguide/gradle_daemon.html#sec:disabling_the_daemon
-    GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    # See: https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues
+    GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
     TERM: dumb
     MYSQL_ROOT_PASSWORD: ubuntu
 
@@ -294,9 +294,6 @@ jobs:
     # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
-    environment:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
-      JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git
       - ensure_branch_has_changes:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
     environment:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dkotlin.incremental=false
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
       JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git
@@ -322,7 +322,7 @@ jobs:
               | sed 's/\.[^.]*$//' \
               | circleci tests split --split-by=timings --timings-type=classname --index=$CIRCLE_NODE_INDEX)
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests", $i}')
-            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS --stacktrace
+            java -version && gradle -v && gradle test $GRADLE_ARGS
       - run:
           # Lint last; it's more important to surface test failures early.
           name: Java linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
     environment:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dkotlin.incremental=false
       JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,7 @@ jobs:
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
     environment:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dkotlin.incremental=false
       JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,9 @@ commands:
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] &&
               [ ${CIRCLE_BRANCH} != "master" ] &&
-              ! git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvE '(.md$)|(.pdf$)'; then
+              ! git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) \
+                | grep -qvE '(.md)|(.pdf)|(.png)|(.svg)|(Test.java)|(Test.kt)|(.mp4)|(.log)|(.txt)'; then
+
                 echo "No code changes on non-master branch. halting job."
                 circleci step halt
             fi
@@ -124,7 +126,9 @@ commands:
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] &&
               [ ${CIRCLE_BRANCH} != "master" ] &&
-              [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep << parameters.dir_name >>/ | wc -l | xargs) == 0 ]; then
+              [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep << parameters.dir_name >>/ | wc -l | xargs) == 0 ] &&
+              git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvE '(Test.kt)|(Test.java)|(.yaml)'; then
+
                 echo "No relevant changes in << parameters.dir_name >> directory on non-master branch. halting job."
                 circleci step halt
             fi
@@ -158,7 +162,7 @@ commands:
           name: "restore e2e cache"
           keys:
             - v1-e2e-cache-{{ .Branch }}-{{ checksum "~/workbench/e2e/yarn.lock" }}
-            - v1-e2e-cache-master
+            - v1-e2e-cache-{{ .Branch }}
             - v1-e2e-cache-
       - run:
           name: "workbench/e2e: yarn install dependencies"
@@ -187,17 +191,18 @@ commands:
             - save_cache:
                 name: "save api gradle cache"
                 paths:
+                  - .gradle
                   - ~/.gradle
-                key: v1-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
+                key: v2-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
       - when:
           condition: << parameters.restore >>
           steps:
             - restore_cache:
                 name: "restore api gradle cache"
                 keys:
-                  - v1-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
-                  - v1-gradle-cache-master
-                  - v1-gradle-cache-
+                  - v2-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
+                  - v2-gradle-cache-{{ .Branch }}
+                  - v2-gradle-cache-
 
   run_e2e_test:
     description: "Run puppeteer e2e integration tests"
@@ -223,7 +228,6 @@ commands:
           destination: logs
       - store_test_results:
           path: ~/workbench/e2e/logs
-
 
   start_local_api:
     description: "Start local API server"
@@ -284,11 +288,14 @@ commands:
 #        JOBS
 # -------------------------
 jobs:
-  api-build-test:
+  api-unit-test:
+    <<: *defaults
+    parallelism: 4
     # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     resource_class: medium+
-    <<: *java_defaults
+    environment:
+      JAVA_TOOL_OPTIONS: -Xmx4g
     steps:
       - checkout_init_git
       - ensure_branch_has_changes:
@@ -298,18 +305,36 @@ jobs:
       - run:
           name: Validate Swagger definitions
           working_directory: ~/workbench/api
-          command: ./project.rb validate-swagger --project-prop verboseTestLogging=yes
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+              ./project.rb validate-swagger --project-prop verboseTestLogging=yes
+            fi
       - run:
           name: Run Java unit tests
           working_directory: ~/workbench/api
-          command: ./project.rb test
+          # See: https://circleci.com/docs/2.0/language-java/#sample-configuration
+          command: |
+            CLASSNAMES=$(circleci tests glob "src/test/java/**/*Test.java" "src/test/java/**/*Test.kt" \
+              | cut -c 1- \
+              | sed 's@src/test/java/@@' \
+              | sed 's@/@.@g' \
+              | sed 's/\.[^.]*$//' \
+              | circleci tests split --split-by=timings --timings-type=classname --index=$CIRCLE_NODE_INDEX)
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests", $i}')
+            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS
       - run:
           # Lint last; it's more important to surface test failures early.
           name: Java linting
           working_directory: ~/workbench/api
-          command: ./gradlew spotlessCheck
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+              ./gradlew spotlessCheck
+            fi
       - store_test_results:
-           path: ~/workbench/api/build/test-results/test
+          path: ~/workbench/api/build/test-results/test
+      - store_artifacts:
+          path: ~/workbench/api/build/test-results/test
+          destination: JunitTestResult
       - manage_api_cache:
           save: true
 
@@ -360,13 +385,14 @@ jobs:
               --version circle-ci-test \
               --key-file circle-sa-key.json \
               --promote
-      - manage_api_cache:
-          save: true
+
 
   api-deps-check:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - manage_api_cache:
+          restore: true
       - run:
           name: Scan dependencies for vulnerabilities
           working_directory: ~/workbench/api
@@ -492,8 +518,7 @@ jobs:
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file ~/workbench/api/circle-sa-key.json \
               --promote
-      - manage_api_cache:
-          save: true
+
 
   deploy-perf:
     <<: *defaults
@@ -514,8 +539,7 @@ jobs:
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file ~/workbench/api/circle-sa-key.json \
               --promote
-      - manage_api_cache:
-          save: true
+
 
   # Run Puppeteer e2e UI tests on deployed "test" environment.
   puppeteer-e2e-test:
@@ -561,7 +585,7 @@ workflows:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
       - api-local-test
-      - api-build-test
+      - api-unit-test
       - ui-build-test
       - api-bigquery-test
       - api-integration-test
@@ -570,7 +594,7 @@ workflows:
       - api-deploy-to-test:
           filters: *filter_only_master_branch
           requires:
-            - api-build-test
+            - api-unit-test
       - ui-deploy-to-test:
           filters: *filter_only_master_branch
           requires:
@@ -586,7 +610,7 @@ workflows:
     jobs:
       - api-local-test:
           filters: *filter_only_release_tags
-      - api-build-test:
+      - api-unit-test:
           filters: *filter_only_release_tags
       - ui-build-test:
           filters: *filter_only_release_tags
@@ -601,7 +625,7 @@ workflows:
           filters: *filter_only_release_tags
           requires:
             - api-local-test
-            - api-build-test
+            - api-unit-test
             - api-bigquery-test
             - api-deps-check
             - api-integration-test
@@ -610,7 +634,7 @@ workflows:
           filters: *filter_only_release_tags
           requires:
             - api-local-test
-            - api-build-test
+            - api-unit-test
             - api-bigquery-test
             - api-deps-check
             - api-integration-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
     # So we want the Java memory limit to be below half of that: other things on the
     # machine need memory as well. The medium+ machine has 6GB.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
-    resource_class: medium+
+    # resource_class: medium+
     docker:
       - image: << pipeline.parameters.workbench_image >>
       - image: << pipeline.parameters.mysql_image >>
@@ -417,7 +417,7 @@ jobs:
   api-bigquery-test:
     # We're hitting OOM failures as of 13 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
-    resource_class: medium+
+    # resource_class: medium+
     <<: *java_defaults
     steps:
       - checkout_init_git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
               | sed 's/\.[^.]*$//' \
               | circleci tests split --split-by=timings --timings-type=classname --index=$CIRCLE_NODE_INDEX)
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests", $i}')
-            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS --scan
+            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS --stacktrace
       - run:
           # Lint last; it's more important to surface test failures early.
           name: Java linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
               | sed 's/\.[^.]*$//' \
               | circleci tests split --split-by=timings --timings-type=classname --index=$CIRCLE_NODE_INDEX)
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests", $i}')
-            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS
+            java -version && gradle -v && gradle --no-daemon test $GRADLE_ARGS --scan
       - run:
           # Lint last; it's more important to surface test failures early.
           name: Java linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
     environment:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dkotlin.incremental=false
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false
       JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,13 +289,11 @@ commands:
 # -------------------------
 jobs:
   api-unit-test:
-    <<: *defaults
+    <<: *java_defaults
     parallelism: 4
     # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
-    resource_class: medium+
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx4g
+    # resource_class: medium+
     steps:
       - checkout_init_git
       - ensure_branch_has_changes:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,8 @@ jobs:
     # We're hitting OOM failures as of 1 May 2020.  Increase to 6GB RAM by specifying a medium+ machine.
     # Refers to https://circleci.com/docs/2.0/configuration-reference/#resource_class
     # resource_class: medium+
+    environment:
+      JAVA_TOOL_OPTIONS: -Xmx1536m
     steps:
       - checkout_init_git
       - ensure_branch_has_changes:

--- a/api/src/main/java/org/pmiops/workbench/profile/AddressMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/AddressMapper.java
@@ -11,6 +11,6 @@ public interface AddressMapper {
   Address dbAddressToAddress(DbAddress dbAddress);
 
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "user", ignore = true) // set by UserService.createUser.
+  @Mapping(target = "user", ignore = true) // set by UserService.createUser
   DbAddress addressToDbAddress(Address address);
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/AddressMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/AddressMapper.java
@@ -11,6 +11,6 @@ public interface AddressMapper {
   Address dbAddressToAddress(DbAddress dbAddress);
 
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "user", ignore = true) // set by UserService.createUser
+  @Mapping(target = "user", ignore = true) // set by UserService.createUser.
   DbAddress addressToDbAddress(Address address);
 }


### PR DESCRIPTION
827 unit tests in `api/src/test/java/org/pmiops/workbench/**/*.java` and `*.kt`.

<img width="502" alt="Screen Shot 2020-06-04 at 6 59 45 PM" src="https://user-images.githubusercontent.com/35533885/83818523-94805e00-a695-11ea-91f6-1a9a93756d58.png">

Without parallelism, `api-unit-test` job takes some time to finish, range from 15 - 25 min long.
With parallelism 4, job time is reduced to under 10 min every time.

Larger parallelism does not dramatically further reduces test duration time.