### PR TITLE
[risk=low] Upgradle to 4.10.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ parameters:
     default: "circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com"
   workbench_image:
     type: string
-    default: "allofustest/workbench:buildimage-0.0.17"
+    default: "allofustest/workbench:buildimage-0.0.18"
   mysql_image:
     type: string
     default: "circleci/mysql:5.7"

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -10,7 +10,7 @@ x-api-defaults: &api-defaults
   # it from the provided build context or use a cached local version.
   # When making changes to this image, you can modify this tag to force all devs
   # to rebuild.
-  image: allofustest/workbench-dev-api:local
+  image: allofustest/workbench-dev-api:local-1
   build:
     context: ./src/dev/server
   user: ${UID}

--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -60,7 +60,7 @@ ENV GRADLE_USER_HOME /.gradle
 # It never makes sense for Gradle to run a daemon within a docker container.
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
-RUN curl https://services.gradle.org/distributions/gradle-4.3.1-bin.zip -L > /tmp/gradle.zip
+RUN curl https://services.gradle.org/distributions/gradle-4.10.3-bin.zip -L > /tmp/gradle.zip
 WORKDIR /tmp
 RUN unzip gradle.zip && rm gradle.zip \
   && mv gradle-* /gradle

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -39,7 +39,7 @@ RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > /tmp/cloud
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
 # We're not yet ready to upgrade to gradle 5 (the new default for apt-get).
-ENV GRADLE_VERSION 4.10.2
+ENV GRADLE_VERSION 4.10.3
 
 RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -O /tmp/gradle.zip \
   && sudo unzip /tmp/gradle.zip -d /opt/gradle

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   deploy:
-    image: allofustest/workbench:buildimage-0.0.17
+    image: allofustest/workbench:buildimage-0.0.18
     entrypoint: /bootstrap-docker.sh
     user: circleci
     environment:


### PR DESCRIPTION
- Bump local dev image from 4.3.1 -> 4.10.3
- Bump Circle image from 4.10.2 -> 4.10.3, these shouldn't have diverged (I probably was responsible)

I want this upgrade as part of [RW-1794](https://precisionmedicineinitiative.atlassian.net/browse/RW-1794). 4.3.1 has some undesirable behavior w.r.t. daemons/locking which seem to be addressed in later versions.

This is a stacked PR against https://github.com/all-of-us/workbench/pull/3658 , I will merge that one first - then rebase this on master.