### PR TITLE
[risk=no][RW-4361] API portion: rm code depending on Feature Flag requireInstitutionalVerification

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -238,9 +238,7 @@ public class ProfileController implements ProfileApiDelegate {
       verifyInvitationKey(request.getInvitationKey());
     }
 
-    if (workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
-      profileService.validateInstitutionalAffiliation(request.getProfile());
-    }
+    profileService.validateInstitutionalAffiliation(request.getProfile());
 
     final Profile profile = request.getProfile();
 
@@ -300,19 +298,17 @@ public class ProfileController implements ProfileApiDelegate {
       throw new WorkbenchException(e);
     }
 
-    if (workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
-      institutionService
-          .getInstitutionUserInstructions(
-              profile.getVerifiedInstitutionalAffiliation().getInstitutionShortName())
-          .ifPresent(
-              instructions -> {
-                try {
-                  mail.sendInstitutionUserInstructions(profile.getContactEmail(), instructions);
-                } catch (MessagingException e) {
-                  throw new WorkbenchException(e);
-                }
-              });
-    }
+    institutionService
+        .getInstitutionUserInstructions(
+            profile.getVerifiedInstitutionalAffiliation().getInstitutionShortName())
+        .ifPresent(
+            instructions -> {
+              try {
+                mail.sendInstitutionUserInstructions(profile.getContactEmail(), instructions);
+              } catch (MessagingException e) {
+                throw new WorkbenchException(e);
+              }
+            });
 
     // Note: Avoid getProfileResponse() here as this is not an authenticated request.
     final Profile createdProfile = profileService.getProfile(user);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -391,16 +391,11 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
             finalDbUserReference.addInstitutionalAffiliation(affiliation);
           });
     }
-    // set via the newer Verified Institutional Affiliation flow
-    boolean requireInstitutionalVerification =
-        configProvider.get().featureFlags.requireInstitutionalVerification;
 
     try {
       dbUser = userDao.save(dbUser);
-      if (requireInstitutionalVerification) {
-        dbVerifiedAffiliation.setUser(dbUser);
-        this.verifiedInstitutionalAffiliationDao.save(dbVerifiedAffiliation);
-      }
+      dbVerifiedAffiliation.setUser(dbUser);
+      verifiedInstitutionalAffiliationDao.save(dbVerifiedAffiliation);
     } catch (DataIntegrityViolationException e) {
       dbUser = userDao.findUserByUsername(username);
       if (dbUser == null) {

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -133,10 +133,6 @@ public class ProfileService {
   }
 
   public void validateInstitutionalAffiliation(Profile profile) {
-    if (!workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
-      return;
-    }
-
     VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
         profile.getVerifiedInstitutionalAffiliation();
 
@@ -231,21 +227,19 @@ public class ProfileService {
 
     userService.updateUserWithConflictHandling(user);
 
-    if (workbenchConfigProvider.get().featureFlags.requireInstitutionalVerification) {
-      // Save the verified institutional affiliation in the DB. The affiliation has already been
-      // verified as part of the `validateProfile` call.
-      DbVerifiedInstitutionalAffiliation updatedDbVerifiedAffiliation =
-          verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
-              updatedProfile.getVerifiedInstitutionalAffiliation(), institutionService);
-      updatedDbVerifiedAffiliation.setUser(user);
-      Optional<DbVerifiedInstitutionalAffiliation> dbVerifiedAffiliation =
-          verifiedInstitutionalAffiliationDao.findFirstByUser(user);
-      dbVerifiedAffiliation.ifPresent(
-          verifiedInstitutionalAffiliation ->
-              updatedDbVerifiedAffiliation.setVerifiedInstitutionalAffiliationId(
-                  verifiedInstitutionalAffiliation.getVerifiedInstitutionalAffiliationId()));
-      this.verifiedInstitutionalAffiliationDao.save(updatedDbVerifiedAffiliation);
-    }
+    // Save the verified institutional affiliation in the DB. The affiliation has already been
+    // verified as part of the `validateProfile` call.
+    DbVerifiedInstitutionalAffiliation updatedDbVerifiedAffiliation =
+        verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
+            updatedProfile.getVerifiedInstitutionalAffiliation(), institutionService);
+    updatedDbVerifiedAffiliation.setUser(user);
+    Optional<DbVerifiedInstitutionalAffiliation> dbVerifiedAffiliation =
+        verifiedInstitutionalAffiliationDao.findFirstByUser(user);
+    dbVerifiedAffiliation.ifPresent(
+        verifiedInstitutionalAffiliation ->
+            updatedDbVerifiedAffiliation.setVerifiedInstitutionalAffiliationId(
+                verifiedInstitutionalAffiliation.getVerifiedInstitutionalAffiliationId()));
+    this.verifiedInstitutionalAffiliationDao.save(updatedDbVerifiedAffiliation);
 
     final Profile appliedUpdatedProfile = getProfile(user);
     profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -963,6 +963,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void sendUserInstructions_none() throws MessagingException {
+    // default Institution in this test class has no instructions
     createAccountAndDbUserWithAffiliation();
     verify(mockMailService).sendWelcomeEmail(any(), any(), any());
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -296,6 +296,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test(expected = BadRequestException.class)
   public void testInvitationKeyVerification_invitationKeyMismatch() {
+    invitationVerificationRequest.setInvitationKey("wrong key");
     profileController.invitationKeyVerification(invitationVerificationRequest);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -310,6 +310,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new VerifiedInstitutionalAffiliation()
             .institutionShortName("Broad")
             .institutionalRoleEnum(InstitutionalRole.STUDENT);
+    createAccountRequest.getProfile().contactEmail("bob@broad.com");
     createAccount(verifiedInstitutionalAffiliation);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -300,6 +300,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
+            .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
             .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
             .emailDomains(Collections.singletonList("example.com"))
             .duaTypeEnum(DuaType.RESTRICTED);
@@ -318,6 +319,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
+            .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
             .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
             .emailDomains(Collections.singletonList("example.com"))
             .duaTypeEnum(DuaType.MASTER);
@@ -337,6 +339,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
+            .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
             .emailAddresses(Collections.singletonList(CONTACT_EMAIL))
             .emailDomains(Collections.singletonList("example.com"));
     institutionService.createInstitution(broad);
@@ -693,6 +696,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
+            .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
             .emailAddresses(Collections.emptyList())
             .duaTypeEnum(DuaType.RESTRICTED);
     institutionService.createInstitution(broad);
@@ -714,6 +718,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         new Institution()
             .shortName("Broad")
             .displayName("The Broad Institute")
+            .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
             .emailDomains(emailDomains)
             .duaTypeEnum(DuaType.MASTER);
     institutionService.createInstitution(broad);

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -129,7 +129,6 @@ public class ProfileServiceTest {
   @Before
   public void setUp() {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.featureFlags.requireInstitutionalVerification = true;
   }
 
   @Test
@@ -220,7 +219,6 @@ public class ProfileServiceTest {
     when(mockInstitutionService.validateAffiliation(
             dbVerifiedInstitutionalAffiliation, "kibitz@broadinstitute.org"))
         .thenReturn(true);
-    ;
 
     profileService.validateInstitutionalAffiliation(profile);
 


### PR DESCRIPTION
Description:

The code changes are big enough (in line count) that I'm splitting this into API and UI PRs.  This does NOT remove the flag itself!  Only the API code which references it - and many small changes to ProfileControllerTest

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
