### PR TITLE
[risk=no][rw-4945] Add URL validation to account creation and profile

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -410,14 +410,18 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
       }
     }
 
-    const urlResult = validationData.professionalUrl ? validate({website: validationData.professionalUrl}, {
-      website: {
-        url: {
-          message: '^Proffesional URL %{value} is not a valid URL'}
-      }
-    }) : {};
+    const urlError = validationData.professionalUrl
+      ? validate({website: validationData.professionalUrl}, {
+        website: { url: { message: '^Professional URL %{value} is not a valid URL' } }
+      })
+      : undefined;
 
-    return {...validate(validationData, validationCheck), ...urlResult};
+    const errors = {
+      ...validate(validationData, validationCheck),
+      ...urlError
+    };
+
+    return fp.isEmpty(errors) ? undefined : errors;
   }
 
   render() {

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -164,7 +164,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
       showInstitution: true,
       showNonAcademicAffiliationRole: false,
       showNonAcademicAffiliationOther: false,
-      showMostInterestedInKnowingBlurb: false,
+      showMostInterestedInKnowingBlurb: false
     };
 
     // TODO(RW-4361): remove after we switch to verified institutional affiliation
@@ -351,7 +351,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           allowEmpty: false,
           message: '^Country cannot be blank'
         }
-      },
+      }
     };
 
     // The validation data for this form is *almost* the raw Profile, except for the additional
@@ -409,14 +409,22 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         };
       }
     }
-    return validate(validationData, validationCheck);
+
+    const urlResult = validationData.professionalUrl ? validate({website: validationData.professionalUrl}, {
+      website: {
+        url: {
+          message: '^Proffesional URL %{value} is not a valid URL'}
+      }
+    }) : {};
+
+    return {...validate(validationData, validationCheck), ...urlResult};
   }
 
   render() {
     const {
       profile: {
         givenName, familyName,
-        contactEmail, username, areaOfResearch, professionalUrl,
+        contactEmail, username, areaOfResearch, professionalUrl = '',
         address: {
           streetAddress1, streetAddress2, city, state, zipCode, country
         },


### PR DESCRIPTION
Description:

Add validation to the professional URL field in the account creation and profile pages.
I also updated the error messages in the profile page when the save button is disabled to enumerate the errors as it done on other pages.

I looked into URL sanitization, but could not find a library I was satisfied with and also feel some requirements around sanitization should be defined - not only for URL's but all inputs. Also, it is not clear to me what we want to guard against on the client side (URL or HTML sanitization?) and how we want to sanitize (e.g. should we immediately change the input on a change? On a blur? Or not update the field, but save the sanitized value? Will there be server side sanitization, and if so should we converge on a library? etc...)

I added two additional tech debt tickets:
RW-5160 Converge on validation error handling
RW-5161 Spike on user input validation

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
