### PR TITLE
[noTicket][RISK=HIGH]Needs research prompt update always setting to true on update

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -691,7 +691,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             });
           workspace = cloneWorkspace.workspace;
         } else {
-          workspace.researchPurpose.needsReviewPrompt = true;
+          workspace.researchPurpose.needsReviewPrompt = false;
           workspace = await workspacesApi()
               .updateWorkspace(this.state.workspace.namespace, this.state.workspace.id,
                   {workspace: this.state.workspace});


### PR DESCRIPTION
As part of the story:
https://precisionmedicineinitiative.atlassian.net/browse/RW-2400

Researchers are supposed to be prompted with an information banner to approve/update the research purpose if the workspace has been created and year back or 15 days earlier. There is a cron job that runs every night to updates the attribute need_research_review_prompt to true ,if workspace is 15 days or an year old. This cron job is enabled only on TEST.

There is a bug in the story,  the update workspace call was always setting the attribute need_research_review_prompt to true hence irrespective of the environment if the user will update the workspace , they will start seeing the information banner rather than other way around.
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
