### PR TITLE
[RW-4696][risk=no] Bump the z-index of the floating dropdown in the share modal

### DIFF
--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -412,7 +412,10 @@ export const WorkspaceShare = withCurrentWorkspace()(class extends React.Compone
                     </h5>
                     <div data-test-id='collab-user-email'
                          style={styles.userName}>{user.email}</div>
+                    {/* Minimally, the z-index must be higher than that of the
+                        modal. See https://react-select.com/advanced#portaling */}
                     <Select value={user.role}
+                            styles={{menuPortal: base => ({ ...base, zIndex: 110 })}}
                             menuPortalTarget={document.getElementById('popup-root')}
                             isDisabled={user.email === this.props.userEmail}
                             classNamePrefix={this.cleanClassNameForSelect(user.email)}


### PR DESCRIPTION
Footer-related-fix `#3` and counting. The z-index changes inadvertently caused issues with the sharing role dropdown, which gets rendered as a floating fixed element. After auditing the other dialogs in the app, this appears to be the only regression caused by the modal z index changes.

I could not write a regression test using enzyme. Instead, I have created a puppeteer test to cover the sharing flow. I've verified that it serves as a regression test for this issue, as well as for RW-5013.