### PR TITLE
[risk=low] Only lock out free tier workspaces on credit expiration

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -117,7 +117,7 @@ public class FreeTierBillingService {
       } catch (final MessagingException e) {
         logger.log(Level.WARNING, e.getMessage());
       }
-      setActiveStatusForCreatedWorkspaces(user, BillingStatus.INACTIVE);
+      updateFreeTierWorkspacesStatus(user, BillingStatus.INACTIVE);
     }
 
     final Set<DbUser> usersWithNonNullRegistration =
@@ -147,7 +147,7 @@ public class FreeTierBillingService {
         .equals(workbenchConfigProvider.get().billing.freeTierBillingAccountName());
   }
 
-  private void setActiveStatusForCreatedWorkspaces(final DbUser user, final BillingStatus status) {
+  private void updateFreeTierWorkspacesStatus(final DbUser user, final BillingStatus status) {
     workspaceDao.findAllByCreator(user).stream()
         .filter(this::isFreeTier)
         .map(DbWorkspace::getWorkspaceId)

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -117,7 +117,7 @@ public class FreeTierBillingService {
       } catch (final MessagingException e) {
         logger.log(Level.WARNING, e.getMessage());
       }
-      deactivateUserWorkspaces(user);
+      setActiveStatusForCreatedWorkspaces(user, BillingStatus.INACTIVE);
     }
 
     final Set<DbUser> usersWithNonNullRegistration =
@@ -140,11 +140,18 @@ public class FreeTierBillingService {
     return compareCosts(currentCost, getUserFreeTierDollarLimit(user)) > 0;
   }
 
-  private void deactivateUserWorkspaces(final DbUser user) {
-    final Set<DbWorkspace> toDeactivate = workspaceDao.findAllByCreator(user);
-    for (final DbWorkspace workspace : toDeactivate) {
-      workspaceDao.updateBillingStatus(workspace.getWorkspaceId(), BillingStatus.INACTIVE);
-    }
+  // TODO: move to DbWorkspace?  RW-5107
+  private boolean isFreeTier(final DbWorkspace workspace) {
+    return workspace
+        .getBillingAccountName()
+        .equals(workbenchConfigProvider.get().billing.freeTierBillingAccountName());
+  }
+
+  private void setActiveStatusForCreatedWorkspaces(final DbUser user, final BillingStatus status) {
+    workspaceDao.findAllByCreator(user).stream()
+        .filter(this::isFreeTier)
+        .map(DbWorkspace::getWorkspaceId)
+        .forEach(id -> workspaceDao.updateBillingStatus(id, status));
   }
 
   private void sendAlertsForCostThresholds(


### PR DESCRIPTION
Description:

We were disabling *all* workspaces, not just free tier.

No ticket, just happened to see this while looking elsewhere.

Note: Not addressed here, but there are two possibilities for determining if a Workspace is Free Tier.  We should fix that: https://precisionmedicineinitiative.atlassian.net/browse/RW-5107


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
