### PR TITLE
[RW-4918][RW-4767][risk=no] Validate against whitespace-only strings on workspace create/edit/clone

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -393,4 +393,16 @@ describe('WorkspaceEdit', () => {
 
     expect(getSaveButtonDisableMsg(wrapper, 'otherPopulationDetails')).toBeDefined();
   });
+
+  it ('should show error message when other disseminate checked but empty', async() => {
+    const wrapper = component();
+    wrapper.find('[data-test-id="OTHER-checkbox"]').at(1).simulate('change', { target: { checked: true } });
+    const validInput = fp.repeat(8, 'a');
+    wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: validInput}});
+
+    expect(getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings')).toBeUndefined();
+    const inValidInput = fp.repeat(8, ' ');
+    wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: inValidInput}});
+    expect(getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings')).toBeDefined();
+  });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -325,23 +325,19 @@ describe('WorkspaceEdit', () => {
 
   it ('should show error message if Other primary purpose is more than 500 characters', async() => {
     const wrapper = component();
-    let otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
-    expect(otherPrimaryPurposeError).toBeUndefined();
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPurposeDetails')).toBeUndefined();
     wrapper.find('[data-test-id="otherPurpose-checkbox"]').at(1).simulate('change', { target: { checked: true } });
 
-    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
-    expect(otherPrimaryPurposeError[0]).toBe('Other primary purpose must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPurposeDetails')).toBeDefined();
 
     // Other Primary Purpose
     const validInput = fp.repeat(500, 'a');
     wrapper.find('[data-test-id="otherPrimaryPurposeText"]').first().simulate('change', {target: {value: validInput}});
-    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
-    expect(otherPrimaryPurposeError).toBeUndefined();
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPurposeDetails')).toBeUndefined();
 
     const inValidInput = fp.repeat(501, 'b');
     wrapper.find('[data-test-id="otherPrimaryPurposeText"]').first().simulate('change', {target: {value: inValidInput}});
-    otherPrimaryPurposeError = getSaveButtonDisableMsg(wrapper, 'otherPrimaryPurpose');
-    expect(otherPrimaryPurposeError[0]).toBe('Other primary purpose must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPurposeDetails')).toBeDefined();
   });
 
   it ('should show error message if Disease of focus is more than 80 characters', async() => {
@@ -352,8 +348,7 @@ describe('WorkspaceEdit', () => {
     wrapper.find('[data-test-id="researchPurpose-checkbox"]').at(1).simulate('change', { target: { checked: true } })
     wrapper.find('[data-test-id="diseaseFocusedResearch-checkbox"]').at(1).simulate('change', { target: { checked: true } });
 
-    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
-    expect(diseaseNameError[0]).toBe('Disease of focus must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus')).toBeDefined();
 
     const validInput = fp.repeat(8, 'a');
     wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: validInput}});
@@ -363,8 +358,7 @@ describe('WorkspaceEdit', () => {
     //
     const inValidInput = fp.repeat(81, 'b');
     wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: inValidInput}});
-    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
-    expect(fp.first(diseaseNameError)).toBe('Disease of focus must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus')).toBeDefined();
   });
 
   it ('should show error message if Other text for disseminate research is more than 100 characters', async() => {
@@ -378,8 +372,7 @@ describe('WorkspaceEdit', () => {
     expect(otherDisseminateResearchFindingsError).toBeUndefined();
     const inValidInput = fp.repeat(101, 'b');
     wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: inValidInput}});
-    otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
-    expect(fp.first(otherDisseminateResearchFindingsError)).toBe('Other disseminate research findings must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings')).toBeDefined();
   });
 
   it ('should show error message if Other text for Special Population is more than 100 characters', async() => {
@@ -392,13 +385,12 @@ describe('WorkspaceEdit', () => {
     const validInput = fp.repeat(100, 'a');
     wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: validInput}});
 
-    let otherSpecificPopulationError = getSaveButtonDisableMsg(wrapper, 'otherSpecificPopulation');
-    expect(otherSpecificPopulationError).toBeUndefined();
+    let otherPopulationDetailsError = getSaveButtonDisableMsg(wrapper, 'otherPopulationDetails');
+    expect(otherPopulationDetailsError).toBeUndefined();
 
     const inValidInput = fp.repeat(101, 'a');
     wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: inValidInput}});
 
-    otherSpecificPopulationError = getSaveButtonDisableMsg(wrapper, 'otherSpecificPopulation');
-    expect(fp.first(otherSpecificPopulationError)).toBe('Other specific population must be true');
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPopulationDetails')).toBeDefined();
   });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -342,8 +342,7 @@ describe('WorkspaceEdit', () => {
 
   it ('should show error message if Disease of focus is more than 80 characters', async() => {
     const wrapper = component();
-    let diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
-    expect(diseaseNameError).toBeUndefined();
+    expect(getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus')).toBeUndefined();
 
     wrapper.find('[data-test-id="researchPurpose-checkbox"]').at(1).simulate('change', { target: { checked: true } })
     wrapper.find('[data-test-id="diseaseFocusedResearch-checkbox"]').at(1).simulate('change', { target: { checked: true } });
@@ -353,9 +352,8 @@ describe('WorkspaceEdit', () => {
     const validInput = fp.repeat(8, 'a');
     wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: validInput}});
 
-    diseaseNameError = getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus');
-    expect(diseaseNameError).toBeUndefined();
-    //
+    expect(getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus')).toBeUndefined();
+
     const inValidInput = fp.repeat(81, 'b');
     wrapper.find('[data-test-id="search-input"]').first().simulate('change', {target: {value: inValidInput}});
     expect(getSaveButtonDisableMsg(wrapper, 'diseaseOfFocus')).toBeDefined();
@@ -364,12 +362,10 @@ describe('WorkspaceEdit', () => {
   it ('should show error message if Other text for disseminate research is more than 100 characters', async() => {
     const wrapper = component();
     wrapper.find('[data-test-id="OTHER-checkbox"]').at(1).simulate('change', { target: { checked: true } });
-    let otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
     const validInput = fp.repeat(8, 'a');
     wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: validInput}});
 
-    otherDisseminateResearchFindingsError = getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings');
-    expect(otherDisseminateResearchFindingsError).toBeUndefined();
+    expect(getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings')).toBeUndefined();
     const inValidInput = fp.repeat(101, 'b');
     wrapper.find('[data-test-id="otherDisseminateResearch-text"]').first().simulate('change', {target: {value: inValidInput}});
     expect(getSaveButtonDisableMsg(wrapper, 'otherDisseminateResearchFindings')).toBeDefined();
@@ -385,8 +381,7 @@ describe('WorkspaceEdit', () => {
     const validInput = fp.repeat(100, 'a');
     wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: validInput}});
 
-    let otherPopulationDetailsError = getSaveButtonDisableMsg(wrapper, 'otherPopulationDetails');
-    expect(otherPopulationDetailsError).toBeUndefined();
+    expect(getSaveButtonDisableMsg(wrapper, 'otherPopulationDetails')).toBeUndefined();
 
     const inValidInput = fp.repeat(101, 'a');
     wrapper.find('[data-test-id="other-specialPopulation-text"]').first().simulate('change', {target: {value: inValidInput}});

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -797,6 +797,10 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
       return options;
     }
 
+    /**
+     * Validates the current workspace state. This is a pass-through to validate.js
+     * which returns the standard error object if any validation errors occur.
+     */
     private validate(): any {
       const {
         populationChecked,
@@ -832,7 +836,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         disseminateResearchFindingList,
         'primaryPurpose': this.primaryPurposeIsSelected
       };
-      // TODO: This validation spec should include erorr messages which get
+      // TODO: This validation spec should include error messages which get
       // surfaced directly. Currently these constraints are entirely separate
       // from the user facing error strings we render.
       const constraints: object = {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -860,13 +860,13 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           length: {
             maximum: 500
           }
-        }
+        };
       }
       if (populationChecked) {
         values = {...values, populationDetails};
         constraints['populationDetails'] = {
           presence: true
-        }
+        };
       }
       if (populationDetails &&
           populationDetails.includes(SpecificPopulationEnum.OTHER)) {
@@ -878,7 +878,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           length: {
             maximum: 100
           }
-        }
+        };
       }
       if (diseaseFocusedResearch) {
         values = {...values, diseaseOfFocus};
@@ -889,7 +889,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           length: {
             maximum: 80
           }
-        }
+        };
       }
       if (disseminateResearchFindingList &&
           disseminateResearchFindingList.includes(DisseminateResearchEnum.OTHER)) {
@@ -901,7 +901,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           length: {
             maximum: 100
           }
-        }
+        };
       }
       return validate(values, constraints);
     }
@@ -1254,7 +1254,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                   approaches you plan to use for your study (Question 2.2)</i> must be between 0 and 1000 characters</li>}
                 {errors.anticipatedFindings && <li> Answer for <i>What are the anticipated findings
                   from the study? (Question 2.3)</i> must be between 0 and 1000 characters</li>}
-                {errors.disseminateResearchFindingList && <li> You must specific how you plan to disseminate your research findings (Question 3)</li>}
+                {errors.disseminateResearchFindingList && <li>
+                  You must specific how you plan to disseminate your research findings (Question 3)</li>}
                 {errors.otherDisseminateResearchFindings && <li>
                     Disseminate Research Findings Other text should not be blank and should be at most 100 characters</li>}
                 {errors.researchOutcomeList && <li> You must specify the outcome of the research (Question 4)</li>}


### PR DESCRIPTION
Notes:
- Refactored validate.js usage to take better advantage built-in capabilities, including `allowEmpty: false`
- Switched to a conditional validation approach, rather than including this in the validation check
- Does not implement any API-level check for non-whitespace strings, this is probably something we should have but is out of scope.

Future work:
- We should rework the error messages to utilize the validate.js error messaging framework. Currently there's a fair amount of duplication going on in this file.