### PR TITLE
[risk=no] Revert CB age options change

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -100,7 +100,7 @@
     "useKeylessDelegatedCredentials": true,
     "sendFreeTierAlertEmails": true,
     "enableMoodleV2Api": true,
-    "enableCBAgeTypeOptions": true,
+    "enableCBAgeTypeOptions": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,


### PR DESCRIPTION
Disables `enableCBAgeTypeOptions` in test env