### PR TITLE
[RW-5125][risk=no] Update grep regex patters in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,18 +100,19 @@ commands:
           name: Update git submodules
           command: git submodule update --init --recursive
 
-  halt_job_noncode_changes:
-    description: "Halt job and succeed early if no code changes on non-master branch"
+  halt_if_code_unchanged:
+    description: "Halt job if no code changed"
     steps:
       - run:
           command: |
-            if [ ${CIRCLE_BRANCH} != "" ] &&
-              [ ${CIRCLE_BRANCH} != "master" ] &&
-              ! git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvE '(.md$)|(.pdf$)'; then
-                echo "No code changes on non-master branch. halting job."
-                circleci step halt
+            if ! git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvFf .circleci/e2e-job-ignore-patterns.txt; then
+              echo "Application code have not changed. halting job."
+              circleci step halt
+            else
+              git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -vFf .circleci/e2e-job-ignore-patterns.txt
+              echo "job continuing."
             fi
-          name: Halt job and succeed early if no code changes on non-master branch
+          name: Halt job if no code changed
 
   ensure_branch_has_changes:
     description: Halt job and succeed early if no code changes in << parameters.dir_name >> directory on non-master branch
@@ -559,7 +560,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout_init_git
-      - halt_job_noncode_changes
+      - halt_if_code_unchanged
       - browser-tools/install-browser-tools
       - run_e2e_test
 
@@ -573,16 +574,11 @@ jobs:
     working_directory: ~/workbench
     parallelism: 1
     steps:
-      - run:
-          name: Skip job if this is not a pull request
-          command: |
-            echo "PR: $CI_PULL_REQUEST"
-            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} == "master" ] ; then
-              echo "Not a PR, skipping Puppeteer tests"
-              circleci-agent step halt
-            fi
       - checkout_init_git
-      - halt_job_noncode_changes
+      - run:
+          name: Halt job if not a pull request
+          command: bash .circleci/pr-skip-ci.sh
+      - halt_if_code_unchanged
       - browser-tools/install-browser-tools
       - start_local_ui
       - run_e2e_test
@@ -597,7 +593,6 @@ workflows:
       - ui-unit-test
       - api-bigquery-test
       - api-integration-test
-      # Disable e2e tests https://precisionmedicineinitiative.atlassian.net/browse/RW-5080 is resolved.
       # - puppeteer-e2e-local-ui
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,7 +593,7 @@ workflows:
       - ui-unit-test
       - api-bigquery-test
       - api-integration-test
-      # - puppeteer-e2e-local-ui
+      - puppeteer-e2e-local-ui
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
           filters: *filter_only_master_branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,11 +604,11 @@ workflows:
           requires:
             - ui-unit-test
       # On master merges, run Puppeteer e2e tests after ui and api deployed to "test" env successfully.
-      # - puppeteer-e2e-test:
-          # filters: *filter_only_master_branch
-          # requires:
-            # - api-deploy-to-test
-            # - ui-deploy-to-test
+      - puppeteer-e2e-test:
+          filters: *filter_only_master_branch
+          requires:
+            - api-deploy-to-test
+            - ui-deploy-to-test
 
   deploy-staging:
     jobs:

--- a/.circleci/e2e-job-ignore-patterns.txt
+++ b/.circleci/e2e-job-ignore-patterns.txt
@@ -1,0 +1,8 @@
+.md
+.jpg
+.png
+.svg
+.mp4
+.log
+.pdf
+.gitignore

--- a/.circleci/e2e-job-ignore-patterns.txt
+++ b/.circleci/e2e-job-ignore-patterns.txt
@@ -6,3 +6,5 @@
 .log
 .pdf
 .gitignore
+Test.java
+Test.kt

--- a/.circleci/pr-skip-ci.sh
+++ b/.circleci/pr-skip-ci.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# This script makes CircleCI exit a non pull-request job.
+
+echo "CIRCLE_PULL_REQUEST: ${CIRCLE_PULL_REQUEST}"
+regexp="[[:digit:]]\+$"
+PR_NUMBER=`echo $CIRCLE_PULL_REQUEST | grep -o $regexp`
+echo "PR_NUMBER: ${PR_NUMBER}"
+
+# puppeteer-e2e-local-* jobs to skip running if this is not a pull request.
+if [[ -z "${CIRCLE_PULL_REQUEST}" ]] || ([[ ${CIRCLE_BRANCH} != "" ]] && [[ ${CIRCLE_BRANCH} == "master" ]]); then
+	echo "Not a pull request, stop job now."
+	circleci step halt
+fi

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   "verbose": true,
+  "bail": 3,  // Stop running tests after `n` failures
   "preset": "jest-puppeteer",
   "testTimeout": 600000,
   "testRunner": "jest-circus/runner",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test": "cross-env WORKBENCH_ENV=dev jest --maxWorkers=3",
     "test:debug": "cross-env WORKBENCH_ENV=dev HEADLESS=false jest --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local jest --maxWorkers=2",
-    "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2 --forceExit",
+    "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test": "cross-env WORKBENCH_ENV=dev jest --maxWorkers=3",
     "test:debug": "cross-env WORKBENCH_ENV=dev HEADLESS=false jest --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local jest --maxWorkers=2",
-    "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=1",
+    "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",


### PR DESCRIPTION
The command `halt_job_noncode_changes` is called by `puppeteer-*` jobs only. Update its' regex expression to skip `puppeteer-*` job.

Don't run e2e tests if the commit includes non-product code change. I think running e2e tests would be waste of time and resources.
