### PR TITLE
[risk=no][RW-5142] Undo Router Reversion 

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -8,7 +8,6 @@ import {AppRouting} from './app-routing';
 
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
-import {DataUserCodeOfConductComponent} from 'app/pages/profile/data-user-code-of-conduct';
 import {UserDisabledComponent} from 'app/pages/user-disabled';
 import {AdminBannerComponent} from './pages/admin/admin-banner';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
@@ -310,11 +309,6 @@ const routes: Routes = [
         data: {title: 'Homepage'},
       },
       {
-        path: 'data-code-of-conduct',
-        component: DataUserCodeOfConductComponent,
-        data: {title: 'Data User Code of Conduct'}
-      },
-      {
         path: 'admin',
         children: [
           {
@@ -364,6 +358,11 @@ const routes: Routes = [
             component: AdminInstitutionEditComponent,
             data: { title: 'Institution Admin'},
           }]
+      },
+      {
+        path: '**',
+        component: AppRouting,
+        data: {}
       }
     ]
   }, {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,17 +1,39 @@
 import {Component as AComponent} from '@angular/core';
-import {AppRoute, AppRouter} from 'app/components/app-router';
+import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
+import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import { ReactWrapperBase } from 'app/utils';
+import {authStore, useStore} from 'app/utils/stores';
+import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {CookiePolicyComponent} from './pages/cookie-policy';
 
+
+const signInGuard: Guard = {
+  allowed: (): boolean => authStore.get().isSignedIn,
+  redirectPath: '/login'
+};
+
+const DUCC = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
+
 export const AppRoutingComponent: React.FunctionComponent = () => {
-  return <AppRouter>
+  const {authLoaded = false} = useStore(authStore);
+
+  return authLoaded && <AppRouter>
     <AppRoute path='/cookie-policy' component={CookiePolicyComponent}/>
+    <ProtectedRoutes guards={[signInGuard]}>
+        <AppRoute
+        path='/data-code-of-conduct'
+          component={ () => <DUCC routeData={{
+            title: 'Data User Code of Conduct',
+            minimizeChrome: true
+          }} />}
+        />
+    </ProtectedRoutes>
   </AppRouter>;
 };
 
 @AComponent({
-  template: '<div #root></div>'
+  template: '<div #root style="display: inline;"></div>'
 })
 export class AppRouting extends ReactWrapperBase {
   constructor() {

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -43,7 +43,6 @@ import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-detai
 import {HomepageComponent} from './pages/homepage/homepage';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignInComponent} from './pages/login/sign-in';
-import {DataUserCodeOfConductComponent} from './pages/profile/data-user-code-of-conduct';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SessionExpiredComponent} from './pages/session-expired';
 import {SignInAgainComponent} from './pages/sign-in-again';
@@ -154,7 +153,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     CreateReviewModalComponent,
     DataPageComponent,
     DataSetPageComponent,
-    DataUserCodeOfConductComponent,
     DetailPageComponent,
     FooterComponent,
     HelpSidebarComponent,

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -1,3 +1,4 @@
+import {navigate} from 'app/utils/navigation';
 import {routeDataStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
@@ -5,11 +6,9 @@ import { BrowserRouter, Link, Redirect, Route, Switch, useHistory, useLocation, 
 
 const {Fragment} = React;
 
-interface Guards {
-  [index: number]: {
-    checkGuard: () => boolean;
-    redirectPath: string;
-  };
+export interface Guard {
+  allowed: () => boolean;
+  redirectPath: string;
 }
 
 export const usePath = () => {
@@ -31,6 +30,14 @@ export const AppRouter = ({children}): React.ReactElement => <BrowserRouter><Sub
 
 export const RouteLink = ({path, style = {}, children}): React.ReactElement => <Link style={{...style}} to={path}>{children}</Link>;
 
+// To compensate for Angular, while keeping true to the declarative/componentized nature of the router
+// We will utilize a redirect component that uses the Angular navigation.
+// Upon completing the migration this can be replaced with a react-router Redirect component
+const NavRedirect = ({path}) => {
+  navigate([path]);
+  return null;
+};
+
 export const AppRoute = ({path, data = {}, component: Component}): React.ReactElement => {
   const routeParams = useParams();
   const routeHistory = useHistory();
@@ -41,12 +48,10 @@ export const AppRoute = ({path, data = {}, component: Component}): React.ReactEl
 };
 
 export const ProtectedRoutes = (
-  {path, guards, children}: {path: string, guards: Guards, children: React.ReactNode[] }): React.ReactElement => {
-  const { redirectPath } = fp.find(({checkGuard}) => checkGuard(), guards);
-  const location = useLocation();
-  return redirectPath ? <AppRoute
-      path={path}
-      component={() => <Redirect to={{pathname: redirectPath, state: {from: location} }}/>}/>
+  {guards, children}: {guards: Guard[], children: any }): React.ReactElement => {
+  const { redirectPath = null } = fp.find(({allowed}) => !allowed(), guards) || {};
+
+  return redirectPath ? <NavRedirect path={redirectPath}/>
   : <Fragment>{children}</Fragment>;
 };
 

--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -18,6 +18,7 @@ import {
   serverConfigStore,
   urlParamsStore
 } from 'app/utils/navigation';
+import {routeDataStore} from 'app/utils/stores';
 import {environment} from 'environments/environment';
 
 import outdatedBrowserRework from 'outdated-browser-rework';
@@ -95,6 +96,7 @@ export class AppComponent implements OnInit {
       }
     });
 
+    routeDataStore.subscribe(({title}) => this.setTitleFromReactRoute(title));
     initializeAnalytics();
   }
 
@@ -116,6 +118,17 @@ export class AppComponent implements OnInit {
           this.titleService.setTitle(`${routeTitle} | ${this.baseTitle}`);
         });
       }
+    }
+  }
+
+  private setTitleFromReactRoute(title: string): void {
+    const currentRoute = this.getLeafRoute();
+    if (currentRoute.outlet === 'primary') {
+      currentRoute.data.subscribe(value => {
+        const routeTitle = title ||
+          decodeURIComponent(currentRoute.params.getValue()[value.pathElementForTitle]);
+        this.titleService.setTitle(`${routeTitle} | ${this.baseTitle}`);
+      });
     }
   }
 

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -1,4 +1,3 @@
-import {Component} from '@angular/core';
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {HtmlViewer} from 'app/components/html-viewer';
@@ -13,7 +12,7 @@ import {
 } from 'app/pages/profile/data-user-code-of-conduct-styles';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {reactStyles, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {getLiveDataUseAgreementVersion} from 'app/utils/code-of-conduct';
 import {navigate, serverConfigStore} from 'app/utils/navigation';
@@ -269,12 +268,3 @@ export const DataUserCodeOfConduct = withUserProfile()(
       }
     }
   });
-
-@Component({
-  template: '<div #root style="height: 100%"></div>'
-})
-export class DataUserCodeOfConductComponent extends ReactWrapperBase {
-  constructor() {
-    super(DataUserCodeOfConduct, []);
-  }
-}

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -5,6 +5,7 @@ import {Injectable, NgZone} from '@angular/core';
 import {ServerConfigService} from 'app/services/server-config.service';
 import {setLoggedInState} from 'app/utils/analytics';
 import {signInStore} from 'app/utils/navigation';
+import {authStore} from 'app/utils/stores';
 import {environment} from 'environments/environment';
 import {ConfigResponse} from 'generated';
 import {ReplaySubject} from 'rxjs/ReplaySubject';
@@ -67,6 +68,7 @@ export class SignInService {
   private subscribeToAuth2User(): void {
     // The listen below only fires on changes, so we need an initial
     // check to handle the case where the user is already signed in.
+    authStore.set({...authStore.get(), authLoaded: true, isSignedIn: gapi.auth2.getAuthInstance().isSignedIn.get()});
     this.zone.run(() => {
       const isSignedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
       this.isSignedIn.next(isSignedIn);
@@ -77,6 +79,7 @@ export class SignInService {
       setLoggedInState(isSignedIn);
     });
     gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn: boolean) => {
+      authStore.set({...authStore.get(), isSignedIn});
       this.zone.run(() => {
         this.isSignedIn.next(isSignedIn);
         if (isSignedIn) {


### PR DESCRIPTION
Description:

Puts back the router changes. The original issue that required this code to be reverted should have been addressed in 
[3724](https://github.com/all-of-us/workbench/pull/3724)

The user registration flow is currently down on test. I tested this by manually setting the registered user flag in the code to click on the code of conduct link.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
