### PR TITLE
[risk=no] Remove our hacky API mapper

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
@@ -1,7 +1,8 @@
-package org.pmiops.workbench.billing;
+package org.pmiops.workbench.api;
 
-import org.pmiops.workbench.api.OfflineBillingApiDelegate;
-import org.pmiops.workbench.monitoring.LogsBasedMetricService;
+import org.pmiops.workbench.billing.BillingGarbageCollectionService;
+import org.pmiops.workbench.billing.BillingProjectBufferService;
+import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,18 +13,15 @@ public class OfflineBillingController implements OfflineBillingApiDelegate {
   private final FreeTierBillingService freeTierBillingService;
   private final BillingProjectBufferService billingProjectBufferService;
   private final BillingGarbageCollectionService billingGarbageCollectionService;
-  private LogsBasedMetricService logsBasedMetricService;
 
   @Autowired
   OfflineBillingController(
       FreeTierBillingService freeTierBillingService,
       BillingProjectBufferService billingProjectBufferService,
-      BillingGarbageCollectionService billingGarbageCollectionService,
-      LogsBasedMetricService logsBasedMetricService) {
+      BillingGarbageCollectionService billingGarbageCollectionService) {
     this.freeTierBillingService = freeTierBillingService;
     this.billingProjectBufferService = billingProjectBufferService;
     this.billingGarbageCollectionService = billingGarbageCollectionService;
-    this.logsBasedMetricService = logsBasedMetricService;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/StatusAlertController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/StatusAlertController.java
@@ -1,12 +1,12 @@
-package org.pmiops.workbench.statusalerts;
+package org.pmiops.workbench.api;
 
 import java.util.Optional;
 import org.pmiops.workbench.annotations.AuthorityRequired;
-import org.pmiops.workbench.api.StatusAlertApiDelegate;
 import org.pmiops.workbench.db.dao.StatusAlertDao;
 import org.pmiops.workbench.db.model.DbStatusAlert;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.StatusAlert;
+import org.pmiops.workbench.statusalerts.StatusAlertConversionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -1,12 +1,12 @@
-package org.pmiops.workbench.workspaceadmin;
+package org.pmiops.workbench.api;
 
 import javax.annotation.Nullable;
 import org.pmiops.workbench.annotations.AuthorityRequired;
-import org.pmiops.workbench.api.WorkspaceAdminApiDelegate;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
+import org.pmiops.workbench.workspaceadmin.WorkspaceAdminService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -1,4 +1,4 @@
-package org.pmiops.workbench.workspaces;
+package org.pmiops.workbench.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
-import org.pmiops.workbench.api.Etags;
-import org.pmiops.workbench.api.WorkspacesApiDelegate;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.billing.EmptyBufferException;
 import org.pmiops.workbench.billing.FreeTierBillingService;
@@ -85,6 +83,7 @@ import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.pmiops.workbench.notebooks.BlobAlreadyExistsException;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
+import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;

--- a/api/src/main/java/org/pmiops/workbench/interceptors/InterceptorUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/InterceptorUtils.java
@@ -1,23 +1,10 @@
 package org.pmiops.workbench.interceptors;
 
-import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
-import java.util.Map;
 import java.util.regex.Pattern;
 import org.springframework.web.method.HandlerMethod;
 
 public class InterceptorUtils {
-
-  private static Map<String, String> apiImplMap =
-      ImmutableMap.of(
-          "org.pmiops.workbench.api.WorkspacesApiController",
-              "org.pmiops.workbench.workspaces.WorkspacesController",
-          "org.pmiops.workbench.api.BillingApiController",
-              "org.pmiops.workbench.billing.BillingController",
-          "org.pmiops.workbench.api.StatusAlertApiController",
-              "org.pmiops.workbench.statusalerts.StatusAlertController",
-          "org.pmiops.workbench.api.WorkspaceAdminApiController",
-              "org.pmiops.workbench.workspaceadmin.WorkspaceAdminController");
 
   private InterceptorUtils() {}
 
@@ -32,14 +19,8 @@ public class InterceptorUtils {
 
     // The matcher assumes that all Controllers are within the same package as the generated
     // ApiController (api package)
-    // The following code allows Controllers to be moved into other packages by specifying the
-    // mapping in `apiImplMap`
-    String controllerName;
-    if (apiImplMap.containsKey(apiControllerName)) {
-      controllerName = apiImplMap.get(apiControllerName);
-    } else {
-      controllerName = apiControllerPattern.matcher(apiControllerName).replaceAll("$1$2");
-    }
+    final String controllerName =
+        apiControllerPattern.matcher(apiControllerName).replaceAll("$1$2");
 
     Class<?> controllerClass;
     try {

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -98,7 +98,6 @@ import org.pmiops.workbench.utils.mappers.UserMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
-import org.pmiops.workbench.workspaces.WorkspacesController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -81,7 +81,6 @@ import org.pmiops.workbench.utils.mappers.UserMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
-import org.pmiops.workbench.workspaces.WorkspacesController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -124,7 +124,6 @@ import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
-import org.pmiops.workbench.workspaces.WorkspacesController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/api/src/test/java/org/pmiops/workbench/api/StatusAlertControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/StatusAlertControllerTest.java
@@ -1,4 +1,4 @@
-package org.pmiops.workbench.statusalerts;
+package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -1,4 +1,4 @@
-package org.pmiops.workbench.workspaceadmin;
+package org.pmiops.workbench.api;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -37,6 +37,7 @@ import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
+import org.pmiops.workbench.workspaceadmin.WorkspaceAdminService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1,4 +1,4 @@
-package org.pmiops.workbench.workspaces;
+package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -63,13 +63,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
-import org.pmiops.workbench.api.BigQueryService;
-import org.pmiops.workbench.api.CohortAnnotationDefinitionController;
-import org.pmiops.workbench.api.CohortReviewController;
-import org.pmiops.workbench.api.CohortsController;
-import org.pmiops.workbench.api.ConceptSetsController;
-import org.pmiops.workbench.api.DataSetController;
-import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
@@ -187,6 +180,8 @@ import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;


### PR DESCRIPTION
Description:

Inspired by #2643 - let's just remove this thing.

As a consequence of doing so, move Controllers to the standard location, the `org.pmiops.workbench.api` package.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
