### PR TITLE
[no ticket][risk=no] Puppeteer disable test retries for local test development

### DIFF
--- a/e2e/jest-circus.setup.ts
+++ b/e2e/jest-circus.setup.ts
@@ -2,4 +2,4 @@ require('expect-puppeteer');
 
 // Runs failed tests n-times until they pass or until the max number of retries is exhausted. This only works with jest-circus.
 // This file loaded in jest.config.js ==> setupFilesAfterEnv
-jest.retryTimes(1);
+jest.retryTimes(process.env.DEBUG === 'true' ? 0 : 1);

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -9,6 +9,9 @@ module.exports = {
     "<rootDir>/jest-circus.setup.ts",
     "<rootDir>/jest.test-setup.ts"
   ],
+  setupFiles: [
+    "dotenv/config"
+  ],
   "reporters": [
     "default",
     "jest-junit"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "license": "BSD",
   "scripts": {
-    "test": "cross-env WORKBENCH_ENV=dev jest --maxWorkers=3",
-    "test:debug": "cross-env WORKBENCH_ENV=dev HEADLESS=false jest --detectOpenHandles",
+    "test": "cross-env jest --maxWorkers=3",
+    "test:debug": "cross-env HEADLESS=false DEBUG=true jest --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local jest --maxWorkers=2",
     "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2",
     "lint": "tslint --project tsconfig.json",

--- a/e2e/puppeteer-custom-environment.ts
+++ b/e2e/puppeteer-custom-environment.ts
@@ -3,8 +3,8 @@ const fs = require('fs-extra');
 const fp = require('lodash/fp');
 require('jest-circus');
 
-// jest-circus retryTimes
-const retryTimes = 1;
+// jest-circus retryTimes. No retry on failed test if env DEBUG=true. e.g. "yarn test:debug"
+const retryTimes = process.env.DEBUG === 'true' ? 0 : 1;
 
 class PuppeteerCustomEnvironment extends PuppeteerEnvironment {
   async setup() {

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -1,4 +1,3 @@
-require('dotenv').config();
 import * as fp from 'lodash/fp';
 
 const env = process.env.WORKBENCH_ENV || 'dev';


### PR DESCRIPTION
Issue: the auto-retry in the jest-circus config is annoying for local development. It has be set manually to 0 retries when working on the test on localhost.