### PR TITLE
[RW-5148][risk=no] Fix user creation via directory service

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -281,7 +281,9 @@ public class ProfileController implements ProfileApiDelegate {
         directoryService.createUser(
             profile.getGivenName(),
             profile.getFamilyName(),
-            profile.getUsername(),
+            profile.getUsername()
+                + "@"
+                + workbenchConfigProvider.get().googleDirectoryService.gSuiteDomain,
             profile.getContactEmail());
 
     // Create a user that has no data access or FC user associated.

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -26,6 +26,13 @@ public interface DirectoryService {
   /** Looks up a user by username and returns their stored contact email address, if available. */
   Optional<String> getContactEmail(String username);
 
+  /**
+   * @param givenName
+   * @param familyName
+   * @param username The full RW username, e.g. "jdoe@researchallofus.org"
+   * @param contactEmail The user's contact email address, e.g. "jdoe@gmail.com"
+   * @return
+   */
   User createUser(String givenName, String familyName, String username, String contactEmail);
 
   User resetUserPassword(String username);

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5024,7 +5024,9 @@ definitions:
         type: integer
         format: int64
       username:
-        description: researchallofus username
+        description: 'The username prefix, e.g. "gjordan". Note that this is different
+          from the use of "username" elsewhere in the RW codebase, where username represents
+          the full email address.'
         type: string
       creationNonce:
         description: 'A value which can be used to secure API calls during the account

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5026,7 +5026,7 @@ definitions:
       username:
         description: 'The username prefix, e.g. "gjordan". Note that this is different
           from the use of "username" elsewhere in the RW codebase, where username represents
-          the full email address.'
+          the full GSuite email address.'
         type: string
       creationNonce:
         description: 'A value which can be used to secure API calls during the account

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -120,6 +120,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final String CURRENT_POSITION = "Tester";
   private static final String FAMILY_NAME = "Bobberson";
   private static final String GIVEN_NAME = "Bob";
+  private static final String GSUITE_DOMAIN = "Bob";
   private static final String INVITATION_KEY = "secretpassword";
   private static final String NONCE = Long.toString(NONCE_LONG);
   private static final String ORGANIZATION = "Test";
@@ -127,7 +128,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final String RESEARCH_PURPOSE = "To test things";
   private static final String STATE = "EX";
   private static final String STREET_ADDRESS = "1 Example Lane";
-  private static final String USERNAME = "bob";
+  private static final String USER_PREFIX = "bob";
   private static final String WRONG_CAPTCHA_TOKEN = "WrongCaptchaToken";
   private static final String ZIP_CODE = "12345";
   private static final Timestamp TIMESTAMP = new Timestamp(fakeClock.millis());
@@ -212,12 +213,13 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     // Most tests should run with institutional verification off by default.
     config.featureFlags.requireInstitutionalVerification = false;
+    config.googleDirectoryService.gSuiteDomain = GSUITE_DOMAIN;
 
     Profile profile = new Profile();
     profile.setContactEmail(CONTACT_EMAIL);
     profile.setFamilyName(FAMILY_NAME);
     profile.setGivenName(GIVEN_NAME);
-    profile.setUsername(USERNAME);
+    profile.setUsername(USER_PREFIX);
     profile.setCurrentPosition(CURRENT_POSITION);
     profile.setOrganization(ORGANIZATION);
     profile.setAreaOfResearch(RESEARCH_PURPOSE);
@@ -1249,7 +1251,8 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   private Profile createUser() {
     when(mockCloudStorageService.readInvitationKey()).thenReturn(INVITATION_KEY);
-    when(mockDirectoryService.createUser(GIVEN_NAME, FAMILY_NAME, USERNAME, CONTACT_EMAIL))
+    when(mockDirectoryService.createUser(
+            GIVEN_NAME, FAMILY_NAME, USER_PREFIX + "@" + GSUITE_DOMAIN, CONTACT_EMAIL))
         .thenReturn(googleUser);
     Profile result = profileController.createAccount(createAccountRequest).getBody();
     dbUser = userDao.findUserByUsername(PRIMARY_EMAIL);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -120,7 +120,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final String CURRENT_POSITION = "Tester";
   private static final String FAMILY_NAME = "Bobberson";
   private static final String GIVEN_NAME = "Bob";
-  private static final String GSUITE_DOMAIN = "Bob";
+  private static final String GSUITE_DOMAIN = "researchallofus.org";
   private static final String INVITATION_KEY = "secretpassword";
   private static final String NONCE = Long.toString(NONCE_LONG);
   private static final String ORGANIZATION = "Test";


### PR DESCRIPTION
This was a simple regression due to some refactoring I'd done in https://github.com/all-of-us/workbench/pull/3708. It turns out our Profile API model uses 'username' with a different meaning than our codebase, which I overlooked.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
