### PR TITLE
[RW-4257] [risk=low] Enable new Shibboleth service in stable, preprod & prod

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -104,7 +104,7 @@
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
-    "useNewShibbolethService": false
+    "useNewShibbolethService": true
   },
   "actionAudit": {
     "logName":"workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -104,8 +104,7 @@
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
-    "useNewShibbolethService": false
-
+    "useNewShibbolethService": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -104,8 +104,7 @@
     "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
-    "useNewShibbolethService": false
-
+    "useNewShibbolethService": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",


### PR DESCRIPTION
This PR makes it so this flag is enabled across all environments. If we encounter any issues in production, the oncall should be able to push a config change to quickly revet to the old behavior.
