### PR TITLE
[RW-5013][risk=no] Correct the parameter order on BP removal...

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingGarbageCollectionService.java
@@ -143,8 +143,8 @@ public class BillingGarbageCollectionService {
       garbageCollectionCredentials.refresh();
 
       fireCloudService.removeOwnerFromBillingProject(
-          projectName,
           appEngineSA,
+          projectName,
           Optional.of(garbageCollectionCredentials.getAccessToken().getTokenValue()));
     } catch (final ExecutionException e) {
       final String msg =

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -62,7 +62,7 @@ public interface FireCloudService {
    * that as the caller instead.
    */
   void removeOwnerFromBillingProject(
-      String projectName, String ownerEmailToRemove, Optional<String> callerAccessToken);
+      String ownerEmailToRemove, String projectName, Optional<String> callerAccessToken);
 
   /** Creates a new FC workspace. */
   FirecloudWorkspace createWorkspace(String projectName, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -6,6 +6,7 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
@@ -271,6 +272,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   private void addRoleToBillingProject(String email, String projectName, String role) {
+    Preconditions.checkArgument(email.contains("@"));
+
     BillingApi billingApi = billingApiProvider.get();
     retryHandler.run(
         (context) -> {
@@ -286,7 +289,9 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public void removeOwnerFromBillingProject(
-      String projectName, String ownerEmailToRemove, Optional<String> callerAccessToken) {
+      String ownerEmailToRemove, String projectName, Optional<String> callerAccessToken) {
+    Preconditions.checkArgument(ownerEmailToRemove.contains("@"));
+
     final BillingApi scopedBillingApi;
 
     if (callerAccessToken.isPresent()) {


### PR DESCRIPTION
Would like to regression test this, but in the unit tests the mocks are effectively change detector tests. I think we need to invest in an API integration test with appropriate data seeding. This kind of a mixup was more or less inevitable with the many multi-string parameter method signatures we use throughout the application.

At least added some very primitive validation that the email looks like an email. Open to suggestions on improvements to testing or preventing this issue.

I'm working on a puppeteer test to cover workspace sharing, which I'm ensuring will catch this issue.