### PR TITLE
[RW-5062][risk=no] Implement full DataSetMapper

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -30,6 +30,7 @@ import org.pmiops.workbench.cohortreview.ReviewQueryBuilder;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortFactory;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
@@ -112,6 +113,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   })
   @MockBean({
     CohortFactory.class,
+    CohortService.class,
     ConceptSetService.class,
     DataSetService.class,
     FireCloudService.class,

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -91,11 +91,9 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   private DataSetController controller;
   @Autowired private BigQueryService bigQueryService;
   @Autowired private CdrVersionDao cdrVersionDao;
-  @Autowired private CohortService cohortService;
   @Autowired private CdrVersionService cdrVersionService;
   @Autowired private CohortDao cohortDao;
   @Autowired private ConceptSetDao conceptSetDao;
-  @Autowired private ConceptSetService conceptSetService;
   @Autowired private DataDictionaryEntryDao dataDictionaryEntryDao;
   @Autowired private DataSetMapper dataSetMapper;
   @Autowired private DataSetService dataSetService;

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -182,9 +182,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
             new DataSetController(
                 bigQueryService,
                 CLOCK,
-                cohortService,
                 cdrVersionService,
-                conceptSetService,
                 dataDictionaryEntryDao,
                 dataSetMapper,
                 dataSetService,

--- a/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortsController.java
@@ -17,6 +17,7 @@ import javax.persistence.OptimisticLockException;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cohorts.CohortFactory;
 import org.pmiops.workbench.cohorts.CohortMaterializationService;
+import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
@@ -296,7 +297,7 @@ public class CohortsController implements CohortsApiDelegate {
                 "Couldn't find concept set with name %s in workspace %s/%s",
                 conceptSetName, workspace.getWorkspaceNamespace(), workspace.getWorkspaceId()));
       }
-      String tableName = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(conceptSet.getDomainEnum());
+      String tableName = BigQueryTableInfo.getTableName(conceptSet.getDomainEnum());
       if (tableName == null) {
         throw new ServerErrorException(
             "Couldn't find table for domain: " + conceptSet.getDomainEnum());

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -20,7 +20,7 @@ import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapper;
 import org.pmiops.workbench.conceptset.ConceptSetService;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbStorageEnums;
@@ -269,7 +269,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     if (dbConceptSet.getConceptIds().isEmpty()) {
       dbConceptSet.setParticipantCount(0);
     } else {
-      String omopTable = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(dbConceptSet.getDomainEnum());
+      String omopTable = BigQueryTableInfo.getTableName(dbConceptSet.getDomainEnum());
       dbConceptSet.setParticipantCount(
           conceptBigQueryService.getParticipantCountForConcepts(
               dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
@@ -394,7 +394,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     if (dbConceptSet.getConceptIds().size() > maxConceptsPerSet) {
       throw new BadRequestException("Exceeded " + maxConceptsPerSet + " in concept set");
     }
-    String omopTable = ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(request.getConceptSet().getDomain());
+    String omopTable = BigQueryTableInfo.getTableName(request.getConceptSet().getDomain());
     dbConceptSet.setParticipantCount(
         conceptBigQueryService.getParticipantCountForConcepts(
             dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -88,7 +88,7 @@ public class DataSetController implements DataSetApiDelegate {
   private final WorkspaceService workspaceService;
 
   // See https://cloud.google.com/appengine/articles/deadlineexceedederrors for details
-  private static long APP_ENGINE_HARD_TIMEOUT_MSEC_MINUS_FIVE_SEC = 55000l;
+  private static final long APP_ENGINE_HARD_TIMEOUT_MSEC_MINUS_FIVE_SEC = 55000L;
 
   private static final String DATE_FORMAT_STRING = "yyyy/MM/dd HH:mm:ss";
   public static final String EMPTY_CELL_MARKER = "";

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -31,8 +31,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.pmiops.workbench.cdr.CdrVersionService;
-import org.pmiops.workbench.cohorts.CohortService;
-import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.dataset.DataSetMapper;
 import org.pmiops.workbench.dataset.DataSetService;
@@ -96,20 +94,16 @@ public class DataSetController implements DataSetApiDelegate {
   private static final Logger log = Logger.getLogger(DataSetController.class.getName());
 
   private final CdrVersionService cdrVersionService;
-  private final ConceptSetService conceptSetService;
   private final DataDictionaryEntryDao dataDictionaryEntryDao;
   private final DataSetMapper dataSetMapper;
   private final FireCloudService fireCloudService;
   private final NotebooksService notebooksService;
-  private final CohortService cohortService;
 
   @Autowired
   DataSetController(
       BigQueryService bigQueryService,
       Clock clock,
-      CohortService cohortService,
       CdrVersionService cdrVersionService,
-      ConceptSetService conceptSetService,
       DataDictionaryEntryDao dataDictionaryEntryDao,
       DataSetMapper dataSetMapper,
       DataSetService dataSetService,
@@ -120,9 +114,7 @@ public class DataSetController implements DataSetApiDelegate {
       WorkspaceService workspaceService) {
     this.bigQueryService = bigQueryService;
     this.clock = clock;
-    this.cohortService = cohortService;
     this.cdrVersionService = cdrVersionService;
-    this.conceptSetService = conceptSetService;
     this.dataDictionaryEntryDao = dataDictionaryEntryDao;
     this.dataSetMapper = dataSetMapper;
     this.dataSetService = dataSetService;
@@ -413,7 +405,7 @@ public class DataSetController implements DataSetApiDelegate {
 
     response.setItems(
         dataSets.stream()
-            .map(dbDataSet -> dataSetMapper.dbModelToClient(dbDataSet))
+            .map(dataSetMapper::dbModelToClient)
             .sorted(Comparator.comparing(DataSet::getName))
             .collect(Collectors.toList()));
     return ResponseEntity.ok(response);
@@ -495,7 +487,7 @@ public class DataSetController implements DataSetApiDelegate {
         new DataSetListResponse()
             .items(
                 dbDataSets.stream()
-                    .map(dbDataSet -> dataSetMapper.dbModelToClient(dbDataSet))
+                    .map(dataSetMapper::dbModelToClient)
                     .collect(Collectors.toList()));
     return ResponseEntity.ok(dataSetResponse);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -560,7 +560,7 @@ public class DataSetController implements DataSetApiDelegate {
       throw new NotFoundException();
     }
 
-    return ResponseEntity.ok(dataSetMapper.toApi(dataDictionaryEntries.get(0)));
+    return ResponseEntity.ok(dataSetMapper.dbModelToClient(dataDictionaryEntries.get(0)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -34,6 +33,7 @@ import org.json.JSONObject;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.dataset.DataSetMapper;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.DatasetConfig;
@@ -158,7 +158,7 @@ public class DataSetController implements DataSetApiDelegate {
             dataSetRequest.getPrePackagedConceptSet(),
             userProvider.get().getUserId(),
             now);
-    return ResponseEntity.ok(TO_CLIENT_DATA_SET.apply(savedDataSet));
+    return ResponseEntity.ok(dataSetMapper.dbModelToClient(savedDataSet));
   }
 
   private DbDatasetValue getDataSetValuesFromDomainValueSet(DomainValuePair domainValuePair) {
@@ -184,46 +184,6 @@ public class DataSetController implements DataSetApiDelegate {
       throw new BadRequestException("Missing values");
     }
   }
-
-  private final Function<DbDataset, DataSet> TO_CLIENT_DATA_SET =
-      new Function<DbDataset, DataSet>() {
-        @Override
-        public DataSet apply(DbDataset dataSet) {
-          final DataSet result =
-              new DataSet()
-                  .name(dataSet.getName())
-                  .includesAllParticipants(dataSet.getIncludesAllParticipants())
-                  .id(dataSet.getDataSetId())
-                  .etag(Etags.fromVersion(dataSet.getVersion()))
-                  .description(dataSet.getDescription())
-                  .prePackagedConceptSet(dataSet.getPrePackagedConceptSetEnum());
-          if (dataSet.getLastModifiedTime() != null) {
-            result.setLastModifiedTime(dataSet.getLastModifiedTime().getTime());
-          }
-          result.setConceptSets(
-              conceptSetService.findAll(dataSet.getConceptSetIds()).stream()
-                  .map(conceptSet -> conceptSetService.toClientConceptSet(conceptSet))
-                  .collect(Collectors.toList()));
-          result.setCohorts(
-              cohortService.findAll(dataSet.getCohortIds()).stream()
-                  .map(CohortsController.TO_CLIENT_COHORT)
-                  .collect(Collectors.toList()));
-          result.setDomainValuePairs(
-              dataSet.getValues().stream()
-                  .map(TO_CLIENT_DOMAIN_VALUE)
-                  .collect(Collectors.toList()));
-          return result;
-        }
-      };
-
-  // TODO(jaycarlton): move into helper methods in one or both of these classes
-  private static final Function<DbDatasetValue, DomainValuePair> TO_CLIENT_DOMAIN_VALUE =
-      dataSetValue -> {
-        DomainValuePair domainValuePair = new DomainValuePair();
-        domainValuePair.setValue(dataSetValue.getValue());
-        domainValuePair.setDomain(dataSetValue.getDomainEnum());
-        return domainValuePair;
-      };
 
   @VisibleForTesting
   public String generateRandomEightCharacterQualifier() {
@@ -453,7 +413,7 @@ public class DataSetController implements DataSetApiDelegate {
 
     response.setItems(
         dataSets.stream()
-            .map(TO_CLIENT_DATA_SET)
+            .map(dbDataSet -> dataSetMapper.dbModelToClient(dbDataSet))
             .sorted(Comparator.comparing(DataSet::getName))
             .collect(Collectors.toList()));
     return ResponseEntity.ok(response);
@@ -510,7 +470,7 @@ public class DataSetController implements DataSetApiDelegate {
 
     dataSetService.saveDataSet(dbDataSet);
 
-    return ResponseEntity.ok(TO_CLIENT_DATA_SET.apply(dbDataSet));
+    return ResponseEntity.ok(dataSetMapper.dbModelToClient(dbDataSet));
   }
 
   @Override
@@ -520,8 +480,8 @@ public class DataSetController implements DataSetApiDelegate {
         workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 
-    DbDataset dataSet = dataSetService.getDbDataSet(workspace, dataSetId).get();
-    return ResponseEntity.ok(TO_CLIENT_DATA_SET.apply(dataSet));
+    DbDataset dbDataset = dataSetService.getDbDataSet(workspace, dataSetId).get();
+    return ResponseEntity.ok(dataSetMapper.dbModelToClient(dbDataset));
   }
 
   @Override
@@ -533,7 +493,10 @@ public class DataSetController implements DataSetApiDelegate {
     List<DbDataset> dbDataSets = dataSetService.getDataSets(resourceType, id);
     DataSetListResponse dataSetResponse =
         new DataSetListResponse()
-            .items(dbDataSets.stream().map(TO_CLIENT_DATA_SET).collect(Collectors.toList()));
+            .items(
+                dbDataSets.stream()
+                    .map(dbDataSet -> dataSetMapper.dbModelToClient(dbDataSet))
+                    .collect(Collectors.toList()));
     return ResponseEntity.ok(dataSetResponse);
   }
 
@@ -548,7 +511,7 @@ public class DataSetController implements DataSetApiDelegate {
                   throw new BadRequestException("Invalid CDR Version");
                 });
 
-    String omopTable = conceptSetService.getOmpTable(domain);
+    String omopTable = BigQueryTableInfo.getTableName(Domain.fromValue(domain));
     if (omopTable == null) {
       throw new BadRequestException("Invalid Domain");
     }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
@@ -1,19 +1,28 @@
 package org.pmiops.workbench.cohorts;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.model.Cohort;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CohortService {
   private CohortDao cohortDao;
+  private CohortMapper cohortMapper;
 
-  public CohortService(CohortDao cohortDao) {
+  @Autowired
+  public CohortService(CohortDao cohortDao, CohortMapper cohortMapper) {
     this.cohortDao = cohortDao;
+    this.cohortMapper = cohortMapper;
   }
 
-  public List<DbCohort> findAll(List<Long> cohortIds) {
-    return (List<DbCohort>) cohortDao.findAll(cohortIds);
+  public List<Cohort> findAll(List<Long> cohortIds) {
+    return ((List<DbCohort>) cohortDao.findAll(cohortIds))
+        .stream()
+            .map(dbCohort -> cohortMapper.dbModelToClient(dbCohort))
+            .collect(Collectors.toList());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
@@ -21,8 +21,6 @@ public class CohortService {
 
   public List<Cohort> findAll(List<Long> cohortIds) {
     return ((List<DbCohort>) cohortDao.findAll(cohortIds))
-        .stream()
-            .map(dbCohort -> cohortMapper.dbModelToClient(dbCohort))
-            .collect(Collectors.toList());
+        .stream().map(cohortMapper::dbModelToClient).collect(Collectors.toList());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CohortService {
-  private CohortDao cohortDao;
-  private CohortMapper cohortMapper;
+  private final CohortDao cohortDao;
+  private final CohortMapper cohortMapper;
 
   @Autowired
   public CohortService(CohortDao cohortDao, CohortMapper cohortMapper) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -3,9 +3,7 @@ package org.pmiops.workbench.conceptset;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.pmiops.workbench.api.ConceptSetsController;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
-import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.model.DbConceptSet;
@@ -20,20 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConceptSetService {
 
   private static final int CONCEPT_SET_VERSION = 1;
-  private ConceptSetDao conceptSetDao;
-  private ConceptBigQueryService conceptBigQueryService;
-  private ConceptService conceptService;
-  private ConceptSetMapper conceptSetMapper;
+  private final ConceptSetDao conceptSetDao;
+  private final ConceptBigQueryService conceptBigQueryService;
+  private final ConceptSetMapper conceptSetMapper;
 
   @Autowired
   public ConceptSetService(
       ConceptSetDao conceptSetDao,
       ConceptBigQueryService conceptBigQueryService,
-      ConceptService conceptService,
       ConceptSetMapper conceptSetMapper) {
     this.conceptSetDao = conceptSetDao;
     this.conceptBigQueryService = conceptBigQueryService;
-    this.conceptService = conceptService;
     this.conceptSetMapper = conceptSetMapper;
   }
 
@@ -49,18 +44,9 @@ public class ConceptSetService {
     return Optional.of(conceptSetDao.findOne(conceptSetId));
   }
 
-  public ConceptSet toClientConceptSet(DbConceptSet dbConceptSet) {
-    ConceptSet result = conceptSetMapper.dbModelToClient(dbConceptSet);
-    return result.concepts(
-        conceptService.findAll(
-            dbConceptSet.getConceptIds(), ConceptSetsController.CONCEPT_NAME_ORDERING));
-  }
-
   public List<ConceptSet> findAll(List<Long> conceptSetIds) {
     return ((List<DbConceptSet>) conceptSetDao.findAll(conceptSetIds))
-        .stream()
-            .map(conceptSet -> conceptSetMapper.dbModelToClient(conceptSet))
-            .collect(Collectors.toList());
+        .stream().map(conceptSetMapper::dbModelToClient).collect(Collectors.toList());
   }
 
   public DbConceptSet findOne(Long conceptSetId, DbWorkspace workspace) {

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryTableInfo.java
@@ -1,0 +1,34 @@
+package org.pmiops.workbench.dataset;
+
+import org.pmiops.workbench.model.Domain;
+
+public enum BigQueryTableInfo {
+  CONDITION(Domain.CONDITION, "condition_occurrence"),
+  PROCEDURE(Domain.PROCEDURE, "procedure_occurrence"),
+  DRUG(Domain.DRUG, "drug_exposure"),
+  DEATH(Domain.DEATH, "death"),
+  DEVICE(Domain.DEVICE, "device_exposure"),
+  MEASUREMENT(Domain.MEASUREMENT, "measurement"),
+  SURVEY(Domain.SURVEY, "observation"),
+  PERSON(Domain.PERSON, "person"),
+  OBSERVATION(Domain.OBSERVATION, "observation"),
+  VISIT(Domain.VISIT, "visit_occurrence"),
+  PHYSICALMEASUREMENT(Domain.PHYSICALMEASUREMENT, "measurement");
+
+  private final Domain domain;
+  private final String tableName;
+
+  BigQueryTableInfo(Domain domain, String tableName) {
+    this.domain = domain;
+    this.tableName = tableName;
+  }
+
+  public static String getTableName(Domain domain) {
+    for (BigQueryTableInfo info : values()) {
+      if (info.domain.equals(domain)) {
+        return info.tableName;
+      }
+    }
+    return null;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -1,20 +1,25 @@
 package org.pmiops.workbench.dataset;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.cohorts.CohortService;
+import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbDatasetValue;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.model.DataDictionaryEntry;
 import org.pmiops.workbench.model.DataSet;
+import org.pmiops.workbench.model.DomainValuePair;
 import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(
     config = MapStructConfig.class,
-    uses = {CommonMappers.class, ConceptSetDao.class})
+    uses = {CommonMappers.class, ConceptSetService.class, CohortService.class})
 public interface DataSetMapper {
 
   // This is a lightweight version of a client mapper that doesn't make any extra db calls for extra
@@ -32,13 +37,23 @@ public interface DataSetMapper {
 
   @Mapping(target = "id", source = "dataSetId")
   @Mapping(target = "conceptSets", source = "conceptSetIds")
-  @Mapping(target = "cohorts", ignore = true)
-  @Mapping(target = "domainValuePairs", ignore = true)
+  @Mapping(target = "cohorts", source = "cohortIds")
+  @Mapping(target = "domainValuePairs", source = "values")
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
   DataSet dbModelToClient(DbDataset dbDataset);
 
   default PrePackagedConceptSetEnum prePackagedConceptSetFromStorage(Short prePackagedConceptSet) {
     return DbStorageEnums.prePackagedConceptSetsFromStorage(prePackagedConceptSet);
+  }
+
+  default List<DomainValuePair> copyDomainValuePairsToClient(List<DbDatasetValue> values) {
+    return values.stream().map(this::createDomainValuePair).collect(Collectors.toList());
+  }
+
+  default DomainValuePair createDomainValuePair(DbDatasetValue dbDatasetValue) {
+    return new DomainValuePair()
+        .value(dbDatasetValue.getValue())
+        .domain(dbDatasetValue.getDomainEnum());
   }
 
   @Mapping(target = "cdrVersionId", source = "dbModel.cdrVersion.cdrVersionId")

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -34,5 +34,5 @@ public interface DataSetMapper {
   }
 
   @Mapping(target = "cdrVersionId", source = "dbModel.cdrVersion.cdrVersionId")
-  DataDictionaryEntry toApi(DbDataDictionaryEntry dbModel);
+  DataDictionaryEntry dbModelToClient(DbDataDictionaryEntry dbModel);
 }

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
@@ -33,6 +34,7 @@ public interface DataSetMapper {
   @Mapping(target = "domainValuePairs", ignore = true)
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
   // TODO (RW-4756): Define a DatasetLight type.
+  @Named("dbModelToClientLight")
   DataSet dbModelToClientLight(DbDataset dbDataset);
 
   @Mapping(target = "id", source = "dataSetId")

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.dataset;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbStorageEnums;
@@ -13,7 +14,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(
     config = MapStructConfig.class,
-    uses = {CommonMappers.class})
+    uses = {CommonMappers.class, ConceptSetDao.class})
 public interface DataSetMapper {
 
   // This is a lightweight version of a client mapper that doesn't make any extra db calls for extra
@@ -28,6 +29,13 @@ public interface DataSetMapper {
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
   // TODO (RW-4756): Define a DatasetLight type.
   DataSet dbModelToClientLight(DbDataset dbDataset);
+
+  @Mapping(target = "id", source = "dataSetId")
+  @Mapping(target = "conceptSets", source = "conceptSetIds")
+  @Mapping(target = "cohorts", ignore = true)
+  @Mapping(target = "domainValuePairs", ignore = true)
+  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  DataSet dbModelToClient(DbDataset dbDataset);
 
   default PrePackagedConceptSetEnum prePackagedConceptSetFromStorage(Short prePackagedConceptSet) {
     return DbStorageEnums.prePackagedConceptSetsFromStorage(prePackagedConceptSet);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -1,30 +1,12 @@
 package org.pmiops.workbench.db.dao;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbConceptSet;
-import org.pmiops.workbench.model.Domain;
 import org.springframework.data.repository.CrudRepository;
 
 public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
-
-  // TODO: consider putting this in CDM config, fetching it from there
-  static final ImmutableMap<Domain, String> DOMAIN_TO_TABLE_NAME =
-      ImmutableMap.<Domain, String>builder()
-          .put(Domain.CONDITION, "condition_occurrence")
-          .put(Domain.DEATH, "death")
-          .put(Domain.DEVICE, "device_exposure")
-          .put(Domain.DRUG, "drug_exposure")
-          .put(Domain.MEASUREMENT, "measurement")
-          .put(Domain.OBSERVATION, "observation")
-          .put(Domain.PROCEDURE, "procedure_occurrence")
-          .put(Domain.PERSON, "person")
-          .put(Domain.VISIT, "visit_occurrence")
-          .put(Domain.SURVEY, "observation")
-          .put(Domain.PHYSICALMEASUREMENT, "measurement")
-          .build();
 
   Optional<DbConceptSet> findByConceptSetIdAndWorkspaceId(long conceptId, long workspaceId);
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDataset.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDataset.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -14,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
 
 @Entity
@@ -35,6 +37,23 @@ public class DbDataset {
   private List<Long> cohortIds;
   private List<DbDatasetValue> values;
   private short prePackagedConceptSet;
+
+  private DbDataset(DbDataset.Builder builder) {
+    setDataSetId(builder.dataSetId);
+    setWorkspaceId(builder.workspaceId);
+    setName(builder.name);
+    setVersion(builder.version);
+    setDescription(builder.description);
+    setCreatorId(builder.creatorId);
+    setCreationTime(builder.creationTime);
+    setLastModifiedTime(builder.lastModifiedTime);
+    setInvalid(builder.invalid);
+    setIncludesAllParticipants(builder.includesAllParticipants);
+    setConceptSetIds(builder.conceptSetIds);
+    setCohortIds(builder.cohortIds);
+    setValues(builder.values);
+    setPrePackagedConceptSet(builder.prePackagedConceptSet);
+  }
 
   public DbDataset() {
     setVersion(DbDataset.INITIAL_VERSION);
@@ -210,5 +229,149 @@ public class DbDataset {
 
   public void setPrePackagedConceptSetEnum(PrePackagedConceptSetEnum domain) {
     this.prePackagedConceptSet = DbStorageEnums.prePackagedConceptSetsToStorage(domain);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DbDataset dbDataset = (DbDataset) o;
+    return workspaceId == dbDataset.workspaceId
+        && version == dbDataset.version
+        && creatorId == dbDataset.creatorId
+        && prePackagedConceptSet == dbDataset.prePackagedConceptSet
+        && Objects.equals(name, dbDataset.name)
+        && Objects.equals(description, dbDataset.description)
+        && Objects.equals(creationTime, dbDataset.creationTime)
+        && Objects.equals(lastModifiedTime, dbDataset.lastModifiedTime)
+        && Objects.equals(invalid, dbDataset.invalid)
+        && Objects.equals(includesAllParticipants, dbDataset.includesAllParticipants)
+        && Objects.equals(conceptSetIds, dbDataset.conceptSetIds)
+        && Objects.equals(cohortIds, dbDataset.cohortIds)
+        && Objects.equals(values, dbDataset.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        workspaceId,
+        name,
+        version,
+        description,
+        creatorId,
+        creationTime,
+        lastModifiedTime,
+        invalid,
+        includesAllParticipants,
+        conceptSetIds,
+        cohortIds,
+        values,
+        prePackagedConceptSet);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
+  }
+
+  public static DbDataset.Builder builder() {
+    return new DbDataset.Builder();
+  }
+
+  public static class Builder {
+    private long dataSetId;
+    private long workspaceId;
+    private String name;
+    private int version;
+    private String description;
+    private long creatorId;
+    private Timestamp creationTime;
+    private Timestamp lastModifiedTime;
+    private Boolean invalid;
+    private Boolean includesAllParticipants;
+    private List<Long> conceptSetIds;
+    private List<Long> cohortIds;
+    private List<DbDatasetValue> values;
+    private short prePackagedConceptSet;
+
+    private Builder() {}
+
+    public DbDataset.Builder addDataSetId(long dataSetId) {
+      this.dataSetId = dataSetId;
+      return this;
+    }
+
+    public DbDataset.Builder addWorkspaceId(long workspaceId) {
+      this.workspaceId = workspaceId;
+      return this;
+    }
+
+    public DbDataset.Builder addName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public DbDataset.Builder addVersion(int version) {
+      this.version = version;
+      return this;
+    }
+
+    public DbDataset.Builder addDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public DbDataset.Builder addCreatorId(long creatorId) {
+      this.creatorId = creatorId;
+      return this;
+    }
+
+    public DbDataset.Builder addCreationTime(Timestamp creationTime) {
+      this.creationTime = creationTime;
+      return this;
+    }
+
+    public DbDataset.Builder addLastModifiedTime(Timestamp lastModifiedTime) {
+      this.lastModifiedTime = lastModifiedTime;
+      return this;
+    }
+
+    public DbDataset.Builder addInvalid(Boolean invalid) {
+      this.invalid = invalid;
+      return this;
+    }
+
+    public DbDataset.Builder addIncludesAllParticipants(Boolean includesAllParticipants) {
+      this.includesAllParticipants = includesAllParticipants;
+      return this;
+    }
+
+    public DbDataset.Builder addConceptSetIds(List<Long> conceptSetIds) {
+      this.conceptSetIds = conceptSetIds;
+      return this;
+    }
+
+    public DbDataset.Builder addCohortIds(List<Long> cohortIds) {
+      this.cohortIds = cohortIds;
+      return this;
+    }
+
+    public DbDataset.Builder addValues(List<DbDatasetValue> values) {
+      this.values = values;
+      return this;
+    }
+
+    public DbDataset.Builder addPrePackagedConceptSets(short prePackagedConceptSet) {
+      this.prePackagedConceptSet = prePackagedConceptSet;
+      return this;
+    }
+
+    public DbDataset build() {
+      return new DbDataset(this);
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDatasetValue.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDatasetValue.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db.model;
 
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Table;
@@ -51,5 +52,22 @@ public class DbDatasetValue {
   public boolean equals(DbDatasetValue dataSetValue) {
     return getValue().equals(dataSetValue.getValue())
         && getDomainEnum().equals(dataSetValue.getDomainEnum());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DbDatasetValue that = (DbDatasetValue) o;
+    return Objects.equals(domainId, that.domainId) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(domainId, value);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.utils.mappers;
 
-import static org.mapstruct.NullValuePropertyMappingStrategy.*;
+import static org.mapstruct.NullValuePropertyMappingStrategy.SET_TO_DEFAULT;
 
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
@@ -181,7 +181,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "permission", source = "accessLevel")
-  @Mapping(target = "dataSet", source = "dbDataset")
+  @Mapping(target = "dataSet", source = "dbDataset", qualifiedByName = "dbModelToClientLight")
   // All workspaceResources have one object and all others are null.
   @Mapping(target = "cohort", ignore = true)
   @Mapping(target = "cohortReview", ignore = true)

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -83,8 +83,7 @@ public class WorkspaceAuditorTest {
     DataSetMapperImpl.class,
     FirecloudMapperImpl.class,
     WorkspaceAuditorImpl.class,
-    WorkspaceMapperImpl.class,
-    ConceptSetService.class
+    WorkspaceMapperImpl.class
   })
   @MockBean({UserDao.class, ConceptSetService.class, CohortService.class})
   static class Config {

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -27,7 +27,9 @@ import org.pmiops.workbench.actionaudit.TargetType;
 import org.pmiops.workbench.actionaudit.targetproperties.AclTargetProperty;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
+import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -82,8 +84,9 @@ public class WorkspaceAuditorTest {
     FirecloudMapperImpl.class,
     WorkspaceAuditorImpl.class,
     WorkspaceMapperImpl.class,
+    ConceptSetService.class
   })
-  @MockBean({UserDao.class})
+  @MockBean({UserDao.class, ConceptSetService.class, CohortService.class})
   static class Config {
     @Bean
     WorkbenchConfig workbenchConfig() {

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -33,8 +33,10 @@ import org.pmiops.workbench.actionaudit.auditors.ClusterAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
+import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
@@ -125,8 +127,9 @@ public class ClusterControllerTest {
     WorkspaceMapperImpl.class,
     CommonMappers.class,
     PublicInstitutionDetailsMapperImpl.class,
-    UserServiceTestConfiguration.class,
+    UserServiceTestConfiguration.class
   })
+  @MockBean({ConceptSetService.class, CohortService.class})
   static class Configuration {
 
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ClusterControllerTest.java
@@ -127,7 +127,7 @@ public class ClusterControllerTest {
     WorkspaceMapperImpl.class,
     CommonMappers.class,
     PublicInstitutionDetailsMapperImpl.class,
-    UserServiceTestConfiguration.class
+    UserServiceTestConfiguration.class,
   })
   @MockBean({ConceptSetService.class, CohortService.class})
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -37,6 +37,7 @@ import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortFactoryImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMaterializationService;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
@@ -214,6 +215,7 @@ public class CohortsControllerTest {
     CdrVersionService.class,
     CloudStorageService.class,
     CohortMaterializationService.class,
+    CohortService.class,
     ComplianceService.class,
     ConceptBigQueryService.class,
     DataSetService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -32,6 +32,7 @@ import org.pmiops.workbench.cohortreview.CohortReviewServiceImpl;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortFactoryImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
@@ -248,6 +249,7 @@ public class ConceptSetsControllerTest {
     CloudStorageService.class,
     ComplianceService.class,
     ConceptBigQueryService.class,
+    CohortService.class,
     DataSetService.class,
     DirectoryService.class,
     FireCloudService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptsControllerTest.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.cdr.model.DbSurveyModule;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
 import org.pmiops.workbench.conceptset.ConceptSetService;
@@ -282,6 +283,7 @@ public class ConceptsControllerTest {
     FireCloudService.class,
     CohortCloningService.class,
     ConceptSetService.class,
+    CohortService.class,
     ConceptBigQueryService.class,
     Clock.class,
     DataSetService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -17,10 +16,10 @@ import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapper;
 import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.DataDictionaryEntryDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
@@ -50,7 +49,6 @@ public class DataDictionaryTest {
   @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private DataDictionaryEntryDao dataDictionaryEntryDao;
   @Autowired private DataSetController dataSetController;
-  @Autowired private ConceptSetService conceptSetService;
 
   @Rule public ExpectedException expectedEx = ExpectedException.none();
 
@@ -90,7 +88,7 @@ public class DataDictionaryTest {
     DbDataDictionaryEntry dataDictionaryEntry = new DbDataDictionaryEntry();
     dataDictionaryEntry.setCdrVersion(cdrVersion);
     dataDictionaryEntry.setDefinedTime(new Timestamp(CLOCK.millis()));
-    dataDictionaryEntry.setRelevantOmopTable(ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(Domain.DRUG));
+    dataDictionaryEntry.setRelevantOmopTable(BigQueryTableInfo.getTableName(Domain.DRUG));
     dataDictionaryEntry.setFieldName("TEST FIELD");
     dataDictionaryEntry.setOmopCdmStandardOrCustomField("A");
     dataDictionaryEntry.setDescription("B");
@@ -107,15 +105,13 @@ public class DataDictionaryTest {
     final Domain domain = Domain.DRUG;
     final String domainValue = "FIELD NAME / DOMAIN VALUE";
 
-    when(conceptSetService.getOmpTable(domain.toString())).thenReturn("drug_occurrence");
-
     DbCdrVersion cdrVersion = new DbCdrVersion();
     cdrVersionDao.save(cdrVersion);
 
     DbDataDictionaryEntry dataDictionaryEntry = new DbDataDictionaryEntry();
     dataDictionaryEntry.setCdrVersion(cdrVersion);
     dataDictionaryEntry.setDefinedTime(new Timestamp(CLOCK.millis()));
-    dataDictionaryEntry.setRelevantOmopTable(ConceptSetDao.DOMAIN_TO_TABLE_NAME.get(domain));
+    dataDictionaryEntry.setRelevantOmopTable(BigQueryTableInfo.getTableName(domain));
     dataDictionaryEntry.setFieldName(domainValue);
     dataDictionaryEntry.setOmopCdmStandardOrCustomField("A");
     dataDictionaryEntry.setDescription("B");
@@ -167,7 +163,6 @@ public class DataDictionaryTest {
 
   @Test
   public void testGetDataDictionaryEntry_notFound() {
-    when(conceptSetService.getOmpTable(Domain.DRUG.toString())).thenReturn("drug_occurrence");
     expectedEx.expect(NotFoundException.class);
 
     dataSetController.getDataDictionaryEntry(1L, Domain.DRUG.toString(), "random");

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -104,7 +104,7 @@ public class WorkspaceAdminControllerTest {
     DataSetMapperImpl.class,
     FirecloudMapperImpl.class,
     WorkspaceAdminController.class,
-    WorkspaceMapperImpl.class
+    WorkspaceMapperImpl.class,
   })
   @MockBean({
     CloudStorageService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -14,7 +14,9 @@ import org.junit.runner.RunWith;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
+import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -102,11 +104,13 @@ public class WorkspaceAdminControllerTest {
     DataSetMapperImpl.class,
     FirecloudMapperImpl.class,
     WorkspaceAdminController.class,
-    WorkspaceMapperImpl.class,
+    WorkspaceMapperImpl.class
   })
   @MockBean({
     CloudStorageService.class,
     NotebooksService.class,
+    ConceptSetService.class,
+    CohortService.class
   })
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -24,9 +24,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 public class DataSetMapperTest {
 
-  private DataSet clientDataSet;
   private DbDataset dbDataset;
-  private DataDictionaryEntry clientDataDictionaryEntry;
   private DbDataDictionaryEntry dbDataDictionaryEntry;
 
   @Autowired private DataSetMapper dataSetMapper;
@@ -38,16 +36,6 @@ public class DataSetMapperTest {
   @Before
   public void setUp() {
     long time = new Date().getTime();
-    clientDataSet =
-        new DataSet()
-            .etag("ETAG_ETAG")
-            .id(101L)
-            .name("All Blue-eyed Blondes")
-            .includesAllParticipants(false)
-            .description("All Blue-eyed Blondes")
-            .workspaceId(1L)
-            .lastModifiedTime(time)
-            .prePackagedConceptSet(PrePackagedConceptSetEnum.NONE);
 
     dbDataset =
         DbDataset.builder()
@@ -61,19 +49,6 @@ public class DataSetMapperTest {
             .addPrePackagedConceptSets(
                 DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE))
             .build();
-
-    clientDataDictionaryEntry =
-        new DataDictionaryEntry()
-            .cdrVersionId(1L)
-            .definedTime(time)
-            .relevantOmopTable("person")
-            .fieldName("field")
-            .omopCdmStandardOrCustomField("field")
-            .description("desc")
-            .fieldType("type")
-            .dataProvenance("p")
-            .sourcePpiModule("s")
-            .transformedByRegisteredTierPrivacyMethods(false);
 
     dbDataDictionaryEntry = new DbDataDictionaryEntry();
     DbCdrVersion cdrVersion = new DbCdrVersion();

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -1,0 +1,144 @@
+package org.pmiops.workbench.dataset;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.api.Etags;
+import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbStorageEnums;
+import org.pmiops.workbench.model.DataDictionaryEntry;
+import org.pmiops.workbench.model.DataSet;
+import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class DataSetMapperTest {
+
+  private DataSet clientDataSet;
+  private DbDataset dbDataset;
+  private DataDictionaryEntry clientDataDictionaryEntry;
+  private DbDataDictionaryEntry dbDataDictionaryEntry;
+
+  @Autowired private DataSetMapper dataSetMapper;
+
+  @TestConfiguration
+  @Import({DataSetMapperImpl.class, CommonMappers.class})
+  static class Configuration {}
+
+  @Before
+  public void setUp() {
+    long time = new Date().getTime();
+    clientDataSet =
+        new DataSet()
+            .etag("ETAG_ETAG")
+            .id(101L)
+            .name("All Blue-eyed Blondes")
+            .includesAllParticipants(false)
+            .description("All Blue-eyed Blondes")
+            .workspaceId(1L)
+            .lastModifiedTime(time)
+            .prePackagedConceptSet(PrePackagedConceptSetEnum.NONE);
+
+    dbDataset =
+        DbDataset.builder()
+            .addVersion(1)
+            .addDataSetId(101L)
+            .addName("All Blue-eyed Blondes")
+            .addIncludesAllParticipants(false)
+            .addDescription("All Blue-eyed Blondes")
+            .addLastModifiedTime(new Timestamp(time))
+            .addWorkspaceId(1L)
+            .addPrePackagedConceptSets(
+                DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE))
+            .build();
+
+    clientDataDictionaryEntry =
+        new DataDictionaryEntry()
+            .cdrVersionId(1L)
+            .definedTime(time)
+            .relevantOmopTable("person")
+            .fieldName("field")
+            .omopCdmStandardOrCustomField("field")
+            .description("desc")
+            .fieldType("type")
+            .dataProvenance("p")
+            .sourcePpiModule("s")
+            .transformedByRegisteredTierPrivacyMethods(false);
+
+    dbDataDictionaryEntry = new DbDataDictionaryEntry();
+    DbCdrVersion cdrVersion = new DbCdrVersion();
+    cdrVersion.setCdrVersionId(1L);
+    dbDataDictionaryEntry.setCdrVersion(cdrVersion);
+    dbDataDictionaryEntry.setDefinedTime(new Timestamp(time));
+    dbDataDictionaryEntry.setDataProvenance("p");
+    dbDataDictionaryEntry.setRelevantOmopTable("person");
+    dbDataDictionaryEntry.setFieldName("field");
+    dbDataDictionaryEntry.setOmopCdmStandardOrCustomField("field");
+    dbDataDictionaryEntry.setDescription("desc");
+    dbDataDictionaryEntry.setFieldType("type");
+    dbDataDictionaryEntry.setSourcePpiModule("s");
+    dbDataDictionaryEntry.setTransformedByRegisteredTierPrivacyMethods(false);
+  }
+
+  @Test
+  public void dbModelToClientLight() {
+    final DataSet toClientDataSet = dataSetMapper.dbModelToClientLight(dbDataset);
+    assertDbModelToClientLight(toClientDataSet, dbDataset);
+  }
+
+  @Test
+  public void dbModelToClient() {
+    final DataDictionaryEntry toClientDataDictionaryEntry =
+        dataSetMapper.dbModelToClient(dbDataDictionaryEntry);
+    assertDbModelToClient(toClientDataDictionaryEntry, dbDataDictionaryEntry);
+  }
+
+  private void assertDbModelToClientLight(DataSet dataSet, DbDataset dbDataset) {
+    assertThat(dbDataset.getDataSetId()).isEqualTo(dataSet.getId());
+    assertThat(dbDataset.getVersion()).isEqualTo(Etags.toVersion(dataSet.getEtag()));
+    assertThat(dbDataset.getName()).isEqualTo(dataSet.getName());
+    assertThat(dbDataset.getIncludesAllParticipants())
+        .isEqualTo(dataSet.getIncludesAllParticipants());
+    assertThat(dbDataset.getDescription()).isEqualTo(dataSet.getDescription());
+    assertThat(dbDataset.getWorkspaceId()).isEqualTo(dataSet.getWorkspaceId());
+    assertThat(dbDataset.getLastModifiedTime().toInstant().toEpochMilli())
+        .isEqualTo(dataSet.getLastModifiedTime());
+    assertThat(dbDataset.getPrePackagedConceptSet())
+        .isEqualTo(
+            DbStorageEnums.prePackagedConceptSetsToStorage(dataSet.getPrePackagedConceptSet()));
+  }
+
+  private void assertDbModelToClient(
+      DataDictionaryEntry dataDictionaryEntry, DbDataDictionaryEntry dbDataDictionaryEntry) {
+    assertThat(dbDataDictionaryEntry.getCdrVersion().getCdrVersionId())
+        .isEqualTo(dataDictionaryEntry.getCdrVersionId());
+    assertThat(dbDataDictionaryEntry.getDefinedTime().toInstant().toEpochMilli())
+        .isEqualTo(dataDictionaryEntry.getDefinedTime());
+    assertThat(dbDataDictionaryEntry.getDataProvenance())
+        .isEqualTo(dataDictionaryEntry.getDataProvenance());
+    assertThat(dbDataDictionaryEntry.getRelevantOmopTable())
+        .isEqualTo(dataDictionaryEntry.getRelevantOmopTable());
+    assertThat(dbDataDictionaryEntry.getDescription())
+        .isEqualTo(dataDictionaryEntry.getDescription());
+    assertThat(dbDataDictionaryEntry.getFieldName()).isEqualTo(dataDictionaryEntry.getFieldName());
+    assertThat(dbDataDictionaryEntry.getOmopCdmStandardOrCustomField())
+        .isEqualTo(dataDictionaryEntry.getOmopCdmStandardOrCustomField());
+    assertThat(dbDataDictionaryEntry.getDescription())
+        .isEqualTo(dataDictionaryEntry.getDescription());
+    assertThat(dbDataDictionaryEntry.getFieldType()).isEqualTo(dataDictionaryEntry.getFieldType());
+    assertThat(dbDataDictionaryEntry.getSourcePpiModule())
+        .isEqualTo(dataDictionaryEntry.getSourcePpiModule());
+    assertThat(dbDataDictionaryEntry.getTransformedByRegisteredTierPrivacyMethods())
+        .isEqualTo(dataDictionaryEntry.getTransformedByRegisteredTierPrivacyMethods());
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -1,23 +1,36 @@
 package org.pmiops.workbench.dataset;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.api.Etags;
+import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
+import org.pmiops.workbench.concept.ConceptService;
+import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
+import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbStorageEnums;
+import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.DataDictionaryEntry;
 import org.pmiops.workbench.model.DataSet;
 import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -28,9 +41,24 @@ public class DataSetMapperTest {
   private DbDataDictionaryEntry dbDataDictionaryEntry;
 
   @Autowired private DataSetMapper dataSetMapper;
+  @Autowired private ConceptSetDao mockConceptSetDao;
 
   @TestConfiguration
-  @Import({DataSetMapperImpl.class, CommonMappers.class})
+  @Import({
+    DataSetMapperImpl.class,
+    CommonMappers.class,
+    ConceptSetService.class,
+    ConceptSetMapperImpl.class,
+    CohortService.class,
+    CohortMapperImpl.class
+  })
+  @MockBean({
+    ConceptSetDao.class,
+    ConceptBigQueryService.class,
+    ConceptService.class,
+    CohortDao.class,
+    UserDao.class
+  })
   static class Configuration {}
 
   @Before
@@ -47,6 +75,9 @@ public class DataSetMapperTest {
             .addPrePackagedConceptSets(
                 DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE))
             .build();
+    doReturn(Arrays.asList(new ConceptSet()))
+        .when(mockConceptSetDao)
+        .findAll(dbDataset.getConceptSetIds());
 
     dbDataDictionaryEntry = new DbDataDictionaryEntry();
     DbCdrVersion cdrVersion = new DbCdrVersion();

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -3,7 +3,7 @@ package org.pmiops.workbench.dataset;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.sql.Timestamp;
-import java.util.Date;
+import java.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,8 +35,6 @@ public class DataSetMapperTest {
 
   @Before
   public void setUp() {
-    long time = new Date().getTime();
-
     dbDataset =
         DbDataset.builder()
             .addVersion(1)
@@ -44,7 +42,7 @@ public class DataSetMapperTest {
             .addName("All Blue-eyed Blondes")
             .addIncludesAllParticipants(false)
             .addDescription("All Blue-eyed Blondes")
-            .addLastModifiedTime(new Timestamp(time))
+            .addLastModifiedTime(Timestamp.from(Instant.now()))
             .addWorkspaceId(1L)
             .addPrePackagedConceptSets(
                 DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE))
@@ -54,7 +52,7 @@ public class DataSetMapperTest {
     DbCdrVersion cdrVersion = new DbCdrVersion();
     cdrVersion.setCdrVersionId(1L);
     dbDataDictionaryEntry.setCdrVersion(cdrVersion);
-    dbDataDictionaryEntry.setDefinedTime(new Timestamp(time));
+    dbDataDictionaryEntry.setDefinedTime(Timestamp.from(Instant.now()));
     dbDataDictionaryEntry.setDataProvenance("p");
     dbDataDictionaryEntry.setRelevantOmopTable("person");
     dbDataDictionaryEntry.setFieldName("field");

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -13,7 +13,9 @@ import org.junit.runner.RunWith;
 import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
+import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -75,7 +77,7 @@ public class WorkspaceMapperTest {
     FirecloudMapperImpl.class,
     WorkspaceMapperImpl.class,
   })
-  @MockBean({UserDao.class, WorkspaceDao.class})
+  @MockBean({UserDao.class, WorkspaceDao.class, ConceptSetService.class, CohortService.class})
   static class Configuration {
     @Bean
     WorkbenchConfig workbenchConfig() {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -21,6 +21,7 @@ import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cohortreview.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -70,6 +71,7 @@ public class WorkspaceServiceTest {
   })
   @MockBean({
     ConceptSetService.class,
+    CohortService.class,
     CohortCloningService.class,
     DataSetService.class,
     FirecloudMapper.class,


### PR DESCRIPTION
This PR addresses:
1. Implementing `DataSetMapper` to allow full db model to client conversion
2. Removing `DataSetController#TO_CLIENT_DATA_SET` and `DataSetController#TO_CLIENT_DOMAIN_VALUE ` functions and using `DataSetMapper`
3. Implementing `DataSetMapperTest`
4. Updating all affected test classes that use `DataSetMapper`
5. Creation of `BigQueryTableInfo` enum to replace `ConceptSetDao#DOMAIN_TO_TABLE_NAME`