### PR TITLE
[risk=no] Puppeteer fix for concept search failure

### DIFF
--- a/e2e/app/component/concept-domain-card.ts
+++ b/e2e/app/component/concept-domain-card.ts
@@ -6,7 +6,7 @@ import Container from 'app/container';
 export enum Domain {
    Conditions = 'Conditions',
    DrugExposures = 'Drug Exposures',
-   Measurements = 'Measurements',
+   Measurements = 'Labs and Measurements',
    Observations =  'Observations',
    Procedures = 'Procedures',
 }


### PR DESCRIPTION
'Measurements' was changed to 'Labs and Measurements' in the domain_info table.