### PR TITLE
[RW-4646][RISK=LOW]  Update Data Dictionary definitions

### DIFF
--- a/api/tools/README.md
+++ b/api/tools/README.md
@@ -3,7 +3,7 @@
 ## Load Data Dictionary
 To load/update data dictionary follow the steps:
 
-1. Create 2 yaml files : one for PROD and  another for synthetic CDR version, under
+1. Create 2 yaml files : one for PROD and  another for synthetic CDR, under
     <em>/api/tools/src/main/resources/data_dictionary_exports</em> with the following fields:
     
     a) meta_data -> id, name, version, created_time, modified_time,

--- a/api/tools/README.md
+++ b/api/tools/README.md
@@ -4,14 +4,14 @@
 To load/update data dictionary follow the steps:
 
 1. Create 2 yaml files : one for PROD and  another for synthetic CDR version, under
-    <i>/api/tools/src/main/resources/data_dictionary_exports</i> with the following fields:
+    <em>/api/tools/src/main/resources/data_dictionary_exports</em> with the following fields:
     
     a) meta_data -> id, name, version, created_time, modified_time,
        last_modifying_user_display_name and cdr_version (make sure cdr_version matches that of Environment else it will not load entries)
     b) transformations ->  available_fields
     
   
-3. To verify on local
+2. To verify on local
   a) run the command 
      ./gradlew loadDataDictionary -PappArgs={true for dry_run else false}
   b) Confirm the new entries are added to table  data_dictionary_entry

--- a/api/tools/README.md
+++ b/api/tools/README.md
@@ -1,11 +1,17 @@
 # All of Us Workbench TOOLS
 
 ## Load Data Dictionary
-To load data dictionary follow the following steps:
+To load/update data dictionary follow the steps:
 
-1. Create yaml file from CDR yaml under /api/tools/src/main/resources/data_dictionary_exports with fields:
-    a) meta_data -> id, name, version, created_time, modified_time, last_modifying_user_display_name and cdr_version
-    b) transformations ->  available_fields:
-2. Make sure the cdr_version in the file is same as that of the current environment cdr version (PROD will be different than other synthetic cdr versions).
-3. To verify on local use the command ./gradlew loadDataDictionary -PappArgs={true for dry_run else false}
-4. Running the command should create entries in the Database
+1. Create 2 yaml files : one for PROD and  another for synthetic CDR version, under
+    <i>/api/tools/src/main/resources/data_dictionary_exports</i> with the following fields:
+    
+    a) meta_data -> id, name, version, created_time, modified_time,
+       last_modifying_user_display_name and cdr_version (make sure cdr_version matches that of Environment else it will not load entries)
+    b) transformations ->  available_fields
+    
+  
+3. To verify on local
+  a) run the command 
+     ./gradlew loadDataDictionary -PappArgs={true for dry_run else false}
+  b) Confirm the new entries are added to table  data_dictionary_entry

--- a/api/tools/README.md
+++ b/api/tools/README.md
@@ -1,0 +1,11 @@
+# All of Us Workbench TOOLS
+
+## Load Data Dictionary
+To load data dictionary follow the following steps:
+
+1. Create yaml file from CDR yaml under /api/tools/src/main/resources/data_dictionary_exports with fields:
+    a) meta_data -> id, name, version, created_time, modified_time, last_modifying_user_display_name and cdr_version
+    b) transformations ->  available_fields:
+2. Make sure the cdr_version in the file is same as that of the current environment cdr version (PROD will be different than other synthetic cdr versions).
+3. To verify on local use the command ./gradlew loadDataDictionary -PappArgs={true for dry_run else false}
+4. Running the command should create entries in the Database

--- a/api/tools/README.md
+++ b/api/tools/README.md
@@ -14,4 +14,6 @@ To load/update data dictionary follow the steps:
 2. To verify on local
   a) run the command 
      ./gradlew loadDataDictionary -PappArgs={true for dry_run else false}
+     NOTE:  For other environments : deploy command calls loadDataDictionary
   b) Confirm the new entries are added to table  data_dictionary_entry
+  

--- a/api/tools/src/main/resources/data_dictionary_exports/AllofUsDatasetV3_20200701.yaml
+++ b/api/tools/src/main/resources/data_dictionary_exports/AllofUsDatasetV3_20200701.yaml
@@ -1,0 +1,7347 @@
+meta_data:
+  -
+    id: '1dsvJV8B7EXQj5EWa2XG-KAhs-l7FsQnyJSSFMstLF2U'
+    name: 'All of Us Registered Tier CDR Data Dictionary'
+    version: 3034
+    created_time: 2019-01-15 18:38:57
+    modified_time: 2020-07-01 14:55:15
+    last_modifying_user_display_name: 'Alpha Parrott'
+    cdr_version: 'All of Us Dataset v3'
+
+transformations:
+  - 
+    available_fields:
+      - 
+        field_name:  'attribute_definition_id'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Attribute.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_description'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A complete description of the Attribute definition'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_name'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A short description of the Attribute.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_syntax'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Syntax or code to operationalize the Attribute definition'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_type_concept_id'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Type defining what kind of Attribute Definition the record represents and how the syntax may be executed'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'code'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The concept code represents the identifier of the Concept in the source vocabulary, such as SNOMED-CT concept IDs, RxNorm RXCUIs etc. Note that the concept may not have a concept code (some parent items in ICD9/ICD10/CPT have a code from UMLS, which doesn''t exist in OMOP)'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies. For rows representing PPI, this will be the concept ID of the question'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The domain where this item will show up in Cohort Builder (ie, if "Condition" then this item will show up when viewing the condition wizard in search. This will NOT always match the domain_id of the item in OMOP.'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'est_count'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Number of subjects who have at least one coding of this item. For items where is_group =1, this is a rolled up count of the number of subject with at least one coding of any item subsumed by this item.,  -1 = For items we don''t generate a count for.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_ancestor_data'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item has data in the criteria_ancestor table that is needed for searching in the Cohort Builder,  0 = nothing'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_attribute'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item can have additional attributes added for searching (ie, a lab where you want to specify a value),  0 = this item has no additional attributes.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_hierarchy'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item is part of a hierarchy tree in the Cohort Builder,  0 = not part of a hierarchy'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Auto-generated primary key for the recorded event'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_group'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this is an item which subsumes other items,  0 = this item does not subsume any items.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_selectable'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item is selectable in the Cohort Builder,  0 = this item cannot be selected.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_standard'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Defines whether the concept relates to a standard vocabulary or not.,  1 = this is a standard concept,  0 = this is a source concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'name'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A brief, descriptive name for the Concept.'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'parent_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If the item is part of a hierarchy, this is the ID of the criteria item that subsumes this item. If parent_id = 0 and has_hierarchy = 1 then this item is a root item for the hierarchical tree.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'path'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '"." delimited list of IDs that can be used to trace the hierarchy path for a given item. This includes the ID of the current item,  Ex: 1.5.100.150'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'subtype'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Subtype of an item (Ex: type = PPI and subtype = BP)'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'synonyms'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '"|" delimited list of possible text matches/alternative names for the Concept.,  Usually in the form: Code | name | synonyms,  Ex: 100.1 | neoplasm | neo | plasm'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'type'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The type of item (ie, ICD9CM, SNOMED, LOINC). Should match the vocabulary_id of the item in OMOP.'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'For PPI answers, this is either the answer concept ID that will be searched for in value_source_concept_id OR, where applicable, this field holds a numeric value to be searched in the value_as_number field.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'ancestor_id'
+        relevant_omop_table:  'cb_criteria_ancestor'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the concept in the concept table for the higher-level concept that forms the ancestor in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'descendant_id'
+        relevant_omop_table:  'cb_criteria_ancestor'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the concept in the concept table for the lower-level concept that forms the descendant in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_name'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If categorial, text name of categorical value,  If numeric, either "MIN" or "MAX",  This is applicable to observation where the result can be expressed as a Standard Concept from the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'est_count'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If numeric, the MIN or MAX value,  If categorical, the number of distinct subjects who were coded with this result for this item'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Auto-generated primary key for the recorded event'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'type'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A descriptor of the type of value attached to the concept,  NUM - numeric,  CAT - categorical'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If categorical, the concept ID of the categorical value,  0 - if numeric result,  In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id_1'
+        relevant_omop_table:  'cb_criteria_relationship'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the source concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id_2'
+        relevant_omop_table:  'cb_criteria_relationship'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the destination concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'age_at_event'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The age of the Person at the event start_datetime'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'data_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier assigned to the event recorded.'
+        field_type:  'bigint'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'domain'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'dose'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for information about the dose unit of a drug exposure as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'first_mention'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the first instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'last_mention'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the last instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'num_mentions'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The number of instances of the Concept ID for the event in the Person''s record.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the event is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'ref_range'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The upper and lower limits of the normal range of a Measurement result. The range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'route'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for information about the route of administration for a drug exposure as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_code'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the event as given in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_concept_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept ID that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_name'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the event as given in the source data.'
+        field_type:  'varchar(255)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the event.'
+        field_type:  'varchar'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_code'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the event from the standard vocabulary the source was mapped to'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_concept_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the recorded event.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_name'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the event from the standard vocabulary.'
+        field_type:  'varchar(255)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the standard vocabulary the source was mapped to.'
+        field_type:  'varchar'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'start_datetime'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for the date and time when the instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Personal Medical History/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'strength'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key referring to the numeric value associated with the amount of active ingredient contained within the product.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'unit'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept ID of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An event result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'visit_type'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the type of source data from which the visit record is derived belonging to the "Visit Type" vocabulary'
+        field_type:  'varchar'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'answer'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The answer selected by the Person for the question given in the "question" field.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'data_id'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier assigned to the event recorded.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the survey response is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'question'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The question within the survey given in the "survey" field being answered.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'start_datetime'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the instance of the survey response is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'survey'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The title of the PPI survey.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'age_at_event'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The age of the Person at the entry date'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'diastolic'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'the diastolic blood pressure value for PPI Physical Measurements'
+        field_type:  'float'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'entry_date'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date on which the event was recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'entry_datetime'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The datetime at which the event was recorded to have occurred'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_standard'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Defines whether a concept relates to a standard vocabulary or not.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values are 1 for standard vocabulary or 0 if not. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person being called in the search. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'systolic'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'the systolic blood pressure value for PPI Physical Measurements'
+        field_type:  'float'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An event result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept for the value in the source data. This is applicable to observations where the result can be expressed as a non-standard concept. This will largely hold only the concept IDs for PPI survey answers'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the event occurred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'dob'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date of birth of the person.'
+        field_type:  'date'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench. Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'ethnicity'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique gender of the person.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person being called in the search. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'race'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the person, belonging to the ''Race'' vocabulary.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbenc. This field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'cdm_etl_reference'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'URL or other external reference to location of ETL specification documentation and ETL source code'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_holder'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The name of the organization responsible for the development of the CDM instance'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_release_date'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The date when the CDM was instantiated'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_source_abbreviation'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'An abbreviation of the source name'
+        field_type:  'varchar(25)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_source_name'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The full name of the source'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_version'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The version of CDM used'
+        field_type:  'varchar(10)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_description'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'A description of the source data origin and purpose for collection. The description may contain a summary of the period of time that is expected to be covered by this dataset.'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_documentation_reference'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'URL or other external reference to location of source documentation'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_release_date'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The date for which the source data are most current, such as the last day of data capture'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_version'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The version of the vocabulary used'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The attribute or concept class of the Concept.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Examples are "Clinical Drug", "Ingredient", "Clinical Finding" etc.'
+
+      - 
+        field_name:  'concept_code'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The concept code represents the identifier of the Concept in the source vocabulary, such as SNOMED-CT concept IDs, RxNorm RXCUIs etc.'
+        field_type:  'varchar(50)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Note that concept codes are not unique across vocabularies.'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Concept across all domains.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_name'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'An unambiguous, meaningful and descriptive name for the Concept.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the DOMAIN table the Concept belongs to.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the Concept was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are D (deleted), U (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'standard_concept'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'This flag determines where a Concept is a Standard Concept, i.e. is used in the data, a Classification Concept, or a non-standard Source Concept.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The allowables values are ''S'' (Standard Concept) and ''C'' (Classification Concept), otherwise the content is NULL.'
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept became invalid because it was deleted or superseded (updated) by a new concept.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept was first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept has no (known) date of inception.'
+
+      - 
+        field_name:  'vocabulary_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the VOCABULARY table indicating from which source the Concept has been adapted.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'ancestor_concept_id'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the concept in the concept table for the higher-level concept that forms the ancestor in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'descendant_concept_id'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the concept in the concept table for the lower-level concept that forms the descendant in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'max_levels_of_separation'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The maximum separation in number of levels of hierarchy between ancestor and descendant concepts. This is an attribute that is used to simplify hierarchic analysis.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'min_levels_of_separation'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The minimum separation in number of levels of hierarchy between ancestor and descendant concepts. This is an attribute that is used to simplify hierarchic analysis.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_concept_id'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique Concept Class the record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_id'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique key for each class'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_name'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the Concept Class.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Clinical Finding", "Ingredient", etc.'
+
+      - 
+        field_name:  'concept_id_1'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the source concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_id_2'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the destination concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the relationship was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are ''D'' (deleted), ''U'' (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'relationship_id'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier to the type or nature of the Relationship as defined in the RELATIONSHIP table.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept Relationship became invalid because it was deleted or superseded (updated) by a new relationship.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept Relationship is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the instance of the Concept Relationship is first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept Relationship has no (known) date of inception.'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_synonym_name'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The alternative name for the Concept.'
+        field_type:  'varchar(1000)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'language_concept_id'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept representing the language.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Condition'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies in the ''Condition'' domain include HCPCS, ICDO3, OPCS4, and SNOMED.'
+
+      - 
+        field_name:  'condition_end_date'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is considered to have ended.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_end_datetime'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is considered to have ended.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_occurrence_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Condition Occurrence event.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_source_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Condition Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_source_value'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Condition source codes come from a variety of vocabularies; CIEL, ICD10, ICD10CM, ICD9CM, ICDO3, Read, and SNOMED are the most common.'
+
+      - 
+        field_name:  'condition_start_date'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_start_datetime'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time when the instance of the Condition is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_status_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the condition status as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_status_source_value'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the condition status as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_type_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the source data from which the Condition was recorded, the level of standardization, and the type of occurrence.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Condition Type'' vocabulary'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the condition is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Provider in the PROVIDER table who was responsible for capturing (diagnosing) the Condition.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The reason that the Condition was no longer present, as indicated in the source data.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the unique identifier for the visit in the VISIT_OCCURRENCE table during which the Condition was determined (diagnosed).'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_occurrence_id'
+        relevant_omop_table:  'condition_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the condition occurrence table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'condition_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'cause_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to a standard concept identifier in the Standardized Vocabularies for conditions.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cause_source_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the concept that refers to the code used in the source. Note, this variable name is abbreviated to ensure it will be allowable across database platforms.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cause_source_value'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the cause of death as it appears in the source data. This code is mapped to a standard concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_date   '
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_datetime'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_type_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to the predefined concept identifier in the Standardized Vocabularies reflecting how the death was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Codes referring to death are contained within the SNOMED Standardized Vocabulary'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the deceased person. The demographic details of that person are stored in the person table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Device'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Device'' domain; NDC, SNOMED, and dm+d are the most common.'
+
+      - 
+        field_name:  'device_exposure_end_date'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date use of the Device or supply was ceased.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_end_datetime'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time use of the Device or supply was ceased.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Device Exposure.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_start_date'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the Device or supply was applied or used.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_start_datetime'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time the Device or supply was applied or used.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_source_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Device Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_source_value'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Device as it appears in the source data. This code is mapped to a Standard Device Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for the ''Device'' domain; DPD, LPD_Belgium, NDC, SNOMED, and dm+d are the most common.'
+
+      - 
+        field_name:  'device_type_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Device Exposure recorded. It indicates how the Device Exposure was represented in the source data and belongs to the ''Device Type'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Device. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who initiated or administered the Device.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of individual Devices used in the exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unique_device_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A UDI or equivalent identifying the instance of the Device used in the Person.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Device Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the Device was used.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_id'
+        relevant_omop_table:  'device_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the device exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'device_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'domain_concept_id'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique Domain Concept the Domain record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique key for each domain.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_name'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc.'
+
+      - 
+        field_name:  'days_supply'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of days of supply of the medication as prescribed. This reflects the intention of the provider for the length of exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'dose_unit_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the dose unit as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Drug'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension'
+
+      - 
+        field_name:  'drug_exposure_end_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_end_datetime'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date and time for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and time and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Drug utilization event.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_start_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date for the current instance of Drug utilization. Valid entries include a start date of a prescription, the date a prescription was filled, or the date on which a Drug administration procedure was recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_start_datetime'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date and time for the current instance of Drug utilization. Valid entries include a start datetime of a prescription, the date and time a prescription was filled, or the date and time on which a Drug administration procedure was recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_source_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Drug Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Drug as it appears in the source data. This code is mapped to a Standard Drug concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Drug source codes come from a variety of vocabularies; AMT, DPD, NDC, RxNorm, RxNorm Extension, SNOMED, SPL, and dm+d are the most common.'
+
+      - 
+        field_name:  'drug_type_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Drug Exposure recorded. It indicates how the Drug Exposure was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Drug Type'' vocabulary'
+
+      - 
+        field_name:  'lot_number'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'An identifier assigned to a particular quantity or lot of Drug product from the manufacturer.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Drug. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who initiated (prescribed or administered) the Drug Exposure.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The quantity of drug as recorded in the original prescription or dispensing record.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'refills'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of refills after the initial prescription. The initial prescription is not counted, values start with null.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values begin with null as the initial prescription is not counted'
+
+      - 
+        field_name:  'route_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies reflecting the route of administration and belonging to the ''Route'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'SNOMED is the Standardized Vocabulary for the ''Route'' domain'
+
+      - 
+        field_name:  'route_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the route of administration as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'sig'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The directions (''signetur'') on the Drug prescription as recorded in the original prescription (and printed on the container) or dispensing record.'
+        field_type:  'varchar(MAX)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The reason the Drug was stopped.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Reasons include regimen completed, changed, removed, etc.'
+
+      - 
+        field_name:  'verbatim_end_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The known end date of a Drug Exposure as provided by the source.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_id'
+        relevant_omop_table:  'drug_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the drug exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'drug_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'amount_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the Unit for the absolute amount of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'amount_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The numeric value associated with the amount of active ingredient contained within the product.'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'box_size'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The number of units of Clinical of Branded Drug, or Quantified Clinical or Branded Drug contained in a box as dispensed to the patient'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'denominator_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the denominator Unit for the concentration of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'denominator_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The amount of total liquid (or other divisible product, such as ointment, gel, spray, etc.).'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for Branded Drug or Clinical Drug Concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension'
+
+      - 
+        field_name:  'ingredient_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table, representing the identifier for drug Ingredient Concept contained within the drug product.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the concept was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are ''D'' (deleted), ''U'' (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'numerator_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the numerator Unit for the concentration of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'numerator_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The numeric value associated with the concentration of the active ingredient contained in the product'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the concept became invalid because it was deleted or superseded (updated) by a new Concept.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept was first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept has no (known) date of inception.'
+
+      - 
+        field_name:  'condition_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Condition'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies in the ''Condition'' domain include HCPCS, ICDO3, OPCS4, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_end_datetime'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time when the instance of the Condition is considered to have ended.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_source_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Condition Concept that refers to the code or identifier used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_source_value'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Condition source codes come from a variety of vocabularies; CIEL, ICD10, ICD10CM, ICD9CM, ICDO3, Read, and SNOMED are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_start_datetime'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time when the instance of the Condition is recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code or identifier for the Condition Status as it appears in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name representing the Condition Status as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_source_value'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Condition Status as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_type_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the source data from which the Condition was recorded, the level of standardization, and the type of occurrence.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Condition Type'' vocabulary.  This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_type_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Condition which occurred as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the condition is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Condition as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Condition.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Condition from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Condition as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the reason that the Condition is no longer present, as indicated in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Condition was determined (diagnosed).'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'days_supply'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the number of days of supply of the medication as prescribed. This reflects the intention of the provider for the length of exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'dose_unit_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the information about the dose unit as detailed in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Drug'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_exposure_end_datetime'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the end date and time for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and time and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_exposure_start_datetime'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the start date and time for the current instance of Drug utilization. Valid entries include a start datetime of a prescription, the date and time a prescription was filled, or the date and time on which a Drug administration procedure was recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_source_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Drug Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Drug as it appears in the source data. This code is mapped to a Standard Drug concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Drug source codes come from a variety of vocabularies; AMT, DPD, NDC, RxNorm, RxNorm Extension, SNOMED, SPL, and dm+d are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_type_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Drug Exposure recorded. It indicates how the Drug Exposure was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Drug Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_type_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Drug involved in the exposure as it appears in the Standardized Vocabulary.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'lot_number'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an identifier assigned to a particular quantity or lot of Drug product from the manufacturer.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the drug is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the quantity of drug as recorded in the original prescription or dispensing record.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'refills'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the number of refills after the initial prescription. The initial prescription is not counted, values start with null.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values begin with null as the initial prescription is not counted. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies reflecting the route of administration and belonging to the ''Route'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'SNOMED is the Standardized Vocabulary for the ''Route'' domain. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the route of administration of the Drug as it appears in the Standardized Vocabulary'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the information about the route of administration as detailed in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'sig'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the directions (''signetur'') on the Drug prescription as recorded in the original prescription (and printed on the container) or dispensing record.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Drug as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Drug as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Drug.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Drug from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Drug as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the reason the Drug was stopped as indicated in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Reasons include regimen completed, changed, removed, etc. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'verbatim_end_date'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the known end date of the Drug Exposure as provided by the source.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the standard measurement concept identifier in the Standardized Vocabularies. These belong to the ''Measurement'' domain, but could overlap with the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Measurement'' domain include CPT4, HCPCS, LOINC, OPCS4, PPI, and SNOMED. Standardized Vocabularies for the ''Observation'' domain include the vocabularies of the ''Measurement'' domain as well as APC, CDT, DRG, MDC, MMI, NUCC, PCORNet, and UB04. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_datetime'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time of the Measurement. Some database systems don''t have a datatype of time.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_source_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the Standard Vocabularies that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Measurement name as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Measurement source codes are typically LOINC, SNOMED, CPT4, or CIEL codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_type_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept in the Standardized Vocabularies reflecting the provenance from where the Measurement record was recorded.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Meas Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_type_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the Measurement taken as it appears in the Standardized Vocabulary'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'operator_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the predefined Concept in the Standardized Vocabularies reflecting the mathematical operator that is applied to the value_as_number.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Operators are <, <=, =, >=, > and these concepts belong to the ''Meas Value Operator'' domain. Null values indicate that there is no operator applied. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'operator_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for the mathematical operator applied to the measurement value as given in the Standardized Vocabulary.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the measurement is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'range_high'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the upper limit of the normal range of the Measurement. The upper range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'range_low'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the lower limit of the normal range of the Measurement result. The lower range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Measurement as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Measurement as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Measurement.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Measurement from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Measurement as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the units of the Measurement taken.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Measurement result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the value of the Measurement taken.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Measurement result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source value associated with the content of the value_as_number or value_as_concept_id as stored in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Measurement was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the standard observation concept identifier in the Standardized Vocabularies. In cases where the recorded observation is the answer to a PPI question, this field will contain the Standard Concept ID for the corresponding question (or, if the question is non-standard, its standard LOINC/SNOMED equivalent).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied for some concepts. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_datetime'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time at which the Observation was made.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_source_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept that refers to the code used in the source. If the recorded observation is the answer to a PPI question, the PPI concept for the question is stored here.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for Observations; ICD10CM, LOINC, Read, SNOMED, and SNOMED Veterinary are the most common. If the Observation is the response to a PPI question, the PPI concept for that question will be stored here. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation code as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied to some concepts. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_type_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept identifier in the Standardized Vocabularies reflecting the type of the observation belonging to the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Observation'' domain; HCPCS, LOINC, SNOMED, and SNOMED Veterinary are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_type_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Observation that was made.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the observation is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier for a qualifier (e.g., severity of drug-drug interaction alert) for the observation, if one exists'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for a qualifier for the observation, if one exists.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value associated with a qualifier to characterize the observation'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'questionnaire_response_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier representing the response to the question that was answered.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Observation as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Observation as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Observation.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Observation from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Observation as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier of measurement units in the Standardized Vocabularies belonging to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for the measurement units for the observation.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain. In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard). For PPI, this field is derived from value_source_concept_id.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the obervation result. This is applicable to observation where the result can be expressed as a Standard Concept from the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation result stored as a number. This is applicable to observations where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_string'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation result stored as a string. This is applicable to observations where the result is expressed as verbatim text.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an Observation result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  If the recorded observation is the response to a PPI question, this field will contain the PPI concept for the answer.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value associated with the content of the value_as_number or value_source_concept_id as stored in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'date_of_birth'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time of birth of the person.'
+        field_type:  'timestamp'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench. Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'ethnicity'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The ethnicity of the person corresponding to the value of ethnicity_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The gender of the Person corresponding to the value of gender_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'gender_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique gender of the person.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'race'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The race of the Person corresponding to the value of race_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the Person, belonging to the ''Race'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; this field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'A foreign key to the self-reported sex at birth for the participant that refers to the source code. Available in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; this field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'modifier_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept identifier for a modifier to the Procedure (e.g. bilateral).'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These concepts are typically distinguished by ''Modifier'' concept classes (e.g., ''CPT4 Modifier'' as part of the ''CPT4'' vocabulary). This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'modifier_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing a modifier to the Procedure.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the procedure is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a standard procedure Concept identifier in the Standardized Vocabularies. These belong to the ''Procedure'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Procedure'' domain include CDT, CPT4, HCPCS, ICD10PCS, ICD9Proc, OPCS4, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_datetime'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time on which the Procedure was performed.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_source_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Procedure Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_source_value'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the Procedure as it appears in the source data. This code is mapped to a standard procedure Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Procedure source codes are typically ICD-9-Proc, CPT-4, HCPCS or OPCS-4 codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_type_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the procedure record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Procedure Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_type_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the type of Procedure performed.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value for the qualifier as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the quantity of procedures ordered or administered.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Procedure as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Procedure as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Procedure.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Procedure from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Procedure as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Procedure was carried out.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'answer'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The answer selected by the Person for the question given in the "question" field.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'answer_concept_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Standard Concept Identifier referring to the answer selected by the Person for the question given in the "question" field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the survey was recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'question'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The question within the survey given in the "survey" field that was answered.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'question_concept_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Standard Concept Identifier referring to the question within the survey given in the "survey" field that was answered.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'survey'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The title of the PPI survey.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'survey_datetime'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the instance of the survey response is recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the admitting source for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the admitting source for a visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the admitting source as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the discharge disposition for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the discharge disposition for a visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the discharge disposition as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whome the visit was recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Condition as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Visit from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_end_datetime'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time the Visit ended.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_source_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign code to the source code for the visit as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Visit source codes are typically UB04 Typ bill and NUCC codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_start_datetime'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time the Visit started.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_type_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the visit record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Visit Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_type_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier referring to the type of Visit recorded.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain_concept_id_1'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The concept representing the domain of fact one, from which the corresponding table can be inferred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_concept_id_2'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The concept representing the domain of fact two, from which the corresponding table can be inferred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'fact_id_1'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The unique identifier in the table corresponding to the domain of fact one.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'fact_id_2'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The unique identifier in the table corresponding to the domain of fact two.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'relationship_concept_id'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of relationship in the Standardized Vocabularies belonging to the ''Relationship'' domain.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabulary for the ''Relationship'' domain is SNOMED.'
+
+      - 
+        field_name:  'measurement_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the standard measurement concept identifier in the Standardized Vocabularies. These belong to the ''Measurement'' domain, but could overlap with the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Measurement'' domain include CPT4, HCPCS, LOINC, OPCS4, PPI, and SNOMED. Standardized Vocabularies for the ''Observation'' domain include the vocabularies of the ''Measurement'' domain as well as APC, CDT, DRG, MDC, MMI, NUCC, PCORNet, and UB04'
+
+      - 
+        field_name:  'measurement_date'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date of the Measurement.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_datetime'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the Measurement. Some database systems don''t have a datatype of time. To accommodate all temporal analyses, datatype datetime can be used (combining measurement_date and measurement_time forum discussion)'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Measurement.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_source_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept in the Standard Vocabularies that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Measurement name as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Measurement source codes are typically LOINC, SNOMED, CPT4, or CIEL codes.'
+
+      - 
+        field_name:  'measurement_type_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept in the Standardized Vocabularies reflecting the provenance from where the Measurement record was recorded.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Meas Type'' vocabulary.'
+
+      - 
+        field_name:  'operator_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the predefined Concept in the Standardized Vocabularies reflecting the mathematical operator that is applied to the value_as_number.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Operators are <, <=, =, >=, > and these concepts belong to the ''Meas Value Operator'' domain. Null values indicate that there is no operator applied.'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person about whom the measurement was recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for initiating or obtaining the measurement.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'range_high'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The upper limit of the normal range of the Measurement. The upper range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'range_low'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The lower limit of the normal range of the Measurement result. The lower range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM.'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Measurement result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A Measurement result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value associated with the content of the value_as_number or value_as_concept_id as stored in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Measurement was taken.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Measurement was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_id'
+        relevant_omop_table:  'measurement_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the measurement table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'measurement_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'observation_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the standard observation concept identifier in the Standardized Vocabularies. In cases where the recorded observation is the answer to a PPI question, this field will contain the Standard Concept ID for the corresponding question (or, if the question is non-standard, its standard LOINC/SNOMED equivalent).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied to some concepts.'
+
+      - 
+        field_name:  'observation_date'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date of the observation.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_datetime'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the observation.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each observation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_source_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept that refers to the code used in the source. If the recorded observation is the answer to a PPI question, the PPI concept for the question is stored here.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for Observations; ICD10CM, LOINC, Read, SNOMED, and SNOMED Veterinary are the most common. If the Observation is the response to a PPI question, the PPI concept for that question will be stored here.'
+
+      - 
+        field_name:  'observation_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation code as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference. If the recorded observation is the answer to a PPI question, the code for the PPI question is stored here.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_type_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept identifier in the Standardized Vocabularies reflecting the type of the observation belonging to the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Observation'' domain; HCPCS, LOINC, SNOMED, and SNOMED Veterinary are the most common.'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person about whom the observation was recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for making the observation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID for a qualifier (e.g., severity of drug-drug interaction alert)'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value associated with a qualifier to characterize the observation'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of measurement units in the Standardized Vocabularies belonging to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM.'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain. In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard). For PPI, this field is derived from value_source_concept_id.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation result stored as a number. This is applicable to observations where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_as_string'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation result stored as a string. This is applicable to observations where the result is expressed as verbatim text.'
+        field_type:  'varchar(60)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.3'
+        description:  'A foreign key to an Observation result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  For EHR data, these will be from the "Meas Val" domain. ,  ,  If the recorded observation is the response to a PPI question, this field will contain the PPI concept for the answer.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_id'
+        relevant_omop_table:  'observation_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the observation table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'observation_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'observation_period_end_date'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date of the observation period for which data are available from the data source'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_period_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each observation period'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_period_start_date'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date of the observation period for which data are available from the data source'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'period_type_concept_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the predefined concept in the Standardized Vocabularies reflecting the source of the observation period information, belonging to the ''Obs Period Type'' vocabulary'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the person for whom the observation period is defined. The demographic details of that person are stored in the person table'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'birth_datetime'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of birth of the person.'
+        field_type:  'datetime'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'care_site_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the site of primary care in the care_site table, where the details of the care site are stored.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'day_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The day of the month of birth of the person. For data sources that provide the precise date of birth, the day is extracted and stored in this field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'ethnicity_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the ethnicity concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the ethnicity of the person as it appears in the source data. The person ethnicity is mapped to a standard ethnicity concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) for the participant.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'gender_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) concept for the participant that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'gender_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) for the participant as it appears in the source data. The person''s response is mapped to a standard oncept in the Standardized Vocabularies; the original value is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'location_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the place of residency for the person in the location table, where the detailed address information is stored.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'month_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The month of birth of the person. For data sources that provide the precise date of birth, the month is extracted and stored in this field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each person.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'An (encrypted) key derived from the person identifier in the source data. This is necessary when a use case requires a link back to the person data at the source dataset.'
+        field_type:  'varchar(50)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the primary care provider the person is seeing in the provider table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'race_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the person, belonging to the ''Race'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the race concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the race of the person as it appears in the source data. The person race is mapped to a standard race concept in the Standardized Vocabularies and the original value is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_id for the "Sex at Birth" PPI question (observation_source_concept_id = 1585845) representing the participant''s self-reported sex at birth for R2019Q4R3 ONLY'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'A foreign key to the self-reported sex at birth for the participant that refers to the source code. Available in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'year_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The year of birth of the person. For data sources with date of birth, the year is extracted. For data sources where the year of birth is not available, the approximate year of birth is derived based on any age group categorization available.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'modifier_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for a modifier to the Procedure (e.g. bilateral).'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These concepts are typically distinguished by ''Modifier'' concept classes (e.g., ''CPT4 Modifier'' as part of the ''CPT4'' vocabulary).'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Procedure. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a standard procedure Concept identifier in the Standardized Vocabularies. These belong to the ''Procedure'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Procedure'' domain include CDT, CPT4, HCPCS, ICD10PCS, ICD9Proc, OPCS4, and SNOMED'
+
+      - 
+        field_name:  'procedure_date'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date on which the Procedure was performed.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_datetime'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time on which the Procedure was performed.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Procedure Occurrence.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_source_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Procedure Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_source_value'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Procedure as it appears in the source data. This code is mapped to a standard procedure Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Procedure source codes are typically ICD-9-Proc, CPT-4, HCPCS or OPCS-4 codes.'
+
+      - 
+        field_name:  'procedure_type_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the procedure record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Procedure Type'' vocabulary.'
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for carrying out the procedure.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value for the qualifier as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The quantity of procedures ordered or administered.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Procedure was carried out.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the procedure occurrence table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'procedure_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'defines_ancestry'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Defines whether a hierarchical relationship contributes to the concept_ancestor table. These are subsets of the hierarchical relationships.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Valid values are 1 or 0.'
+
+      - 
+        field_name:  'is_hierarchical'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Defines whether a relationship defines concepts into classes or hierarchies.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values are 1 for hierarchical relationship or 0 if not.'
+
+      - 
+        field_name:  'relationship_concept_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique relationship concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabulary for the ''Relationship'' domain is SNOMED.'
+
+      - 
+        field_name:  'relationship_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The type of relationship captured by the relationship record.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'relationship_name'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The text that describes the relationship type.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'reverse_relationship_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The identifier for the relationship used to define the reverse relationship between two concepts.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'anatomic_site_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the anatomic location of specimen collection.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'anatomic_site_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the anatomic site as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'disease_status_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the Disease Status of specimen collection.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'disease_status_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the disease status as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the Specimen is recorded.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The amount of specimen collection from the person during the sampling procedure.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to a Standard Concept identifier in the Standardized Vocabularies for the Specimen belonging to the ''Specimen'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabularies for the ''Specimen'' domain are SNOMED and SNOMED Veterinary.'
+
+      - 
+        field_name:  'specimen_date'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the specimen was obtained from the Person.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_datetime'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time on the date when the Specimen was obtained from the person.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each specimen.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_source_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Specimen identifier as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Source codes for the Specimen domain are typically CIEL, Read, SNOMED, or SNOMED Veterinary codes'
+
+      - 
+        field_name:  'specimen_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Specimen value as it appears in the source data. This value is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_type_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to the Concept identifier in the Standardized Vocabularies reflecting the system of record from which the Specimen was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the Unit associated with the numeric quantity of the Specimen collection belonging to the ''Unit'' domain/'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the Unit as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'admitting_source_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the admitting source for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary'
+
+      - 
+        field_name:  'admitting_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the admitting source as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'care_site_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the care site in the care site table that was visited'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'discharge_to_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the discharge disposition for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary'
+
+      - 
+        field_name:  'discharge_to_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the discharge disposition as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the visit is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'preceding_visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit_occurrence table of the visit immediately preceding this visit.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the provider table who was associated with the visit.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for Visit include Visit, UB04 Typ bill, NUCC, and CMS Place of Service, among others'
+
+      - 
+        field_name:  'visit_end_date'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date of the visit. If this is a one-day visit the end date should match the start date.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_end_datetime'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the visit end.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Person''s visit or encounter at a healthcare provider.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_source_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the visit as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Visit source codes are typically UB04 Typ bill and NUCC codes.'
+
+      - 
+        field_name:  'visit_start_date'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date of the visit.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_start_datetime'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the visit started.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_type_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the visit record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Visit Type'' vocabulary.'
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'visit_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the device exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_concept_id'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to a standard concept identifier in the CONCEPT table for the Vocabulary the VOCABULARY record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_id'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Vocabulary, such as ICD9CM, SNOMED, Visit.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_name'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the vocabulary, for example "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 1 and 2 (NCHS)" etc.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_reference'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'External reference to documentation or available download of the about the vocabulary.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_version'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Version of the Vocabulary as indicated in the source.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  

--- a/api/tools/src/main/resources/data_dictionary_exports/SyntheticDatasetV3_20200701.yaml
+++ b/api/tools/src/main/resources/data_dictionary_exports/SyntheticDatasetV3_20200701.yaml
@@ -1,0 +1,7347 @@
+meta_data:
+  -
+    id: '1dsvJV8B7EXQj5EWa2XG-KAhs-l7FsQnyJSSFMstLF2U'
+    name: 'All of Us Registered Tier CDR Data Dictionary'
+    version: 3034
+    created_time: 2019-01-15 18:38:57
+    modified_time: 2020-07-01 14:55:15
+    last_modifying_user_display_name: 'Alpha Parrott'
+    cdr_version: 'Synthetic Dataset v3'
+
+transformations:
+  - 
+    available_fields:
+      - 
+        field_name:  'attribute_definition_id'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Attribute.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_description'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A complete description of the Attribute definition'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_name'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A short description of the Attribute.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_syntax'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Syntax or code to operationalize the Attribute definition'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'attribute_type_concept_id'
+        relevant_omop_table:  'attribute_definition'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Type defining what kind of Attribute Definition the record represents and how the syntax may be executed'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'code'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The concept code represents the identifier of the Concept in the source vocabulary, such as SNOMED-CT concept IDs, RxNorm RXCUIs etc. Note that the concept may not have a concept code (some parent items in ICD9/ICD10/CPT have a code from UMLS, which doesn''t exist in OMOP)'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies. For rows representing PPI, this will be the concept ID of the question'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The domain where this item will show up in Cohort Builder (ie, if "Condition" then this item will show up when viewing the condition wizard in search. This will NOT always match the domain_id of the item in OMOP.'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'est_count'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Number of subjects who have at least one coding of this item. For items where is_group =1, this is a rolled up count of the number of subject with at least one coding of any item subsumed by this item.,  -1 = For items we don''t generate a count for.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_ancestor_data'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item has data in the criteria_ancestor table that is needed for searching in the Cohort Builder,  0 = nothing'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_attribute'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item can have additional attributes added for searching (ie, a lab where you want to specify a value),  0 = this item has no additional attributes.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'has_hierarchy'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item is part of a hierarchy tree in the Cohort Builder,  0 = not part of a hierarchy'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Auto-generated primary key for the recorded event'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_group'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this is an item which subsumes other items,  0 = this item does not subsume any items.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_selectable'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '1 = this item is selectable in the Cohort Builder,  0 = this item cannot be selected.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_standard'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Defines whether the concept relates to a standard vocabulary or not.,  1 = this is a standard concept,  0 = this is a source concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'name'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A brief, descriptive name for the Concept.'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'parent_id'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If the item is part of a hierarchy, this is the ID of the criteria item that subsumes this item. If parent_id = 0 and has_hierarchy = 1 then this item is a root item for the hierarchical tree.'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'path'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '"." delimited list of IDs that can be used to trace the hierarchy path for a given item. This includes the ID of the current item,  Ex: 1.5.100.150'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'subtype'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Subtype of an item (Ex: type = PPI and subtype = BP)'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'synonyms'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  '"|" delimited list of possible text matches/alternative names for the Concept.,  Usually in the form: Code | name | synonyms,  Ex: 100.1 | neoplasm | neo | plasm'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'type'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The type of item (ie, ICD9CM, SNOMED, LOINC). Should match the vocabulary_id of the item in OMOP.'
+        field_type:  'string'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value'
+        relevant_omop_table:  'cb_criteria'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'For PPI answers, this is either the answer concept ID that will be searched for in value_source_concept_id OR, where applicable, this field holds a numeric value to be searched in the value_as_number field.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'ancestor_id'
+        relevant_omop_table:  'cb_criteria_ancestor'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the concept in the concept table for the higher-level concept that forms the ancestor in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'descendant_id'
+        relevant_omop_table:  'cb_criteria_ancestor'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the concept in the concept table for the lower-level concept that forms the descendant in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_name'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If categorial, text name of categorical value,  If numeric, either "MIN" or "MAX",  This is applicable to observation where the result can be expressed as a Standard Concept from the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'est_count'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If numeric, the MIN or MAX value,  If categorical, the number of distinct subjects who were coded with this result for this item'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Auto-generated primary key for the recorded event'
+        field_type:  'integer'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'type'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A descriptor of the type of value attached to the concept,  NUM - numeric,  CAT - categorical'
+        field_type:  'string'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'cb_criteria_attribute'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'If categorical, the concept ID of the categorical value,  0 - if numeric result,  In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id_1'
+        relevant_omop_table:  'cb_criteria_relationship'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the source concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'concept_id_2'
+        relevant_omop_table:  'cb_criteria_relationship'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the destination concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'age_at_event'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The age of the Person at the event start_datetime'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'data_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier assigned to the event recorded.'
+        field_type:  'bigint'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'domain'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'dose'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for information about the dose unit of a drug exposure as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'first_mention'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the first instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'last_mention'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the last instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'num_mentions'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The number of instances of the Concept ID for the event in the Person''s record.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the event is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'ref_range'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The upper and lower limits of the normal range of a Measurement result. The range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'route'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for information about the route of administration for a drug exposure as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_code'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the event as given in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_concept_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept ID that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_name'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the event as given in the source data.'
+        field_type:  'varchar(255)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the event.'
+        field_type:  'varchar'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_code'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the event from the standard vocabulary the source was mapped to'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_concept_id'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the recorded event.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_name'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the event from the standard vocabulary.'
+        field_type:  'varchar(255)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the standard vocabulary the source was mapped to.'
+        field_type:  'varchar'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'start_datetime'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key for the date and time when the instance of the event is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Personal Medical History/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'strength'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key referring to the numeric value associated with the amount of active ingredient contained within the product.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'unit'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept ID of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An event result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'visit_type'
+        relevant_omop_table:  'cb_review_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the type of source data from which the visit record is derived belonging to the "Visit Type" vocabulary'
+        field_type:  'varchar'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'answer'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The answer selected by the Person for the question given in the "question" field.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'data_id'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier assigned to the event recorded.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the survey response is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'question'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The question within the survey given in the "survey" field being answered.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'start_datetime'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the instance of the survey response is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'survey'
+        relevant_omop_table:  'cb_review_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The title of the PPI survey.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'age_at_event'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The age of the Person at the entry date'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Concept Identifier in the Standardized Vocabularies'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'diastolic'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'the diastolic blood pressure value for PPI Physical Measurements'
+        field_type:  'float'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'entry_date'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date on which the event was recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'entry_datetime'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The datetime at which the event was recorded to have occurred'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'is_standard'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'Defines whether a concept relates to a standard vocabulary or not.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values are 1 for standard vocabulary or 0 if not. This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person being called in the search. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'systolic'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'the systolic blood pressure value for PPI Physical Measurements'
+        field_type:  'float'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An event result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept for the value in the source data. This is applicable to observations where the result can be expressed as a non-standard concept. This will largely hold only the concept IDs for PPI survey answers'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'cb_search_all_events'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the event occurred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'dob'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date of birth of the person.'
+        field_type:  'date'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench. Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'ethnicity'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique gender of the person.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person being called in the search. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench'
+
+      - 
+        field_name:  'race'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the person, belonging to the ''Race'' vocabulary.'
+        field_type:  'varchar'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth'
+        relevant_omop_table:  'cb_search_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Cohort Builder and Cohort Review tools in the Workbenc. This field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'cdm_etl_reference'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'URL or other external reference to location of ETL specification documentation and ETL source code'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_holder'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The name of the organization responsible for the development of the CDM instance'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_release_date'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The date when the CDM was instantiated'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_source_abbreviation'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'An abbreviation of the source name'
+        field_type:  'varchar(25)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_source_name'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The full name of the source'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cdm_version'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The version of CDM used'
+        field_type:  'varchar(10)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_description'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'A description of the source data origin and purpose for collection. The description may contain a summary of the period of time that is expected to be covered by this dataset.'
+        field_type:  'CLOB'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_documentation_reference'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'URL or other external reference to location of source documentation'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'source_release_date'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The date for which the source data are most current, such as the last day of data capture'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_version'
+        relevant_omop_table:  'cdm_source'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Metadata v5.2'
+        description:  'The version of the vocabulary used'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The attribute or concept class of the Concept.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Examples are "Clinical Drug", "Ingredient", "Clinical Finding" etc.'
+
+      - 
+        field_name:  'concept_code'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The concept code represents the identifier of the Concept in the source vocabulary, such as SNOMED-CT concept IDs, RxNorm RXCUIs etc.'
+        field_type:  'varchar(50)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Note that concept codes are not unique across vocabularies.'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Concept across all domains.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_name'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'An unambiguous, meaningful and descriptive name for the Concept.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the DOMAIN table the Concept belongs to.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the Concept was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are D (deleted), U (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'standard_concept'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'This flag determines where a Concept is a Standard Concept, i.e. is used in the data, a Classification Concept, or a non-standard Source Concept.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The allowables values are ''S'' (Standard Concept) and ''C'' (Classification Concept), otherwise the content is NULL.'
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept became invalid because it was deleted or superseded (updated) by a new concept.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept was first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept has no (known) date of inception.'
+
+      - 
+        field_name:  'vocabulary_id'
+        relevant_omop_table:  'concept'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the VOCABULARY table indicating from which source the Concept has been adapted.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'ancestor_concept_id'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the concept in the concept table for the higher-level concept that forms the ancestor in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'descendant_concept_id'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the concept in the concept table for the lower-level concept that forms the descendant in the relationship.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'max_levels_of_separation'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The maximum separation in number of levels of hierarchy between ancestor and descendant concepts. This is an attribute that is used to simplify hierarchic analysis.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'min_levels_of_separation'
+        relevant_omop_table:  'concept_ancestor'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The minimum separation in number of levels of hierarchy between ancestor and descendant concepts. This is an attribute that is used to simplify hierarchic analysis.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_concept_id'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique Concept Class the record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_id'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique key for each class'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_class_name'
+        relevant_omop_table:  'concept_class'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the Concept Class.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Clinical Finding", "Ingredient", etc.'
+
+      - 
+        field_name:  'concept_id_1'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the source concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_id_2'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept in the CONCEPT table associated with the relationship. Relationships are directional, and this field represents the destination concept designation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the relationship was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are ''D'' (deleted), ''U'' (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'relationship_id'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier to the type or nature of the Relationship as defined in the RELATIONSHIP table.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept Relationship became invalid because it was deleted or superseded (updated) by a new relationship.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept Relationship is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'concept_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the instance of the Concept Relationship is first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept Relationship has no (known) date of inception.'
+
+      - 
+        field_name:  'concept_id'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'concept_synonym_name'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The alternative name for the Concept.'
+        field_type:  'varchar(1000)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'language_concept_id'
+        relevant_omop_table:  'concept_synonym'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to a Concept representing the language.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Condition'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies in the ''Condition'' domain include HCPCS, ICDO3, OPCS4, and SNOMED.'
+
+      - 
+        field_name:  'condition_end_date'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is considered to have ended.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_end_datetime'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is considered to have ended.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_occurrence_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Condition Occurrence event.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_source_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Condition Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_source_value'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Condition source codes come from a variety of vocabularies; CIEL, ICD10, ICD10CM, ICD9CM, ICDO3, Read, and SNOMED are the most common.'
+
+      - 
+        field_name:  'condition_start_date'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date when the instance of the Condition is recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_start_datetime'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time when the instance of the Condition is recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_status_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the condition status as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_status_source_value'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the condition status as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_type_concept_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the source data from which the Condition was recorded, the level of standardization, and the type of occurrence.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Condition Type'' vocabulary'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the condition is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Provider in the PROVIDER table who was responsible for capturing (diagnosing) the Condition.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The reason that the Condition was no longer present, as indicated in the source data.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the unique identifier for the visit in the VISIT_OCCURRENCE table during which the Condition was determined (diagnosed).'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'condition_occurrence_id'
+        relevant_omop_table:  'condition_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the condition occurrence table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'condition_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'cause_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to a standard concept identifier in the Standardized Vocabularies for conditions.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cause_source_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the concept that refers to the code used in the source. Note, this variable name is abbreviated to ensure it will be allowable across database platforms.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'cause_source_value'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the cause of death as it appears in the source data. This code is mapped to a standard concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_date   '
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_datetime'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'death_type_concept_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to the predefined concept identifier in the Standardized Vocabularies reflecting how the death was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Codes referring to death are contained within the SNOMED Standardized Vocabulary'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'death'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the deceased person. The demographic details of that person are stored in the person table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Device'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Device'' domain; NDC, SNOMED, and dm+d are the most common.'
+
+      - 
+        field_name:  'device_exposure_end_date'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date use of the Device or supply was ceased.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_end_datetime'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time use of the Device or supply was ceased.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Device Exposure.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_start_date'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the Device or supply was applied or used.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_start_datetime'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time the Device or supply was applied or used.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_source_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Device Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_source_value'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Device as it appears in the source data. This code is mapped to a Standard Device Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for the ''Device'' domain; DPD, LPD_Belgium, NDC, SNOMED, and dm+d are the most common.'
+
+      - 
+        field_name:  'device_type_concept_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Device Exposure recorded. It indicates how the Device Exposure was represented in the source data and belongs to the ''Device Type'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Device. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who initiated or administered the Device.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of individual Devices used in the exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unique_device_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A UDI or equivalent identifying the instance of the Device used in the Person.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Device Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'device_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the Device was used.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'device_exposure_id'
+        relevant_omop_table:  'device_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the device exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'device_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'domain_concept_id'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique Domain Concept the Domain record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_id'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique key for each domain.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_name'
+        relevant_omop_table:  'domain'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the Domain.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'e.g. "Condition", "Procedure", "Measurement", etc.'
+
+      - 
+        field_name:  'days_supply'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of days of supply of the medication as prescribed. This reflects the intention of the provider for the length of exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'dose_unit_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the dose unit as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Drug'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension'
+
+      - 
+        field_name:  'drug_exposure_end_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_end_datetime'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date and time for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and time and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Drug utilization event.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_start_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date for the current instance of Drug utilization. Valid entries include a start date of a prescription, the date a prescription was filled, or the date on which a Drug administration procedure was recorded.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_start_datetime'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date and time for the current instance of Drug utilization. Valid entries include a start datetime of a prescription, the date and time a prescription was filled, or the date and time on which a Drug administration procedure was recorded.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_source_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Drug Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Drug as it appears in the source data. This code is mapped to a Standard Drug concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Drug source codes come from a variety of vocabularies; AMT, DPD, NDC, RxNorm, RxNorm Extension, SNOMED, SPL, and dm+d are the most common.'
+
+      - 
+        field_name:  'drug_type_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Drug Exposure recorded. It indicates how the Drug Exposure was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Drug Type'' vocabulary'
+
+      - 
+        field_name:  'lot_number'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'An identifier assigned to a particular quantity or lot of Drug product from the manufacturer.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Drug. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who initiated (prescribed or administered) the Drug Exposure.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The quantity of drug as recorded in the original prescription or dispensing record.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'refills'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The number of refills after the initial prescription. The initial prescription is not counted, values start with null.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values begin with null as the initial prescription is not counted'
+
+      - 
+        field_name:  'route_concept_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies reflecting the route of administration and belonging to the ''Route'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'SNOMED is the Standardized Vocabulary for the ''Route'' domain'
+
+      - 
+        field_name:  'route_source_value'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the route of administration as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'sig'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The directions (''signetur'') on the Drug prescription as recorded in the original prescription (and printed on the container) or dispensing record.'
+        field_type:  'varchar(MAX)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The reason the Drug was stopped.'
+        field_type:  'varchar(20)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Reasons include regimen completed, changed, removed, etc.'
+
+      - 
+        field_name:  'verbatim_end_date'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The known end date of a Drug Exposure as provided by the source.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'drug_exposure'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_exposure_id'
+        relevant_omop_table:  'drug_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the drug exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'drug_exposure_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'amount_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the Unit for the absolute amount of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'amount_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The numeric value associated with the amount of active ingredient contained within the product.'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'box_size'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The number of units of Clinical of Branded Drug, or Quantified Clinical or Branded Drug contained in a box as dispensed to the patient'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'denominator_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the denominator Unit for the concentration of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'denominator_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The amount of total liquid (or other divisible product, such as ointment, gel, spray, etc.).'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for Branded Drug or Clinical Drug Concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension'
+
+      - 
+        field_name:  'ingredient_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table, representing the identifier for drug Ingredient Concept contained within the drug product.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'invalid_reason'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Reason the concept was invalidated.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Possible values are ''D'' (deleted), ''U'' (replaced with an update) or NULL when valid_end_date has the default value.'
+
+      - 
+        field_name:  'numerator_unit_concept_id'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key to the Concept in the CONCEPT table representing the identifier for the numerator Unit for the concentration of active ingredient.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'numerator_value'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The numeric value associated with the concentration of the active ingredient contained in the product'
+        field_type:  'float'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'valid_end_date'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the concept became invalid because it was deleted or superseded (updated) by a new Concept.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 31-Dec-2099, meaning, the Concept is valid until it becomes deprecated.'
+
+      - 
+        field_name:  'valid_start_date'
+        relevant_omop_table:  'drug_strength'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The date when the Concept was first recorded.'
+        field_type:  'date'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The default value is 1-Jan-1970, meaning, the Concept has no (known) date of inception.'
+
+      - 
+        field_name:  'condition_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Condition'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies in the ''Condition'' domain include HCPCS, ICDO3, OPCS4, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_end_datetime'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time when the instance of the Condition is considered to have ended.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_source_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Condition Concept that refers to the code or identifier used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_source_value'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Condition source codes come from a variety of vocabularies; CIEL, ICD10, ICD10CM, ICD9CM, ICDO3, Read, and SNOMED are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_start_datetime'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time when the instance of the Condition is recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code or identifier for the Condition Status as it appears in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name representing the Condition Status as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_status_source_value'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Condition Status as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_type_concept_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the source data from which the Condition was recorded, the level of standardization, and the type of occurrence.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Condition Type'' vocabulary.  This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'condition_type_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Condition which occurred as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the condition is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Condition as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Condition.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Condition from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Condition as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the reason that the Condition is no longer present, as indicated in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_condition_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Condition was determined (diagnosed).'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'days_supply'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the number of days of supply of the medication as prescribed. This reflects the intention of the provider for the length of exposure.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'dose_unit_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the information about the dose unit as detailed in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies belonging to the ''Drug'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Drug'' domain include CPT4, CVX, HCPCS, RxNorm, and RxNorm Extension. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_exposure_end_datetime'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the end date and time for the current instance of Drug utilization. Depending on different sources, it could be a known or an inferred date and time and denotes the last day at which the patient was still exposed to Drug.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_exposure_start_datetime'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the start date and time for the current instance of Drug utilization. Valid entries include a start datetime of a prescription, the date and time a prescription was filled, or the date and time on which a Drug administration procedure was recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_source_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Drug Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the Drug as it appears in the source data. This code is mapped to a Standard Drug concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Drug source codes come from a variety of vocabularies; AMT, DPD, NDC, RxNorm, RxNorm Extension, SNOMED, SPL, and dm+d are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_type_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Drug Exposure recorded. It indicates how the Drug Exposure was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Drug Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'drug_type_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Drug involved in the exposure as it appears in the Standardized Vocabulary.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'lot_number'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an identifier assigned to a particular quantity or lot of Drug product from the manufacturer.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the drug is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the quantity of drug as recorded in the original prescription or dispensing record.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'refills'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the number of refills after the initial prescription. The initial prescription is not counted, values start with null.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values begin with null as the initial prescription is not counted. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_concept_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies reflecting the route of administration and belonging to the ''Route'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'SNOMED is the Standardized Vocabulary for the ''Route'' domain. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the route of administration of the Drug as it appears in the Standardized Vocabulary'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'route_source_value'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the information about the route of administration as detailed in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'sig'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the directions (''signetur'') on the Drug prescription as recorded in the original prescription (and printed on the container) or dispensing record.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Drug as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Drug as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Drug.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Drug from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Drug as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'stop_reason'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the reason the Drug was stopped as indicated in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Reasons include regimen completed, changed, removed, etc. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'verbatim_end_date'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the known end date of the Drug Exposure as provided by the source.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_drug_exposure'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Drug Exposure was initiated.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the standard measurement concept identifier in the Standardized Vocabularies. These belong to the ''Measurement'' domain, but could overlap with the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Measurement'' domain include CPT4, HCPCS, LOINC, OPCS4, PPI, and SNOMED. Standardized Vocabularies for the ''Observation'' domain include the vocabularies of the ''Measurement'' domain as well as APC, CDT, DRG, MDC, MMI, NUCC, PCORNet, and UB04. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_datetime'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time of the Measurement. Some database systems don''t have a datatype of time.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_source_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept in the Standard Vocabularies that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Measurement name as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Measurement source codes are typically LOINC, SNOMED, CPT4, or CIEL codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_type_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept in the Standardized Vocabularies reflecting the provenance from where the Measurement record was recorded.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Meas Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'measurement_type_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the Measurement taken as it appears in the Standardized Vocabulary'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'operator_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the predefined Concept in the Standardized Vocabularies reflecting the mathematical operator that is applied to the value_as_number.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Operators are <, <=, =, >=, > and these concepts belong to the ''Meas Value Operator'' domain. Null values indicate that there is no operator applied. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'operator_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for the mathematical operator applied to the measurement value as given in the Standardized Vocabulary.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the measurement is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'range_high'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the upper limit of the normal range of the Measurement. The upper range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'range_low'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the lower limit of the normal range of the Measurement result. The lower range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Measurement as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Measurement as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Measurement.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Measurement from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Measurement as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the units of the Measurement taken.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Measurement result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the value of the Measurement taken.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Measurement result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source value associated with the content of the value_as_number or value_as_concept_id as stored in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_measurement'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Measurement was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the standard observation concept identifier in the Standardized Vocabularies. In cases where the recorded observation is the answer to a PPI question, this field will contain the Standard Concept ID for the corresponding question (or, if the question is non-standard, its standard LOINC/SNOMED equivalent).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied for some concepts. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_datetime'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time at which the Observation was made.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_source_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept that refers to the code used in the source. If the recorded observation is the answer to a PPI question, the PPI concept for the question is stored here.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for Observations; ICD10CM, LOINC, Read, SNOMED, and SNOMED Veterinary are the most common. If the Observation is the response to a PPI question, the PPI concept for that question will be stored here. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation code as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied to some concepts. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_type_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept identifier in the Standardized Vocabularies reflecting the type of the observation belonging to the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Observation'' domain; HCPCS, LOINC, SNOMED, and SNOMED Veterinary are the most common. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'observation_type_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the type of Observation that was made.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the observation is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier for a qualifier (e.g., severity of drug-drug interaction alert) for the observation, if one exists'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for a qualifier for the observation, if one exists.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value associated with a qualifier to characterize the observation'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'questionnaire_response_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'An identifier representing the response to the question that was answered.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Observation as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Observation as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Observation.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Observation from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Observation as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept Identifier of measurement units in the Standardized Vocabularies belonging to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier for the measurement units for the observation.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain. In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard). For PPI, this field is derived from value_source_concept_id.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the obervation result. This is applicable to observation where the result can be expressed as a Standard Concept from the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation result stored as a number. This is applicable to observations where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_as_string'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the observation result stored as a string. This is applicable to observations where the result is expressed as verbatim text.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to an Observation result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  If the recorded observation is the response to a PPI question, this field will contain the PPI concept for the answer.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value associated with the content of the value_as_number or value_source_concept_id as stored in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_observation'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'date_of_birth'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time of birth of the person.'
+        field_type:  'timestamp'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench. Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'ethnicity'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The ethnicity of the person corresponding to the value of ethnicity_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The gender of the Person corresponding to the value of gender_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'gender_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique gender of the person.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'race'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The race of the Person corresponding to the value of race_concept_id as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the Person, belonging to the ''Race'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; the value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; this field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_concept_id'
+        relevant_omop_table:  'ds_person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'A foreign key to the self-reported sex at birth for the participant that refers to the source code. Available in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench; this field exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'modifier_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Standard Concept identifier for a modifier to the Procedure (e.g. bilateral).'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These concepts are typically distinguished by ''Modifier'' concept classes (e.g., ''CPT4 Modifier'' as part of the ''CPT4'' vocabulary). This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'modifier_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing a modifier to the Procedure.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the procedure is recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a standard procedure Concept identifier in the Standardized Vocabularies. These belong to the ''Procedure'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Procedure'' domain include CDT, CPT4, HCPCS, ICD10PCS, ICD9Proc, OPCS4, and SNOMED. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_datetime'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the date and time on which the Procedure was performed.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_source_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Procedure Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_source_value'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the Procedure as it appears in the source data. This code is mapped to a standard procedure Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Procedure source codes are typically ICD-9-Proc, CPT-4, HCPCS or OPCS-4 codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_type_concept_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the procedure record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Procedure Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'procedure_type_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier representing the type of Procedure performed.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the source value for the qualifier as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the quantity of procedures ordered or administered.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Procedure as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Procedure as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Procedure.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Procedure from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Procedure as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_concept_name'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit concept as it appears in the Standardized Vocabularies'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'ds_procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Procedure was carried out.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'answer'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The answer selected by the Person for the question given in the "question" field.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'answer_concept_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Standard Concept Identifier referring to the answer selected by the Person for the question given in the "question" field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whom the survey was recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'question'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The question within the survey given in the "survey" field that was answered.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'question_concept_id'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The Standard Concept Identifier referring to the question within the survey given in the "survey" field that was answered.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'survey'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The title of the PPI survey.'
+        field_type:  'string'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'survey_datetime'
+        relevant_omop_table:  'ds_survey'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time when the instance of the survey response is recorded.'
+        field_type:  'timestamp'
+        data_provenance:  'PPI'
+        source_ppi_module:  'All modules'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the admitting source for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the admitting source for a visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'admitting_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the admitting source as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the discharge disposition for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier reflecting the discharge disposition for a visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'discharge_to_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The source code for the discharge disposition as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key identifier to the Person for whome the visit was recorded. The demographic details of that Person are stored in the PERSON and ds_PERSON tables.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_code'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the code for the Condition as it appears in the source data. This code is mapped to a Standard Condition Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Condition as it appears in the source.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'source_vocabulary'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the source vocabulary for the Visit.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_code'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The code for the Visit from the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The full name of the Visit as it appears in the Standardized Vocabularies.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'standard_vocabulary'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name of the Standardized Vocabulary the source was mapped to.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_end_datetime'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time the Visit ended.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_source_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to a Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_source_value'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign code to the source code for the visit as it appears in the source data.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Visit source codes are typically UB04 Typ bill and NUCC codes. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_start_datetime'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The date and time the Visit started.'
+        field_type:  'timestamp'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_type_concept_id'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the visit record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Visit Type'' vocabulary. This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'visit_type_concept_name'
+        relevant_omop_table:  'ds_visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Workbench Support Table'
+        description:  'The name corresponding to the Standard Concept Identifier referring to the type of Visit recorded.'
+        field_type:  'string'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'This table is derived from the CDR and supports the Dataset Selector in the Workbench'
+
+      - 
+        field_name:  'domain_concept_id_1'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The concept representing the domain of fact one, from which the corresponding table can be inferred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'domain_concept_id_2'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The concept representing the domain of fact two, from which the corresponding table can be inferred.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'fact_id_1'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The unique identifier in the table corresponding to the domain of fact one.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'fact_id_2'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The unique identifier in the table corresponding to the domain of fact two.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'relationship_concept_id'
+        relevant_omop_table:  'fact_relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of relationship in the Standardized Vocabularies belonging to the ''Relationship'' domain.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabulary for the ''Relationship'' domain is SNOMED.'
+
+      - 
+        field_name:  'measurement_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the standard measurement concept identifier in the Standardized Vocabularies. These belong to the ''Measurement'' domain, but could overlap with the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Measurement'' domain include CPT4, HCPCS, LOINC, OPCS4, PPI, and SNOMED. Standardized Vocabularies for the ''Observation'' domain include the vocabularies of the ''Measurement'' domain as well as APC, CDT, DRG, MDC, MMI, NUCC, PCORNet, and UB04'
+
+      - 
+        field_name:  'measurement_date'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date of the Measurement.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_datetime'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the Measurement. Some database systems don''t have a datatype of time. To accommodate all temporal analyses, datatype datetime can be used (combining measurement_date and measurement_time forum discussion)'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Measurement.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_source_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept in the Standard Vocabularies that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Measurement name as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Measurement source codes are typically LOINC, SNOMED, CPT4, or CIEL codes.'
+
+      - 
+        field_name:  'measurement_type_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept in the Standardized Vocabularies reflecting the provenance from where the Measurement record was recorded.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Meas Type'' vocabulary.'
+
+      - 
+        field_name:  'operator_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the predefined Concept in the Standardized Vocabularies reflecting the mathematical operator that is applied to the value_as_number.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Operators are <, <=, =, >=, > and these concepts belong to the ''Meas Value Operator'' domain. Null values indicate that there is no operator applied.'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person about whom the measurement was recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for initiating or obtaining the measurement.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'range_high'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The upper limit of the normal range of the Measurement. The upper range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'range_low'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The lower limit of the normal range of the Measurement result. The lower range is assumed to be of the same unit of measure as the Measurement value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of Measurement Units in the Standardized Vocabularies that belong to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM.'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Measurement result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A Measurement result where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_source_value'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value associated with the content of the value_as_number or value_as_concept_id as stored in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Measurement was taken.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'measurement'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Measurement was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'measurement_id'
+        relevant_omop_table:  'measurement_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the measurement table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'measurement_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'observation_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the standard observation concept identifier in the Standardized Vocabularies. In cases where the recorded observation is the answer to a PPI question, this field will contain the Standard Concept ID for the corresponding question (or, if the question is non-standard, its standard LOINC/SNOMED equivalent).'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Transformations only applied to some concepts.'
+
+      - 
+        field_name:  'observation_date'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date of the observation.'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_datetime'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the observation.'
+        field_type:  'datetime'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each observation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_source_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept that refers to the code used in the source. If the recorded observation is the answer to a PPI question, the PPI concept for the question is stored here.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several types of source codes for Observations; ICD10CM, LOINC, Read, SNOMED, and SNOMED Veterinary are the most common. If the Observation is the response to a PPI question, the PPI concept for that question will be stored here.'
+
+      - 
+        field_name:  'observation_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation code as it appears in the source data. This code is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference. If the recorded observation is the answer to a PPI question, the code for the PPI question is stored here.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_type_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept identifier in the Standardized Vocabularies reflecting the type of the observation belonging to the ''Observation'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'There are several Standardized Vocabularies in the ''Observation'' domain; HCPCS, LOINC, SNOMED, and SNOMED Veterinary are the most common.'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person about whom the observation was recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for making the observation.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID for a qualifier (e.g., severity of drug-drug interaction alert)'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value associated with a qualifier to characterize the observation'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept ID of measurement units in the Standardized Vocabularies belonging to the ''Unit'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the unit as it appears in the source data. This code is mapped to a standard unit concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Unit source codes are typically CIEL, Read, SNOMED, or UCUM.'
+
+      - 
+        field_name:  'value_as_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to an observation result stored as a Concept ID. This is applicable to observations where the result can be expressed as a Standard Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.). These belong to the ''Meas Value'' domain. In cases where the recorded observation is the answer to a PPI question, this field will contain the standard PPI answer Concept ID or its standard LOINC/SNOMED equivalent (if the answer is non-standard). For PPI, this field is derived from value_source_concept_id.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Meas Value'' domain include LOINC, PPI, and SNOMED'
+
+      - 
+        field_name:  'value_as_number'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation result stored as a number. This is applicable to observations where the result is expressed as a numeric value.'
+        field_type:  'float'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_as_string'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The observation result stored as a string. This is applicable to observations where the result is expressed as verbatim text.'
+        field_type:  'varchar(60)'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'value_source_concept_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.3'
+        description:  'A foreign key to an Observation result represented as a Concept from the Standardized Vocabularies (e.g., positive/negative, present/absent, low/high, etc.).  For EHR data, these will be from the "Meas Val" domain. ,  ,  If the recorded observation is the response to a PPI question, this field will contain the PPI concept for the answer.'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_detail_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit Detail in the VISIT_DETAIL table during which the Observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'observation'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit in the VISIT_OCCURRENCE table during which the observation was recorded.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_id'
+        relevant_omop_table:  'observation_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the observation table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'observation_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'observation_period_end_date'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date of the observation period for which data are available from the data source'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_period_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each observation period'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'observation_period_start_date'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date of the observation period for which data are available from the data source'
+        field_type:  'date'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'period_type_concept_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the predefined concept in the Standardized Vocabularies reflecting the source of the observation period information, belonging to the ''Obs Period Type'' vocabulary'
+        field_type:  'integer'
+        data_provenance:  'EHR/PPI'
+        source_ppi_module:  'All modules/Consent Process/Physical Measurements'
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'observation_period'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the person for whom the observation period is defined. The demographic details of that person are stored in the person table'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'birth_datetime'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of birth of the person.'
+        field_type:  'datetime'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'care_site_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the site of primary care in the care_site table, where the details of the care site are stored.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'day_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The day of the month of birth of the person. For data sources that provide the precise date of birth, the day is extracted and stored in this field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'ethnicity_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to the standard concept identifier in the Standardized Vocabularies for the ethnicity of the person, belonging to the ''Ethnicity'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the ethnicity concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'ethnicity_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the ethnicity of the person as it appears in the source data. The person ethnicity is mapped to a standard ethnicity concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with whether or not the participant selected "Hispanic" as part of their response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that all other specific responses are excluded from the ethnicity field.'
+
+      - 
+        field_name:  'gender_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) for the participant.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'gender_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) concept for the participant that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'gender_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the self-reported gender (in R2019Q4R3) or sex at birth (in R2019Q4R3_base) for the participant as it appears in the source data. The person''s response is mapped to a standard oncept in the Standardized Vocabularies; the original value is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "What was your biological sex assigned at birth?" NOTE: This gender field contains the response to the sex at birth question in R2019Q4R3_base but the response to the gender identity question in R2019Q4R3.'
+
+      - 
+        field_name:  'location_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the place of residency for the person in the location table, where the detailed address information is stored.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'month_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The month of birth of the person. For data sources that provide the precise date of birth, the month is extracted and stored in this field.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each person.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'An (encrypted) key derived from the person identifier in the source data. This is necessary when a use case requires a link back to the person data at the source dataset.'
+        field_type:  'varchar(50)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the primary care provider the person is seeing in the provider table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'race_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique race of the person, belonging to the ''Race'' vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the race concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'race_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the race of the person as it appears in the source data. The person race is mapped to a standard race concept in the Standardized Vocabularies and the original value is stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The value of this field from the EHR is suppressed and repopulated with the response to the PPI question "Which categories describe you? ,   Select all that apply. Note, you may select more than one group."; note that the response "Hispanic" is excluded from the race field.'
+
+      - 
+        field_name:  'sex_at_birth_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_id for the "Sex at Birth" PPI question (observation_source_concept_id = 1585845) representing the participant''s self-reported sex at birth for R2019Q4R3 ONLY'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_source_concept_id'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'A foreign key to the self-reported sex at birth for the participant that refers to the source code. Available in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'sex_at_birth_source_value'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us field'
+        description:  'The concept_code associated with the participant''s provided sex at birth concept_id in R2019Q4R3 ONLY.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'The Basics'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Exists only in R2019Q4R3 and contains the response to the PPI question "What was your biological sex assigned at birth?"'
+
+      - 
+        field_name:  'year_of_birth'
+        relevant_omop_table:  'person'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The year of birth of the person. For data sources with date of birth, the year is extracted. For data sources where the year of birth is not available, the approximate year of birth is derived based on any age group categorization available.'
+        field_type:  'integer'
+        data_provenance:  'PPI'
+        source_ppi_module:  'Consent Process'
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Participants over the age of 89 are dropped.'
+
+      - 
+        field_name:  'modifier_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for a modifier to the Procedure (e.g. bilateral).'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These concepts are typically distinguished by ''Modifier'' concept classes (e.g., ''CPT4 Modifier'' as part of the ''CPT4'' vocabulary).'
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person who is subjected to the Procedure. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a standard procedure Concept identifier in the Standardized Vocabularies. These belong to the ''Procedure'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Procedure'' domain include CDT, CPT4, HCPCS, ICD10PCS, ICD9Proc, OPCS4, and SNOMED'
+
+      - 
+        field_name:  'procedure_date'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date on which the Procedure was performed.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_datetime'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time on which the Procedure was performed.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A system-generated unique identifier for each Procedure Occurrence.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_source_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Procedure Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_source_value'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the Procedure as it appears in the source data. This code is mapped to a standard procedure Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Procedure source codes are typically ICD-9-Proc, CPT-4, HCPCS or OPCS-4 codes.'
+
+      - 
+        field_name:  'procedure_type_concept_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the procedure record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Procedure Type'' vocabulary.'
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the PROVIDER table who was responsible for carrying out the procedure.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'qualifier_source_value'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source value for the qualifier as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The quantity of procedures ordered or administered.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Procedure was carried out.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'procedure_occurrence_id'
+        relevant_omop_table:  'procedure_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the procedure occurrence table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'procedure_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'defines_ancestry'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Defines whether a hierarchical relationship contributes to the concept_ancestor table. These are subsets of the hierarchical relationships.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Valid values are 1 or 0.'
+
+      - 
+        field_name:  'is_hierarchical'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Defines whether a relationship defines concepts into classes or hierarchies.'
+        field_type:  'varchar(1)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Values are 1 for hierarchical relationship or 0 if not.'
+
+      - 
+        field_name:  'relationship_concept_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to an identifier in the CONCEPT table for the unique relationship concept.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabulary for the ''Relationship'' domain is SNOMED.'
+
+      - 
+        field_name:  'relationship_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The type of relationship captured by the relationship record.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'relationship_name'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The text that describes the relationship type.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'reverse_relationship_id'
+        relevant_omop_table:  'relationship'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The identifier for the relationship used to define the reverse relationship between two concepts.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'anatomic_site_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the anatomic location of specimen collection.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'anatomic_site_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the anatomic site as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'disease_status_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the Disease Status of specimen collection.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'disease_status_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the disease status as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the Specimen is recorded.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'quantity'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The amount of specimen collection from the person during the sampling procedure.'
+        field_type:  'float'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to a Standard Concept identifier in the Standardized Vocabularies for the Specimen belonging to the ''Specimen'' domain.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'The Standardized Vocabularies for the ''Specimen'' domain are SNOMED and SNOMED Veterinary.'
+
+      - 
+        field_name:  'specimen_date'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date the specimen was obtained from the Person.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_datetime'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time on the date when the Specimen was obtained from the person.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each specimen.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_source_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Specimen identifier as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Source codes for the Specimen domain are typically CIEL, Read, SNOMED, or SNOMED Veterinary codes'
+
+      - 
+        field_name:  'specimen_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The Specimen value as it appears in the source data. This value is mapped to a Standard Concept in the Standardized Vocabularies and the original code is, stored here for reference.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'specimen_type_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key referring to the Concept identifier in the Standardized Vocabularies reflecting the system of record from which the Specimen was represented in the source data.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'unit_concept_id'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Standard Concept identifier for the Unit associated with the numeric quantity of the Specimen collection belonging to the ''Unit'' domain/'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for the ''Unit'' domain include UCUM and SNOMED.'
+
+      - 
+        field_name:  'unit_source_value'
+        relevant_omop_table:  'specimen'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The information about the Unit as detailed in the source.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'admitting_source_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the admitting source for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary'
+
+      - 
+        field_name:  'admitting_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the admitting source as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'care_site_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the care site in the care site table that was visited'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'discharge_to_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined concept in the Place of Service Vocabulary reflecting the discharge disposition for a visit.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Place of Service'' Vocabulary'
+
+      - 
+        field_name:  'discharge_to_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the discharge disposition as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'person_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key identifier to the Person for whom the visit is recorded. The demographic details of that Person are stored in the PERSON table.'
+        field_type:  'bigint'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'preceding_visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the visit_occurrence table of the visit immediately preceding this visit.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'provider_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the provider in the provider table who was associated with the visit.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key that refers to a visit Concept identifier in the Standardized Vocabularies belonging to the ''Visit'' Vocabulary.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Standardized Vocabularies for Visit include Visit, UB04 Typ bill, NUCC, and CMS Place of Service, among others'
+
+      - 
+        field_name:  'visit_end_date'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The end date of the visit. If this is a one-day visit the end date should match the start date.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_end_datetime'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the visit end.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A unique identifier for each Person''s visit or encounter at a healthcare provider.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_source_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to a Concept that refers to the code used in the source.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_source_value'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The source code for the visit as it appears in the source data.'
+        field_type:  'varchar(50)'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Visit source codes are typically UB04 Typ bill and NUCC codes.'
+
+      - 
+        field_name:  'visit_start_date'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The start date of the visit.'
+        field_type:  'date'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_start_datetime'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'The date and time of the visit started.'
+        field_type:  'datetime'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  True
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'visit_type_concept_id'
+        relevant_omop_table:  'visit_occurrence'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Clinical Data Table v5.2'
+        description:  'A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the visit record is derived.'
+        field_type:  'integer'
+        data_provenance:  'EHR'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'These belong to the ''Visit Type'' vocabulary.'
+
+      - 
+        field_name:  'src_id'
+        relevant_omop_table:  'visit_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'An identifier delineating whether data was EHR or Program data and, if EHR, representing the recruiting site providing the data with a numeric code.'
+        field_type:  'varchar'
+        data_provenance:  'AoU Metadata (Internally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  'Value will be a code representing the site contributing the EHR for EHR data and "PPI/PM" for Program data'
+
+      - 
+        field_name:  'visit_occurrence_id'
+        relevant_omop_table:  'visit_occurrence_ext'
+        omop_cdm_standard_or_custom_field:  'Custom All of Us Metadata Table'
+        description:  'A foreign key to the unique identifier for the row in the device exposure table.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_concept_id'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A foreign key that refers to a standard concept identifier in the CONCEPT table for the Vocabulary the VOCABULARY record belongs to.'
+        field_type:  'integer'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_id'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'A unique identifier for each Vocabulary, such as ICD9CM, SNOMED, Visit.'
+        field_type:  'varchar(20)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_name'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'The name describing the vocabulary, for example "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 1 and 2 (NCHS)" etc.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_reference'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'External reference to documentation or available download of the about the vocabulary.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  
+
+      - 
+        field_name:  'vocabulary_version'
+        relevant_omop_table:  'vocabulary'
+        omop_cdm_standard_or_custom_field:  'OMOP Standardized Vocabularies v5.2'
+        description:  'Version of the Vocabulary as indicated in the source.'
+        field_type:  'varchar(255)'
+        data_provenance:  'OMOP CDM Metadata (Externally generated)'
+        source_ppi_module:  
+        transformed_by_registered_tier_privacy_methods:  
+        transformation_applied_(registered_tier):  
+        transformed_by_privacy_methodology_(controlled_tier):  
+        transformation_applied_(controlled_tier):  
+        data_cleaning_rule_(cdr_clean):  
+        additional_notes:  

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -342,7 +342,7 @@ export class ValueListItem extends React.Component<
                 color: colors.accent, height: 18, width: 18}} />
             </Clickable>
           </FlexRow>
-          {showDataDictionaryEntry && <DataDictionaryDescription dataDictionaryEntry={dataDictionaryEntry}/>}
+          {!dataDictionaryEntryError && showDataDictionaryEntry && <DataDictionaryDescription dataDictionaryEntry={dataDictionaryEntry}/>}
           {dataDictionaryEntryError && showDataDictionaryEntry && <div>Data Dictionary Entry not found.</div>}
         </div>
       </FlexRow>


### PR DESCRIPTION
Update Data Dictionary entries to include say sex_at_birth_concept_id, sex_at_birth
<img width="470" alt="Screen Shot 2020-07-02 at 1 35 59 PM" src="https://user-images.githubusercontent.com/34481816/86393282-d1c31600-bc6a-11ea-90b7-2b1563bd27de.png">

Input file ref: https://github.com/all-of-us/cdrdatadictionary/blob/development/yaml_files/CDRDD_R2019Q4R3_20200701.yaml 

Also as part of this PR, if there is no data dictionary is not present for a value,   remove the loading spinner and just show the message "Data Dictionary not found" 
This is just an example :
<img width="468" alt="Screen Shot 2020-07-02 at 1 55 21 PM" src="https://user-images.githubusercontent.com/34481816/86393899-ae4c9b00-bc6b-11ea-889a-5edb0dae97fd.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
