### PR TITLE
[RW-4940][RISK=NO]If all participants is selected in UI we should unselect other cohorts.

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -313,7 +313,7 @@ describe('DataSetPage', () => {
     expect(domains).toEqual([Domain.PERSON, Domain.CONDITION, Domain.MEASUREMENT, Domain.SURVEY]);
   });
 
-  it('should deselect any workspace Cohort if PrePackaged is selected', async() => {
+  it('should unselect any workspace Cohort if PrePackaged is selected', async() => {
     const wrapper = mount(<DataSetPage />);
     await waitOneTickAndUpdate(wrapper);
     // Select one cohort
@@ -330,7 +330,7 @@ describe('DataSetPage', () => {
     expect(wrapper.find('[data-test-id="all-participant"]').props().checked).toBeTruthy();
   });
 
-  it('should deselect PrePackaged is selected if Workspace Cohort is selected', async() => {
+  it('should unselect PrePackaged cohort is selected if Workspace Cohort is selected', async() => {
     const wrapper = mount(<DataSetPage />);
     await waitOneTickAndUpdate(wrapper);
 

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -312,4 +312,40 @@ describe('DataSetPage', () => {
     domains.sort(COMPARE_DOMAINS_FOR_DISPLAY);
     expect(domains).toEqual([Domain.PERSON, Domain.CONDITION, Domain.MEASUREMENT, Domain.SURVEY]);
   });
+
+  it('should deselect any workspace Cohort if PrePackaged is selected', async() => {
+    const wrapper = mount(<DataSetPage />);
+    await waitOneTickAndUpdate(wrapper);
+    // Select one cohort
+    wrapper.find('[data-test-id="cohort-list-item"]').first()
+      .find('input').first().simulate('change');
+
+    expect(wrapper.find('[data-test-id="cohort-list-item"]').first().props().checked).toBeTruthy();
+    expect(wrapper.find('[data-test-id="all-participant"]').props().checked).toBeFalsy();
+
+    wrapper.find('[data-test-id="all-participant"]').first()
+      .find('input').first().simulate('change');
+
+    expect(wrapper.find('[data-test-id="cohort-list-item"]').first().props().checked).toBeFalsy();
+    expect(wrapper.find('[data-test-id="all-participant"]').props().checked).toBeTruthy();
+  });
+
+  it('should deselect PrePackaged is selected if Workspace Cohort is selected', async() => {
+    const wrapper = mount(<DataSetPage />);
+    await waitOneTickAndUpdate(wrapper);
+
+    wrapper.find('[data-test-id="all-participant"]').first()
+        .find('input').first().simulate('change');
+
+    expect(wrapper.find('[data-test-id="cohort-list-item"]').first().props().checked).toBeFalsy();
+    expect(wrapper.find('[data-test-id="all-participant"]').props().checked).toBeTruthy();
+
+    // Select one cohort
+    wrapper.find('[data-test-id="cohort-list-item"]').first()
+        .find('input').first().simulate('change');
+
+    expect(wrapper.find('[data-test-id="cohort-list-item"]').first().props().checked).toBeTruthy();
+    expect(wrapper.find('[data-test-id="all-participant"]').props().checked).toBeFalsy();
+
+  });
 });

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -649,7 +649,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
     selectCohort(cohort: Cohort): void {
       const selectedCohortList = toggleIncludes(cohort.id, this.state.selectedCohortIds);
-      // If Workspace Cohort is selected, de-select Pre packaged cohort
+      // If Workspace Cohort is selected, un-select Pre packaged cohort
       if (selectedCohortList && selectedCohortList.length > 0) {
         this.setState({
           dataSetTouched: true,
@@ -666,7 +666,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
     }
 
     selectPrePackageCohort(): void {
-      // De-select any workspace Cohort if Pre Packaged cohort is selected
+      // Un-select any workspace Cohort if Pre Packaged cohort is selected
       if (!this.state.includesAllParticipants) {
         this.setState({includesAllParticipants: !this.state.includesAllParticipants, selectedCohortIds: []});
       } else {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -665,7 +665,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
     }
 
-    selectPrePackageCohort(): void {
+    selectPrePackagedCohort(): void {
       // Un-select any workspace Cohort if Pre Packaged cohort is selected
       if (!this.state.includesAllParticipants) {
         this.setState({includesAllParticipants: !this.state.includesAllParticipants, selectedCohortIds: []});
@@ -956,7 +956,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                   <ImmutableListItem name='All Participants' data-test-id='all-participant'
                                      checked={includesAllParticipants}
                                      onChange={
-                                       () => this.selectPrePackageCohort()}/>
+                                       () => this.selectPrePackagedCohort()}/>
                   <Subheader>Workspace Cohorts</Subheader>
                   {!loadingResources && this.state.cohortList.map(cohort =>
                     <ImmutableListItem key={cohort.id} name={cohort.name}

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -648,10 +648,30 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
     }
 
     selectCohort(cohort: Cohort): void {
-      this.setState({
-        dataSetTouched: true,
-        selectedCohortIds: toggleIncludes(cohort.id, this.state.selectedCohortIds)
-      });
+      const selectedCohortList = toggleIncludes(cohort.id, this.state.selectedCohortIds);
+      // If Workspace Cohort is selected, de-select Pre packaged cohort
+      if (selectedCohortList && selectedCohortList.length > 0) {
+        this.setState({
+          dataSetTouched: true,
+          selectedCohortIds: selectedCohortList,
+          includesAllParticipants: false
+        });
+      } else {
+        this.setState({
+          dataSetTouched: true,
+          selectedCohortIds: selectedCohortList
+        });
+      }
+
+    }
+
+    selectPrePackageCohort(): void {
+      // De-select any workspace Cohort if Pre Packaged cohort is selected
+      if (!this.state.includesAllParticipants) {
+        this.setState({includesAllParticipants: !this.state.includesAllParticipants, selectedCohortIds: []});
+      } else {
+        this.setState({includesAllParticipants: !this.state.includesAllParticipants});
+      }
     }
 
     selectDomainValue(domain: Domain, domainValue: DomainValue): void {
@@ -933,12 +953,10 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                 </BoxHeader>
                 <div style={{height: '9rem', overflowY: 'auto'}}>
                   <Subheader>Prepackaged Cohorts</Subheader>
-                  <ImmutableListItem name='All Participants' checked={includesAllParticipants}
+                  <ImmutableListItem name='All Participants' data-test-id='all-participant'
+                                     checked={includesAllParticipants}
                                      onChange={
-                                       () => this.setState({
-                                         includesAllParticipants: !includesAllParticipants,
-                                         dataSetTouched: true
-                                       })}/>
+                                       () => this.selectPrePackageCohort()}/>
                   <Subheader>Workspace Cohorts</Subheader>
                   {!loadingResources && this.state.cohortList.map(cohort =>
                     <ImmutableListItem key={cohort.id} name={cohort.name}


### PR DESCRIPTION
On data set page, if researcher selects a Pre packaged cohort then all workspace cohort should be unselect and vice versa

<img width="498" alt="Screen Shot 2020-06-15 at 1 55 07 PM" src="https://user-images.githubusercontent.com/34481816/84690120-fa7ba980-af0f-11ea-9eb1-474c30af6dbb.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
