### PR TITLE
[RW-4696][risk=no] Update footer per mocks and fix flow issues

### DIFF
--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,5 +1,5 @@
 import {Component as AComponent} from '@angular/core';
-import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withTitle} from 'app/components/app-router';
+import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
 import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import { ReactWrapperBase } from 'app/utils';
 import {authStore, useStore} from 'app/utils/stores';
@@ -13,7 +13,7 @@ const signInGuard: Guard = {
   redirectPath: '/login'
 };
 
-const DUCC = fp.flow(withTitle, withFullHeight)(DataUserCodeOfConduct);
+const DUCC = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
 
 export const AppRoutingComponent: React.FunctionComponent = () => {
   const {authLoaded = false} = useStore(authStore);
@@ -23,7 +23,10 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
     <ProtectedRoutes guards={[signInGuard]}>
         <AppRoute
         path='/data-code-of-conduct'
-        component={ () => <DUCC title='Data User Code of Conduct'/>}
+          component={ () => <DUCC routeData={{
+            title: 'Data User Code of Conduct',
+            minimizeChrome: true
+          }} />}
         />
     </ProtectedRoutes>
   </AppRouter>;

--- a/ui/src/app/cohort-search/modal/modal.component.tsx
+++ b/ui/src/app/cohort-search/modal/modal.component.tsx
@@ -55,7 +55,7 @@ const styles = reactStyles({
     visibility: 'hidden',
     transform: 'scale(1.1)',
     transition: 'visibility 0.25s linear, opacity 0.25s 0s, transform 0.25s',
-    zIndex: 102,
+    zIndex: 105,
   },
   panelLeft: {
     display: 'none',

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -16,8 +16,8 @@ export const usePath = () => {
   return path;
 };
 
-export const withTitle = WrappedComponent => ({title, ...props}) => {
-  routeDataStore.set({title});
+export const withRouteData = WrappedComponent => ({routeData, ...props}) => {
+  routeDataStore.set(routeData);
   return <WrappedComponent {...props}/>;
 };
 

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -42,7 +42,7 @@ const styles = reactStyles({
     backgroundColor: colors.primary,
     padding: '1rem',
     // Must be higher than the side helpbar index. See help-bar.tsx.
-    zIndex: 201
+    zIndex: 102
   },
   workbenchFooterItem: {
     width: '12rem',
@@ -73,7 +73,7 @@ const FooterTemplate = ({style = {}, ...props}) => {
         {props.children}
         <div style={{...styles.footerAside, marginTop: '20px'}}>
           The <AoU/> logo is a service mark of the&nbsp;
-          <NewTabFooterAnchorTag href="https://www.hhs.gov">
+          <NewTabFooterAnchorTag href='https://www.hhs.gov'>
             U.S. Department of Health and Human Services
           </NewTabFooterAnchorTag>.<br/>
           The <AoU/> platform is for research only and does not provide medical advice, diagnosis or treatment. Copyright 2020.

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -34,14 +34,16 @@ const styles = reactStyles({
   },
   footerSectionDivider: {
     borderBottom: `1px solid ${colors.white}`,
-    marginBottom: '5px',
-    paddingBottom: '5px'
+    marginBottom: '.2rem',
+    paddingBottom: '.2rem'
   },
   footerTemplate: {
     width: '100%',
     backgroundColor: colors.primary,
     padding: '1rem',
-    // Must be higher than the side helpbar index. See help-bar.tsx.
+    // Must be higher than the side helpbar index for now. See help-bar.tsx.
+    // Eventually the footer should be reflowed benetah this, per RW-5110. The footer
+    // should be beneath any other floating elements, such as modals.
     zIndex: 102
   },
   workbenchFooterItem: {

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -1,20 +1,24 @@
 import {Component, Input} from '@angular/core';
 import { Link, StyledAnchorTag } from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
+import {SemiBoldHeader} from 'app/components/headers';
+import {AoU} from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {openZendeskWidget} from 'app/utils/zendesk';
 import { environment } from 'environments/environment';
 import * as React from 'react';
 
+
 const styles = reactStyles({
   footerAnchor: {
-    color: colors.secondary
+    color: colors.secondary,
+    fontSize: 12,
   },
   footerAside: {
     color: colors.white,
     fontSize: 10,
-    lineHeight: '18px',
+    lineHeight: '22px',
     alignSelf: 'center'
   },
   footerImage: {
@@ -23,18 +27,26 @@ const styles = reactStyles({
   },
   footerSectionHeader: {
     color: colors.white,
-    borderBottom: `1px solid ${colors.white}`,
+    fontSize: 12,
+    marginTop: 0,
+    textTransform: 'uppercase',
     width: '100%'
+  },
+  footerSectionDivider: {
+    borderBottom: `1px solid ${colors.white}`,
+    marginBottom: '5px',
+    paddingBottom: '5px'
   },
   footerTemplate: {
     width: '100%',
-    height: '6.5rem',
     backgroundColor: colors.primary,
-    padding: '1rem'
+    padding: '1rem',
+    // Must be higher than the side helpbar index. See help-bar.tsx.
+    zIndex: 201
   },
   workbenchFooterItem: {
-    width: '18rem',
-    marginRight: '2rem'
+    width: '12rem',
+    marginRight: '3rem'
   }
 });
 
@@ -57,8 +69,15 @@ const FooterTemplate = ({style = {}, ...props}) => {
         <img style={styles.footerImage} src='assets/images/all-of-us-logo-footer.svg'/>
         <img style={{...styles.footerImage, height: '1rem'}} src='assets/images/nih-logo-footer.png'/>
       </FlexColumn>
-      <div style={{marginLeft: '1.5rem', width: '100%', marginTop: '0.5rem'}}>
+      <div style={{marginLeft: '1.5rem', width: '100%'}}>
         {props.children}
+        <div style={{...styles.footerAside, marginTop: '20px'}}>
+          The <AoU/> logo is a service mark of the&nbsp;
+          <NewTabFooterAnchorTag href="https://google.com/TODO">
+            U.S. Department of Health and Human Services
+          </NewTabFooterAnchorTag>.<br/>
+          The <AoU/> platform is for research only and does not provide medical advice, diagnosis or treatment. Copyright 2020.
+        </div>
       </div>
     </FlexRow>
   </div>;
@@ -66,7 +85,9 @@ const FooterTemplate = ({style = {}, ...props}) => {
 
 const FooterSection = ({style = {}, header, ...props}) => {
   return <FlexColumn style={style}>
-    <div style={styles.footerSectionHeader}>{header}</div>
+    <SemiBoldHeader style={{
+      ...styles.footerSectionDivider,
+      ...styles.footerSectionHeader}}>{header}</SemiBoldHeader>
     <div>{props.children}</div>
   </FlexColumn>;
 };
@@ -88,13 +109,13 @@ const WorkbenchFooter = withUserProfile()(
 
     render() {
       return <FooterTemplate>
-        <FlexRow style={{justifyContent: 'flex-start', width: '100%', height: '100%'}}>
+        <FlexRow style={{justifyContent: 'flex-start', width: '100%'}}>
           <FooterSection style={styles.workbenchFooterItem} header='Quick Links'>
             <FlexRow>
               <FlexColumn style={{width: '50%'}}>
                 <FooterAnchorTag href='/'>Home</FooterAnchorTag>
                 <FooterAnchorTag href='library'>Featured Workspaces</FooterAnchorTag>
-                <FooterAnchorTag href='workspaces'>Your workspaces</FooterAnchorTag>
+                <FooterAnchorTag href='workspaces'>Your Workspaces</FooterAnchorTag>
               </FlexColumn>
               <FlexColumn style={{width: '50%'}}>
                 <NewTabFooterAnchorTag href={environment.publicUiUrl}>
@@ -136,12 +157,6 @@ const WorkbenchFooter = withUserProfile()(
               </FlexColumn>
             </FlexRow>
           </FooterSection>
-          <div style={{...styles.workbenchFooterItem, ...styles.footerAside, marginRight: 0}}>
-            The <i>All of Us</i> logo is a service mark of the
-            U.S. Department of Health and Human Services.
-            The <i>All of Us</i> platform is for research only and does
-            not provide medical advice, diagnosis or treatment. Copyright 2020.
-          </div>
         </FlexRow>
       </FooterTemplate>;
     }
@@ -152,23 +167,19 @@ const supportEmailAddress = 'support@researchallofus.org';
 const RegistrationFooter = ({style = {}, ...props}) => {
   return <FooterTemplate {...props}>
     <FlexColumn>
-      <FlexRow style={{...styles.footerSectionHeader, width: '25rem'}}>
+      <FlexRow style={{...styles.footerSectionDivider, color: colors.white, width: '25rem'}}>
         <NewTabFooterAnchorTag href={environment.publicUiUrl}>
           Data Browser
         </NewTabFooterAnchorTag>
         <NewTabFooterAnchorTag style={{marginLeft: '1.5rem'}} href='https://researchallofus.org'>
           Research Hub
         </NewTabFooterAnchorTag>
-        <div style={{marginLeft: '1.5rem'}}>
+        <div style={{fontSize: 12, marginLeft: '1.5rem'}}>
           Contact Us: <FooterAnchorTag href={'mailto:' + supportEmailAddress}>
             {supportEmailAddress}
           </FooterAnchorTag>
         </div>
       </FlexRow>
-      <div style={{...styles.footerAside, alignSelf: 'flex-start', marginTop: '1rem'}}>The All of Us logo is a service
-        mark of the U.S. Department of Health and Human Services.</div>
-      <div style={{...styles.footerAside, alignSelf: 'flex-start'}}>The All of Us platform is for research only and
-        does not provide medical advice, diagnosis or treatment. Copyright 2020.</div>
     </FlexColumn>
   </FooterTemplate>;
 };
@@ -206,4 +217,3 @@ export class FooterComponent extends ReactWrapperBase {
     ]);
   }
 }
-

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -73,7 +73,7 @@ const FooterTemplate = ({style = {}, ...props}) => {
         {props.children}
         <div style={{...styles.footerAside, marginTop: '20px'}}>
           The <AoU/> logo is a service mark of the&nbsp;
-          <NewTabFooterAnchorTag href="https://google.com/TODO">
+          <NewTabFooterAnchorTag href="https://www.hhs.gov">
             U.S. Department of Health and Human Services
           </NewTabFooterAnchorTag>.<br/>
           The <AoU/> platform is for research only and does not provide medical advice, diagnosis or treatment. Copyright 2020.

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -15,7 +15,9 @@ const styles = reactStyles({
 
   overlay: {
     backgroundColor: Color(colors.dark).alpha(0.85).toString(), padding: '1rem', display: 'flex',
-    position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
+    position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto',
+    // Keep z-index in sync with popups.tsx.
+    zIndex: 105
   },
 
   modalTitle: {

--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -10,6 +10,7 @@ const styles = {
     background: colors.dark,
     color: colors.white,
     padding: '0.5rem',
+    // Keep z-index in sync with modals.tsx.
     position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 105,
     maxWidth: 400, borderRadius: 4
   },

--- a/ui/src/app/components/status-alert-banner.tsx
+++ b/ui/src/app/components/status-alert-banner.tsx
@@ -19,7 +19,7 @@ const styles = reactStyles({
     position: 'absolute',
     top: '0',
     right: '0',
-    zIndex: 101,
+    zIndex: 103,
   }
 });
 

--- a/ui/src/app/pages/login/account-creation/account-creation-success.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-success.tsx
@@ -111,7 +111,7 @@ export class AccountCreationSuccess
           }}
           onClose={() => this.setState({updateModal: false})}
       />}
-      <div style={{paddingTop: '1rem'}}>
+      <div style={{marginBottom: '.5rem', paddingTop: '1rem'}}>
         <div style={styles.borderStyle}>
           Please note: For full access to the Research Workbench data and tools, you'll be required
           to complete the necessary registration steps.

--- a/ui/src/app/pages/login/login.tsx
+++ b/ui/src/app/pages/login/login.tsx
@@ -44,7 +44,7 @@ export const styles = reactStyles({
 export const LoginReactComponent: React.FunctionComponent<{
   signIn: Function, onCreateAccount: Function }> = ({ signIn, onCreateAccount}) => {
     return <React.Fragment>
-      <div data-test-id='login' style={{marginTop: '5.5rem',  paddingLeft: '3rem'}}>
+      <div data-test-id='login' style={{marginBottom: '.5rem', marginTop: '5.5rem',  paddingLeft: '3rem'}}>
         <div>
           <Header style={{width: '14rem', lineHeight: '30px'}}>
             Already have a

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -340,6 +340,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
 
 
   render() {
+    const showFooter = environment.enableFooter && this.state.currentStep !== SignInStep.TERMS_OF_SERVICE;
     const backgroundImages = StepToImageConfig.get(this.state.currentStep);
     return <FlexColumn style={styles.signInContainer} data-test-id='sign-in-container'>
       <FlexColumn data-test-id='sign-in-page'
@@ -348,7 +349,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
                   src={PUBLIC_HEADER_IMAGE}/></div>
         {this.renderSignInStep(this.state.currentStep)}
       </FlexColumn>
-      {environment.enableFooter && <Footer type={FooterTypeEnum.Registration} />}
+      {showFooter && <Footer type={FooterTypeEnum.Registration} />}
     </FlexColumn>;
   }
 }

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -25,6 +25,10 @@ const styles = reactStyles({
     margin: 'auto',
     color: colors.primary,
     height: '100%',
+    // The chrome is minimized on this page to increase scroll space. This has
+    // the unwanted side-effect of removing the app padding. Add this same padding back.
+    paddingLeft: '.6rem',
+    paddingRight: '.6rem'
   },
   dataUserCodeOfConductFooter: {
     backgroundColor: colors.white,

--- a/ui/src/app/pages/signed-in/component.css
+++ b/ui/src/app/pages/signed-in/component.css
@@ -43,3 +43,8 @@ body {
 .create-account__degree-select .p-multiselect-header {
   display: none;
 }
+
+/* Must be higher than the side helpbar index. See help-bar.tsx. */
+app-footer {
+  z-index: 201;
+}

--- a/ui/src/app/pages/signed-in/component.css
+++ b/ui/src/app/pages/signed-in/component.css
@@ -44,7 +44,11 @@ body {
   display: none;
 }
 
-/* Must be higher than the side helpbar index. See help-bar.tsx. */
+/*
+  Must be higher than the side helpbar index for now. See help-bar.tsx.
+  Eventually the footer should be reflowed benetah this, per RW-5110. The footer
+  should be beneath any other floating elements, such as modals.
+*/
 app-footer {
-  z-index: 201;
+  z-index: 102;
 }

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -10,6 +10,7 @@ import {cdrVersionsApi} from 'app/services/swagger-fetch-clients';
 import {FooterTypeEnum} from 'app/components/footer';
 import {debouncer, hasRegisteredAccessFetch} from 'app/utils';
 import {cdrVersionStore, navigateSignOut, routeConfigDataStore} from 'app/utils/navigation';
+import {routeDataStore} from 'app/utils/stores';
 import {initializeZendeskWidget} from 'app/utils/zendesk';
 import {environment} from 'environments/environment';
 import {Profile as FetchProfile} from 'generated/fetch';
@@ -96,8 +97,16 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
     });
     this.subscriptions.push(this.signOutNavigateSub);
 
+    // This handles detection of Angular-based routing data.
     this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
       this.minimizeChrome = minimizeChrome;
+    }));
+
+    // This handles detection of React-based routing data. During migrations,
+    // we assume React routing data will be set deeper/later in the component
+    // hierarchy, therefore it will generally take precendence over React.
+    this.subscriptions.push(routeDataStore.subscribe(({minimizeChrome}) => {
+      this.minimizeChrome = !!minimizeChrome;
     }));
 
     // As a special case, if we determine the user is inactive immediately after

--- a/ui/src/app/utils/stores.ts
+++ b/ui/src/app/utils/stores.ts
@@ -3,6 +3,7 @@ import {atom, Atom} from './subscribable';
 
 interface RouteDataStore {
   title?: string;
+  minimizeChrome?: boolean;
 }
 
 export const routeDataStore = atom<RouteDataStore>({});

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,5 +23,5 @@ export const testEnvironmentBase = {
   enablePublishedWorkspaces: false,
   enableProfileCapsFeatures: true,
   enableNewConceptTabs: false,
-  enableFooter: false
+  enableFooter: true
 };


### PR DESCRIPTION
Demo @ https://calbach-dot-all-of-us-workbench-test.appspot.com

- Update footer to match latest mocks
  - The updated content reduced the width below our minimum, which fixed several flow issues
- Fix overlap between footer and right-hand help bar
- Add some extra margin-bottom in a few places where the footer was crowding the page content
- Hide the footer in two new places: TOS and DUCC
  - TOS: the account creation TOS change can just be hardcoded, due to the nature of the component
  - DUCC: needed to extend the React app router HOC to also include `minimizeChrome`, which is a route config data we have in the Angular router
- Put modals on top of the side bar / footer. Previously, the help bar was not behind the modal overlay - which was a bug

Feedback on the route data changes would be appreciated @petesantos , not sure if you were planning something else for this kind of use case.