### PR TITLE
[RW-4941][RISK=LOW]Refactor UI to only pass in values(columns) for the specific domain being requested(Preview DataSet)

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -801,7 +801,9 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
         includesAllParticipants: this.state.includesAllParticipants,
         cohortIds: this.state.selectedCohortIds,
         prePackagedConceptSet: this.getPrePackagedConceptSetApiEnum(),
-        values: this.state.selectedDomainValuePairs.map(domainValue => domainValue.value)
+        values: this.state.selectedDomainValuePairs
+            .filter(values => values.domain === domain)
+            .map( domainValue => domainValue.value)
       };
       let newPreviewInformation;
       try {


### PR DESCRIPTION

Problem: Data Set page: Selecting preview table link, sends getPreview request per domain. However the attribute "values(or column)" in the request was not filtered out by domain i.e all selected Values from all domain was part of the each domain request.
As part of this PR only domain specific values will be passed in the getPreviewData by domain request


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
