### PR TITLE
[RW-4599][RISK=NO] Backend: add Age at Event as modifier to Surveys

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1019,6 +1019,30 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void countParticipantsForSurveyWithAgeAtEventModifiers() {
+    SearchGroupItem icd9SGI =
+        new SearchGroupItem()
+            .type(DomainType.SURVEY.toString())
+            .addSearchParametersItem(icd9())
+            .temporalGroup(0)
+            .addModifiersItem(ageModifier());
+
+    // First Mention Of (ICD9 w/modifiers or Snomed) 5 Days After ICD10 w/modifiers
+    SearchGroup temporalGroup =
+        new SearchGroup()
+            .items(ImmutableList.of(icd9SGI))
+            .temporal(true)
+            .mention(TemporalMention.FIRST_MENTION)
+            .time(TemporalTime.X_DAYS_AFTER)
+            .timeValue(5L);
+
+    SearchRequest searchRequest = new SearchRequest().includes(ImmutableList.of(temporalGroup));
+    // matches icd9SGI in group 0 and icd10SGI in group 1
+    assertParticipants(
+        controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
+  }
+
+  @Test
   public void firstMentionOfDrug5DaysBeforeICD10WithModifiers() {
     SearchGroupItem drugSGI =
         new SearchGroupItem()

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1022,7 +1022,9 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsForSurveyWithAgeModifiers() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.SURVEY.toString(), ImmutableList.of(survey()), Arrays.asList(ageModifier()));
+            DomainType.SURVEY.toString(),
+            ImmutableList.of(survey()),
+            ImmutableList.of(ageModifier()));
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1019,25 +1019,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void countParticipantsForSurveyWithAgeAtEventModifiers() {
-    SearchGroupItem icd9SGI =
-        new SearchGroupItem()
-            .type(DomainType.SURVEY.toString())
-            .addSearchParametersItem(icd9())
-            .temporalGroup(0)
-            .addModifiersItem(ageModifier());
+  public void countSubjectsForSurveyWithAgeModifiers() {
+    SearchRequest searchRequest =
+        createSearchRequests(
+            DomainType.SURVEY.toString(), ImmutableList.of(survey()), Arrays.asList(ageModifier()));
 
-    // First Mention Of (ICD9 w/modifiers or Snomed) 5 Days After ICD10 w/modifiers
-    SearchGroup temporalGroup =
-        new SearchGroup()
-            .items(ImmutableList.of(icd9SGI))
-            .temporal(true)
-            .mention(TemporalMention.FIRST_MENTION)
-            .time(TemporalTime.X_DAYS_AFTER)
-            .timeValue(5L);
-
-    SearchRequest searchRequest = new SearchRequest().includes(ImmutableList.of(temporalGroup));
-    // matches icd9SGI in group 0 and icd10SGI in group 1
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }


### PR DESCRIPTION
Modifier AGE_AT_EVENT is working for Domain survey. This PR is just to add a test for the same

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
