### PR TITLE
[RW-4696][risk=no] Sticky the dataset builder footer

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -174,19 +174,12 @@ export const styles = reactStyles({
     width: '6.5rem',
     color: colors.secondary
   },
-  footer: {
-    display: 'block',
-    padding: '20px',
-    height: '60px',
-    width: '100%'
-  },
   stickyFooter: {
     backgroundColor: colors.white,
     borderTop: `1px solid ${colors.light}`,
     textAlign: 'right',
     padding: '3px 55px 50px 20px',
-    position: 'fixed',
-    left: '0',
+    position: 'sticky',
     bottom: '0',
     height: '60px',
     width: '100%'
@@ -1132,19 +1125,16 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
             }
           </div>
         </FadeBox>
-        <div>
-          <div style={styles.footer} />
-          <div style={styles.stickyFooter}>
-            <TooltipTrigger data-test-id='save-tooltip'
-              content='Requires Owner or Writer permission' disabled={this.canWrite}>
-            <Button style={{marginBottom: '2rem'}} data-test-id='save-button'
-              onClick ={() => this.setState({openSaveModal: true})}
-              disabled={this.disableSave() || !this.canWrite}>
-                {this.editing ? !(dataSetTouched && this.canWrite) ? 'Analyze' :
-                  'Update and Analyze' : 'Save and Analyze'}
-            </Button>
-            </TooltipTrigger>
-          </div>
+        <div style={styles.stickyFooter}>
+          <TooltipTrigger data-test-id='save-tooltip'
+            content='Requires Owner or Writer permission' disabled={this.canWrite}>
+          <Button style={{marginBottom: '2rem'}} data-test-id='save-button'
+            onClick ={() => this.setState({openSaveModal: true})}
+            disabled={this.disableSave() || !this.canWrite}>
+              {this.editing ? !(dataSetTouched && this.canWrite) ? 'Analyze' :
+                'Update and Analyze' : 'Save and Analyze'}
+          </Button>
+          </TooltipTrigger>
         </div>
         {openSaveModal && <NewDataSetModal includesAllParticipants={includesAllParticipants}
                                            selectedConceptSetIds={selectedConceptSetIds}


### PR DESCRIPTION
fixed --> sticky, to avoid bad double-footer interactions

I checked the codebase for fixed position, but missed this as I didn't understand the analyze button was implemented as a footer.

![stick-dataset](https://user-images.githubusercontent.com/822298/85183617-316bfb00-b241-11ea-81f2-d5f1f05010a4.gif)
