### PR TITLE
[risk=no] Refactor docker-compose to leverage anchors

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,16 +1,22 @@
-version: "3"
+version: "3.4"
+x-api-defaults: &api-defaults
+  build:
+    context: ./src/dev/server
+  image: allofustest/workbench-dev-api:local
+  user: ${UID}
+  working_dir: /w/api
+  environment:
+    - GOOGLE_APPLICATION_CREDENTIALS=/w/api/sa-key.json
+  env_file:
+    - db/vars.env
+  volumes:
+    - src-sync:/w:nocopy
+    - gradle-cache:/.gradle
+    - ~/.config:/.config:cached
+    - ~/.gsutil:/.gsutil:cached
 services:
   scripts:
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
-    working_dir: /w/api
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
+    <<: *api-defaults
   db:
     image: mysql:5.7.27
     env_file:
@@ -20,165 +26,52 @@ services:
     ports:
       - 127.0.0.1:3306:3306
   api:
+    <<: *api-defaults
     depends_on:
       - db
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
-    working_dir: /w/api
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
     command: ./project.rb start-api-and-incremental-build
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/w/api/sa-key.json
-    env_file:
-      - db/vars.env
     ports:
       - 127.0.0.1:8081:8081
       - 127.0.0.1:8001:8001
   es-scripts:
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
-    working_dir: /w/api
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/w/api/sa-key.json
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
+    <<: *api-defaults
   db-scripts:
+    <<: *api-defaults
     depends_on:
       - db
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
     working_dir: /w/api/db
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
     entrypoint: ['with-uid.sh', 'wait-for-it', 'db:3306', '-t', '30', --]
-    env_file:
-      - db/vars.env
 
   api-scripts:
+    <<: *api-defaults
     depends_on:
       - db
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
-    working_dir: /w/api
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
     entrypoint: ['with-uid.sh', 'wait-for-it', 'db:3306', '-t', '30', --]
-    env_file:
-      - db/vars.env
 
   cdr-scripts:
+    <<: *api-defaults
     depends_on:
       - db
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
     working_dir: /w/api/db-cdr
-    volumes:
-      - src-sync:/w:nocopy
-      - gradle-cache:/.gradle
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
     entrypoint: ['with-uid.sh', 'wait-for-it', 'db:3306', '-t', '30', --]
-    env_file:
-      - db-cdr/vars.env
+    env_file: db-cdr/vars.env
 
   db-make-bq-tables:
+    <<: *api-defaults
     depends_on:
       - db
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
     working_dir: /w/db-cdr
-    volumes:
-      - gradle-cache:/.gradle
-      - .:/w:cached
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
-
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
-    env_file:
-      - db-cdr/vars.env
+    env_file: db-cdr/vars.env
 
   db-cloudsql-import:
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
+    <<: *api-defaults
     working_dir: /w/db-cdr
-    volumes:
-      - gradle-cache:/.gradle
-      - .:/w:cached
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
-
     entrypoint: ["./generate-cdr/cloudsql-import.sh"]
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
-    env_file:
-      - db/vars.env
 
   db-local-mysql-import:
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
+    <<: *api-defaults
     working_dir: /w/db-cdr
-    volumes:
-      - gradle-cache:/.gradle
-      - .:/w:cached
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
-
     entrypoint: ["./generate-cdr/local-mysql-import.sh"]
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
-    env_file:
-      - db/vars.env
-
-  cloud-sql-proxy:
-    build:
-      context: ./src/dev/server
-    image: allofustest/workbench-dev-api:local
-    user: ${UID}
-    working_dir: /w
-    volumes:
-      - .:/w:cached
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
-    command: |
-      cloud_sql_proxy
-        -instances all-of-us-workbench-test:us-central1:workbenchmaindb=tcp:0.0.0.0:3307
-        -credential_file=/w/sa-key.json
-
-  mysql-cloud:
-    depends_on:
-      - cloud-sql-proxy
-    image: mysql:5.7.27
-    user: ${UID}
-    working_dir: /w
-    volumes:
-      - .:/w:cached
-    entrypoint: mysql --host=cloud-sql-proxy --port=3307
 
 volumes:
   db:

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,8 +1,18 @@
 version: "3.4"
+
+# x- indicates an "extension", so docker-compose will ignore the attribute. The
+# name is not important, it's just the necessary syntax to create a YAML anchor
+# for reuse across the below services.
 x-api-defaults: &api-defaults
+  # This image label exists for documentation purposes only, e.g. to identify
+  # it via `docker images`. We do not actually push this image up to DockerHub.
+  # Since docker-compose should never find this image remotely, it will rebuild
+  # it from the provided build context or use a cached local version.
+  # When making changes to this image, you can modify this tag to force all devs
+  # to rebuild.
+  image: allofustest/workbench-dev-api:local
   build:
     context: ./src/dev/server
-  image: allofustest/workbench-dev-api:local
   user: ${UID}
   working_dir: /w/api
   environment:
@@ -14,6 +24,7 @@ x-api-defaults: &api-defaults
     - gradle-cache:/.gradle
     - ~/.config:/.config:cached
     - ~/.gsutil:/.gsutil:cached
+
 services:
   scripts:
     <<: *api-defaults


### PR DESCRIPTION
Behavioral change:
- In a few cases, this adds the GOOGLE_APPLICATION_CREDENTIALS. Based on manual testing of commands, this looks like it had no effect, so I'll prefer just making the configs consistent.
- Remove some unused services: mysql-cloud, cloud-sql-proxy. @freemabd in case you're aware of some reason we still need these

Manually tested:
- Ran `./project.rb` commands with coverage of the various docker-compose services

Future work:
- Several of these services are redundant and could be further merged / removed