### PR TITLE
[no ticket][risk=no] DataSetController cleanup

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -185,10 +185,8 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
             new DataSetController(
                 bigQueryService,
                 CLOCK,
-                cdrVersionDao,
                 cohortService,
                 cdrVersionService,
-                cohortDao,
                 conceptService,
                 conceptSetService,
                 dataDictionaryEntryDao,


### PR DESCRIPTION
this PR contains
1. removing unused daos (cdrVersionDao and cohortDao)
2. removing an unused method -> DataSetController#generateDataSetRequestFromPreviewRequest
3. removing unnecessary curly braces from lambda statements

