### PR TITLE
[RW-4827][risk=no] Link to DUAA when user is loading notebook or trying to download notebook

### DIFF
--- a/api/src/main/webapp/static/aou-download-policy-extension.js
+++ b/api/src/main/webapp/static/aou-download-policy-extension.js
@@ -8,12 +8,10 @@ define([
     // File will be downloaded only if the user clicks OK else it will just close the dialog box and do nothing.
     $('#download_menu li a').click(function(e) {
       e.preventDefault();
-      return confirm("Policy Reminder" + "\n\n" +
-        "It is All of Us data use policy that researchers should not make copies of " +
-        "or download individual-level data (including taking screenshots or other means of viewing " +
-        "individual-level data) outside of the All of Us research environment without approval from " +
-        "All of Us Resource Access Board. So, please make sure that the output cells in the notebook " +
-        "you are downloading do not contain individual-level data.");
+      return confirm("Data Download Reminder" + "\n\n" +
+        "You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench.\n\n" +
+        "You are also prohibited from publishing or otherwise distributing any data or aggregate statistics corresponding to fewer than 20 participants unless expressly permitted by our data use policies.\n\n" +
+        "For more information, please see our Data Use Policies by visiting https://www.researchallofus.org/data-use-policies/.");
     });
   };
 

--- a/api/src/main/webapp/static/aou-download-policy-extension.js
+++ b/api/src/main/webapp/static/aou-download-policy-extension.js
@@ -9,8 +9,8 @@ define([
     $('#download_menu li a').click(function(e) {
       e.preventDefault();
       return confirm("Data Download Reminder" + "\n\n" +
-        "You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench.\n\n" +
-        "You are also prohibited from publishing or otherwise distributing any data or aggregate statistics corresponding to fewer than 20 participants unless expressly permitted by our data use policies.\n\n" +
+        "You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench. " +
+        "You are also prohibited from publishing or otherwise distributing any data or aggregate statistics corresponding to fewer than 20 participants unless expressly permitted by our data use policies. " +
         "For more information, please see our Data Use Policies by visiting https://www.researchallofus.org/data-use-policies/.");
     });
   };

--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -7,6 +7,7 @@ import {urlParamsStore} from 'app/utils/navigation';
 import {fetchAbortableRetry} from 'app/utils/retry';
 
 import {Button} from 'app/components/buttons';
+import {FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {Spinner} from 'app/components/spinners';
@@ -28,7 +29,6 @@ import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
 import {Cluster, ClusterStatus, Profile} from 'generated/fetch';
 import {appendNotebookFileSuffix, dropNotebookFileSuffix} from './util';
-import {FlexRow} from "../../components/flex";
 
 export enum Progress {
   Unknown,

--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -28,6 +28,7 @@ import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
 import {Cluster, ClusterStatus, Profile} from 'generated/fetch';
 import {appendNotebookFileSuffix, dropNotebookFileSuffix} from './util';
+import {FlexRow} from "../../components/flex";
 
 export enum Progress {
   Unknown,
@@ -70,7 +71,7 @@ const styles = reactStyles({
     textAlign: 'center', color: colors.black, fontSize: 14, lineHeight: '22px', marginTop: '10px'
   },
   reminderText: {
-    display: 'flex', flexDirection: 'row', marginTop: '1rem', fontSize: 14, color: colors.primary
+    marginTop: '1rem', fontSize: 14, color: colors.primary
   }
 });
 
@@ -406,15 +407,19 @@ export const NotebookRedirect = fp.flow(withUserProfile(), withCurrentWorkspace(
                                    creatingNewNotebook={creatingNewNotebook} progressComplete={progressComplete}/>;
             })}
           </div>
-          <div style={styles.reminderText}>
+          <FlexRow style={styles.reminderText}>
             <ReminderIcon
-              style={{height: '80px', width: '80px', marginRight: '0.5rem'}}/>
+              style={{width: '1.75rem', height: '1.75rem', marginRight: '0.5rem'}}/>
             <div>
-              It is <i>All of Us</i> data use policy that researchers should not make copies of
-              or download individual-level data (including taking screenshots or other means
-              of viewing individual-level data) outside of the <i>All of Us</i> research environment
-              without approval from <i>All of Us</i> Resource Access Board (RAB).
+              You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench.
             </div>
+          </FlexRow>
+          <div style={{marginLeft: '2rem', ...styles.reminderText}}>
+            You are also prohibited from publishing or otherwise distributing any data or aggregate statistics corresponding to fewer than
+            20 participants unless expressly permitted by our data use policies.
+          </div>
+          <div style={{marginLeft: '2rem', ...styles.reminderText}}>
+            For more information, please see our  <a href={'/data-code-of-conduct'}>Data Use Policies.</a>
           </div>
         </div> : <div style={{height: '100%'}}>
           <div style={{borderBottom: '5px solid #2691D0', width: '100%'}}/>


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2020-06-23 at 1 58 32 PM" src="https://user-images.githubusercontent.com/1847690/85759171-fa816380-b6de-11ea-9e0e-9e0fffbd6b86.png">
When a user is loading a notebook, provide a link to the DUAA on the notebook-redirect page.
<img width="1680" alt="Screen Shot 2020-06-25 at 11 57 58 AM" src="https://user-images.githubusercontent.com/1847690/85759952-61068180-b6df-11ea-91a9-3c9bb19620ea.png">
When a user tries to download a notebook (dialog path visible in screenshot), show the URL to the DUAA in the alert dialog.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
