### PR TITLE
[RW-4929][risk=low] Add flag control & GSuite email extraction for dev auto-registration

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromOauthData": true,
+    "unsafeAllowUserCreationFromGSuiteData": true,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
+    "unsafeAllowUserCreationFromOauthData": true,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -90,7 +90,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromOauthData": false,
+    "unsafeAllowUserCreationFromGSuiteData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -90,6 +90,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
+    "unsafeAllowUserCreationFromOauthData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromOauthData": false,
+    "unsafeAllowUserCreationFromGSuiteData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
+    "unsafeAllowUserCreationFromOauthData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromOauthData": false,
+    "unsafeAllowUserCreationFromGSuiteData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
+    "unsafeAllowUserCreationFromOauthData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromOauthData": false,
+    "unsafeAllowUserCreationFromGSuiteData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
+    "unsafeAllowUserCreationFromOauthData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromOauthData": false,
+    "unsafeAllowUserCreationFromGSuiteData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
+    "unsafeAllowUserCreationFromOauthData": false,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -87,7 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromOauthData": true,
+    "unsafeAllowUserCreationFromGSuiteData": true,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -87,6 +87,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
+    "unsafeAllowUserCreationFromOauthData": true,
     "requireInvitationKey": false
   },
   "featureFlags": {

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.google;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import java.time.Clock;
 import java.util.Map;
@@ -53,13 +54,11 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
                 });
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(aouMeta).containsEntry("Institution", "All of Us Research Workbench");
-    assertThat(service.getContactEmail(userName).get()).isEqualTo("notasecret@gmail.com");
+    assertThat(service.getContactEmail(userName)).hasValue("notasecret@gmail.com");
     assertThat(
-            service
-                .getContactEmailFromGSuiteEmail(
-                    userName + "@" + config.googleDirectoryService.gSuiteDomain)
-                .get())
-        .isEqualTo("notasecret@gmail.com");
+            service.getContactEmailFromGSuiteEmail(
+                userName + "@" + config.googleDirectoryService.gSuiteDomain))
+        .hasValue("notasecret@gmail.com");
 
     service.deleteUser(userName);
     assertThat(service.isUsernameTaken(userName)).isFalse();

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -53,7 +53,12 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
                 });
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(aouMeta).containsEntry("Institution", "All of Us Research Workbench");
-    assertThat(service.getContactEmailAddress(userName)).isEqualTo("notasecret@gmail.com");
+    assertThat(service.getContactEmail(userName)).isEqualTo("notasecret@gmail.com");
+    assertThat(
+            service.getContactEmailFromGSuiteEmail(
+                userName + "@" + config.googleDirectoryService.gSuiteDomain))
+        .isEqualTo("notasecret@gmail.com");
+
     service.deleteUser(userName);
     assertThat(service.isUsernameTaken(userName)).isFalse();
   }

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -53,10 +53,12 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
                 });
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(aouMeta).containsEntry("Institution", "All of Us Research Workbench");
-    assertThat(service.getContactEmail(userName)).isEqualTo("notasecret@gmail.com");
+    assertThat(service.getContactEmail(userName).get()).isEqualTo("notasecret@gmail.com");
     assertThat(
-            service.getContactEmailFromGSuiteEmail(
-                userName + "@" + config.googleDirectoryService.gSuiteDomain))
+            service
+                .getContactEmailFromGSuiteEmail(
+                    userName + "@" + config.googleDirectoryService.gSuiteDomain)
+                .get())
         .isEqualTo("notasecret@gmail.com");
 
     service.deleteUser(userName);

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -897,7 +897,7 @@ public class ProfileController implements ProfileApiDelegate {
     }
     DbUser user = userProvider.get();
     log.log(Level.WARNING, "Deleting profile: user email: " + user.getUsername());
-    directoryService.deleteUser(user.getUsername().split("@")[0]);
+    directoryService.deleteUser(user.getUsername());
     userDao.delete(user.getUserId());
     profileAuditor.fireDeleteAction(user.getUserId(), user.getUsername());
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -197,6 +197,13 @@ public class WorkbenchConfig {
     // Allows a user to bypass their own access modules. This is used for testing purposes so that
     // We can give control over 3rd party access modules
     public boolean unsafeAllowSelfBypass;
+    // Indicates that the system should be allowed to re-create a DbUser row based on data from an
+    // inbound OAuth token and GSuite. This path is used primarily as a convenience for developers
+    // in their local environment. When a local database is wiped and a user logs into the Workbench
+    // with their RW-test @fake-research-aou.org credentials, the AuthInterceptor will lazily call
+    // createUser to allow continued Workbench access.
+    public boolean unsafeAllowUserCreationFromOauthData;
+
     // These booleans control whether each of our core access modules are enabled per environment.
     public boolean enableComplianceTraining;
     public boolean enableEraCommons;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -197,12 +197,12 @@ public class WorkbenchConfig {
     // Allows a user to bypass their own access modules. This is used for testing purposes so that
     // We can give control over 3rd party access modules
     public boolean unsafeAllowSelfBypass;
-    // Indicates that the system should be allowed to re-create a DbUser row based on data from an
-    // inbound OAuth token and GSuite. This path is used primarily as a convenience for developers
+    // Indicates that the system should be allowed to re-create a DbUser row based on data from
+    // GSuite OAuth and directory data. This path is used primarily as a convenience for developers
     // in their local environment. When a local database is wiped and a user logs into the Workbench
     // with their RW-test @fake-research-aou.org credentials, the AuthInterceptor will lazily call
     // createUser to allow continued Workbench access.
-    public boolean unsafeAllowUserCreationFromOauthData;
+    public boolean unsafeAllowUserCreationFromGSuiteData;
 
     // These booleans control whether each of our core access modules are enabled per environment.
     public boolean enableComplianceTraining;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -21,7 +21,7 @@ public interface UserService {
 
   DbUser createServiceAccountUser(String email);
 
-  // version used by AuthInterceptor
+  // version used by DevUserRegistrationService
   DbUser createUser(
       Userinfoplus oAuth2Userinfo,
       String contactEmail,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -22,7 +22,7 @@ public interface UserService {
   DbUser createServiceAccountUser(String email);
 
   // version used by AuthInterceptor
-  DbUser createUser(Userinfoplus oAuth2Userinfo);
+  DbUser createUser(Userinfoplus oAuth2Userinfo, String contactEmail);
 
   DbUser createUser(
       String givenName,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -22,7 +22,10 @@ public interface UserService {
   DbUser createServiceAccountUser(String email);
 
   // version used by AuthInterceptor
-  DbUser createUser(Userinfoplus oAuth2Userinfo, String contactEmail);
+  DbUser createUser(
+      Userinfoplus oAuth2Userinfo,
+      String contactEmail,
+      DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation);
 
   DbUser createUser(
       String givenName,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -312,7 +312,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public DbUser createUser(final Userinfoplus oAuth2Userinfo, final String contactEmail) {
+  public DbUser createUser(
+      final Userinfoplus oAuth2Userinfo,
+      final String contactEmail,
+      DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation) {
     return createUser(
         oAuth2Userinfo.getGivenName(),
         oAuth2Userinfo.getFamilyName(),
@@ -326,7 +329,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         null,
         null,
         null,
-        null);
+        dbVerifiedAffiliation);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -313,13 +313,14 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   @Override
   public DbUser createUser(
-      final Userinfoplus oAuth2Userinfo,
+      final Userinfoplus userInfo,
       final String contactEmail,
       DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation) {
     return createUser(
-        oAuth2Userinfo.getGivenName(),
-        oAuth2Userinfo.getFamilyName(),
-        oAuth2Userinfo.getEmail(),
+        userInfo.getGivenName(),
+        userInfo.getFamilyName(),
+        // This GSuite primary email address is what RW refers to as `username`.
+        userInfo.getEmail(),
         contactEmail,
         null,
         null,
@@ -336,7 +337,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   public DbUser createUser(
       String givenName,
       String familyName,
-      String userName,
+      String username,
       String contactEmail,
       String currentPosition,
       String organization,
@@ -350,7 +351,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     DbUser dbUser = new DbUser();
     dbUser.setCreationNonce(Math.abs(random.nextLong()));
     dbUser.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
-    dbUser.setUsername(userName);
+    dbUser.setUsername(username);
     dbUser.setContactEmail(contactEmail);
     dbUser.setCurrentPosition(currentPosition);
     dbUser.setOrganization(organization);
@@ -399,7 +400,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         this.verifiedInstitutionalAffiliationDao.save(dbVerifiedAffiliation);
       }
     } catch (DataIntegrityViolationException e) {
-      dbUser = userDao.findUserByUsername(userName);
+      dbUser = userDao.findUserByUsername(username);
       if (dbUser == null) {
         throw e;
       }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -312,12 +312,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public DbUser createUser(final Userinfoplus oAuth2Userinfo) {
+  public DbUser createUser(final Userinfoplus oAuth2Userinfo, final String contactEmail) {
     return createUser(
         oAuth2Userinfo.getGivenName(),
         oAuth2Userinfo.getFamilyName(),
         oAuth2Userinfo.getEmail(),
-        oAuth2Userinfo.getEmail(),
+        contactEmail,
         null,
         null,
         null,

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -1,25 +1,29 @@
 package org.pmiops.workbench.google;
 
 import com.google.api.services.directory.model.User;
+import java.util.Optional;
 
 /** Encapsulate Googe APIs for handling GSuite user accounts. */
 public interface DirectoryService {
   boolean isUsernameTaken(String username);
 
-  /** Returns a user via email address lookup. */
+  /** Returns a user via email address lookup. Returns null if no user was found. */
   User getUser(String email);
 
   /**
    * Returns a user via username lookup (e.g. the user's GSuite email address without the domain
-   * suffix.
+   * suffix. Returns null if no user was found.
    */
   User getUserByUsername(String username);
 
+  /** Looks up a user by username and returns their stored contact email address, if available. */
+  Optional<String> getContactEmail(String username);
+
   /**
-   * Looks up a user by username and returns their stored contact email address. If no contact email
-   * is stored in G Suite, then null is returned.
+   * Looks up a user by GSuite email address and returns their stored contact email address, if
+   * available.
    */
-  String getContactEmailAddress(String username);
+  Optional<String> getContactEmailFromGSuiteEmail(String gSuiteEmailAddress);
 
   User createUser(String givenName, String familyName, String username, String contactEmail);
 

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -3,31 +3,28 @@ package org.pmiops.workbench.google;
 import com.google.api.services.directory.model.User;
 import java.util.Optional;
 
-/** Encapsulate Googe APIs for handling GSuite user accounts. */
+/**
+ * Google APIs for handling GSuite user accounts.
+ *
+ * <p>Terminology used by this service: * username: The GSuite primary email address, e.g.
+ * "jdoe@researchallofus.org". This is consistent with most usage in RW, where `username` refers to
+ * the full email address. * user prefix: The user-specific prefix of a GSuite email address, e.g.
+ * "jdoe". * contact email: The user's specified contact email address, which is stored in GSuite as
+ * well as the RW database.
+ */
 public interface DirectoryService {
-  boolean isUsernameTaken(String username);
+  /** Returns whether the given user prefix corresponds to an existing GSuite user account. */
+  boolean isUsernameTaken(String userPrefix);
 
-  /** Returns a user via email address lookup. Returns null if no user was found. */
-  User getUser(String email);
-
-  /**
-   * Returns a user via username lookup (e.g. the user's GSuite email address without the domain
-   * suffix. Returns null if no user was found.
-   */
-  User getUserByUsername(String username);
+  /** Returns a user via username lookup. Returns null if no user was found. */
+  User getUser(String username);
 
   /** Looks up a user by username and returns their stored contact email address, if available. */
   Optional<String> getContactEmail(String username);
 
-  /**
-   * Looks up a user by GSuite email address and returns their stored contact email address, if
-   * available.
-   */
-  Optional<String> getContactEmailFromGSuiteEmail(String gSuiteEmailAddress);
-
   User createUser(String givenName, String familyName, String username, String contactEmail);
 
-  User resetUserPassword(String userName);
+  User resetUserPassword(String username);
 
   void deleteUser(String username);
 }

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -6,11 +6,15 @@ import java.util.Optional;
 /**
  * Google APIs for handling GSuite user accounts.
  *
- * <p>Terminology used by this service: * username: The GSuite primary email address, e.g.
- * "jdoe@researchallofus.org". This is consistent with most usage in RW, where `username` refers to
- * the full email address. * user prefix: The user-specific prefix of a GSuite email address, e.g.
- * "jdoe". * contact email: The user's specified contact email address, which is stored in GSuite as
- * well as the RW database.
+ * <p>Terminology used by this service:
+ *
+ * <p>username: The GSuite primary email address, e.g. "jdoe@researchallofus.org". This is
+ * consistent with most usage in RW, where `username` refers to the full email address.
+ *
+ * <p>user prefix: The user-specific prefix of a GSuite email address, e.g. "jdoe".
+ *
+ * <p>contact email: The user's specified contact email address, which is stored in GSuite as well
+ * as the RW database.
  */
 public interface DirectoryService {
   /** Returns whether the given user prefix corresponds to an existing GSuite user account. */

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -200,7 +200,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   }
 
   private String gSuiteEmailToUsername(String gSuiteEmail) {
-    if (gSuiteEmail.indexOf("@" + gSuiteDomain()) >= 0) {
+    if (gSuiteEmail.contains("@" + gSuiteDomain())) {
       return gSuiteEmail.replace("@" + gSuiteDomain(), "");
     } else {
       throw new IllegalArgumentException("Input email address does not match the G Suite domain.");

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -189,12 +189,26 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   }
 
   // Returns a user's contact email address via the custom schema in the directory API.
-  public String getContactEmailAddress(String username) {
-    return (String)
-        getUserByUsername(username)
-            .getCustomSchemas()
-            .get(GSUITE_AOU_SCHEMA_NAME)
-            .get(GSUITE_FIELD_CONTACT_EMAIL);
+  public Optional<String> getContactEmail(String username) {
+    return Optional.ofNullable(getUserByUsername(username))
+        .map(
+            user ->
+                (String)
+                    user.getCustomSchemas()
+                        .get(GSUITE_AOU_SCHEMA_NAME)
+                        .get(GSUITE_FIELD_CONTACT_EMAIL));
+  }
+
+  private String gSuiteEmailToUsername(String gSuiteEmail) {
+    if (gSuiteEmail.indexOf("@" + gSuiteDomain()) >= 0) {
+      return gSuiteEmail.replace("@" + gSuiteDomain(), "");
+    } else {
+      throw new IllegalArgumentException("Input email address does not match the G Suite domain.");
+    }
+  }
+
+  public Optional<String> getContactEmailFromGSuiteEmail(String gSuiteEmail) {
+    return getContactEmail(gSuiteEmailToUsername(gSuiteEmail));
   }
 
   public static void addCustomSchemaAndEmails(User user, String primaryEmail, String contactEmail) {

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -151,26 +151,21 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     return String.format("%s.%s", parts[firstIndex], parts[firstIndex + 1]);
   }
 
-  @Override
-  public User getUserByUsername(String username) {
-    return getUser(username + "@" + gSuiteDomain());
-  }
-
   /**
    * Fetches a user by their GSuite email address.
    *
    * <p>If the user is not found, a null value will be returned (no exception is thrown).
    *
-   * @param email
+   * @param username
    * @return
    */
   @Override
-  public User getUser(String email) {
+  public User getUser(String username) {
     try {
       // We use the "full" projection to include custom schema fields in the Directory API response.
       return retryHandler.runAndThrowChecked(
           (context) ->
-              getGoogleDirectoryService().users().get(email).setProjection("full").execute());
+              getGoogleDirectoryService().users().get(username).setProjection("full").execute());
     } catch (GoogleJsonResponseException e) {
       // Handle the special case where we're looking for a not found user by returning
       // null.
@@ -184,13 +179,13 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   }
 
   @Override
-  public boolean isUsernameTaken(String username) {
-    return getUserByUsername(username) != null;
+  public boolean isUsernameTaken(String userPrefix) {
+    return getUser(userPrefix + "@" + gSuiteDomain()) != null;
   }
 
   // Returns a user's contact email address via the custom schema in the directory API.
   public Optional<String> getContactEmail(String username) {
-    return Optional.ofNullable(getUserByUsername(username))
+    return Optional.ofNullable(getUser(username))
         .map(
             user ->
                 (String)
@@ -199,19 +194,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
                         .get(GSUITE_FIELD_CONTACT_EMAIL));
   }
 
-  private String gSuiteEmailToUsername(String gSuiteEmail) {
-    if (gSuiteEmail.contains("@" + gSuiteDomain())) {
-      return gSuiteEmail.replace("@" + gSuiteDomain(), "");
-    } else {
-      throw new IllegalArgumentException("Input email address does not match the G Suite domain.");
-    }
-  }
-
-  public Optional<String> getContactEmailFromGSuiteEmail(String gSuiteEmail) {
-    return getContactEmail(gSuiteEmailToUsername(gSuiteEmail));
-  }
-
-  public static void addCustomSchemaAndEmails(User user, String primaryEmail, String contactEmail) {
+  public static void addCustomSchemaAndEmails(User user, String username, String contactEmail) {
     // GSuite custom fields for Workbench user accounts.
     // See the Moodle integration doc (broad.io/aou-moodle) for more details, as this
     // was primarily set up for Moodle SSO integration.
@@ -231,8 +214,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     // email address with type "home". This makes it show up nicely in GSuite admin as the
     // user's "Secondary email".
     List<UserEmail> emails =
-        Lists.newArrayList(
-            new UserEmail().setType("work").setAddress(primaryEmail).setPrimary(true));
+        Lists.newArrayList(new UserEmail().setType("work").setAddress(username).setPrimary(true));
     if (contactEmail != null) {
       emails.add(new UserEmail().setType("home").setAddress(contactEmail));
     }
@@ -244,29 +226,28 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   @Override
   public User createUser(
       String givenName, String familyName, String username, String contactEmail) {
-    String primaryEmail = username + "@" + gSuiteDomain();
     String password = randomString();
 
     User user =
         new User()
-            .setPrimaryEmail(primaryEmail)
+            .setPrimaryEmail(username)
             .setPassword(password)
             .setName(new UserName().setGivenName(givenName).setFamilyName(familyName))
             .setChangePasswordAtNextLogin(true)
             .setOrgUnitPath(GSUITE_WORKBENCH_ORG_UNIT_PATH);
-    addCustomSchemaAndEmails(user, primaryEmail, contactEmail);
+    addCustomSchemaAndEmails(user, username, contactEmail);
 
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());
     return user;
   }
 
   @Override
-  public User resetUserPassword(String email) {
-    User user = getUser(email);
+  public User resetUserPassword(String username) {
+    User user = getUser(username);
     String password = randomString();
     user.setPassword(password);
     retryHandler.run(
-        (context) -> getGoogleDirectoryService().users().update(email, user).execute());
+        (context) -> getGoogleDirectoryService().users().update(username, user).execute());
     return user;
   }
 
@@ -274,11 +255,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   public void deleteUser(String username) {
     try {
       retryHandler.runAndThrowChecked(
-          (context) ->
-              getGoogleDirectoryService()
-                  .users()
-                  .delete(username + "@" + gSuiteDomain())
-                  .execute());
+          (context) -> getGoogleDirectoryService().users().delete(username).execute());
     } catch (GoogleJsonResponseException e) {
       if (e.getDetails().getCode() == HttpStatus.NOT_FOUND.value()) {
         // Deleting a user that doesn't exist will have no effect.

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -106,4 +106,13 @@ public interface InstitutionService {
    * @return
    */
   boolean validateOperationalUser(DbInstitution institution);
+
+  /**
+   * Searches through all institutions and returns the first institution that matches the given
+   * contact email address, if any.
+   *
+   * @param contactEmail
+   * @return
+   */
+  Optional<Institution> getFirstMatchingInstitution(final String contactEmail);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -356,4 +356,10 @@ public class InstitutionServiceImpl implements InstitutionService {
               });
     }
   }
+
+  public Optional<Institution> getFirstMatchingInstitution(final String contactEmail) {
+    return getInstitutions().stream()
+        .filter(institution -> validateInstitutionalEmail(institution, contactEmail))
+        .findFirst();
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -159,7 +159,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     }
     DbUser user = userDao.findUserByUsername(userName);
     if (user == null) {
-      if (workbenchConfigProvider.get().access.unsafeAllowUserCreationFromOauthData) {
+      if (workbenchConfigProvider.get().access.unsafeAllowUserCreationFromGSuiteData) {
         DbUser dbUser = devUserRegistrationService.createUserFromUserInfo(userInfo);
         log.info(String.format("Dev user '%s' has been re-created.", dbUser.getUsername()));
       } else {

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -160,19 +160,19 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     DbUser user = userDao.findUserByUsername(userName);
     if (user == null) {
       if (workbenchConfigProvider.get().access.unsafeAllowUserCreationFromGSuiteData) {
-        DbUser dbUser = devUserRegistrationService.createUserFromUserInfo(userInfo);
-        log.info(String.format("Dev user '%s' has been re-created.", dbUser.getUsername()));
+        user = devUserRegistrationService.createUserFromUserInfo(userInfo);
+        log.info(String.format("Dev user '%s' has been re-created.", user.getUsername()));
       } else {
         log.severe(String.format("No User row exists for user '%s'", userName));
         return false;
       }
-    } else {
-      if (user.getDisabled()) {
-        throw new ForbiddenException(
-            WorkbenchException.errorResponse(
-                "Rejecting request for disabled user account: " + user.getUsername(),
-                ErrorCode.USER_DISABLED));
-      }
+    }
+
+    if (user.getDisabled()) {
+      throw new ForbiddenException(
+          WorkbenchException.errorResponse(
+              "Rejecting request for disabled user account: " + user.getUsername(),
+              ErrorCode.USER_DISABLED));
     }
 
     SecurityContextHolder.getContext()

--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -160,7 +160,7 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
     DbUser user = userDao.findUserByUsername(userName);
     if (user == null) {
       if (workbenchConfigProvider.get().access.unsafeAllowUserCreationFromGSuiteData) {
-        user = devUserRegistrationService.createUserFromUserInfo(userInfo);
+        user = devUserRegistrationService.createUser(userInfo);
         log.info(String.format("Dev user '%s' has been re-created.", user.getUsername()));
       } else {
         log.severe(String.format("No User row exists for user '%s'", userName));

--- a/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationService.java
@@ -4,5 +4,8 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import org.pmiops.workbench.db.model.DbUser;
 
 public interface DevUserRegistrationService {
-  DbUser createUserFromUserInfo(Userinfoplus userInfo);
+  // Creates a user row in the RW system based on OAuth user info from GSuite. This method fetches
+  // additional details from GSuite and the RW system, and calls UserService to create the
+  // actual user database entry.
+  DbUser createUser(Userinfoplus userInfo);
 }

--- a/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationService.java
@@ -1,0 +1,8 @@
+package org.pmiops.workbench.user;
+
+import com.google.api.services.oauth2.model.Userinfoplus;
+import org.pmiops.workbench.db.model.DbUser;
+
+public interface DevUserRegistrationService {
+  DbUser createUserFromUserInfo(Userinfoplus userInfo);
+}

--- a/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
@@ -39,7 +39,7 @@ public class DevUserRegistrationServiceImpl implements DevUserRegistrationServic
   }
 
   @Override
-  public DbUser createUserFromUserInfo(Userinfoplus userInfo) {
+  public DbUser createUser(Userinfoplus userInfo) {
     // We'll try to lookup the GSuite contact email if available. Otherwise, fall back to the
     // username email address (e.g. foobar@fake-research-aou.org).
     Optional<String> gSuiteContactEmail =

--- a/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.user;
 
 import com.google.api.services.oauth2.model.Userinfoplus;
-import java.util.Optional;
 import java.util.logging.Logger;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
@@ -42,9 +41,8 @@ public class DevUserRegistrationServiceImpl implements DevUserRegistrationServic
   public DbUser createUser(Userinfoplus userInfo) {
     // We'll try to lookup the GSuite contact email if available. Otherwise, fall back to the
     // username email address (e.g. foobar@fake-research-aou.org).
-    Optional<String> gSuiteContactEmail =
-        directoryService.getContactEmailFromGSuiteEmail(userInfo.getEmail());
-    String contactEmail = gSuiteContactEmail.orElse(userInfo.getEmail());
+    String contactEmail =
+        directoryService.getContactEmail(userInfo.getEmail()).orElse(userInfo.getEmail());
 
     log.info(
         String.format(

--- a/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/user/DevUserRegistrationServiceImpl.java
@@ -1,0 +1,75 @@
+package org.pmiops.workbench.user;
+
+import com.google.api.services.oauth2.model.Userinfoplus;
+import java.util.Optional;
+import java.util.logging.Logger;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
+import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
+import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.model.InstitutionalRole;
+import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DevUserRegistrationServiceImpl implements DevUserRegistrationService {
+
+  private static final Logger log =
+      Logger.getLogger(DevUserRegistrationServiceImpl.class.getName());
+
+  private final DirectoryService directoryService;
+  private final InstitutionService institutionService;
+  private final UserService userService;
+  private final VerifiedInstitutionalAffiliationMapper verifiedInstitutionalAffiliationMapper;
+
+  @Autowired
+  DevUserRegistrationServiceImpl(
+      DirectoryService directoryService,
+      InstitutionService institutionService,
+      UserService userService,
+      VerifiedInstitutionalAffiliationMapper verifiedInstitutionalAffiliationMapper) {
+    this.directoryService = directoryService;
+    this.institutionService = institutionService;
+    this.userService = userService;
+    this.verifiedInstitutionalAffiliationMapper = verifiedInstitutionalAffiliationMapper;
+  }
+
+  @Override
+  public DbUser createUserFromUserInfo(Userinfoplus userInfo) {
+    // We'll try to lookup the GSuite contact email if available. Otherwise, fall back to the
+    // username email address (e.g. foobar@fake-research-aou.org).
+    Optional<String> gSuiteContactEmail =
+        directoryService.getContactEmailFromGSuiteEmail(userInfo.getEmail());
+    String contactEmail = gSuiteContactEmail.orElse(userInfo.getEmail());
+
+    log.info(
+        String.format(
+            "Re-creating dev user '%s' with contact email '%s'.",
+            userInfo.getEmail(), contactEmail));
+
+    Institution institution =
+        institutionService
+            .getFirstMatchingInstitution(contactEmail)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        String.format(
+                            "Contact email %s does not match any institutions. Cannot register new dev user.",
+                            contactEmail)));
+    VerifiedInstitutionalAffiliation verifiedAffiliation =
+        new VerifiedInstitutionalAffiliation()
+            .institutionShortName(institution.getShortName())
+            .institutionalRoleEnum(InstitutionalRole.OTHER)
+            .institutionalRoleOtherText("System developer");
+
+    return userService.createUser(
+        userInfo,
+        contactEmail,
+        verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
+            verifiedAffiliation, institutionService));
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
+++ b/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
@@ -14,7 +14,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInProd() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_prod.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
-    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromGSuiteData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 
@@ -22,7 +22,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInStable() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_stable.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
-    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromGSuiteData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 
@@ -30,7 +30,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInStaging() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_staging.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
-    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromGSuiteData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
+++ b/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
@@ -14,6 +14,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInProd() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_prod.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 
@@ -21,6 +22,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInStable() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_stable.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 
@@ -28,6 +30,7 @@ public class WorkbenchConfigTest {
   public void testUnsafeEndpointsDisabledInStaging() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_staging.json");
     assertThat(workbenchConfig.access.unsafeAllowSelfBypass).isFalse();
+    assertThat(workbenchConfig.access.unsafeAllowUserCreationFromOauthData).isFalse();
     assertThat(workbenchConfig.featureFlags.unsafeAllowDeleteUser).isFalse();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -222,7 +222,7 @@ public class AuthInterceptorTest {
     mockUserInfoSuccess();
     // Override the userDao mock to return a null record.
     when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
-    when(devUserRegistrationService.createUserFromUserInfo(any())).thenReturn(user);
+    when(devUserRegistrationService.createUser(any())).thenReturn(user);
 
     assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
@@ -236,7 +236,7 @@ public class AuthInterceptorTest {
 
     assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isFalse();
 
-    verify(devUserRegistrationService, never()).createUserFromUserInfo(any());
+    verify(devUserRegistrationService, never()).createUser(any());
   }
 
   private Method getProfileApiMethod(String methodName) {

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -1,6 +1,8 @@
 package org.pmiops.workbench.interceptors;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +18,7 @@ import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -32,8 +35,16 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.firecloud.model.FirecloudUserInfo;
+import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.Authority;
-import org.pmiops.workbench.test.Providers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.method.HandlerMethod;
 
 /** mimicing a Swagger-generated wrapper */
@@ -47,42 +58,61 @@ class FakeController {
   public void handle() {}
 }
 
+@RunWith(SpringRunner.class)
 public class AuthInterceptorTest {
 
   private static final long USER_ID = 123L;
 
-  @Mock private UserInfoService userInfoService;
-  @Mock private FireCloudService fireCloudService;
-  @Mock private UserDao userDao;
+  @MockBean private UserInfoService userInfoService;
+  @MockBean private FireCloudService fireCloudService;
+  @MockBean private UserDao userDao;
+  @MockBean private UserService userService;
+  @MockBean private DirectoryService directoryService;
+
+  private static WorkbenchConfig workbenchConfig;
+
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private HandlerMethod handler;
-  @Mock private UserService userService;
+  private DbUser user;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  private AuthInterceptor interceptor;
-  private DbUser user;
+  @Autowired private AuthInterceptor interceptor;
+
+  @TestConfiguration
+  @Import({AuthInterceptor.class})
+  static class Configuration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig getWorkbenchConfig() {
+      return workbenchConfig;
+    }
+  }
 
   @Before
   public void setUp() {
-    WorkbenchConfig workbenchConfig = new WorkbenchConfig();
+    workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.googleDirectoryService = new GoogleDirectoryServiceConfig();
     workbenchConfig.googleDirectoryService.gSuiteDomain = "fake-domain.org";
     workbenchConfig.auth = new AuthConfig();
     workbenchConfig.auth.serviceAccountApiUsers = new ArrayList<>();
     workbenchConfig.auth.serviceAccountApiUsers.add("service-account@appspot.gserviceaccount.com");
-    this.interceptor =
-        new AuthInterceptor(
-            userInfoService, fireCloudService, Providers.of(workbenchConfig), userDao, userService);
-    this.user = new DbUser();
+    user = new DbUser();
     user.setUserId(USER_ID);
     user.setDisabled(false);
+  }
+
+  private void mockGetCallWithBearerToken() {
+    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
+    when(request.getMethod()).thenReturn(HttpMethods.GET);
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
   }
 
   @Test
   public void preHandleOptions_OPTIONS() throws Exception {
     when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
+
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 
@@ -90,6 +120,7 @@ public class AuthInterceptorTest {
   public void preHandleOptions_publicEndpoint() throws Exception {
     when(handler.getMethod()).thenReturn(getProfileApiMethod("isUsernameTaken"));
     when(request.getMethod()).thenReturn(HttpMethods.GET);
+
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 
@@ -97,45 +128,44 @@ public class AuthInterceptorTest {
   public void preHandleGet_noAuthorization() throws Exception {
     when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
     when(request.getMethod()).thenReturn(HttpMethods.GET);
+
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test
   public void preHandleGet_nonBearerAuthorization() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
+    mockGetCallWithBearerToken();
+    // Override the auth header to be an invalid bearer token.
     when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("blah");
+
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test(expected = NotFoundException.class)
   public void preHandleGet_userInfoError() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+    mockGetCallWithBearerToken();
     when(userInfoService.getUserInfo("foo")).thenThrow(new NotFoundException());
+
     interceptor.preHandle(request, response, handler);
   }
 
   @Test(expected = NotFoundException.class)
   public void preHandleGet_firecloudLookupFails() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+    mockGetCallWithBearerToken();
+
     Userinfoplus userInfo = new Userinfoplus();
     userInfo.setEmail("bob@bad-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(fireCloudService.getMe()).thenThrow(new NotFoundException());
+
     interceptor.preHandle(request, response, handler);
   }
 
   @Test
   public void preHandleGet_firecloudLookupSucceeds() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+    mockGetCallWithBearerToken();
     Userinfoplus userInfo = new Userinfoplus();
     userInfo.setEmail("bob@bad-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
@@ -145,14 +175,13 @@ public class AuthInterceptorTest {
     me.setUserInfo(fcUserInfo);
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(user);
+
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 
   @Test
   public void preHandleGet_firecloudLookupSucceedsNoUserRecordWrongDomain() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+    mockGetCallWithBearerToken();
     Userinfoplus userInfo = new Userinfoplus();
     userInfo.setEmail("bob@bad-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
@@ -162,34 +191,53 @@ public class AuthInterceptorTest {
     me.setUserInfo(fcUserInfo);
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByUsername("bob@also-bad-domain.org")).thenReturn(null);
+
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
-  @Test
-  public void preHandleGet_userInfoSuccess() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+  private void mockUserInfoSuccess() {
     Userinfoplus userInfo = new Userinfoplus();
     userInfo.setEmail("bob@fake-domain.org");
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(user);
+  }
+
+  @Test
+  public void preHandleGet_userInfoSuccess() throws Exception {
+    mockGetCallWithBearerToken();
+    mockUserInfoSuccess();
+
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 
   @Test
   public void preHandleGet_noUserRecord() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
-    Userinfoplus userInfo = new Userinfoplus();
-    userInfo.setGivenName("Bob");
-    userInfo.setFamilyName("Jones");
-    userInfo.setEmail("bob@fake-domain.org");
-    when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
-    when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(null);
-    when(userService.createUser(userInfo)).thenReturn(user);
+    // Tests the flow where userDao doesn't contain a row for the authorized user.
+    // When this functionality is enabled, the auth interceptor will lazily create a new
+    // user record when none is found for the given G Suite user.
+    mockGetCallWithBearerToken();
+    mockUserInfoSuccess();
+    // Override the userDao mock to return a null record.
+    when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
+    when(directoryService.getContactEmailAddress(eq("bob@fake-domain.org")))
+        .thenReturn("bob@gmail.com");
+    when(userService.createUser(any(), eq("bob@gmail.com"))).thenReturn(user);
+
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+
+  @Test
+  public void preHandleGet_noUserRecordAndNoContactEmail() throws Exception {
+    mockGetCallWithBearerToken();
+    mockUserInfoSuccess();
+    when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
+    when(directoryService.getContactEmailAddress(eq("bob@fake-domain.org")))
+        .thenThrow(new NullPointerException());
+    // When GSuite doesn't have the contact email stored, we should fall back to the RW username
+    // as contact email address.s
+    when(userService.createUser(any(), eq("bob@fake-domain.org"))).thenReturn(user);
+
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -72,9 +72,9 @@ public class AuthInterceptorTest {
 
   private static WorkbenchConfig workbenchConfig;
 
-  @Mock private HttpServletRequest request;
-  @Mock private HttpServletResponse response;
-  @Mock private HandlerMethod handler;
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpServletResponse mockResponse;
+  @Mock private HandlerMethod mockHandler;
   private DbUser user;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -105,43 +105,43 @@ public class AuthInterceptorTest {
   }
 
   private void mockGetCallWithBearerToken() {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
+    when(mockHandler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
+    when(mockRequest.getMethod()).thenReturn(HttpMethods.GET);
+    when(mockRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer foo");
   }
 
   @Test
   public void preHandleOptions_OPTIONS() throws Exception {
-    when(request.getMethod()).thenReturn(HttpMethods.OPTIONS);
+    when(mockRequest.getMethod()).thenReturn(HttpMethods.OPTIONS);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
 
   @Test
   public void preHandleOptions_publicEndpoint() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("isUsernameTaken"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
+    when(mockHandler.getMethod()).thenReturn(getProfileApiMethod("isUsernameTaken"));
+    when(mockRequest.getMethod()).thenReturn(HttpMethods.GET);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
 
   @Test
   public void preHandleGet_noAuthorization() throws Exception {
-    when(handler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
-    when(request.getMethod()).thenReturn(HttpMethods.GET);
+    when(mockHandler.getMethod()).thenReturn(getProfileApiMethod("getBillingProjects"));
+    when(mockRequest.getMethod()).thenReturn(HttpMethods.GET);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isFalse();
+    verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test
   public void preHandleGet_nonBearerAuthorization() throws Exception {
     mockGetCallWithBearerToken();
     // Override the auth header to be an invalid bearer token.
-    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("blah");
+    when(mockRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("blah");
 
-    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isFalse();
+    verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test(expected = NotFoundException.class)
@@ -149,7 +149,7 @@ public class AuthInterceptorTest {
     mockGetCallWithBearerToken();
     when(userInfoService.getUserInfo("foo")).thenThrow(new NotFoundException());
 
-    interceptor.preHandle(request, response, handler);
+    interceptor.preHandle(mockRequest, mockResponse, mockHandler);
   }
 
   @Test(expected = NotFoundException.class)
@@ -161,7 +161,7 @@ public class AuthInterceptorTest {
     when(userInfoService.getUserInfo("foo")).thenReturn(userInfo);
     when(fireCloudService.getMe()).thenThrow(new NotFoundException());
 
-    interceptor.preHandle(request, response, handler);
+    interceptor.preHandle(mockRequest, mockResponse, mockHandler);
   }
 
   @Test
@@ -177,7 +177,7 @@ public class AuthInterceptorTest {
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByUsername("bob@fake-domain.org")).thenReturn(user);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
 
   @Test
@@ -193,8 +193,8 @@ public class AuthInterceptorTest {
     when(fireCloudService.getMe()).thenReturn(me);
     when(userDao.findUserByUsername("bob@also-bad-domain.org")).thenReturn(null);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isFalse();
+    verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   private void mockUserInfoSuccess() {
@@ -209,7 +209,7 @@ public class AuthInterceptorTest {
     mockGetCallWithBearerToken();
     mockUserInfoSuccess();
 
-    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
 
   @Test
@@ -224,7 +224,7 @@ public class AuthInterceptorTest {
     when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
     when(devUserRegistrationService.createUserFromUserInfo(any())).thenReturn(user);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isTrue();
   }
 
   @Test
@@ -234,7 +234,7 @@ public class AuthInterceptorTest {
     mockUserInfoSuccess();
     when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
 
-    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
+    assertThat(interceptor.preHandle(mockRequest, mockResponse, mockHandler)).isFalse();
 
     verify(devUserRegistrationService, never()).createUserFromUserInfo(any());
   }

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -223,10 +222,9 @@ public class AuthInterceptorTest {
     mockUserInfoSuccess();
     // Override the userDao mock to return a null record.
     when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);
+    when(devUserRegistrationService.createUserFromUserInfo(any())).thenReturn(user);
 
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();
-
-    verify(devUserRegistrationService, times(1)).createUserFromUserInfo(any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -215,7 +215,7 @@ public class AuthInterceptorTest {
 
   @Test
   public void preHandleGet_noUserRecord() throws Exception {
-    workbenchConfig.access.unsafeAllowUserCreationFromOauthData = true;
+    workbenchConfig.access.unsafeAllowUserCreationFromGSuiteData = true;
     // Tests the flow where userDao doesn't contain a row for the authorized user.
     // When this functionality is enabled, the auth interceptor will lazily create a new
     // user record when none is found for the given G Suite user.
@@ -231,7 +231,7 @@ public class AuthInterceptorTest {
 
   @Test
   public void preHandleGet_noUserRecordAndNoDevRegistration() throws Exception {
-    workbenchConfig.access.unsafeAllowUserCreationFromOauthData = false;
+    workbenchConfig.access.unsafeAllowUserCreationFromGSuiteData = false;
     mockGetCallWithBearerToken();
     mockUserInfoSuccess();
     when(userDao.findUserByUsername(eq("bob@fake-domain.org"))).thenReturn(null);

--- a/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
@@ -1,0 +1,85 @@
+package org.pmiops.workbench.user;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.oauth2.model.Userinfoplus;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
+import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperImpl;
+import org.pmiops.workbench.model.Institution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class DevUserRegistrationServiceTest {
+
+  @MockBean private DirectoryService directoryService;
+  @MockBean private InstitutionService institutionService;
+  @MockBean private UserService userService;
+
+  private Userinfoplus userInfo;
+  private ArgumentCaptor<DbVerifiedInstitutionalAffiliation> dbAffiliationCaptor =
+      ArgumentCaptor.forClass(DbVerifiedInstitutionalAffiliation.class);
+
+  @Autowired private DevUserRegistrationService service;
+
+  @TestConfiguration
+  @Import({DevUserRegistrationServiceImpl.class, VerifiedInstitutionalAffiliationMapperImpl.class})
+  static class Configuration {}
+
+  @Before
+  public void setUp() {
+    userInfo = new Userinfoplus().setEmail("gjordan@fake-research-aou.org");
+  }
+
+  @Test
+  public void testCreateUserFromUserInfo() {
+    // Tests the happy path: a contact email and matching institution are both found, allowing us
+    // to register the dev user.
+    DbUser dbUser = new DbUser();
+    dbUser.setContactEmail("gregory.jordan.123@gmail.com");
+    dbUser.setUsername("gjordan@fake-research-aou.org");
+    DbInstitution dbInstitution = new DbInstitution();
+    dbInstitution.setShortName("Google");
+
+    when(directoryService.getContactEmailFromGSuiteEmail(eq("gjordan@fake-research-aou.org")))
+        .thenReturn(Optional.of("gregory.jordan.123@gmail.com"));
+    when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
+        .thenReturn(Optional.of(new Institution().shortName("Google")));
+    when(institutionService.getDbInstitutionOrThrow(eq("Google"))).thenReturn(dbInstitution);
+    when(userService.createUser(
+            eq(userInfo), eq("gregory.jordan.123@gmail.com"), dbAffiliationCaptor.capture()))
+        .thenReturn(dbUser);
+
+    service.createUserFromUserInfo(userInfo);
+
+    assertThat(dbAffiliationCaptor.getValue().getInstitution().getShortName()).isEqualTo("Google");
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testCreateUserFromUserInfo_NoMatchingInstitution() {
+    // If no matching institution could be found, an exception is thrown.
+    when(directoryService.getContactEmailAddressFromGSuiteEmailAddress(
+            eq("gjordan@fake-research-aou.org")))
+        .thenReturn(Optional.of("gregory.jordan.123@gmail.com"));
+    when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
+        .thenReturn(Optional.empty());
+
+    service.createUserFromUserInfo(userInfo);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
@@ -66,7 +66,7 @@ public class DevUserRegistrationServiceTest {
             eq(userInfo), eq("gregory.jordan.123@gmail.com"), dbAffiliationCaptor.capture()))
         .thenReturn(dbUser);
 
-    service.createUserFromUserInfo(userInfo);
+    service.createUser(userInfo);
 
     assertThat(dbAffiliationCaptor.getValue().getInstitution().getShortName()).isEqualTo("Google");
   }
@@ -79,6 +79,6 @@ public class DevUserRegistrationServiceTest {
     when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
         .thenReturn(Optional.empty());
 
-    service.createUserFromUserInfo(userInfo);
+    service.createUser(userInfo);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
@@ -74,8 +74,7 @@ public class DevUserRegistrationServiceTest {
   @Test(expected = BadRequestException.class)
   public void testCreateUserFromUserInfo_NoMatchingInstitution() {
     // If no matching institution could be found, an exception is thrown.
-    when(directoryService.getContactEmailAddressFromGSuiteEmailAddress(
-            eq("gjordan@fake-research-aou.org")))
+    when(directoryService.getContactEmailFromGSuiteEmail(eq("gjordan@fake-research-aou.org")))
         .thenReturn(Optional.of("gregory.jordan.123@gmail.com"));
     when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
         .thenReturn(Optional.empty());

--- a/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/DevUserRegistrationServiceTest.java
@@ -57,7 +57,7 @@ public class DevUserRegistrationServiceTest {
     DbInstitution dbInstitution = new DbInstitution();
     dbInstitution.setShortName("Google");
 
-    when(directoryService.getContactEmailFromGSuiteEmail(eq("gjordan@fake-research-aou.org")))
+    when(directoryService.getContactEmail(eq("gjordan@fake-research-aou.org")))
         .thenReturn(Optional.of("gregory.jordan.123@gmail.com"));
     when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
         .thenReturn(Optional.of(new Institution().shortName("Google")));
@@ -74,7 +74,7 @@ public class DevUserRegistrationServiceTest {
   @Test(expected = BadRequestException.class)
   public void testCreateUserFromUserInfo_NoMatchingInstitution() {
     // If no matching institution could be found, an exception is thrown.
-    when(directoryService.getContactEmailFromGSuiteEmail(eq("gjordan@fake-research-aou.org")))
+    when(directoryService.getContactEmail(eq("gjordan@fake-research-aou.org")))
         .thenReturn(Optional.of("gregory.jordan.123@gmail.com"));
     when(institutionService.getFirstMatchingInstitution("gregory.jordan.123@gmail.com"))
         .thenReturn(Optional.empty());


### PR DESCRIPTION
This PR attempts to formalize our dev user registration flow, which had previously been inlined into AuthInterceptor.

Breaking this function out into its own service should make it clearer to any readers what's going on.

The only slightly clever thing going on here is with institutional affiliation: to support the follow-up work (where we want to auto-load a few dev institutions into a blank-slate dev database), this PR adds some logic to dev user registration which finds the first matching institution, if available, and uses that for the verified institutional affiliation. This felt to me like the right thing to do in preparation for the future, but I'm open to alternative views.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [No – this adds a long-lived server config variable] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
