### PR TITLE
[no ticket][risk=no] Puppeteer: Use PascalCase for const and enum names

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -114,7 +114,7 @@ export default class WorkspaceCard {
     return this.page.waitForXPath(this.workspaceNameLinkSelector(workspaceName));
   }
 
-  async getWorkspaceMatchAccessLevel(level: WorkspaceAccessLevel = WorkspaceAccessLevel.OWNER): Promise<WorkspaceCard[]> {
+  async getWorkspaceMatchAccessLevel(level: WorkspaceAccessLevel = WorkspaceAccessLevel.Owner): Promise<WorkspaceCard[]> {
     const matchWorkspaceArray: WorkspaceCard[] = [];
     const allWorkspaceCards = await WorkspaceCard.findAllCards(this.page);
     for (const card of allWorkspaceCards) {

--- a/e2e/app/element/xpath-defaults.ts
+++ b/e2e/app/element/xpath-defaults.ts
@@ -56,6 +56,9 @@ export function xPathOptionToXpath(xOpts: XPathOptions, container?: Container): 
   case ElementType.Dropdown:
     selector = `${textExpr}//*[contains(concat(" ", normalize-space(@class))," p-dropdown")]`;
     break;
+  case ElementType.Tab:
+    selector = `//*[(@aria-selected | @tabindex) and @role="button" and text()="${name}"]`;
+    break;
   default:
     console.debug(`Implement unhandled type: ${type}. 
     XPathOptions configuration: 

--- a/e2e/app/page-identifiers.ts
+++ b/e2e/app/page-identifiers.ts
@@ -1,28 +1,22 @@
 import {config} from 'resources/workbench-config';
 
 export enum WorkspaceAccessLevel {
-   OWNER = 'OWNER',
-   READER = 'READER',
-   WRITER = 'WRITER',
+   Owner = 'OWNER',
+   Reader = 'READER',
+   Writer = 'WRITER',
 }
 
 export enum EllipsisMenuAction {
-   DUPLICATE  = 'Duplicate',
-   DELETE = 'Delete',
-   EDIT = 'Edit',
-   SHARE = 'Share',
-   REVIEW = 'Review',
+   Duplicate  = 'Duplicate',
+   Delete = 'Delete',
+   Edit = 'Edit',
+   Share = 'Share',
+   Review = 'Review',
    RenameDataset = 'Rename Dataset',
 }
 
 export enum PageUrl {
-   HOME = config.uiBaseUrl,
-   WORKSPACES = config.uiBaseUrl + config.workspacesUrlPath,
-   ADMIN = config.uiBaseUrl + config.adminUrlPath,
-}
-
-export enum PageTab {
-   DATA = 'DATA',
-   ANALYSIS = 'ANALYSIS',
-   ABOUT = 'ABOUT'
+   Home = config.uiBaseUrl,
+   Workspaces = config.uiBaseUrl + config.workspacesUrlPath,
+   Admin = config.uiBaseUrl + config.adminUrlPath,
 }

--- a/e2e/app/page/analysis-page.ts
+++ b/e2e/app/page/analysis-page.ts
@@ -35,7 +35,7 @@ export default class AnalysisPage extends AuthenticatedPage {
   async deleteNotebook(notebookName: string): Promise<string> {
     const resourceCard = await DataResourceCard.findCard(this.page, notebookName);
     const menu = resourceCard.getEllipsis();
-    await menu.clickAction(EllipsisMenuAction.DELETE, false);
+    await menu.clickAction(EllipsisMenuAction.Delete, false);
 
     const dialog = new Dialog(this.page);
     const dialogContentText = await dialog.getContent();

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -15,61 +15,61 @@ import {waitForText} from 'utils/waits-utils';
 
 const faker = require('faker/locale/en_US');
 
-export const INSTITUTION_VALUE = {
-  VANDERBILT: 'Vanderbilt University Medical Center',
-  BROAD: 'Broad Institute',
-  VERILY: 'Verily LLC',
-  NATIONAL_INSTITUTE_HEALTH: 'National Institute of Health',
-  WONDROS: 'Wondros'
+export const InstitutionSelectValue = {
+  Vanderbilt: 'Vanderbilt University Medical Center',
+  Broad: 'Broad Institute',
+  Verily: 'Verily LLC',
+  NationalInstituteHealth: 'National Institute of Health',
+  Wondros: 'Wondros'
 };
 
-export const INSTITUTION_ROLE_VALUE = {
-  EARLY_CAREER_TENURE_TRACK_RESEARCHER: 'Early career tenure-track researcher',
-  UNDERGRADUATE_STUDENT: 'Undergraduate (Bachelor level) student',
-  INDUSTRY: 'Industry',
-  RESEARCH_ASSISTANT: 'Research Assistant (pre-doctoral)',
-  RESEARCH_ASSOCIATE: 'Research associate (post-doctoral; early/mid career)',
-  SENIOR_RESEARCHER: 'Senior Researcher (PI/Team Lead, senior scientist)',
+export const InstitutionRoleSelectValue = {
+  EarlyCareerTenureTrackResearcher: 'Early career tenure-track researcher',
+  UndergraduteStudent: 'Undergraduate (Bachelor level) student',
+  Industry: 'Industry',
+  ResearchAssistant: 'Research Assistant (pre-doctoral)',
+  ResearchAssociate: 'Research associate (post-doctoral; early/mid career)',
+  SeniorResearcher: 'Senior Researcher (PI/Team Lead, senior scientist)',
 };
 
-export const EDUCATION_LEVEL_VALUE = {
-  DOCTORATE: 'Doctorate',
+export const EducationLevelValue = {
+  Doctorate: 'Doctorate',
   // other option values here
 };
 
 export const LabelAlias = {
-  READ_PRIVACY_STATEMENT: 'I have read, understand, and agree to the All of Us Program Privacy Statement',
-  READ_TERMS_OF_USE: 'I have read, understand, and agree to the Terms of Use described above',
-  INSTITUTION_NAME: 'Institution Name',
-  ARE_YOU_AFFILIATED: 'Are you affiliated with an Academic Research Institution',
-  RESEARCH_BACKGROUND: 'Your research background, experience, and research interests',
-  EDUCATION_LEVEL: 'Highest Level of Education Completed', // Highest Level of Education Completed
-  YEAR_OF_BIRTH: 'Year of Birth',
-  INSTITUTION_EMAIL: 'Your institutional email address',
+  ReadPrivacyStatement: 'I have read, understand, and agree to the All of Us Program Privacy Statement',
+  ReadTermsOfUse: 'I have read, understand, and agree to the Terms of Use described above',
+  InstitutionName: 'Institution Name',
+  AreYouAffiliated: 'Are you affiliated with an Academic Research Institution',
+  ResearchBackground: 'Your research background, experience, and research interests',
+  EducationLevel: 'Highest Level of Education Completed', // Highest Level of Education Completed
+  YearOfBirth: 'Year of Birth',
+  InstitutionEmail: 'Your institutional email address',
 };
 
 export const FieldSelector = {
-  institutionEmailTextbox: {
+  InstitutionEmailTextbox: {
     textOption: {
-      containsText: LabelAlias.INSTITUTION_EMAIL, ancestorLevel: 2
+      containsText: LabelAlias.InstitutionEmail, ancestorLevel: 2
     }
   },
-  educationLevelSelect: {
+  EducationLevelSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LabelAlias.EDUCATION_LEVEL, ancestorLevel: 2
+      type: ElementType.Dropdown, name: LabelAlias.EducationLevel, ancestorLevel: 2
     }
   },
-  birthYearSelect: {
+  BirthYearSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LabelAlias.YEAR_OF_BIRTH, ancestorLevel: 2
+      type: ElementType.Dropdown, name: LabelAlias.YearOfBirth, ancestorLevel: 2
     }
   },
-  institutionSelect: {
+  InstitutionSelect: {
     textOption: {
       type:ElementType.Dropdown, name:'Select your institution', ancestorLevel:2
     }
   },
-  describeRole: {
+  DescribeRole: {
     textOption: {
       type: ElementType.Dropdown, containsText: 'describes your role', ancestorLevel: 2
     }
@@ -117,19 +117,19 @@ export default class CreateAccountPage extends BasePage {
   }
 
   async getPrivacyStatementCheckbox(): Promise<Checkbox> {
-    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.READ_PRIVACY_STATEMENT});
+    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.ReadPrivacyStatement});
   }
 
   async getTermsOfUseCheckbox(): Promise<Checkbox> {
-    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.READ_TERMS_OF_USE});
+    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.ReadTermsOfUse});
   }
 
   async getInstitutionNameInput(): Promise<Textbox> {
-    return await Textbox.findByName(this.page, {name: LabelAlias.INSTITUTION_NAME});
+    return await Textbox.findByName(this.page, {name: LabelAlias.InstitutionName});
   }
 
   async getResearchBackgroundTextarea(): Promise<Textarea> {
-    return await Textarea.findByName(this.page, {normalizeSpace: LabelAlias.RESEARCH_BACKGROUND});
+    return await Textarea.findByName(this.page, {normalizeSpace: LabelAlias.ResearchBackground});
   }
 
   async getUsernameDomain(): Promise<unknown> {
@@ -153,24 +153,24 @@ export default class CreateAccountPage extends BasePage {
 
   // select Institution Affiliation from a dropdown
   async selectInstitution(selectTextValue: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.institutionSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.InstitutionSelect.textOption);
     await dropdown.clickMenuItem(selectTextValue);
   }
 
   async getInstitutionValue() {
-    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.institutionSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.InstitutionSelect.textOption);
     return await dropdown.getSelectedValue();
   }
 
   // select Education Level from a dropdown
   async selectEducationLevel(selectTextValue: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.educationLevelSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.EducationLevelSelect.textOption);
     await dropdown.clickMenuItem(selectTextValue);
   }
 
   // select Year of Birth from a dropdown
   async selectYearOfBirth(year: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.birthYearSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.BirthYearSelect.textOption);
     await dropdown.clickMenuItem(year);
   }
 
@@ -183,15 +183,15 @@ export default class CreateAccountPage extends BasePage {
       waitWhileLoading(this.page, 60000),
     ]);
 
-    await this.selectInstitution(INSTITUTION_VALUE.BROAD);
+    await this.selectInstitution(InstitutionSelectValue.Broad);
     await this.getInstitutionValue();
-    const emailAddressTextbox = await Textbox.findByName(this.page, FieldSelector.institutionEmailTextbox.textOption);
+    const emailAddressTextbox = await Textbox.findByName(this.page, FieldSelector.InstitutionEmailTextbox.textOption);
     await emailAddressTextbox.type(config.institutionContactEmail);
     await emailAddressTextbox.tabKey(); // tab out to start email validation
-    await ClrIconLink.findByName(this.page, {containsText: LabelAlias.INSTITUTION_EMAIL, ancestorLevel: 2, iconShape: 'success-standard'});
+    await ClrIconLink.findByName(this.page, {containsText: LabelAlias.InstitutionEmail, ancestorLevel: 2, iconShape: 'success-standard'});
 
-    const roleSelect = await SelectMenu.findByName(this.page, FieldSelector.describeRole.textOption);
-    await roleSelect.clickMenuItem(INSTITUTION_ROLE_VALUE.UNDERGRADUATE_STUDENT);
+    const roleSelect = await SelectMenu.findByName(this.page, FieldSelector.DescribeRole.textOption);
+    await roleSelect.clickMenuItem(InstitutionRoleSelectValue.UndergraduteStudent);
   }
 
   // Step 3: Accepting Terms of Use and Privacy statement.
@@ -225,7 +225,7 @@ export default class CreateAccountPage extends BasePage {
       await ck.click();
     }
     await this.selectYearOfBirth('1955');
-    await this.selectEducationLevel(EDUCATION_LEVEL_VALUE.DOCTORATE);
+    await this.selectEducationLevel(EducationLevelValue.Doctorate);
   }
 
 }

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -37,7 +37,7 @@ export const EDUCATION_LEVEL_VALUE = {
   // other option values here
 };
 
-export const LABEL_ALIAS = {
+export const LabelAlias = {
   READ_PRIVACY_STATEMENT: 'I have read, understand, and agree to the All of Us Program Privacy Statement',
   READ_TERMS_OF_USE: 'I have read, understand, and agree to the Terms of Use described above',
   INSTITUTION_NAME: 'Institution Name',
@@ -48,20 +48,20 @@ export const LABEL_ALIAS = {
   INSTITUTION_EMAIL: 'Your institutional email address',
 };
 
-export const FIELD = {
+export const FieldSelector = {
   institutionEmailTextbox: {
     textOption: {
-      containsText: LABEL_ALIAS.INSTITUTION_EMAIL, ancestorLevel: 2
+      containsText: LabelAlias.INSTITUTION_EMAIL, ancestorLevel: 2
     }
   },
   educationLevelSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LABEL_ALIAS.EDUCATION_LEVEL, ancestorLevel: 2
+      type: ElementType.Dropdown, name: LabelAlias.EDUCATION_LEVEL, ancestorLevel: 2
     }
   },
   birthYearSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LABEL_ALIAS.YEAR_OF_BIRTH, ancestorLevel: 2
+      type: ElementType.Dropdown, name: LabelAlias.YEAR_OF_BIRTH, ancestorLevel: 2
     }
   },
   institutionSelect: {
@@ -117,19 +117,19 @@ export default class CreateAccountPage extends BasePage {
   }
 
   async getPrivacyStatementCheckbox(): Promise<Checkbox> {
-    return await Checkbox.findByName(this.page, {normalizeSpace: LABEL_ALIAS.READ_PRIVACY_STATEMENT});
+    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.READ_PRIVACY_STATEMENT});
   }
 
   async getTermsOfUseCheckbox(): Promise<Checkbox> {
-    return await Checkbox.findByName(this.page, {normalizeSpace: LABEL_ALIAS.READ_TERMS_OF_USE});
+    return await Checkbox.findByName(this.page, {normalizeSpace: LabelAlias.READ_TERMS_OF_USE});
   }
 
   async getInstitutionNameInput(): Promise<Textbox> {
-    return await Textbox.findByName(this.page, {name: LABEL_ALIAS.INSTITUTION_NAME});
+    return await Textbox.findByName(this.page, {name: LabelAlias.INSTITUTION_NAME});
   }
 
   async getResearchBackgroundTextarea(): Promise<Textarea> {
-    return await Textarea.findByName(this.page, {normalizeSpace: LABEL_ALIAS.RESEARCH_BACKGROUND});
+    return await Textarea.findByName(this.page, {normalizeSpace: LabelAlias.RESEARCH_BACKGROUND});
   }
 
   async getUsernameDomain(): Promise<unknown> {
@@ -153,24 +153,24 @@ export default class CreateAccountPage extends BasePage {
 
   // select Institution Affiliation from a dropdown
   async selectInstitution(selectTextValue: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FIELD.institutionSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.institutionSelect.textOption);
     await dropdown.clickMenuItem(selectTextValue);
   }
 
   async getInstitutionValue() {
-    const dropdown = await SelectMenu.findByName(this.page, FIELD.institutionSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.institutionSelect.textOption);
     return await dropdown.getSelectedValue();
   }
 
   // select Education Level from a dropdown
   async selectEducationLevel(selectTextValue: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FIELD.educationLevelSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.educationLevelSelect.textOption);
     await dropdown.clickMenuItem(selectTextValue);
   }
 
   // select Year of Birth from a dropdown
   async selectYearOfBirth(year: string) {
-    const dropdown = await SelectMenu.findByName(this.page, FIELD.birthYearSelect.textOption);
+    const dropdown = await SelectMenu.findByName(this.page, FieldSelector.birthYearSelect.textOption);
     await dropdown.clickMenuItem(year);
   }
 
@@ -184,13 +184,13 @@ export default class CreateAccountPage extends BasePage {
     ]);
 
     await this.selectInstitution(INSTITUTION_VALUE.BROAD);
-    console.log(await this.getInstitutionValue());
-    const emailAddressTextbox = await Textbox.findByName(this.page, FIELD.institutionEmailTextbox.textOption);
+    await this.getInstitutionValue();
+    const emailAddressTextbox = await Textbox.findByName(this.page, FieldSelector.institutionEmailTextbox.textOption);
     await emailAddressTextbox.type(config.institutionContactEmail);
     await emailAddressTextbox.tabKey(); // tab out to start email validation
-    await ClrIconLink.findByName(this.page, {containsText: LABEL_ALIAS.INSTITUTION_EMAIL, ancestorLevel: 2, iconShape: 'success-standard'});
+    await ClrIconLink.findByName(this.page, {containsText: LabelAlias.INSTITUTION_EMAIL, ancestorLevel: 2, iconShape: 'success-standard'});
 
-    const roleSelect = await SelectMenu.findByName(this.page, FIELD.describeRole.textOption);
+    const roleSelect = await SelectMenu.findByName(this.page, FieldSelector.describeRole.textOption);
     await roleSelect.clickMenuItem(INSTITUTION_ROLE_VALUE.UNDERGRADUATE_STUDENT);
   }
 

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -1,15 +1,17 @@
-import {Page} from 'puppeteer';
-import EllipsisMenu from 'app/component/ellipsis-menu';
-import {EllipsisMenuAction} from 'app/page-identifiers';
-import AuthenticatedPage from 'app/page/authenticated-page';
-import {waitWhileLoading} from 'utils/test-utils';
-import {waitForDocumentTitle} from 'utils/waits-utils';
-import ClrIconLink from 'app/element/clr-icon-link';
 import DataResourceCard from 'app/component/data-resource-card';
 import Dialog from 'app/component/dialog';
+import EllipsisMenu from 'app/component/ellipsis-menu';
 import Button from 'app/element/button';
+import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
+import {EllipsisMenuAction} from 'app/page-identifiers';
+import AuthenticatedPage from 'app/page/authenticated-page';
+import {Page} from 'puppeteer';
+import {waitWhileLoading} from 'utils/test-utils';
+import {waitForDocumentTitle} from 'utils/waits-utils';
+import {xPathOptionToXpath} from 'app/element/xpath-defaults';
+import {ElementType} from 'app/xpath-options';
 import CohortBuildPage from './cohort-build-page';
 import DatasetBuildPage from './dataset-build-page';
 
@@ -56,7 +58,7 @@ export default class DataPage extends AuthenticatedPage {
    */
   async openTab(tabName: LabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
     const {waitPageChange = true} = opts;
-    const selector = `//*[(@aria-selected | @tabindex) and @role="button" and text()="${tabName}"]`;
+    const selector = xPathOptionToXpath({name: tabName, type: ElementType.Tab});
     const tab = await this.page.waitForXPath(selector, {visible: true});
     await tab.click();
     if (waitPageChange) {

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -15,7 +15,7 @@ import {ElementType} from 'app/xpath-options';
 import CohortBuildPage from './cohort-build-page';
 import DatasetBuildPage from './dataset-build-page';
 
-export enum LabelAlias {
+export enum TabLabelAlias {
   Data = 'Data',
   Analysis = 'Analysis',
   About = 'About',
@@ -54,9 +54,9 @@ export default class DataPage extends AuthenticatedPage {
 
   /**
    * Select DATA, ANALYSIS or ABOUT page tab.
-   * @param {LabelAlias} tabName
+   * @param {TabLabelAlias} tabName
    */
-  async openTab(tabName: LabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
     const {waitPageChange = true} = opts;
     const selector = xPathOptionToXpath({name: tabName, type: ElementType.Tab});
     const tab = await this.page.waitForXPath(selector, {visible: true});
@@ -67,11 +67,11 @@ export default class DataPage extends AuthenticatedPage {
   }
 
   async getAddDatasetButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: LabelAlias.Datasets, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Datasets, iconShape: 'plus-circle'});
   }
 
   async getAddCohortsButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: LabelAlias.Cohorts, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Cohorts, iconShape: 'plus-circle'});
   }
 
   // Click Add Datasets button.
@@ -94,7 +94,7 @@ export default class DataPage extends AuthenticatedPage {
   async deleteCohort(cohortName: string): Promise<string> {
     const cohortCard = await DataResourceCard.findCard(this.page, cohortName);
     const menu = cohortCard.getEllipsis();
-    await menu.clickAction(EllipsisMenuAction.DELETE, false);
+    await menu.clickAction(EllipsisMenuAction.Delete, false);
     const dialogContent = await (new CohortBuildPage(this.page)).deleteConfirmationDialog();
     console.log(`Deleted Cohort "${cohortName}"`);
     return dialogContent;
@@ -107,7 +107,7 @@ export default class DataPage extends AuthenticatedPage {
   async deleteDataset(datasetName: string): Promise<string> {
     const datasetCard = await DataResourceCard.findCard(this.page, datasetName);
     const menu = datasetCard.getEllipsis();
-    await menu.clickAction(EllipsisMenuAction.DELETE, false);
+    await menu.clickAction(EllipsisMenuAction.Delete, false);
 
     const dialog = new Dialog(this.page);
     const dialogContentText = await dialog.getContent();

--- a/e2e/app/page/featured-workspaces-page.ts
+++ b/e2e/app/page/featured-workspaces-page.ts
@@ -1,12 +1,10 @@
 import {Page} from 'puppeteer';
 import AuthenticatedPage from 'app/page/authenticated-page';
-import {waitForText} from 'utils/waits-utils';
+import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 
-export const PAGE = {
-  TITLE: 'Workspace Library',
-  HEADER: 'Researcher Workbench Workspace Library',
-};
+export const PageHeader = 'Researcher Workbench Workspace Library';
+export const PageTitle = 'Workspace Library';
 
 export default class FeaturedWorkspacesPage extends AuthenticatedPage {
 
@@ -17,7 +15,8 @@ export default class FeaturedWorkspacesPage extends AuthenticatedPage {
   async isLoaded(): Promise<boolean> {
     try {
       await Promise.all([
-        waitForText(this.page, PAGE.HEADER),
+        waitForDocumentTitle(this.page, PageTitle),
+        waitForText(this.page, PageHeader),
         waitWhileLoading(this.page),
       ]);
       return true;

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -5,13 +5,13 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import BaseElement from 'app/element/base-element';
 import Button from 'app/element/button';
 
-export const SELECTOR = {
-  loginButton: '//*[@role="button"]/*[contains(normalize-space(text()),"Sign In")]',
-  emailInput: '//input[@type="email"]',
-  NextButton: '//*[text()="Next" or @value="Next"]',
-  submitButton: '//*[@id="passwordNext" or @id="submit"]',
-  passwordInput: '//input[@type="password"]',
-};
+export enum FieldSelector {
+  LoginButton= '//*[@role="button"]/*[contains(normalize-space(text()),"Sign In")]',
+  EmailInput = '//input[@type="email"]',
+  NextButton = '//*[text()="Next" or @value="Next"]',
+  SubmitButton = '//*[@id="passwordNext" or @id="submit"]',
+  PasswordInput = '//input[@type="password"]',
+}
 
 
 export default class GoogleLoginPage {
@@ -23,21 +23,21 @@ export default class GoogleLoginPage {
    * Login email input field.
    */
   async email(): Promise<ElementHandle> {
-    return this.page.waitForXPath(SELECTOR.emailInput, {visible: true});
+    return this.page.waitForXPath(FieldSelector.EmailInput, {visible: true});
   }
 
   /**
    * Login password input field.
    */
   async password(): Promise<ElementHandle> {
-    return this.page.waitForXPath(SELECTOR.passwordInput, {visible: true});
+    return this.page.waitForXPath(FieldSelector.PasswordInput, {visible: true});
   }
 
   /**
    * Google login button.
    */
   async loginButton(): Promise<ElementHandle> {
-    return this.page.waitForXPath(SELECTOR.loginButton, {visible: true, timeout: 60000});
+    return this.page.waitForXPath(FieldSelector.LoginButton, {visible: true, timeout: 60000});
   }
 
   /**
@@ -48,7 +48,7 @@ export default class GoogleLoginPage {
     // Handle Google "Use another account" dialog if it exists
     const useAnotherAccountXpath = '//*[@role="link"]//*[text()="Use another account"]';
     const elemt1 = await Promise.race([
-      this.page.waitForXPath(SELECTOR.emailInput, {visible: true, timeout: 60000}),
+      this.page.waitForXPath(FieldSelector.EmailInput, {visible: true, timeout: 60000}),
       this.page.waitForXPath(useAnotherAccountXpath, {visible: true, timeout: 60000}),
     ]);
 
@@ -64,7 +64,7 @@ export default class GoogleLoginPage {
     await emailInput.focus();
     await emailInput.type(userEmail);
 
-    const nextButton = await this.page.waitForXPath(SELECTOR.NextButton);
+    const nextButton = await this.page.waitForXPath(FieldSelector.NextButton);
     await (BaseElement.asBaseElement(this.page, nextButton)).clickAndWait();
   }
 
@@ -82,7 +82,7 @@ export default class GoogleLoginPage {
    * Click Next button to submit login credential.
    */
   async submit() : Promise<void> {
-    const button = await this.page.waitForXPath(SELECTOR.submitButton, {visible: true});
+    const button = await this.page.waitForXPath(FieldSelector.SubmitButton, {visible: true});
     await (BaseElement.asBaseElement(this.page, button)).clickAndWait();
   }
 

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -83,7 +83,7 @@ export default class GoogleLoginPage {
    */
   async submit() : Promise<void> {
     const button = await this.page.waitForXPath(FieldSelector.SubmitButton, {visible: true});
-    await (BaseElement.asBaseElement(this.page, button)).clickAndWait();
+    await (Button.asBaseElement(this.page, button)).clickAndWait();
   }
 
   /**

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -6,9 +6,7 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 
-
 export const PageTitle = 'Homepage';
-export const PageHeader  = 'Workspaces';
 
 export const LabelAlias = {
   SeeAllWorkspaces: 'See all workspaces',
@@ -43,7 +41,7 @@ export default class HomePage extends AuthenticatedPage {
    * Load Home page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.HOME);
+    await this.loadPageUrl(PageUrl.Home);
     return this;
   }
 

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -6,14 +6,13 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 
-export const PAGE = {
-  TITLE: 'Homepage',
-  HEADER: 'Workspaces',
-};
 
-export const LABEL_ALIAS = {
-  SEE_ALL_WORKSPACES: 'See all workspaces',
-  CREATE_NEW_WORKSPACE: 'Workspaces',
+export const PageTitle = 'Homepage';
+export const PageHeader  = 'Workspaces';
+
+export const LabelAlias = {
+  SeeAllWorkspaces: 'See all workspaces',
+  CreateNewWorkspace: 'Workspaces',
 };
 
 
@@ -26,7 +25,7 @@ export default class HomePage extends AuthenticatedPage {
   async isLoaded(): Promise<boolean> {
     try {
       await Promise.all([
-        waitForDocumentTitle(this.page, PAGE.TITLE, 60000),
+        waitForDocumentTitle(this.page, PageTitle, 60000),
         waitWhileLoading(this.page, 60000),
       ]);
       return true;
@@ -37,7 +36,7 @@ export default class HomePage extends AuthenticatedPage {
   }
 
   async getCreateNewWorkspaceLink(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: LABEL_ALIAS.CREATE_NEW_WORKSPACE, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: LabelAlias.CreateNewWorkspace, iconShape: 'plus-circle'});
   }
 
   /**
@@ -49,7 +48,7 @@ export default class HomePage extends AuthenticatedPage {
   }
 
   async getSeeAllWorkspacesLink(): Promise<Link> {
-    return Link.findByName(this.page, {name: LABEL_ALIAS.SEE_ALL_WORKSPACES});
+    return Link.findByName(this.page, {name: LabelAlias.SeeAllWorkspaces});
   }
 
 }

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -2,24 +2,22 @@ import {Page} from 'puppeteer';
 import Textbox from 'app/element/textbox';
 import AuthenticatedPage from 'app/page/authenticated-page';
 import {waitWhileLoading} from 'utils/test-utils';
-import {waitForText, waitForUrl} from 'utils/waits-utils';
+import {waitForDocumentTitle, waitForUrl} from 'utils/waits-utils';
 
-export const PAGE = {
-  TITLE: 'Profile',
-};
+export const PageTitle = 'Profile';
 
-export const LABEL_ALIAS = {
-  FIRST_NAME: 'First Name',
-  LAST_NAME: 'Last Name',
-  CONTACT_EMAIL: 'Contact Email',
-  CURRENT_POSITION: 'Your Current Position',
-  ORGANIZATION: 'Your Organization',
-  CURRENT_RESEARCH_WORK: 'Current Research Work',
-  ABOUT_YOU: 'About You',
-  INSTITUTION: 'Institution',
-  ROLE: 'Role',
-  DISCARD_CHANGES: 'Discard Changes',
-  SAVE_PROFILE: 'Save Profile',
+export const LabelAlias = {
+  FirstName: 'First Name',
+  LastName: 'Last Name',
+  ContactEmail: 'Contact Email',
+  CurrentPosition: 'Your Current Position',
+  Organization: 'Your Organization',
+  CurrentResearchWork: 'Current Research Work',
+  AboutYou: 'About You',
+  Institution: 'Institution',
+  Role: 'Role',
+  DiscardChanges: 'Discard Changes',
+  SaveProfile: 'Save Profile',
 };
 
 export default class ProfilePage extends AuthenticatedPage {
@@ -32,7 +30,7 @@ export default class ProfilePage extends AuthenticatedPage {
     try {
       await Promise.all([
         waitForUrl(this.page, '/profile'),
-        waitForText(this.page, PAGE.TITLE),
+        waitForDocumentTitle(this.page, PageTitle),
         waitWhileLoading(this.page),
       ]);
       return true;
@@ -43,11 +41,11 @@ export default class ProfilePage extends AuthenticatedPage {
   }
 
   async getFirstName(): Promise<Textbox> {
-    return await Textbox.findByName(this.page, {name: LABEL_ALIAS.FIRST_NAME});
+    return await Textbox.findByName(this.page, {name: LabelAlias.FirstName});
   }
 
   async getLastName(): Promise<Textbox> {
-    return await Textbox.findByName(this.page, {name: LABEL_ALIAS.LAST_NAME});
+    return await Textbox.findByName(this.page, {name: LabelAlias.LastName});
   }
 
 }

--- a/e2e/app/page/user-admin-page.ts
+++ b/e2e/app/page/user-admin-page.ts
@@ -1,11 +1,9 @@
 import {Page} from 'puppeteer';
 import AuthenticatedPage from 'app/page/authenticated-page';
 import {waitWhileLoading} from 'utils/test-utils';
-import {waitForText} from 'utils/waits-utils';
+import {waitForDocumentTitle} from 'utils/waits-utils';
 
-export const PAGE = {
-  TITLE: 'User Admin Table',
-};
+export const PageTitle = 'User Admin Table';
 
 export default class UserAdminPage extends AuthenticatedPage {
 
@@ -16,7 +14,7 @@ export default class UserAdminPage extends AuthenticatedPage {
   async isLoaded(): Promise<boolean> {
     try {
       await Promise.all([
-        waitForText(this.page, PAGE.TITLE),
+        waitForDocumentTitle(this.page, PageTitle),
         waitWhileLoading(this.page),
       ]);
       return true;

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -4,7 +4,7 @@ import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils'
 import {xPathOptionToXpath} from 'app/element/xpath-defaults';
 import {ElementType} from 'app/xpath-options';
 import AuthenticatedPage from './authenticated-page';
-import {LabelAlias} from './data-page';
+import {TabLabelAlias} from './data-page';
 
 export const PageTitle = 'View Workspace Details';
 
@@ -19,7 +19,7 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
       await Promise.all([
         waitForDocumentTitle(this.page, PageTitle, 60000),
         waitWhileLoading(this.page),
-        this.page.waitForXPath(xPathOptionToXpath({name: LabelAlias.About, type: ElementType.Tab}), {timeout: 60000}),
+        this.page.waitForXPath(xPathOptionToXpath({name: TabLabelAlias.About, type: ElementType.Tab}), {timeout: 60000}),
       ]);
       return true;
     } catch (err) {
@@ -29,7 +29,7 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
   }
 
   async isOpen(): Promise<boolean> {
-    const selector = xPathOptionToXpath({name: LabelAlias.About, type: ElementType.Tab});
+    const selector = xPathOptionToXpath({name: TabLabelAlias.About, type: ElementType.Tab});
     return waitForAttributeEquality(page, {xpath: selector}, 'aria-selected', 'true');
   }
 

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -1,11 +1,12 @@
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils';
+import {xPathOptionToXpath} from 'app/element/xpath-defaults';
+import {ElementType} from 'app/xpath-options';
 import AuthenticatedPage from './authenticated-page';
 import {LabelAlias} from './data-page';
 
 export const PageTitle = 'View Workspace Details';
-export const AboutTabSelector = `//*[@id="workspace-top-nav-bar"]/*[@aria-selected="true" and @role="button" and text()="${LabelAlias.About}"]`
 
 export default class WorkspaceAboutPage extends AuthenticatedPage{
 
@@ -18,7 +19,7 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
       await Promise.all([
         waitForDocumentTitle(this.page, PageTitle, 60000),
         waitWhileLoading(this.page),
-        this.page.waitForXPath(AboutTabSelector, {timeout: 60000}),
+        this.page.waitForXPath(xPathOptionToXpath({name: LabelAlias.About, type: ElementType.Tab}), {timeout: 60000}),
       ]);
       return true;
     } catch (err) {
@@ -28,7 +29,8 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
   }
 
   async isOpen(): Promise<boolean> {
-    return waitForAttributeEquality(page, {xpath: AboutTabSelector}, 'aria-selected', 'true');
+    const selector = xPathOptionToXpath({name: LabelAlias.About, type: ElementType.Tab});
+    return waitForAttributeEquality(page, {xpath: selector}, 'aria-selected', 'true');
   }
 
 }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -9,15 +9,13 @@ import {ElementType} from 'app/xpath-options';
 import {ElementHandle, Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import {xPathOptionToXpath} from '../element/xpath-defaults';
+import {xPathOptionToXpath} from 'app/element/xpath-defaults';
 
 const faker = require('faker/locale/en_US');
 
-export const PAGE = {
-  TITLE: 'Create Workspace',
-};
+export const PageTitle = 'Create Workspace';
 
-export const LABEL_ALIAS = {
+export const LabelAlias = {
   SYNTHETIC_DATASET: 'Workspace Name',  // select Synthetic Dataset
   SELECT_BILLING: 'Select account',   // select billing account
   CREATE_WORKSPACE: 'Create Workspace',  // button CREATE WORKSPACE on edit page
@@ -69,156 +67,156 @@ export const LABEL_ALIAS = {
 
 export const FIELD = {
   createWorkspaceButton: {
-    textOption: {name: LABEL_ALIAS.CREATE_WORKSPACE}
+    textOption: {name: LabelAlias.CREATE_WORKSPACE}
   },
   duplicateWorkspaceButton: {
-    textOption: {name: LABEL_ALIAS.DUPLICATE_WORKSPACE}
+    textOption: {name: LabelAlias.DUPLICATE_WORKSPACE}
   },
   cancelWorkspaceButton: {
-    textOption: {name: LABEL_ALIAS.CANCEL}
+    textOption: {name: LabelAlias.CANCEL}
   },
   workspaceNameTextbox: {
-    textOption: {name: LABEL_ALIAS.WORKSPACE_NAME, ancestorLevel: 2, type: ElementType.Textbox}
+    textOption: {name: LabelAlias.WORKSPACE_NAME, ancestorLevel: 2, type: ElementType.Textbox}
   },
   dataSetSelect: {
-    textOption: {name: LABEL_ALIAS.SYNTHETIC_DATASET, type: ElementType.Select}
+    textOption: {name: LabelAlias.SYNTHETIC_DATASET, type: ElementType.Select}
   },
   billingAccountSelect: {
-    textOption: {name: LABEL_ALIAS.SELECT_BILLING, type: ElementType.Select}
+    textOption: {name: LabelAlias.SELECT_BILLING, type: ElementType.Select}
   },
   shareWithCollaboratorsCheckbox: {
-    textOption: {name: LABEL_ALIAS.SHARE_WITH_COLLABORATORS, type: ElementType.Checkbox}
+    textOption: {name: LabelAlias.SHARE_WITH_COLLABORATORS, type: ElementType.Checkbox}
   },
   PRIMARY_PURPOSE: { // fields in question #1
     researchPurposeCheckbox: {
-      textOption: {name: LABEL_ALIAS.RESEARCH_PURPOSE, ancestorLevel: 3, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.RESEARCH_PURPOSE, ancestorLevel: 3, type: ElementType.Checkbox}
     },
     diseaseFocusedResearchCheckbox: {
-      textOption:  {name: LABEL_ALIAS.DISEASE_FOCUSED_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox},
+      textOption:  {name: LabelAlias.DISEASE_FOCUSED_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox},
       affiliated: ElementType.Textbox,
     },
     methodsDevelopmentValidationStudyCheckbox: {
-      textOption: {name: LABEL_ALIAS.METHODS_DEVELOPMENT, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.METHODS_DEVELOPMENT, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     researchControlCheckbox: {
-      textOption: {name: LABEL_ALIAS.RESEARCH_CONTROL, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.RESEARCH_CONTROL, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     geneticResearchCheckbox: {
-      textOption: {name: LABEL_ALIAS.GENETIC_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.GENETIC_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     socialBehavioralResearchCheckbox: {
-      textOption: {name: LABEL_ALIAS.SOCIAL_BEHAVIORAL_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.SOCIAL_BEHAVIORAL_RESEARCH, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     populationHealthCheckbox: {
-      textOption: {name: LABEL_ALIAS.POPULATION_HEALTH, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.POPULATION_HEALTH, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     ethicalLegalSocialImplicationsResearchCheckbox: {
-      textOption: {name: LABEL_ALIAS.ETHICAL_LEGAL_SOCIAL_IMPLICATIONS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.ETHICAL_LEGAL_SOCIAL_IMPLICATIONS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     drugTherapeuticsDevelopmentResearchCheckbox: {
-      textOption:  {name: LABEL_ALIAS.DRUG_THERAPEUTIC_DEVELOPMENT, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption:  {name: LabelAlias.DRUG_THERAPEUTIC_DEVELOPMENT, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     educationPurposeCheckbox: {
-      textOption: {name: LABEL_ALIAS.EDUCATION_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.EDUCATION_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     forProfitPurposeCheckbox: {
-      textOption: {name: LABEL_ALIAS.FOR_PROFIT_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {name: LabelAlias.FOR_PROFIT_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     otherPurposeCheckbox: {
-      textOption: {name: LABEL_ALIAS.OTHER_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox},
+      textOption: {name: LabelAlias.OTHER_PURPOSE, ancestorLevel: 2, type: ElementType.Checkbox},
       affiliated: ElementType.Textarea
     }
   },
   RESEARCH_PURPOSE_SUMMARY: {  // fields in question #2
     scientificQuestionsIntentToStudyTextarea: {
-      textOption: {containsText: LABEL_ALIAS.INTENT_TO_STUDY, ancestorLevel: 3, type: ElementType.Textarea}
+      textOption: {containsText: LabelAlias.INTENT_TO_STUDY, ancestorLevel: 3, type: ElementType.Textarea}
     },
     scientificApproachesToUseTextarea: {
-      textOption: {containsText: LABEL_ALIAS.SCIENTIFIC_APPROACHES, ancestorLevel: 3, type: ElementType.Textarea}
+      textOption: {containsText: LabelAlias.SCIENTIFIC_APPROACHES, ancestorLevel: 3, type: ElementType.Textarea}
     },
     anticipatedFindingsFromStudyTextarea: {
-      textOption: {containsText: LABEL_ALIAS.ANTICIPATED_FINDINGS, ancestorLevel: 3, type: ElementType.Textarea}
+      textOption: {containsText: LabelAlias.ANTICIPATED_FINDINGS, ancestorLevel: 3, type: ElementType.Textarea}
     }
   },
   DISSEMINATE_RESEARCH_FINDINGS: {  // fields in question #3
     publicationInScientificJournalsCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PUBLICATION_IN_JOURNALS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PUBLICATION_IN_JOURNALS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     socialMediaCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SOCIAL_MEDIA, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SOCIAL_MEDIA, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     presentationAtScientificConferencesCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PRESENTATION_AT_CONFERENCES, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PRESENTATION_AT_CONFERENCES, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     presentationAtCommunityForumsCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PRESENTATION_AT_COMMUNITY_FORUMS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PRESENTATION_AT_COMMUNITY_FORUMS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     pressReleaseCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PRESS_RELEASE, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PRESS_RELEASE, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     publicationInCommunityJournalsCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PUBLICATION_IN_COMMUNITY_JOURNALS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PUBLICATION_IN_COMMUNITY_JOURNALS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     publicationInPersonalBlogCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.PUBLICATION_IN_PERSONAL_BLOG, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.PUBLICATION_IN_PERSONAL_BLOG, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     otherCheckbox: {
-      textOption: {name: LABEL_ALIAS.OTHER, ancestorLevel: 2, type: ElementType.Checkbox},
+      textOption: {name: LabelAlias.OTHER, ancestorLevel: 2, type: ElementType.Checkbox},
       affiliated: ElementType.Textarea
     }
   },
   DESCRIBE_ANTICIPATED_OUTCOMES: {  // fields in question #4
     seeksIncreaseWellnessCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.INCREASE_WELLNESS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.INCREASE_WELLNESS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     seeksToReduceHealthDisparitiesCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SEEKS_TO_REDUCE_HEALTH_DISPARITIES, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SEEKS_TO_REDUCE_HEALTH_DISPARITIES, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     seeksToDevelopRiskAssessmentCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SEEKS_TO_DEVELOP_RISK_ASSESSMENT, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SEEKS_TO_DEVELOP_RISK_ASSESSMENT, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     seeksToProvideEarlierDiagnosisCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SEEKS_TO_PROVIDE_ACCURATE_DIAGNOSIS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SEEKS_TO_PROVIDE_ACCURATE_DIAGNOSIS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     seeksToReduceBurdenCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SEEKS_TO_REDUCE_BURDEN, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SEEKS_TO_REDUCE_BURDEN, ancestorLevel: 2, type: ElementType.Checkbox}
     }
   },
   POPULATION_OF_INTEREST: {  // fields in question #5
     yesRadiobutton: {
-      textOption: {containsText: LABEL_ALIAS.YES_FOCUS_ON_UNDERREPRESENTED_POPULATION, type: ElementType.RadioButton}
+      textOption: {containsText: LabelAlias.YES_FOCUS_ON_UNDERREPRESENTED_POPULATION, type: ElementType.RadioButton}
     },
     noRadiobutton: {
-      textOption: {containsText: LABEL_ALIAS.NO_FOCUS_ON_UNDERREPRESENTED_POPULATION, type: ElementType.RadioButton}
+      textOption: {containsText: LabelAlias.NO_FOCUS_ON_UNDERREPRESENTED_POPULATION, type: ElementType.RadioButton}
     },
     raceMultiAncestryCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.RACE_MULTI_ANCESTRY, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.RACE_MULTI_ANCESTRY, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     ageGroupsAdolescentsCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.AGE_GROUPS_ADOLESCENTS, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.AGE_GROUPS_ADOLESCENTS, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     sexAtBirthCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.SEX_AT_BIRTH, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.SEX_AT_BIRTH, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     genderIdentityCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.GENDER_IDENTITY, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.GENDER_IDENTITY, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     geographyRuralCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.GEOGRAPHY_RURAL, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.GEOGRAPHY_RURAL, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     educationLevelHighSchoolCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.EDUCATION_LEVEL_HIGHSCHOOL, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.EDUCATION_LEVEL_HIGHSCHOOL, ancestorLevel: 2, type: ElementType.Checkbox}
     },
     disabilityStatusWithDisabilityCheckbox: {
-      textOption: {containsText: LABEL_ALIAS.DISABILITY_STATUS_WITH_DISABILITY, ancestorLevel: 2, type: ElementType.Checkbox}
+      textOption: {containsText: LabelAlias.DISABILITY_STATUS_WITH_DISABILITY, ancestorLevel: 2, type: ElementType.Checkbox}
     }
   },
   REQUEST_FOR_REVIEW: {  // fields in question #6
     yesRequestReviewRadiobutton: {
-      textOption: {containsText: LABEL_ALIAS.YES_REQUEST_REVIEW, type: ElementType.RadioButton}
+      textOption: {containsText: LabelAlias.YES_REQUEST_REVIEW, type: ElementType.RadioButton}
     },
     noRequestReviewRadiobutton: {
-      textOption: {containsText: LABEL_ALIAS.NO_REQUEST_REVIEW, type: ElementType.RadioButton}
+      textOption: {containsText: LabelAlias.NO_REQUEST_REVIEW, type: ElementType.RadioButton}
     }
   }
 
@@ -236,7 +234,7 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
     const select = new Select(this.page, selectXpath);
     try {
       await Promise.all([
-        waitForDocumentTitle(this.page, PAGE.TITLE),
+        waitForDocumentTitle(this.page, PageTitle),
         this.getWorkspaceNameTextbox(),
         select.getSelectedOption(),
         this.getCreateWorkspaceButton(),

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -49,7 +49,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
    * Load 'Your Workspaces' page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.WORKSPACES);
+    await this.loadPageUrl(PageUrl.Workspaces);
     return this;
   }
 

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -9,18 +9,16 @@ import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
 
 const faker = require('faker/locale/en_US');
 
-export const PAGE = {
-  TITLE: 'View Workspace',
+export const PageTitle = 'View Workspace';
+
+export const LabelAlias = {
+  CreateANewWorkspace: 'Create a New Workspace',
 };
 
-export const LABEL_ALIAS = {
-  CREATE_A_NEW_WORKSPACE: 'Create a New Workspace',
-};
-
-export const FIELD = {
-  createNewWorkspaceButton: {
+export const FieldSelector = {
+  CreateNewWorkspaceButton: {
     textOption: {
-      normalizeSpace: LABEL_ALIAS.CREATE_A_NEW_WORKSPACE
+      normalizeSpace: LabelAlias.CreateANewWorkspace
     }
   }
 };
@@ -34,7 +32,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
   async isLoaded(): Promise<boolean> {
     try {
       await Promise.all([
-        waitForDocumentTitle(this.page, PAGE.TITLE),
+        waitForDocumentTitle(this.page, PageTitle),
         this.page.waitForXPath('//a[text()="Workspaces"]', {visible: true}),
         this.page.waitForXPath('//h3[normalize-space(text())="Workspaces"]', {visible: true}),  // Texts above Filter By Select
         waitWhileLoading(this.page),
@@ -66,7 +64,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
   * 4: return
   */
   async clickCreateNewWorkspace(): Promise<WorkspaceEditPage> {
-    const link = await Button.findByName(this.page, FIELD.createNewWorkspaceButton.textOption);
+    const link = await Button.findByName(this.page, FieldSelector.CreateNewWorkspaceButton.textOption);
     await link.clickAndWait();
     const workspaceEdit = new WorkspaceEditPage(this.page);
     await workspaceEdit.waitForLoad();

--- a/e2e/app/xpath-options.ts
+++ b/e2e/app/xpath-options.ts
@@ -17,5 +17,5 @@ export enum ElementType {
   Link = 'link',
   Select = 'select',
   Dropdown = 'dropdown',
-  Tab = `Tab`,
+  Tab = 'Tab',
 }

--- a/e2e/app/xpath-options.ts
+++ b/e2e/app/xpath-options.ts
@@ -17,4 +17,5 @@ export enum ElementType {
   Link = 'link',
   Select = 'select',
   Dropdown = 'dropdown',
+  Tab = `Tab`,
 }

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -19,18 +19,22 @@ afterEach(async () => {
 // Runs this beforeAll() before test's beforeAll().
 beforeAll(async () => {
   await page.setRequestInterception(true);
-  page.on('request', (request) => {
+  page.on('request', async (request) => {
     const requestUrl = url.parse(request.url(), true);
     const host = requestUrl.hostname;
     // to improve page load performance, block requests if it is not for application functions.
-    if (host === 'www.google-analytics.com'
+    try {
+      if (host === 'www.google-analytics.com'
        || host === 'accounts.youtube.com'
        || host === 'static.zdassets.com'
        || host === 'play.google.com'
        || request.url().endsWith('content-security-index-report')) {
-      request.abort()
-    } else {
-      request.continue();
+        await request.abort()
+      } else {
+        await request.continue();
+      }
+    } catch (err) {
+      console.error(err);
     }
   });
 });

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -4,7 +4,7 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
 import {EllipsisMenuAction} from 'app/page-identifiers';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import DataPage, {LabelAlias} from 'app/page/data-page';
+import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -192,14 +192,14 @@ describe('User can create new Cohorts', () => {
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
-    await dataPage.openTab(LabelAlias.Data);
+    await dataPage.openTab(TabLabelAlias.Data);
     await waitWhileLoading(page);
 
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
     cohortCard = await DataResourceCard.findCard(page, cohortName);
     const menu = cohortCard.getEllipsis();
-    await menu.clickAction(EllipsisMenuAction.DUPLICATE, false);
+    await menu.clickAction(EllipsisMenuAction.Duplicate, false);
     await waitWhileLoading(page);
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
     // cards count increase by 1.

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -1,6 +1,6 @@
 import {PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {LabelAlias} from 'app/page/data-page';
+import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
@@ -53,7 +53,7 @@ describe('Cohorts UI tests', () => {
     const exportButton = await cohortPage.getExportButton();
     expect(await exportButton.isDisabled()).toBe(true);
 
-    await dataPage.openTab(LabelAlias.About, {waitPageChange: false});
+    await dataPage.openTab(TabLabelAlias.About, {waitPageChange: false});
 
     // Don't save. Confirm Discard Changes
     const dialogContent = await cohortPage.discardChangesConfirmationDialog();

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import {ButtonLabel} from 'app/component/dialog';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {LabelAlias} from 'app/page/data-page';
+import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import DatasetSaveModal from 'app/page/dataset-save-modal';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -89,7 +89,7 @@ describe('Create Dataset', () => {
     await waitForText(page, 'Cohort Saved Successfully');
     console.log(`Created Cohort "${cohortName}"`);
 
-    await dataPage.openTab(LabelAlias.Data);
+    await dataPage.openTab(TabLabelAlias.Data);
 
     // Click Add Datasets button.
     const datasetPage = await dataPage.clickAddDatasetButton();
@@ -102,7 +102,7 @@ describe('Create Dataset', () => {
     const dataSetName = await saveModal.saveDataset();
 
     // Verify create successful.
-    await dataPage.openTab(LabelAlias.Datasets);
+    await dataPage.openTab(TabLabelAlias.Datasets);
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(dataSetName, CardType.Dataset);
     expect(dataSetExists).toBe(true);
@@ -110,7 +110,7 @@ describe('Create Dataset', () => {
     // Edit the dataset to include "All Participants".
     await resourceCard.findCard(dataSetName)
     const menu = resourceCard.getEllipsis();
-    await menu.clickAction(EllipsisMenuAction.EDIT);
+    await menu.clickAction(EllipsisMenuAction.Edit);
     await waitWhileLoading(page);
 
     await datasetPage.selectCohorts(['All Participants']);

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -1,6 +1,6 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Link from 'app/element/link';
-import DataPage, {LabelAlias} from 'app/page/data-page';
+import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import DatasetSaveModal from 'app/page/dataset-save-modal';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import AnalysisPage from 'app/page/analysis-page';
@@ -76,8 +76,8 @@ describe('Create Dataset', () => {
     expect(newCardsCount).toBe(origCardsCount - 1);
 
     // Delete Dataset.
-    await dataPage.openTab(LabelAlias.Data);
-    await dataPage.openTab(LabelAlias.Datasets);
+    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openTab(TabLabelAlias.Datasets);
     await dataPage.deleteDataset(newDatasetName);
 
   });

--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -1,4 +1,4 @@
-import GoogleLoginPage, {SELECTOR} from 'app/page/google-login';
+import GoogleLoginPage, {FieldSelector} from 'app/page/google-login';
 import {config} from 'resources/workbench-config';
 import {waitForText} from 'utils/waits-utils';
 
@@ -25,7 +25,7 @@ describe('Login tests:', () => {
     await loginPage.enterEmail(config.userEmail);
     await loginPage.enterPassword(INCORRECT_PASSWORD);
 
-    const button = await page.waitForXPath(SELECTOR.NextButton, {visible: true});
+    const button = await page.waitForXPath(FieldSelector.NextButton, {visible: true});
     await button.click();
 
     const err = await waitForText(page, 'Wrong password. Try again');

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -17,7 +17,7 @@ describe('Clone workspace', () => {
       const workspaceCard = await findWorkspace(page);
       await workspaceCard.asElementHandle().hover();
       // click on Ellipsis "Duplicate"
-      await (workspaceCard.getEllipsis()).clickAction(EllipsisMenuAction.DUPLICATE);
+      await (workspaceCard.getEllipsis()).clickAction(EllipsisMenuAction.Duplicate);
 
       // fill out Workspace Name should be just enough for clone successfully
       const workspacesPage = new WorkspacesPage(page);
@@ -53,7 +53,7 @@ describe('Clone workspace', () => {
       await workspaceCard.clickWorkspaceName();
 
       const dataPage = new DataPage(page);
-      await dataPage.selectWorkspaceAction(EllipsisMenuAction.DUPLICATE);
+      await dataPage.selectWorkspaceAction(EllipsisMenuAction.Duplicate);
 
       const workspacesPage = new WorkspacesPage(page);
 

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -1,6 +1,6 @@
 import Link from 'app/element/link';
 import DataPage from 'app/page/data-page';
-import WorkspacesPage, {FIELD} from 'app/page/workspaces-page';
+import WorkspacesPage, {FieldSelector} from 'app/page/workspaces-page';
 import {signIn, performActions} from 'utils/test-utils';
 import Button from 'app/element/button';
 import * as testData from 'resources/data/workspace-data';
@@ -33,7 +33,7 @@ describe('Creating new workspaces', () => {
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();
 
-    const createNewWorkspaceButton  = await Button.findByName(page, FIELD.createNewWorkspaceButton.textOption );
+    const createNewWorkspaceButton  = await Button.findByName(page, FieldSelector.CreateNewWorkspaceButton.textOption );
     await createNewWorkspaceButton.clickAndWait();
 
     // fill out new workspace name

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -191,7 +191,7 @@ export async function findWorkspace(page: Page, createNew: boolean = false): Pro
   await workspacesPage.load();
 
   const workspaceCard = new WorkspaceCard(page);
-  let existingWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.OWNER);
+  let existingWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.Owner);
 
   if (existingWorkspaces.length === 0 || createNew) {
     // Create new workspace
@@ -199,7 +199,7 @@ export async function findWorkspace(page: Page, createNew: boolean = false): Pro
     await workspacesPage.createWorkspace(workspaceName);
 
     await workspacesPage.load();
-    existingWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.OWNER);
+    existingWorkspaces = await workspaceCard.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.Owner);
   }
 
   const oneWorkspaceCard = fp.shuffle(existingWorkspaces)[0];

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -4,7 +4,7 @@ import RadioButton from 'app/element/radiobutton';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
 import GoogleLoginPage from 'app/page/google-login';
-import HomePage, {LABEL_ALIAS} from 'app/page/home-page';
+import HomePage, {LabelAlias} from 'app/page/home-page';
 import {XPathOptions, ElementType} from 'app/xpath-options';
 import * as fp from 'lodash/fp';
 import {JSHandle, Page} from 'puppeteer';
@@ -106,7 +106,7 @@ export async function newUserRegistrationSelfBypass(page: Page) {
   const selfBypassXpath = '//*[@data-test-id="self-bypass"]';
   await Promise.race([
     page.waitForXPath(selfBypassXpath, {visible: true, timeout: 60000}),
-    Link.findByName(page, {name: LABEL_ALIAS.SEE_ALL_WORKSPACES}),
+    Link.findByName(page, {name: LabelAlias.SeeAllWorkspaces}),
   ]);
 
   // check to see if it is the Self-Bypass link


### PR DESCRIPTION
typescript constant name is in PascalCase. See https://www.typescriptlang.org/docs/handbook/enums.html#enums

For consistency and standard, rename Const and Enum names in e2e project to PascalCase (aka. Upper CamelCase).
There are lot of names in `workspace-*-page.ts` which I did not rename in this PR. There will be another PR to cover rest of names for consistency in future.