### PR TITLE
[RW-4352][RISK=LOW]  [P2] API doesn't handle empty response for preview table query

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -911,8 +911,11 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
       const domainDisplayed = formatDomain(this.state.selectedPreviewDomain);
       return <div style={styles.warningMessage}>
         {filteredPreviewData.isLoading ?
-          <div>Generating preview for {domainDisplayed}</div> :
-          <div>{filteredPreviewData.errorText}</div>
+          <div>Generating preview for {domainDisplayed}</div> : <div>
+            {filteredPreviewData.errorText && <div>{filteredPreviewData.errorText}</div>}
+            {/* If there is no error that means no data was return*/}
+            {!filteredPreviewData.errorText && <div>No Results found for {domainDisplayed}</div>}
+            </div>
         }
       </div>;
     }


### PR DESCRIPTION
Data Set page: In case the select Cohort/Concept set does not return any result from API, preview table should show a message rather than a blank table

<img width="1574" alt="Screen Shot 2020-06-15 at 4 42 29 PM" src="https://user-images.githubusercontent.com/34481816/84704408-c3b18d80-af27-11ea-89f5-ab420332b4c1.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
