### PR TITLE
increase goto timeout in workspace-clone.spec

### DIFF
--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -86,7 +86,7 @@ describe('Clone workspace', () => {
       await newPage.setUserAgent(userAgent);
       await signIn(newPage);
 
-      const response = await newPage.goto(workspaceDataUrl, {waitUntil: ['domcontentloaded','networkidle0']});
+      const response = await newPage.goto(workspaceDataUrl, {waitUntil: ['domcontentloaded','networkidle0'], timeout: 60000});
       expect(await response.status()).toEqual(200);
 
       await newPage.close();


### PR DESCRIPTION
First time, encountered a timeOut error in workspace-clone test in CircleCI job. It's an easy fix.
https://app.circleci.com/pipelines/github/all-of-us/workbench/1570/workflows/0688721b-0a8a-41db-b9ae-1dac6b0ef3df

```
FAIL  tests/workspace/workspace-clone.spec.ts (286.246s)
 
  Clone workspace
    From "Your Workspaces" page using Workspace card ellipsis menu
      ✓ As OWNER, user can clone workspace (58684ms)
    From "Data" page using side ellipsis menu
      ✕ As OWNER, user can clone workspace (123058ms)

  ● Clone workspace › From "Data" page using side ellipsis menu › As OWNER, user can clone workspace

    TimeoutError: Navigation timeout of 30000 ms exceeded
      87 |       await signIn(newPage);
      88 | 
    > 89 |       const response = await newPage.goto(workspaceDataUrl, {waitUntil: ['domcontentloaded','networkidle0']});
         |                                      ^
      90 |       expect(await response.status()).toEqual(200);
      91 | 
      92 |       await newPage.close();
      at node_modules/puppeteer/lib/LifecycleWatcher.js:142:21
        -- ASYNC --
      at Frame.<anonymous> (node_modules/puppeteer/lib/helper.js:111:15)
      at Page.goto (node_modules/puppeteer/lib/Page.js:672:49)
      at Page.<anonymous> (node_modules/puppeteer/lib/helper.js:112:23)
      at Object.<anonymous> (tests/workspace/workspace-clone.spec.ts:89:38)
        -- ASYNC --
      at Page.<anonymous> (node_modules/puppeteer/lib/helper.js:111:15)
      at Object.<anonymous> (tests/workspace/workspace-clone.spec.ts:89:38)
 ```
