### PR TITLE
[RW-5099][risk=no] Reactify unguarded static content routes

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -8,7 +8,6 @@ import {AppRouting} from './app-routing';
 
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
-import {UserDisabledComponent} from 'app/pages/user-disabled';
 import {AdminBannerComponent} from './pages/admin/admin-banner';
 import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AdminUserComponent} from './pages/admin/admin-user';
@@ -62,10 +61,6 @@ const routes: Routes = [
     path: 'sign-in-again',
     component: SignInAgainComponent,
     data: {title: 'You have been signed out'}
-  }, {
-    path: 'user-disabled',
-    component: UserDisabledComponent,
-    data: {title: 'Disabled'}
   }, {
     path: '',
     component: SignedInComponent,

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -27,8 +27,6 @@ import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-detai
 import {HomepageComponent} from './pages/homepage/homepage';
 import {SignInComponent} from './pages/login/sign-in';
 import {ProfilePageComponent} from './pages/profile/profile-page';
-import {SessionExpiredComponent} from './pages/session-expired';
-import {SignInAgainComponent} from './pages/sign-in-again';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
 import {WorkspaceEditComponent, WorkspaceEditMode} from './pages/workspace/workspace-edit';
@@ -53,15 +51,8 @@ const routes: Routes = [
     path: 'login',
     component: SignInComponent,
     data: {title: 'Sign In'}
-  }, {
-    path: 'session-expired',
-    component: SessionExpiredComponent,
-    data: {title: 'You have been signed out'}
-  }, {
-    path: 'sign-in-again',
-    component: SignInAgainComponent,
-    data: {title: 'You have been signed out'}
-  }, {
+  },
+  {
     path: '',
     component: SignedInComponent,
     canActivate: [SignInGuard],

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -5,7 +5,8 @@ import { ReactWrapperBase } from 'app/utils';
 import {authStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {CookiePolicyComponent} from './pages/cookie-policy';
+import {CookiePolicy} from './pages/cookie-policy';
+import {UserDisabled} from "./pages/user-disabled";
 
 
 const signInGuard: Guard = {
@@ -19,7 +20,7 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
   const {authLoaded = false} = useStore(authStore);
 
   return authLoaded && <AppRouter>
-    <AppRoute path='/cookie-policy' component={CookiePolicyComponent}/>
+    <AppRoute path='/cookie-policy' component={CookiePolicy}/>
     <ProtectedRoutes guards={[signInGuard]}>
         <AppRoute
         path='/data-code-of-conduct'
@@ -29,6 +30,7 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
           }} />}
         />
     </ProtectedRoutes>
+    <AppRoute path='/user-disabled' component={UserDisabled}/>
   </AppRouter>;
 };
 

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -5,9 +5,11 @@ import { ReactWrapperBase } from 'app/utils';
 import {authStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {CookiePolicy} from './pages/cookie-policy';
-import {UserDisabled} from "./pages/user-disabled";
-
+import {CookiePolicy} from 'app/pages/cookie-policy';
+import {UserDisabled} from "app/pages/user-disabled";
+import {SessionExpired} from "app/pages/session-expired";
+import {SignInAgain} from "app/pages/sign-in-again";
+import {SignInService} from "app/services/sign-in.service";
 
 const signInGuard: Guard = {
   allowed: (): boolean => authStore.get().isSignedIn,
@@ -16,11 +18,15 @@ const signInGuard: Guard = {
 
 const DUCC = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
 
-export const AppRoutingComponent: React.FunctionComponent = () => {
+export const AppRoutingComponent: React.FunctionComponent<{signIn: Function}> = ({signIn}) => {
   const {authLoaded = false} = useStore(authStore);
 
   return authLoaded && <AppRouter>
     <AppRoute path='/cookie-policy' component={CookiePolicy}/>
+    <AppRoute path='/session-expired' data={{signIn: signIn}} component={SessionExpired}/>
+    <AppRoute path='/sign-in-again' data={{signIn: signIn}} component={SignInAgain}/>
+    <AppRoute path='/user-disabled' component={UserDisabled}/>
+
     <ProtectedRoutes guards={[signInGuard]}>
         <AppRoute
         path='/data-code-of-conduct'
@@ -30,7 +36,6 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
           }} />}
         />
     </ProtectedRoutes>
-    <AppRoute path='/user-disabled' component={UserDisabled}/>
   </AppRouter>;
 };
 
@@ -38,7 +43,12 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
   template: '<div #root style="display: inline;"></div>'
 })
 export class AppRouting extends ReactWrapperBase {
-  constructor() {
-    super(AppRoutingComponent, []);
+  constructor(private signInService: SignInService) {
+    super(AppRoutingComponent, ['signIn']);
+    this.signIn = this.signIn.bind(this);
+  }
+
+  signIn(): void {
+    this.signInService.signIn();
   }
 }

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,7 +1,7 @@
 import {Component as AComponent} from '@angular/core';
 import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
-import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import {CookiePolicy} from 'app/pages/cookie-policy';
+import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import {SessionExpired} from 'app/pages/session-expired';
 import {SignInAgain} from 'app/pages/sign-in-again';
 import {UserDisabled} from 'app/pages/user-disabled';

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,15 +1,15 @@
 import {Component as AComponent} from '@angular/core';
 import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
 import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
+import {CookiePolicy} from 'app/pages/cookie-policy';
+import {SessionExpired} from 'app/pages/session-expired';
+import {SignInAgain} from 'app/pages/sign-in-again';
+import {UserDisabled} from 'app/pages/user-disabled';
+import {SignInService} from 'app/services/sign-in.service';
 import { ReactWrapperBase } from 'app/utils';
 import {authStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {CookiePolicy} from 'app/pages/cookie-policy';
-import {UserDisabled} from "app/pages/user-disabled";
-import {SessionExpired} from "app/pages/session-expired";
-import {SignInAgain} from "app/pages/sign-in-again";
-import {SignInService} from "app/services/sign-in.service";
 
 const signInGuard: Guard = {
   allowed: (): boolean => authStore.get().isSignedIn,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -77,7 +77,6 @@ import {InteractiveNotebookComponent} from 'app/pages/analysis/interactive-noteb
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
 import {NavBarComponent} from 'app/pages/signed-in/nav-bar';
-import {UserDisabledComponent} from 'app/pages/user-disabled';
 import {FooterComponent} from './components/footer';
 import {AdminInstitutionComponent} from './pages/admin/admin-institution';
 import {AdminInstitutionEditComponent} from './pages/admin/admin-institution-edit';
@@ -170,7 +169,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     SignInComponent,
     TablePage,
     TextModalComponent,
-    UserDisabledComponent,
     WorkspaceAboutComponent,
     WorkspaceEditComponent,
     WorkspaceLibraryComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -44,8 +44,6 @@ import {HomepageComponent} from './pages/homepage/homepage';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignInComponent} from './pages/login/sign-in';
 import {ProfilePageComponent} from './pages/profile/profile-page';
-import {SessionExpiredComponent} from './pages/session-expired';
-import {SignInAgainComponent} from './pages/sign-in-again';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
 import {WorkspaceEditComponent} from './pages/workspace/workspace-edit';
@@ -164,8 +162,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     RoutingSpinnerComponent,
     SignedInComponent,
     NavBarComponent,
-    SessionExpiredComponent,
-    SignInAgainComponent,
     SignInComponent,
     TablePage,
     TextModalComponent,

--- a/ui/src/app/pages/cookie-policy.tsx
+++ b/ui/src/app/pages/cookie-policy.tsx
@@ -6,6 +6,7 @@ import {PublicLayout} from 'app/components/public-layout';
 import {AouTitle} from 'app/components/text-wrappers';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import * as React from 'react';
+import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = {
   tableItem: {
@@ -46,7 +47,11 @@ const COOKIE_DELETION_LINK = 'https://www.aboutcookies.org/how-to-delete-cookies
 const GOOGLE_PRIVACY_LINK = 'https://policies.google.com/privacy';
 const ZENDESK_PRIVACY_LINK = 'https://www.zendesk.com/company/customers-partners/privacy-policy/';
 
-export class CookiePolicyComponent extends React.Component<{}, {}> {
+export class CookiePolicy extends React.Component<{}, {}> {
+  componentDidMount() {
+    document.title = buildPageTitleForEnvironment('Cookie Policy');
+  }
+
   render() {
     return <PublicLayout>
       <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '100%', color: colors.primary}}>

--- a/ui/src/app/pages/cookie-policy.tsx
+++ b/ui/src/app/pages/cookie-policy.tsx
@@ -5,8 +5,8 @@ import {Header, SmallHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import {AouTitle} from 'app/components/text-wrappers';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
+import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
-import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = {
   tableItem: {

--- a/ui/src/app/pages/session-expired.tsx
+++ b/ui/src/app/pages/session-expired.tsx
@@ -20,7 +20,7 @@ const styles = reactStyles({
   }
 });
 
-export class SessionExpired extends React.Component<{signIn: Function}> {
+export class SessionExpired extends React.Component<{routeConfig: {signIn: Function}}> {
   componentDidMount() {
     document.title = buildPageTitleForEnvironment('You have been signed out');
   }
@@ -31,7 +31,7 @@ export class SessionExpired extends React.Component<{signIn: Function}> {
       <section style={styles.textSection}>
         You were automatically signed out of your session due to inactivity
       </section>
-      <GoogleSignInButton signIn={() => this.props.signIn()}/>
+      <GoogleSignInButton signIn={() => this.props.routeConfig.signIn()}/>
     </PublicLayout>;
   }
 }

--- a/ui/src/app/pages/session-expired.tsx
+++ b/ui/src/app/pages/session-expired.tsx
@@ -6,6 +6,7 @@ import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 import * as React from 'react';
+import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = reactStyles({
   button: {
@@ -19,26 +20,18 @@ const styles = reactStyles({
   }
 });
 
-export const SessionExpired: React.FunctionComponent<{signIn: Function}> = ({signIn}) => {
-  return <PublicLayout>
-    <BoldHeader>You have been signed out</BoldHeader>
-    <section style={styles.textSection}>
-      You were automatically signed out of your session due to inactivity
-    </section>
-    <GoogleSignInButton signIn={signIn} />
-  </PublicLayout>;
-};
-
-@Component({
-  template: '<div #root></div>'
-})
-export class SessionExpiredComponent extends ReactWrapperBase {
-  constructor(private signInService: SignInService) {
-    super(SessionExpired, ['signIn']);
-    this.signIn = this.signIn.bind(this);
+export class SessionExpired extends React.Component<{signIn: Function}> {
+  componentDidMount() {
+    document.title = buildPageTitleForEnvironment('You have been signed out');
   }
 
-  signIn(): void {
-    this.signInService.signIn();
+  render() {
+    return <PublicLayout>
+      <BoldHeader>You have been signed out</BoldHeader>
+      <section style={styles.textSection}>
+        You were automatically signed out of your session due to inactivity
+      </section>
+      <GoogleSignInButton signIn={() => this.props.signIn()}/>
+    </PublicLayout>;
   }
 }

--- a/ui/src/app/pages/session-expired.tsx
+++ b/ui/src/app/pages/session-expired.tsx
@@ -1,12 +1,10 @@
-import {Component} from '@angular/core';
 import {GoogleSignInButton} from 'app/components/google-sign-in';
 import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
-import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {reactStyles} from 'app/utils';
+import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
-import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = reactStyles({
   button: {

--- a/ui/src/app/pages/sign-in-again.tsx
+++ b/ui/src/app/pages/sign-in-again.tsx
@@ -7,6 +7,7 @@ import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 import * as React from 'react';
+import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = reactStyles({
   button: {
@@ -27,33 +28,25 @@ const styles = reactStyles({
 
 const supportUrl = 'support@researchallofus.org';
 
-export const SignInAgain: React.FunctionComponent<{signIn: Function}> = ({signIn}) => {
-  return <PublicLayout contentStyle={{width: '500px'}}>
-    <BoldHeader>You have been signed out</BoldHeader>
-    <section style={styles.textSection}>
-      You’ve been away for a while and we could not verify whether your session was still active.
-    </section>
-    <GoogleSignInButton signIn={signIn} />
-    <section style={styles.noteSection}>
-      <strong>Note</strong>: You may have been redirected to this page immediately after attempting to sign in,
-      if you did not explicitly sign out of your most recent session. If, after signing in
-      again, you continue to be redirected to this page, please contact&nbsp;
-      <StyledAnchorTag href={'mailto:' + supportUrl}>{supportUrl}</StyledAnchorTag> for
-      assistance.
-    </section>
-  </PublicLayout>;
-};
-
-@Component({
-  template: '<div #root></div>'
-})
-export class SignInAgainComponent extends ReactWrapperBase {
-  constructor(private signInService: SignInService) {
-    super(SignInAgain, ['signIn']);
-    this.signIn = this.signIn.bind(this);
+export class SignInAgain extends React.Component<{routeConfig: {signIn: Function}}> {
+  componentDidMount() {
+    document.title = buildPageTitleForEnvironment('You have been signed out');
   }
 
-  signIn(): void {
-    this.signInService.signIn();
+  render() {
+    return <PublicLayout contentStyle={{width: '500px'}}>
+      <BoldHeader>You have been signed out</BoldHeader>
+      <section style={styles.textSection}>
+        You’ve been away for a while and we could not verify whether your session was still active.
+      </section>
+      <GoogleSignInButton signIn={() => this.props.routeConfig.signIn()}/>
+      <section style={styles.noteSection}>
+        <strong>Note</strong>: You may have been redirected to this page immediately after attempting to sign in,
+        if you did not explicitly sign out of your most recent session. If, after signing in
+        again, you continue to be redirected to this page, please contact&nbsp;
+        <StyledAnchorTag href={'mailto:' + supportUrl}>{supportUrl}</StyledAnchorTag> for
+        assistance.
+      </section>
+    </PublicLayout>;
   }
 }

--- a/ui/src/app/pages/sign-in-again.tsx
+++ b/ui/src/app/pages/sign-in-again.tsx
@@ -1,13 +1,11 @@
-import {Component} from '@angular/core';
 import {StyledAnchorTag} from 'app/components/buttons';
 import {GoogleSignInButton} from 'app/components/google-sign-in';
 import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
-import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase} from 'app/utils';
+import {reactStyles} from 'app/utils';
+import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
-import {buildPageTitleForEnvironment} from "../utils/title";
 
 const styles = reactStyles({
   button: {

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -1,11 +1,10 @@
-import {Component} from '@angular/core';
 import * as React from 'react';
 
 import {StyledAnchorTag} from 'app/components/buttons';
 import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import colors from 'app/styles/colors';
-import {buildPageTitleForEnvironment} from "app/utils/title";
+import {buildPageTitleForEnvironment} from 'app/utils/title';
 
 const supportUrl = 'support@researchallofus.org';
 
@@ -13,7 +12,7 @@ export class UserDisabled extends React.Component {
   // TODO: esteemed reviewer, please yell at me if I don't write a paper about a global wrapper that
   // handles this sort of thing before turning this PR in for review
   componentDidMount() {
-    document.title = buildPageTitleForEnvironment('Disabled')
+    document.title = buildPageTitleForEnvironment('Disabled');
   }
 
   render() {

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -9,7 +9,9 @@ import {buildPageTitleForEnvironment} from "app/utils/title";
 
 const supportUrl = 'support@researchallofus.org';
 
-export class UserDisabled extends React.Component<{}, {}> {
+export class UserDisabled extends React.Component {
+  // TODO: esteemed reviewer, please yell at me if I don't write a paper about a global wrapper that
+  // handles this sort of thing before turning this PR in for review
   componentDidMount() {
     document.title = buildPageTitleForEnvironment('Disabled')
   }

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -9,8 +9,6 @@ import {buildPageTitleForEnvironment} from 'app/utils/title';
 const supportUrl = 'support@researchallofus.org';
 
 export class UserDisabled extends React.Component {
-  // TODO: esteemed reviewer, please yell at me if I don't write a paper about a global wrapper that
-  // handles this sort of thing before turning this PR in for review
   componentDidMount() {
     document.title = buildPageTitleForEnvironment('Disabled');
   }

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -5,27 +5,22 @@ import {StyledAnchorTag} from 'app/components/buttons';
 import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import colors from 'app/styles/colors';
-import {
-  ReactWrapperBase
-} from 'app/utils';
+import {buildPageTitleForEnvironment} from "app/utils/title";
 
 const supportUrl = 'support@researchallofus.org';
 
-export const UserDisabled: React.FunctionComponent<{}> = () => {
-  return <PublicLayout>
-    <BoldHeader>Your account has been disabled</BoldHeader>
-    <section style={{color: colors.primary, fontSize: '18px', marginTop: '.5rem'}}>
-      Contact <StyledAnchorTag href={'mailto:' + supportUrl}>{supportUrl}</StyledAnchorTag> for
-      more information.
-    </section>
-  </PublicLayout>;
-};
+export class UserDisabled extends React.Component<{}, {}> {
+  componentDidMount() {
+    document.title = buildPageTitleForEnvironment('Disabled')
+  }
 
-@Component({
-  template: '<div #root></div>'
-})
-export class UserDisabledComponent extends ReactWrapperBase {
-  constructor() {
-    super(UserDisabled, []);
+  render() {
+    return <PublicLayout>
+      <BoldHeader>Your account has been disabled</BoldHeader>
+      <section style={{color: colors.primary, fontSize: '18px', marginTop: '.5rem'}}>
+        Contact <StyledAnchorTag href={'mailto:' + supportUrl}>{supportUrl}</StyledAnchorTag> for
+        more information.
+      </section>
+    </PublicLayout>;
   }
 }

--- a/ui/src/app/utils/strings.ts
+++ b/ui/src/app/utils/strings.ts
@@ -3,3 +3,5 @@ export const ACTION_DISABLED_INVALID_BILLING = 'A valid billing account is requi
 export const NOT_ENOUGH_CHARACTERS_RESEARCH_DESCRIPTION = 'The description you entered seems too short. Please consider ' +
     'adding more descriptive details to help the Program and your fellow Researchers ' +
     'understand your work.';
+
+export const BASE_TITLE = 'All of Us Researcher Workbench';

--- a/ui/src/app/utils/title.ts
+++ b/ui/src/app/utils/title.ts
@@ -5,9 +5,9 @@ import {BASE_TITLE} from 'app/utils/strings';
 export function buildPageTitleForEnvironment(pageTitle?: string) {
   let title = BASE_TITLE;
   if (environment.shouldShowDisplayTag) {
-    title = `[${environment.displayTag}] ` + title;
+    title = `[${environment.displayTag}] ${title}`;
     if (pageTitle) {
-      title = `${pageTitle} | ` + title;
+      title = `${pageTitle} | ${title}`;
     }
   }
   return title;

--- a/ui/src/app/utils/title.ts
+++ b/ui/src/app/utils/title.ts
@@ -1,6 +1,6 @@
-import {environment} from "environments/environment";
+import {environment} from 'environments/environment';
 
-import {BASE_TITLE} from "app/utils/strings";
+import {BASE_TITLE} from 'app/utils/strings';
 
 export function buildPageTitleForEnvironment(pageTitle?: string) {
   let title = BASE_TITLE;

--- a/ui/src/app/utils/title.ts
+++ b/ui/src/app/utils/title.ts
@@ -1,0 +1,14 @@
+import {environment} from "environments/environment";
+
+import {BASE_TITLE} from "app/utils/strings";
+
+export function buildPageTitleForEnvironment(pageTitle?: string) {
+  let title = BASE_TITLE;
+  if (environment.shouldShowDisplayTag) {
+    title = `[${environment.displayTag}] ` + title;
+    if (pageTitle) {
+      title = `${pageTitle} | ` + title;
+    }
+  }
+  return title;
+}


### PR DESCRIPTION
Some of these depend on the Angular `SignInService`. Our overall approach for reactifying these things was to make all the routes themselves react first, then delete the Angular router, then delete the rest of the Angular, so I'm just pushing the `SignInService` down a layer for now.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
