### PR TITLE
[RW-5130][risk=no] Externalize link and button text strings from all Page-Objects to one file

### DIFF
--- a/e2e/app/component/dialog.ts
+++ b/e2e/app/component/dialog.ts
@@ -5,20 +5,8 @@ import Textbox from 'app/element/textbox';
 import Textarea from 'app/element/textarea';
 import Checkbox from 'app/element/checkbox';
 import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
+import {LinkText} from 'app/page-identifiers';
 
-export enum ButtonLabel {
-  Confirm = 'Confirm',
-  KeepEditing = 'Keep Editing',
-  Cancel = 'Cancel',
-  Calculate = 'Calculate',
-  AddThis = 'ADD THIS',
-  Finish = 'Finish',
-  Rename = 'Rename',
-  Save = 'Save',
-  Update = 'Update',
-  CreateSet = 'CREATE SET',
-  DiscardChanges = 'Discard Changes',
-}
 
 const Selector = {
   defaultDialog: '//*[@role="dialog"]',
@@ -50,13 +38,13 @@ export default class Dialog extends Container {
     return modalText.toString();
   }
 
-  async clickButton(buttonLabel: ButtonLabel): Promise<void> {
+  async clickButton(buttonLabel: LinkText): Promise<void> {
     const button = await this.waitForButton(buttonLabel);
     await button.waitUntilEnabled();
     return button.click();
   }
 
-  async waitForButton(buttonLabel: ButtonLabel): Promise<Button> {
+  async waitForButton(buttonLabel: LinkText): Promise<Button> {
     return Button.findByName(this.page, {containsText: buttonLabel}, this);
   }
 

--- a/e2e/app/component/ellipsis-menu.ts
+++ b/e2e/app/component/ellipsis-menu.ts
@@ -1,6 +1,6 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {EllipsisMenuAction} from 'app/page-identifiers';
-import {GroupAction} from '../page/cohort-participants-group';
+import {GroupAction} from 'app/page/cohort-participants-group';
 import TieredMenu from './tiered-menu';
 
 export default class EllipsisMenu {

--- a/e2e/app/page-identifiers.ts
+++ b/e2e/app/page-identifiers.ts
@@ -1,5 +1,11 @@
 import {config} from 'resources/workbench-config';
 
+export enum PageUrl {
+   Home = config.uiBaseUrl,
+   Workspaces = config.uiBaseUrl + config.workspacesUrlPath,
+   Admin = config.uiBaseUrl + config.adminUrlPath,
+}
+
 export enum WorkspaceAccessLevel {
    Owner = 'OWNER',
    Reader = 'READER',
@@ -16,8 +22,34 @@ export enum EllipsisMenuAction {
    Rename = 'Rename',
 }
 
-export enum PageUrl {
-   Home = config.uiBaseUrl,
-   Workspaces = config.uiBaseUrl + config.workspacesUrlPath,
-   Admin = config.uiBaseUrl + config.adminUrlPath,
+export enum LinkText {
+   Confirm = 'Confirm',
+   KeepEditing = 'Keep Editing',
+   Cancel = 'Cancel',
+   Calculate = 'Calculate',
+   AddThis = 'ADD THIS',
+   Finish = 'Finish',
+   Rename = 'Rename',
+   Save = 'Save',
+   Update = 'Update',
+   Next = 'Next',
+   CreateSet = 'CREATE SET',
+   DiscardChanges = 'Discard Changes',
+   SaveCohort = 'Save Cohort',
+   CreateCohort = 'Create Cohort',
+   DeleteCohort = 'Delete Cohort',
+   RenameDataset = 'Rename Dataset',
+   DeleteConceptSet = 'Delete Concept Set',
+   DeleteDataset = 'Delete Dataset',
+   BackToReviewSet = 'Back to review set',
+   BackToCohort = 'Back to cohort',
+   DeleteNotebook = 'Delete Notebook',
+   CreateAnotherCohort = 'Create another Cohort',
+   CreateReviewSets = 'Create Review Sets',
+   CreateDataset = 'Create a Dataset',
+   CreateAnotherConceptSet = 'Create another Concept Set',
+   Submit = 'Submit',
+   CreateNewWorkspace = 'Create a New Workspace',
+   CreateWorkspace = 'Create Workspace',
+   DuplicateWorkspace = 'Duplicate Workspace',
 }

--- a/e2e/app/page/analysis-page.ts
+++ b/e2e/app/page/analysis-page.ts
@@ -4,7 +4,7 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
 import Dialog from 'app/component/dialog';
 import Button from 'app/element/button';
-import {EllipsisMenuAction} from 'app/page-identifiers';
+import {EllipsisMenuAction, LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 
 const PageTitle = 'View Notebooks';
@@ -39,7 +39,7 @@ export default class AnalysisPage extends AuthenticatedPage {
 
     const dialog = new Dialog(this.page);
     const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: 'Delete Notebook'}, dialog);
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteNotebook}, dialog);
     await Promise.all([
       deleteButton.click(),
       dialog.waitUntilDialogIsClosed(),

--- a/e2e/app/page/cohort-actions-page.ts
+++ b/e2e/app/page/cohort-actions-page.ts
@@ -2,6 +2,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import Button from 'app/element/button';
+import {LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 import DatasetBuildPage from './dataset-build-page';
 
@@ -36,15 +37,15 @@ export default class CohortActionsPage extends AuthenticatedPage {
   }
 
   async getCreateAnotherCohortButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Create another Cohort'});
+    return Button.findByName(this.page, {name: LinkText.CreateAnotherCohort});
   }
 
   async getCreateReviewSetsButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Create Review Sets'});
+    return Button.findByName(this.page, {name: LinkText.CreateReviewSets});
   }
 
   async getCreateDatasetButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Create a Dataset'});
+    return Button.findByName(this.page, {name: LinkText.CreateDataset});
   }
 
 }

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -1,25 +1,20 @@
-import Dialog, {ButtonLabel as DialogButtonLabel} from 'app/component/dialog';
+import {Page} from 'puppeteer';
+import Dialog from 'app/component/dialog';
 import TieredMenu from 'app/component/tiered-menu';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import {ElementType} from 'app/xpath-options';
-import {Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForNumericalString} from 'utils/waits-utils';
 import {xPathOptionToXpath} from 'app/element/xpath-defaults';
+import {LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 import CohortParticipantsGroup from './cohort-participants-group';
 
 const faker = require('faker/locale/en_US');
-
 const PageTitle = 'Build Cohort Criteria';
 
-enum ButtonLabel {
-  SaveCohort = 'Save Cohort',
-  CreateCohort = 'Create Cohort',
-  DeleteCohort = 'Delete Cohort',
-}
 
 export enum FieldSelector {
    TotalCount = '//*[contains(normalize-space(text()), "Total Count")]/parent::*//span',
@@ -49,7 +44,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
    * Save Cohort changes.
    */
   async saveChanges(): Promise<void> {
-    const createCohortButton = await Button.findByName(this.page, {normalizeSpace: ButtonLabel.SaveCohort});
+    const createCohortButton = await Button.findByName(this.page, {normalizeSpace: LinkText.SaveCohort});
     await createCohortButton.waitUntilEnabled();
     await createCohortButton.click(); // Click dropdown trigger to open menu
     const menu =  new TieredMenu(this.page);
@@ -76,7 +71,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     const descriptionTextarea = await dialog.waitForTextarea('DESCRIPTION');
     await descriptionTextarea.type(description);
 
-    const saveButton = await Button.findByName(this.page, {name: DialogButtonLabel.Save});
+    const saveButton = await Button.findByName(this.page, {name: LinkText.Save});
     await saveButton.waitUntilEnabled();
     await saveButton.click();
     await dialog.waitUntilDialogIsClosed();
@@ -99,7 +94,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
   async deleteConfirmationDialog(): Promise<string> {
     const dialog = new Dialog(this.page);
     const contentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: ButtonLabel.DeleteCohort}, dialog);
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteCohort}, dialog);
     await Promise.all([
       deleteButton.click(),
       dialog.waitUntilDialogIsClosed(),
@@ -115,7 +110,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
   async discardChangesConfirmationDialog(): Promise<string> {
     const dialog = new Dialog(this.page);
     const contentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: DialogButtonLabel.DiscardChanges}, dialog);
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DiscardChanges}, dialog);
     await Promise.all([
       deleteButton.click(),
       dialog.waitUntilDialogIsClosed(),
@@ -135,12 +130,12 @@ export default class CohortBuildPage extends AuthenticatedPage {
   }
 
   getSaveCohortButton(): Button {
-    const xpath = xPathOptionToXpath({type: ElementType.Button, normalizeSpace: ButtonLabel.SaveCohort});
+    const xpath = xPathOptionToXpath({type: ElementType.Button, normalizeSpace: LinkText.SaveCohort});
     return new Button(this.page, xpath);
   }
 
   getCreateCohortButton(): Button {
-    const xpath = xPathOptionToXpath({type: ElementType.Button, normalizeSpace: ButtonLabel.CreateCohort});
+    const xpath = xPathOptionToXpath({type: ElementType.Button, normalizeSpace: LinkText.CreateCohort});
     return new Button(this.page, xpath);
   }
 

--- a/e2e/app/page/cohort-criteria-modal.ts
+++ b/e2e/app/page/cohort-criteria-modal.ts
@@ -1,13 +1,14 @@
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import {Page} from 'puppeteer';
+import Dialog from 'app/component/dialog';
 import SelectMenu from 'app/component/select-menu';
 import Table from 'app/component/table';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textbox from 'app/element/textbox';
 import {xPathOptionToXpath} from 'app/element/xpath-defaults';
 import {ElementType} from 'app/xpath-options';
-import {Page} from 'puppeteer';
 import {centerPoint, dragDrop, waitWhileLoading} from 'utils/test-utils';
 import {waitForNumericalString, waitForPropertyNotExists} from 'utils/waits-utils';
+import {LinkText} from 'app/page-identifiers';
 
 const defaultXpath = '//*[@class="modal-container"]';
 
@@ -98,7 +99,7 @@ export default class CohortCriteriaModal extends Dialog {
     const numberField = await this.page.waitForXPath(`${this.xpath}//input[@type="number"]`, {visible: true});
     await numberField.type(String(filterValue));
 
-    await this.clickButton(ButtonLabel.Calculate);
+    await this.clickButton(LinkText.Calculate);
     const participantResult = await this.waitForParticipantResult();
     console.debug(`Physical Measurements ${criteriaName}: ${filterSign} ${filterValue}  => number of participants: ${participantResult}`);
 
@@ -107,7 +108,7 @@ export default class CohortCriteriaModal extends Dialog {
     // Before add criteria, first check for nothing in Selected Criteria Content Box.
     await this.page.waitForXPath(removeSelectedCriteriaIconSelector,{hidden: true});
 
-    await this.clickButton(ButtonLabel.AddThis);
+    await this.clickButton(LinkText.AddThis);
     // After add criteria, look for X (remove) icon for indication that add succeeded.
     await this.page.waitForXPath(removeSelectedCriteriaIconSelector,{visible: true});
 
@@ -123,7 +124,7 @@ export default class CohortCriteriaModal extends Dialog {
    */
   async clickFinishButton(opt: {waitUntilClosed?: boolean} = {}): Promise<void> {
     const { waitUntilClosed = true } = opt
-    await this.clickButton(ButtonLabel.Finish);
+    await this.clickButton(LinkText.Finish);
     if (waitUntilClosed) {
       await this.waitUntilDialogIsClosed();
     }
@@ -158,12 +159,12 @@ export default class CohortCriteriaModal extends Dialog {
     await numberField.press('Tab', { delay: 200 });
 
     let participantResult;
-    await this.clickButton(ButtonLabel.Calculate);
+    await this.clickButton(LinkText.Calculate);
     try {
       participantResult = await this.waitForParticipantResult();
     } catch (e) {
       // Retry one more time.
-      await this.clickButton(ButtonLabel.Calculate);
+      await this.clickButton(LinkText.Calculate);
       participantResult = await this.waitForParticipantResult();
     }
     console.debug(`Age Modifier: ${filterSign} ${filterValue}  => number of participants: ${participantResult}`);
@@ -191,7 +192,7 @@ export default class CohortCriteriaModal extends Dialog {
     await (Textbox.asBaseElement(this.page, upperNumberInput)).type(maxAge.toString()).then(input => input.tabKey());
 
     // Click Calculate button.
-    const button = await this.waitForButton(ButtonLabel.Calculate);
+    const button = await this.waitForButton(LinkText.Calculate);
     await waitForPropertyNotExists(this.page, button.getXpath(), 'disabled');
     await button.click();
 

--- a/e2e/app/page/cohort-participant-detail-page.ts
+++ b/e2e/app/page/cohort-participant-detail-page.ts
@@ -1,7 +1,8 @@
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import Button from '../element/button';
+import Button from 'app/element/button';
+import {LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 
 const PageTitle = 'Participant Detail';
@@ -26,7 +27,7 @@ export default class CohortParticipantDetailPage extends AuthenticatedPage {
   }
 
   async getBackToReviewSetButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Back to review set'});
+    return Button.findByName(this.page, {name: LinkText.BackToReviewSet});
   }
 
 }

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -1,11 +1,12 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {FieldSelector} from 'app/page/cohort-build-page';
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import Dialog from 'app/component/dialog';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 import CohortCriteriaModal, {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import TieredMenu from 'app/component/tiered-menu';
 import {waitWhileLoading} from 'utils/test-utils';
+import {LinkText} from 'app/page-identifiers';
 
 export enum GroupAction {
    EditGroupName  = 'Edit group name',
@@ -53,7 +54,7 @@ export default class CohortParticipantsGroup {
     const dialog = new Dialog(this.page);
     const textbox = await dialog.waitForTextbox('New Name:');
     await textbox.type(newGroupName);
-    await dialog.waitForButton(ButtonLabel.Rename).then(b => b.click());
+    await dialog.waitForButton(LinkText.Rename).then(b => b.click());
     await dialog.waitUntilDialogIsClosed();
   }
 

--- a/e2e/app/page/cohort-review-page.ts
+++ b/e2e/app/page/cohort-review-page.ts
@@ -3,6 +3,7 @@ import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import DataTable from 'app/component/data-table';
 import Button from 'app/element/button';
+import {LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 
 const PageTitle = 'Review Cohort Participants';
@@ -32,7 +33,7 @@ export default class CohortReviewPage extends AuthenticatedPage {
   }
 
   async getBackToCohortButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Back to cohort'});
+    return Button.findByName(this.page, {name: LinkText.BackToCohort});
   }
 
    /**

--- a/e2e/app/page/conceptset-actions-page.ts
+++ b/e2e/app/page/conceptset-actions-page.ts
@@ -2,6 +2,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import Button from 'app/element/button';
+import {LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from './authenticated-page';
 import DatasetBuildPage from './dataset-build-page';
 
@@ -41,11 +42,11 @@ export default class ConceptsetActionsPage extends AuthenticatedPage {
   }
 
   async getCreateAnotherConceptSetButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Create another Concept Set'});
+    return Button.findByName(this.page, {name: LinkText.CreateAnotherConceptSet});
   }
 
   async getCreateDatasetButton(): Promise<Button> {
-    return Button.findByName(this.page, {name: 'Create a Dataset'});
+    return Button.findByName(this.page, {name: LinkText.CreateDataset});
   }
 
 }

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -1,9 +1,10 @@
 import {Page} from 'puppeteer';
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import Dialog from 'app/component/dialog';
 import {makeRandomName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
 import Textarea from 'app/element/textarea';
+import {LinkText} from 'app/page-identifiers';
 import ConceptsetActionsPage from './conceptset-actions-page';
 
 const faker = require('faker/locale/en_US');
@@ -29,7 +30,7 @@ export default class ConceptsetSaveModal extends Dialog {
     await descriptionTextarea.type(faker.lorem.words());
 
     // Click SAVE button.
-    await this.clickButton(ButtonLabel.Save);
+    await this.clickButton(LinkText.Save);
 
     const conceptActionPage = new ConceptsetActionsPage(this.page);
     await conceptActionPage.waitForLoad();

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -12,6 +12,7 @@ import {defaultFieldValues} from 'resources/data/user-registration-data';
 import {config} from 'resources/workbench-config';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
+import {LinkText} from 'app/page-identifiers';
 
 const faker = require('faker/locale/en_US');
 
@@ -94,11 +95,11 @@ export default class CreateAccountPage extends BasePage {
   }
 
   async getSubmitButton(): Promise<Button> {
-    return await Button.findByName(this.page, {name: 'Submit'});
+    return await Button.findByName(this.page, {name: LinkText.Submit});
   }
 
   async getNextButton(): Promise<Button> {
-    return await Button.findByName(this.page, {name: 'Next'});
+    return await Button.findByName(this.page, {name: LinkText.Next});
   }
 
   async agreementLoaded(): Promise<boolean> {

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -1,18 +1,18 @@
 import DataResourceCard from 'app/component/data-resource-card';
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import Dialog from 'app/component/dialog';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
 import {xPathOptionToXpath} from 'app/element/xpath-defaults';
-import {EllipsisMenuAction} from 'app/page-identifiers';
+import {EllipsisMenuAction, LinkText} from 'app/page-identifiers';
 import AuthenticatedPage from 'app/page/authenticated-page';
 import {ElementType} from 'app/xpath-options';
 import {Page, Response} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import {makeRandomName} from '../../utils/str-utils';
+import {makeRandomName} from 'utils/str-utils';
 import CohortActionsPage from './cohort-actions-page';
 import CohortBuildPage from './cohort-build-page';
 import {Visits} from './cohort-criteria-modal';
@@ -120,7 +120,7 @@ export default class DataPage extends AuthenticatedPage {
 
     const dialog = new Dialog(this.page);
     const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: 'Delete Dataset'}, dialog);
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteDataset}, dialog);
     await Promise.all([
       deleteButton.click(),
       dialog.waitUntilDialogIsClosed(),
@@ -149,7 +149,7 @@ export default class DataPage extends AuthenticatedPage {
     const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, dialog);
     await descriptionTextarea.type('Puppeteer automation rename dataset.');
 
-    const renameButton = await Button.findByName(this.page, {normalizeSpace: 'Rename Dataset'}, dialog);
+    const renameButton = await Button.findByName(this.page, {normalizeSpace: LinkText.RenameDataset}, dialog);
     await Promise.all([
       renameButton.click(),
       dialog.waitUntilDialogIsClosed(),
@@ -168,7 +168,7 @@ export default class DataPage extends AuthenticatedPage {
 
     const dialog = new Dialog(this.page);
     const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: 'Delete Concept Set'}, dialog);
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteConceptSet}, dialog);
     await Promise.all([
       deleteButton.click(),
       dialog.waitUntilDialogIsClosed(),
@@ -189,7 +189,7 @@ export default class DataPage extends AuthenticatedPage {
     await newNameInput.type(newCohortName);
     const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, dialog);
     await descriptionTextarea.type('Puppeteer automation rename cohort.');
-    await dialog.clickButton(ButtonLabel.Rename);
+    await dialog.clickButton(LinkText.Rename);
     await dialog.waitUntilDialogIsClosed();
     await waitWhileLoading(this.page);
     console.log(`Cohort "${cohortName}" renamed to "${newCohortName}"`);

--- a/e2e/app/page/dataset-save-modal.ts
+++ b/e2e/app/page/dataset-save-modal.ts
@@ -1,9 +1,10 @@
 import {Page} from 'puppeteer';
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import Dialog from 'app/component/dialog';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
+import {LinkText} from 'app/page-identifiers';
 
 export enum Language {
   Python = 'Python',
@@ -52,9 +53,9 @@ export default class DatasetSaveModal extends Dialog {
     }
     await waitWhileLoading(this.page);
     if (isUpdate) {
-      await this.waitForButton(ButtonLabel.Update).then(btn => btn.clickAndWait());
+      await this.waitForButton(LinkText.Update).then(btn => btn.clickAndWait());
     } else {
-      await this.waitForButton(ButtonLabel.Save).then(btn => btn.clickAndWait());
+      await this.waitForButton(LinkText.Save).then(btn => btn.clickAndWait());
     }
     await waitWhileLoading(this.page);
     console.log(`Created Dataset "${newDatasetName}"`);

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -1,4 +1,4 @@
-import Dialog, {ButtonLabel} from 'app/component/dialog';
+import Dialog from 'app/component/dialog';
 import Button from 'app/element/button';
 import Checkbox from 'app/element/checkbox';
 import Select from 'app/element/select';
@@ -10,6 +10,7 @@ import {ElementHandle, Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import {xPathOptionToXpath} from 'app/element/xpath-defaults';
+import {LinkText} from 'app/page-identifiers';
 
 const faker = require('faker/locale/en_US');
 
@@ -18,9 +19,6 @@ export const PageTitle = 'Create Workspace';
 export const LabelAlias = {
   SYNTHETIC_DATASET: 'Workspace Name',  // select Synthetic Dataset
   SELECT_BILLING: 'Select account',   // select billing account
-  CREATE_WORKSPACE: 'Create Workspace',  // button CREATE WORKSPACE on edit page
-  DUPLICATE_WORKSPACE: 'Duplicate Workspace', // button DUPLICATE WORKSPACE on edit page
-  CANCEL: `Cancel`,  // button CANCEL on edit page
   WORKSPACE_NAME: 'Workspace Name',  // Workspace name input textbox
   RESEARCH_PURPOSE: 'Research purpose',
   EDUCATION_PURPOSE: 'Educational Purpose',
@@ -67,13 +65,13 @@ export const LabelAlias = {
 
 export const FIELD = {
   createWorkspaceButton: {
-    textOption: {name: LabelAlias.CREATE_WORKSPACE}
+    textOption: {name: LinkText.CreateWorkspace}
   },
   duplicateWorkspaceButton: {
-    textOption: {name: LabelAlias.DUPLICATE_WORKSPACE}
+    textOption: {name: LinkText.DuplicateWorkspace}
   },
   cancelWorkspaceButton: {
-    textOption: {name: LabelAlias.CANCEL}
+    textOption: {name: LinkText.Cancel}
   },
   workspaceNameTextbox: {
     textOption: {name: LabelAlias.WORKSPACE_NAME, ancestorLevel: 2, type: ElementType.Textbox}
@@ -390,7 +388,7 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
     const dialog = new Dialog(this.page);
     const dialogText = await dialog.getContent();
     await Promise.all([
-      dialog.clickButton(ButtonLabel.Confirm),
+      dialog.clickButton(LinkText.Confirm),
       dialog.waitUntilDialogIsClosed(),
       this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
     ]);

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -1,6 +1,6 @@
 import {Page} from 'puppeteer';
 import Button from 'app/element/button';
-import {PageUrl} from 'app/page-identifiers';
+import {LinkText, PageUrl} from 'app/page-identifiers';
 import WorkspaceEditPage, {FIELD as EDIT_FIELD} from 'app/page/workspace-edit-page';
 import {makeWorkspaceName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
@@ -8,17 +8,12 @@ import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
 
 const faker = require('faker/locale/en_US');
-
 export const PageTitle = 'View Workspace';
-
-export const LabelAlias = {
-  CreateANewWorkspace: 'Create a New Workspace',
-};
 
 export const FieldSelector = {
   CreateNewWorkspaceButton: {
     textOption: {
-      normalizeSpace: LabelAlias.CreateANewWorkspace
+      normalizeSpace: LinkText.CreateNewWorkspace
     }
   }
 };

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -1,7 +1,7 @@
 import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
-import {EllipsisMenuAction} from 'app/page-identifiers';
+import {EllipsisMenuAction, LinkText} from 'app/page-identifiers';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -153,7 +153,7 @@ describe('User can create new Cohorts', () => {
     await addIcon.click();
 
     // Click Next button to add modifier
-    const nextButton = await Button.findByName(page, {name: 'Next'}, modal);
+    const nextButton = await Button.findByName(page, {name: LinkText.Next}, modal);
     await nextButton.waitUntilEnabled();
     await nextButton.click();
 

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -1,6 +1,5 @@
 import {findWorkspace, isValidDate, signIn, waitWhileLoading} from 'utils/test-utils';
-import {ButtonLabel} from 'app/component/dialog';
-import {EllipsisMenuAction} from 'app/page-identifiers';
+import {EllipsisMenuAction, LinkText} from 'app/page-identifiers';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import CohortParticipantDetailPage from 'app/page/cohort-participant-detail-page';
 import CohortReviewModal from 'app/page/cohort-review-modal';
@@ -36,7 +35,7 @@ describe('Cohort review tests', () => {
     await menu.clickAction(EllipsisMenuAction.Review);
     const modal = new CohortReviewModal(page);
     await modal.fillInNumberOfPartcipants(reviewSetNumberOfParticipants);
-    await modal.clickButton(ButtonLabel.CreateSet);
+    await modal.clickButton(LinkText.CreateSet);
     console.log(`Created Review Set with ${reviewSetNumberOfParticipants} participants.`);
 
     const cohortReviewPage = new CohortReviewPage(page);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,12 +1,11 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
-import {ButtonLabel} from 'app/component/dialog';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import DatasetSaveModal from 'app/page/dataset-save-modal';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import {EllipsisMenuAction} from 'app/page-identifiers';
+import {EllipsisMenuAction, LinkText} from 'app/page-identifiers';
 
 describe('Create Dataset', () => {
 
@@ -81,7 +80,7 @@ describe('Create Dataset', () => {
     await addIcon.click();
 
     // Click FINISH button. Criteria dialog closes.
-    await modal.clickButton(ButtonLabel.Finish);
+    await modal.clickButton(LinkText.Finish);
     await cohortBuildPage.getTotalCount();
 
     // Save new cohort.


### PR DESCRIPTION
Have text strings in one location makes easier for update and find.  And, avoid duplication across all Page-Objects files.
Created new `export enum LinkText` in `page-identifiers.ts` and updated all usage files.

<img width="392" alt="Screen Shot 2020-06-25 at 3 13 44 PM" src="https://user-images.githubusercontent.com/35533885/85784861-b732ef00-b6f6-11ea-8128-ef8b7b6477c4.png">
