### PR TITLE
[RW-4430][RISK=NO]  UI: add Age at Event as modifier to Surveys

### DIFF
--- a/ui/src/app/cohort-search/modal/modal.component.tsx
+++ b/ui/src/app/cohort-search/modal/modal.component.tsx
@@ -289,8 +289,7 @@ export class CBModal extends React.Component<Props, State> {
   get showModifiers() {
     const {searchContext: {domain}} = this.props;
     return domain !== DomainType.PHYSICALMEASUREMENT &&
-      domain !== DomainType.PERSON &&
-      domain !== DomainType.SURVEY;
+      domain !== DomainType.PERSON;
   }
 
   get initTree() {

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.spec.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.spec.tsx
@@ -1,12 +1,62 @@
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 
+import {cohortBuilderApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {currentWorkspaceStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
+import {
+  CohortBuilderApi, CohortsApi, DomainType, ModifierType,
+  WorkspacesApi
+} from 'generated/fetch';
 import * as React from 'react';
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
+import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
+import {WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
+import {workspaceDataStub, WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 import {ModifierPage} from './modifier-page.component';
 
 
 describe('ListModifierPage', () => {
+  beforeEach(() => {
+    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
+
+    urlParamsStore.next({
+      ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
+    });
+    currentWorkspaceStore.next(workspaceDataStub);
+    serverConfigStore.next({
+      enableEventDateModifier: true,
+      gsuiteDomain: 'fake-research-aou.org',
+      projectId: 'aaa',
+      publicApiKeyForErrorReports: 'aaa',
+      enableEraCommons: true,
+    });
+  });
+
   it('should render', () => {
     const wrapper = shallow(<ModifierPage disabled={() => {}} wizard={{}}/>);
     expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should display Only Age Event modifier for SURVEY', async() => {
+    const survey = DomainType.SURVEY;
+    const wrapper = mount(<ModifierPage disabled={() => {
+    }} wizard={{}}
+                                        searchContext={{domain: survey, item: {modifiers: []}}}/>);
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.exists()).toBeTruthy();
+    expect(
+      wrapper.find('[data-test-id="' + ModifierType.AGEATEVENT + '"]').length)
+      .toBeGreaterThan(0);
+    expect(
+      wrapper.find('[data-test-id="' + ModifierType.NUMOFOCCURRENCES + '"]').length)
+      .toBe(0);
+    expect(
+      wrapper.find('[data-test-id="' + ModifierType.ENCOUNTERS + '"]').length)
+      .toBe(0);
+    expect(
+      wrapper.find('[data-test-id="' + ModifierType.EVENTDATE + '"]').length)
+      .toBe(0);
   });
 });

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -174,6 +174,7 @@ const validatorFuncs = {
     return null;
   }
 };
+const SURVEY_MODIFIERS = [ModifierType.AGEATEVENT];
 
 interface Selection extends Criteria {
   parameterId: string;
@@ -250,7 +251,7 @@ export const ModifierPage = withCurrentWorkspace()(
 
     async componentDidMount() {
       const {workspace: {cdrVersionId}} = this.props;
-      const {formState} = this.state;
+      let {formState} = this.state;
       if (serverConfigStore.getValue().enableEventDateModifier) {
         formState.push({
           name: ModifierType.EVENTDATE,
@@ -306,10 +307,19 @@ export const ModifierPage = withCurrentWorkspace()(
         formState.push(encounters);
         this.setState({visitCounts});
       }
+      formState = this.modifiersForSurvey;
       this.setState({formState});
       this.getExisting();
     }
 
+    get modifiersForSurvey() {
+      const {formState} = this.state;
+      const {searchContext: {domain}} = this.props;
+      if (domain === DomainType.SURVEY) {
+        return formState.filter(form => SURVEY_MODIFIERS.indexOf(form.name) > -1);
+      }
+      return formState;
+    }
     getExisting() {
       const {searchContext} = this.props;
       const {formState} = this.state;
@@ -511,7 +521,7 @@ export const ModifierPage = withCurrentWorkspace()(
         </div>}
         {formState.map((mod, i) => {
           const {label, name, options, operator} = mod;
-          return <div key={i} style={{marginTop: '0.75rem'}}>
+          return <div data-test-id={name} key={i} style={{marginTop: '0.75rem'}}>
             <label style={styles.label}>{label}</label>
             {name === ModifierType.EVENTDATE &&
               <TooltipTrigger content={<div>{tooltip}</div>}>

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -251,7 +251,7 @@ export const ModifierPage = withCurrentWorkspace()(
 
     async componentDidMount() {
       const {workspace: {cdrVersionId}} = this.props;
-      let {formState} = this.state;
+      const formState = this.formState;
       if (serverConfigStore.getValue().enableEventDateModifier) {
         formState.push({
           name: ModifierType.EVENTDATE,
@@ -307,22 +307,20 @@ export const ModifierPage = withCurrentWorkspace()(
         formState.push(encounters);
         this.setState({visitCounts});
       }
-      formState = this.modifiersForSurvey;
       this.setState({formState});
       this.getExisting();
     }
 
-    get modifiersForSurvey() {
-      const {formState} = this.state;
+    get formState() {
       const {searchContext: {domain}} = this.props;
-      if (domain === DomainType.SURVEY) {
-        return formState.filter(form => SURVEY_MODIFIERS.indexOf(form.name) > -1);
-      }
-      return formState;
+      const {formState} = this.state;
+      return domain === DomainType.SURVEY ?
+        formState.filter(form => SURVEY_MODIFIERS.indexOf(form.name) > -1) : formState;
     }
+
     getExisting() {
       const {searchContext} = this.props;
-      const {formState} = this.state;
+      const formState = this.formState;
       // This reseeds the form state with existing data if we're editing an existing item
       searchContext.item.modifiers.forEach(existing => {
         const index = formState.findIndex(mod => existing.name === mod.name);


### PR DESCRIPTION

<img width="1342" alt="Screen Shot 2020-06-25 at 5 06 23 PM" src="https://user-images.githubusercontent.com/34481816/85795588-8bb80080-b706-11ea-913c-3ba2e8599136.png">
<img width="1334" alt="Screen Shot 2020-06-25 at 5 06 32 PM" src="https://user-images.githubusercontent.com/34481816/85795591-8ce92d80-b706-11ea-800b-7a4c7de94ab6.png">



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
