### PR TITLE
[no ticket][risk=no] Set maximum number of tests run in parallel

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,12 +6,12 @@
   "private": true,
   "license": "BSD",
   "scripts": {
-    "test": "cross-env WORKBENCH_ENV=dev jest",
+    "test": "cross-env WORKBENCH_ENV=dev jest --maxWorkers=3",
     "test:debug": "cross-env WORKBENCH_ENV=dev HEADLESS=false jest --detectOpenHandles",
-    "test-local": "cross-env WORKBENCH_ENV=local jest",
+    "test-local": "cross-env WORKBENCH_ENV=local jest --maxWorkers=2",
     "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2 --forceExit",
     "lint": "tslint --project tsconfig.json",
-    "lint:fix": "yarn run lint --fix",
+    "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",
     "compile": "rimraf tsc-out/ && yarn run tsc-build"
   },


### PR DESCRIPTION
Reduce maximum number of Puppeteer tests to run in parallel on localhost, thus, reducing their probability of failing.