### PR TITLE
[RW-4781][risk=no] add criteria children lookups to BQ count SQL

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1048,12 +1048,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void anyMentionOfCPTParent5DaysAfterICD10Child() {
-    SearchGroupItem icd9SGI =
+  public void anyMentionOfCPT5DaysAfterICD10Child() {
+    SearchGroupItem cptSGI =
         new SearchGroupItem()
             .type(DomainType.CONDITION.toString())
             .addSearchParametersItem(
-                icd9().type(CriteriaType.CPT4.toString()).group(true).conceptId(0L))
+                icd9().type(CriteriaType.CPT4.toString()).group(false).conceptId(1L))
             .temporalGroup(0)
             .addModifiersItem(visitModifier());
     SearchGroupItem icd10SGI =
@@ -1062,10 +1062,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .addSearchParametersItem(icd10())
             .temporalGroup(1);
 
-    // Any Mention Of ICD9 5 Days After ICD10
+    // Any Mention Of CPT 5 Days After ICD10
     SearchGroup temporalGroup =
         new SearchGroup()
-            .items(ImmutableList.of(icd9SGI, icd10SGI))
+            .items(ImmutableList.of(cptSGI, icd10SGI))
             .temporal(true)
             .mention(TemporalMention.ANY_MENTION)
             .time(TemporalTime.X_DAYS_AFTER)
@@ -1501,7 +1501,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter snomed = snomed().group(true).standard(true).conceptId(4302541L);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(snomed), new ArrayList<>());
+            DomainType.PROCEDURE.toString(), ImmutableList.of(snomed), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1914,7 +1914,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         survey().subtype(CriteriaSubType.QUESTION.toString()).conceptId(1585899L);
     SearchRequest searchRequest =
         createSearchRequests(
-            ppiQuestion.getType(), ImmutableList.of(ppiQuestion), new ArrayList<>());
+            ppiQuestion.getDomain(), ImmutableList.of(ppiQuestion), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -74,7 +74,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 @RunWith(BeforeAfterSpringTestRunner.class)
 // Note: normally we shouldn't need to explicitly import our own @TestConfiguration. This might be
@@ -128,8 +127,6 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Mock private Provider<WorkbenchConfig> configProvider;
 
-  @Autowired private JdbcTemplate jdbcTemplate;
-
   private DbCriteria drugNode1;
   private DbCriteria drugNode2;
   private DbCriteria criteriaParent;
@@ -152,7 +149,13 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Override
   public List<String> getTableNames() {
-    return ImmutableList.of("person", "death", "cb_search_person", "cb_search_all_events");
+    return ImmutableList.of(
+        "person",
+        "death",
+        "cb_search_person",
+        "cb_search_all_events",
+        "cb_criteria",
+        "cb_criteria_ancestor");
   }
 
   @Override
@@ -188,14 +191,6 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     saveCriteriaWithPath("0", drugNode1);
     drugNode2 = drugCriteriaChild(drugNode1.getId());
     saveCriteriaWithPath(drugNode1.getPath(), drugNode2);
-    jdbcTemplate.execute(
-        "create table cb_criteria_ancestor(ancestor_id bigint, descendant_id bigint)");
-    jdbcTemplate.execute(
-        "insert into cb_criteria_ancestor(ancestor_id, descendant_id) values ("
-            + 1520218
-            + ", "
-            + 1520218
-            + ")");
 
     criteriaParent = icd9CriteriaParent();
     saveCriteriaWithPath("0", criteriaParent);
@@ -336,6 +331,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .addStandard(false)
             .addName("USA")
             .addConceptId("5")
+            .addSynonyms("[SURVEY_rank1]")
             .build();
     saveCriteriaWithPath(questionNode.getPath(), answerNode);
 
@@ -358,7 +354,6 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @After
   public void tearDown() {
-    jdbcTemplate.execute("drop table cb_criteria_ancestor");
     delete(
         drugNode1,
         drugNode2,
@@ -1053,6 +1048,36 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void anyMentionOfCPTParent5DaysAfterICD10Child() {
+    SearchGroupItem icd9SGI =
+        new SearchGroupItem()
+            .type(DomainType.CONDITION.toString())
+            .addSearchParametersItem(
+                icd9().type(CriteriaType.CPT4.toString()).group(true).conceptId(0L))
+            .temporalGroup(0)
+            .addModifiersItem(visitModifier());
+    SearchGroupItem icd10SGI =
+        new SearchGroupItem()
+            .type(DomainType.CONDITION.toString())
+            .addSearchParametersItem(icd10())
+            .temporalGroup(1);
+
+    // Any Mention Of ICD9 5 Days After ICD10
+    SearchGroup temporalGroup =
+        new SearchGroup()
+            .items(ImmutableList.of(icd9SGI, icd10SGI))
+            .temporal(true)
+            .mention(TemporalMention.ANY_MENTION)
+            .time(TemporalTime.X_DAYS_AFTER)
+            .timeValue(5L);
+
+    SearchRequest searchRequest = new SearchRequest().includes(ImmutableList.of(temporalGroup));
+    ResponseEntity<Long> response =
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
+    assertParticipants(response, 1);
+  }
+
+  @Test
   public void anyMentionOfCPTWithIn5DaysOfVisit() {
     SearchGroupItem cptSGI =
         new SearchGroupItem()
@@ -1291,7 +1316,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchRequest searchRequest =
         createSearchRequests(
             DomainType.CONDITION.toString(),
-            ImmutableList.of(icd9().group(true).conceptId(2L)),
+            ImmutableList.of(icd9().group(true).conceptId(44823922L)),
             new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
@@ -1469,6 +1494,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
+  }
+
+  @Test
+  public void countSubjectsSnomedParentProcedure() {
+    SearchParameter snomed = snomed().group(true).standard(true).conceptId(4302541L);
+    SearchRequest searchRequest =
+        createSearchRequests(
+            DomainType.CONDITION.toString(), ImmutableList.of(snomed), new ArrayList<>());
+    ResponseEntity<Long> response =
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
+    assertParticipants(response, 1);
   }
 
   @Test
@@ -1861,6 +1897,30 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void countSubjectsSurvey() {
+    // Survey
+    SearchRequest searchRequest =
+        createSearchRequests(
+            DomainType.SURVEY.toString(), ImmutableList.of(survey()), new ArrayList<>());
+    ResponseEntity<Long> response =
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
+    assertParticipants(response, 1);
+  }
+
+  @Test
+  public void countSubjectsQuestion() {
+    // Question
+    SearchParameter ppiQuestion =
+        survey().subtype(CriteriaSubType.QUESTION.toString()).conceptId(1585899L);
+    SearchRequest searchRequest =
+        createSearchRequests(
+            ppiQuestion.getType(), ImmutableList.of(ppiQuestion), new ArrayList<>());
+    ResponseEntity<Long> response =
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
+    assertParticipants(response, 1);
+  }
+
+  @Test
   public void countSubjectsSurveyValueSourceConceptId() {
     // value source concept id
     List<Attribute> attributes =
@@ -1870,16 +1930,31 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.IN)
                 .operands(ImmutableList.of("7")));
     SearchParameter ppiValueAsConceptId =
-        survey()
-            .group(false)
-            .subtype(CriteriaSubType.ANSWER.toString())
-            .conceptId(5L)
-            .attributes(attributes);
+        survey().subtype(CriteriaSubType.ANSWER.toString()).conceptId(5L).attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
             ppiValueAsConceptId.getType(),
             ImmutableList.of(ppiValueAsConceptId),
             new ArrayList<>());
+    ResponseEntity<Long> response =
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
+    assertParticipants(response, 1);
+  }
+
+  @Test
+  public void countSubjectsSurveyValueAsNumber() {
+    // value as number
+    List<Attribute> attributes =
+        ImmutableList.of(
+            new Attribute()
+                .name(AttrName.NUM)
+                .operator(Operator.EQUAL)
+                .operands(ImmutableList.of("7")));
+    SearchParameter ppiValueAsNumer =
+        survey().subtype(CriteriaSubType.ANSWER.toString()).conceptId(5L).attributes(attributes);
+    SearchRequest searchRequest =
+        createSearchRequests(
+            ppiValueAsNumer.getType(), ImmutableList.of(ppiValueAsNumer), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -2002,7 +2077,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     criteria = cbCriteriaDao.save(criteria);
     String pathEnd = String.valueOf(criteria.getId());
     criteria.setPath(path.isEmpty() ? pathEnd : path + "." + pathEnd);
-    criteria = cbCriteriaDao.save(criteria);
+    cbCriteriaDao.save(criteria);
   }
 
   private void delete(DbCriteria... criteriaList) {

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -227,7 +227,7 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
   public void testMaterializeCohortICD9Group() {
     MaterializeCohortResponse response =
         cohortMaterializationService.materializeCohort(
-            null, SearchRequests.icd9Codes(), null, 0, makeRequest(1000));
+            null, SearchRequests.icd9CodesChildren(), null, 0, makeRequest(1000));
     assertPersonIds(response, 1L);
     assertThat(response.getNextPageToken()).isNull();
   }

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_criteria_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_criteria_data.json
@@ -63,7 +63,7 @@
     "code": "001.1",
     "name": "Cholera due to vibrio cholerae",
     "est_count": 2,
-    "is_group": 0,
+    "is_group": 1,
     "is_selectable": 1,
     "has_attribute": 0,
     "has_hierarchy": 1,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -404,13 +404,13 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final SearchRequest searchRequest = new Gson().fromJson(cohortDefinition, SearchRequest.class);
     final QueryJobConfiguration participantIdQuery =
         cohortQueryBuilder.buildParticipantIdQuery(new ParticipantCriteria(searchRequest));
-    final QueryJobConfiguration participantQueryConfig =
-        bigQueryService.filterBigQueryConfig(participantIdQuery);
+    //    final QueryJobConfiguration participantQueryConfig =
+    //        bigQueryService.filterBigQueryConfig(participantIdQuery);
     final AtomicReference<String> participantQuery =
-        new AtomicReference<>(participantQueryConfig.getQuery());
+        new AtomicReference<>(participantIdQuery.getQuery());
     final ImmutableMap.Builder<String, QueryParameterValue> cohortNamedParametersBuilder =
         new ImmutableMap.Builder<>();
-    participantQueryConfig
+    participantIdQuery
         .getNamedParameters()
         .forEach(
             (npKey, npValue) -> {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -404,8 +404,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final SearchRequest searchRequest = new Gson().fromJson(cohortDefinition, SearchRequest.class);
     final QueryJobConfiguration participantIdQuery =
         cohortQueryBuilder.buildParticipantIdQuery(new ParticipantCriteria(searchRequest));
-    //    final QueryJobConfiguration participantQueryConfig =
-    //        bigQueryService.filterBigQueryConfig(participantIdQuery);
     final AtomicReference<String> participantQuery =
         new AtomicReference<>(participantIdQuery.getQuery());
     final ImmutableMap.Builder<String, QueryParameterValue> cohortNamedParametersBuilder =

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -1,8 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
-import static org.pmiops.workbench.model.PrePackagedConceptSetEnum.SURVEY;
-
 import static com.google.cloud.bigquery.StandardSQLTypeName.ARRAY;
+import static org.pmiops.workbench.model.PrePackagedConceptSetEnum.SURVEY;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetServiceImpl.java
@@ -2,9 +2,10 @@ package org.pmiops.workbench.db.dao;
 
 import static org.pmiops.workbench.model.PrePackagedConceptSetEnum.SURVEY;
 
+import static com.google.cloud.bigquery.StandardSQLTypeName.ARRAY;
+
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
-import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -22,12 +23,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.engine.jdbc.internal.BasicFormatterImpl;
-import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
@@ -755,42 +756,40 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   //    SELECT * FROM cdr.dataset.person WHERE criteria IN (1, 2, 3)
   private static String fillInQueryParams(
       String query, Map<String, QueryParameterValue> queryParameterValueMap) {
-    StringBuilder stringBuilder = new StringBuilder(query);
-    queryParameterValueMap.forEach(
-        (key, value) -> {
-          if (StandardSQLTypeName.ARRAY.equals(value.getType())) {
-            // This handles the replacement of array parameters.
-            // It finds the parameter (specified by `unnest(NAME)`)
-            String stringToReplace = "unnest(@".concat(key.concat(")"));
-            int startingIndex = stringBuilder.indexOf(stringToReplace);
-            stringBuilder.replace(
-                startingIndex,
-                startingIndex + stringToReplace.length(),
-                arraySqlFromQueryParameter(value));
-          } else {
-            // This handles the replacement of non-array parameters.
-            // getValue should always work, because it handles all value types except arrays and
-            // structs.
-            // We do not use structs.
-            String stringToReplace = "@".concat(key);
-            int startingIndex = stringBuilder.indexOf(stringToReplace);
-            Optional.ofNullable(value.getValue())
-                .ifPresent(
-                    v ->
-                        stringBuilder.replace(
-                            startingIndex, startingIndex + stringToReplace.length(), v));
-          }
-        });
-    return stringBuilder.toString();
+    return queryParameterValueMap.entrySet().stream()
+        .map(param -> (Function<String, String>) s -> replaceParameter(s, param))
+        .reduce(Function.identity(), Function::andThen)
+        .apply(query)
+        .replaceAll("unnest", "");
   }
 
-  @NotNull
-  private static String arraySqlFromQueryParameter(QueryParameterValue value) {
-    return String.format(
-        "(%s)",
-        nullableListToEmpty(value.getArrayValues()).stream()
-            .map(QueryParameterValue::getValue)
-            .collect(Collectors.joining(", ")));
+  private static String replaceParameter(
+      String s, Map.Entry<String, QueryParameterValue> parameter) {
+    String value =
+        ARRAY.equals(parameter.getValue().getType())
+            ? nullableListToEmpty(parameter.getValue().getArrayValues()).stream()
+                .map(DataSetServiceImpl::convertSqlTypeToString)
+                .collect(Collectors.joining(", "))
+            : convertSqlTypeToString(parameter.getValue());
+    String key = String.format("@%s", parameter.getKey());
+    return s.replaceAll(key, value);
+  }
+
+  private static String convertSqlTypeToString(QueryParameterValue parameter) {
+    switch (parameter.getType()) {
+      case BOOL:
+        return Boolean.valueOf(parameter.getValue()) ? "1" : "0";
+      case INT64:
+      case FLOAT64:
+      case NUMERIC:
+        return parameter.getValue();
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
+        return String.format("'%s'", parameter.getValue());
+      default:
+        throw new RuntimeException();
+    }
   }
 
   private static String generateNotebookUserCode(

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -108,13 +108,7 @@ public class DataSetServiceTest {
 
     final DbCohort cohort = buildSimpleCohort();
     when(cohortDao.findCohortByNameAndWorkspaceId(anyString(), anyLong())).thenReturn(cohort);
-    when(cohortQueryBuilder.buildParticipantIdQuery(any()))
-        .thenReturn(
-            QueryJobConfiguration.newBuilder(
-                    "SELECT * FROM person_id from `${projectId}.${dataSetId}.person` person")
-                .build());
-    when(bigQueryService.filterBigQueryConfig(any(QueryJobConfiguration.class)))
-        .thenReturn(QUERY_JOB_CONFIGURATION_1);
+    when(cohortQueryBuilder.buildParticipantIdQuery(any())).thenReturn(QUERY_JOB_CONFIGURATION_1);
   }
 
   private DbCohort buildSimpleCohort() {

--- a/api/src/test/java/org/pmiops/workbench/test/SearchRequests.java
+++ b/api/src/test/java/org/pmiops/workbench/test/SearchRequests.java
@@ -40,14 +40,15 @@ public class SearchRequests {
     return searchRequest(searchGroupItem);
   }
 
-  public static SearchRequest codesRequest(String groupType, String type, String... codes) {
+  public static SearchRequest codesRequest(
+      String groupType, String type, boolean group, String... codes) {
     SearchGroupItem searchGroupItem = new SearchGroupItem().id("id1").type(groupType);
     for (String code : codes) {
       SearchParameter parameter =
           new SearchParameter()
               .domain(groupType)
               .type(type)
-              .group(true)
+              .group(group)
               .conceptId(1L)
               .value(code)
               .standard(false)
@@ -141,7 +142,12 @@ public class SearchRequests {
 
   public static SearchRequest icd9Codes() {
     return codesRequest(
-        DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), ICD9_GROUP_CODE);
+        DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), true, ICD9_GROUP_CODE);
+  }
+
+  public static SearchRequest icd9CodesChildren() {
+    return codesRequest(
+        DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, ICD9_GROUP_CODE);
   }
 
   public static SearchRequest icd9CodeWithModifiers() {


### PR DESCRIPTION
This PR addresses moving criteria children lookups from cloudsql to BQ. Also, fixed an existing bug in the SQL export from DataSetBuilder to notebooks. Important changes are listed below:

1. Removing CriteriaLookupUtil#buildCriteriaLookupMap from CohortQueryBuilder(this looks up criteria children in cloudsql and was causing OOM exceptions because of to many child nodes)
2. Adding BQ SQL to SearchGroupItemQueryBuilder to replace the above lookup.
3. Updated CohortBuilderControllerBQTest to reflect these changes
4. In DataSetController added a check for an empty query response.
5. In DataSetServiceImpl added a method(convertSqlTypeToString) to account for all BQ SQL types. The code was making an assumption that only named parameters where numeric.
6. In DataSetControllerBQTest refactored extractRQuery to be more robust.