### PR TITLE
[noTicket][RISK=LOW] Use config flag in UI to show Research Review Prompt

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -40,6 +40,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableV3DataUserCodeOfConduct(config.featureFlags.enableV3DataUserCodeOfConduct)
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
             .useNewShibbolethService(config.featureFlags.useNewShibbolethService)
-            .enableCohortBuilderV2(config.featureFlags.enableCohortBuilderV2));
+            .enableCohortBuilderV2(config.featureFlags.enableCohortBuilderV2)
+            .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt));
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3799,6 +3799,10 @@ definitions:
         type: boolean
         default: false
         description: Whether to use the Cohort Builder UI.
+      enableResearchReviewPrompt:
+        type: boolean
+        default: false
+        description: Whether user should see a prompt if Workspace Research Purpose needs Review
   FeaturedWorkspacesConfigResponse:
     type: object
     properties:

--- a/ui/src/app/guards/workspace-guard.service.ts
+++ b/ui/src/app/guards/workspace-guard.service.ts
@@ -14,7 +14,6 @@ export class WorkspaceGuard implements CanActivate, CanActivateChild {
     private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    console.log(serverConfigStore.getValue().enableResearchReviewPrompt);
     if (serverConfigStore.getValue().enableResearchReviewPrompt && route.routeConfig.path === 'data' ||
         route.routeConfig.path === 'notebooks') {
       this.workspaceService.getWorkspace(route.params.ns, route.params.wsid).subscribe(workspace => {

--- a/ui/src/app/guards/workspace-guard.service.ts
+++ b/ui/src/app/guards/workspace-guard.service.ts
@@ -3,6 +3,7 @@ import {
   ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router,
   RouterStateSnapshot
 } from '@angular/router';
+import {serverConfigStore} from 'app/utils/navigation';
 import {WorkspacesService} from 'generated';
 import {Observable} from 'rxjs/Observable';
 
@@ -13,7 +14,8 @@ export class WorkspaceGuard implements CanActivate, CanActivateChild {
     private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    if (route.routeConfig.path === 'data' ||
+    console.log(serverConfigStore.getValue().enableResearchReviewPrompt);
+    if (serverConfigStore.getValue().enableResearchReviewPrompt && route.routeConfig.path === 'data' ||
         route.routeConfig.path === 'notebooks') {
       this.workspaceService.getWorkspace(route.params.ns, route.params.wsid).subscribe(workspace => {
         if (workspace.accessLevel === 'OWNER'

--- a/ui/src/app/pages/workspace/research-purpose.tsx
+++ b/ui/src/app/pages/workspace/research-purpose.tsx
@@ -15,6 +15,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {navigate} from 'app/utils/navigation';
+import {serverConfigStore} from 'app/utils/navigation';
 import {
   getSelectedPopulations,
   getSelectedResearchPurposeItems
@@ -105,7 +106,8 @@ export const ResearchPurpose = withCurrentWorkspace()(
                               style={styles.editIcon}/>
         </Clickable>
       </div>
-      {isOwner && workspace.researchPurpose.needsReviewPrompt && <FlexRow style={styles.reviewPurposeReminder}>
+      {serverConfigStore.getValue().enableResearchReviewPrompt && isOwner
+        && workspace.researchPurpose.needsReviewPrompt && <FlexRow style={styles.reviewPurposeReminder}>
         <ClrIcon style={{color: colors.warning, marginLeft: '0.3rem'}} className='is-solid'
         shape='exclamation-triangle' size='25'/>
         <FlexColumn style={{paddingRight: '0.5rem', paddingLeft: '0.5rem', color: colors.primary}}>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -18,6 +18,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {displayDate, reactStyles} from 'app/utils';
 import {AnalyticsTracker, triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore, navigate} from 'app/utils/navigation';
+import {serverConfigStore} from 'app/utils/navigation';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 
 const EVENT_CATEGORY = 'Workspace list';
@@ -233,7 +234,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
 
   onClick() {
     const {workspace} = this.props;
-    if (workspace.researchPurpose.needsReviewPrompt) {
+    if (serverConfigStore.getValue().enableResearchReviewPrompt && workspace.researchPurpose.needsReviewPrompt) {
       this.setState({showResearchPurposeReviewModal: true});
     } else {
       workspace.published ?

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -691,7 +691,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             });
           workspace = cloneWorkspace.workspace;
         } else {
-          workspace.researchPurpose.needsReviewPrompt = true;
+          workspace.researchPurpose.needsReviewPrompt = false;
           workspace = await workspacesApi()
               .updateWorkspace(this.state.workspace.namespace, this.state.workspace.id,
                   {workspace: this.state.workspace});

--- a/ui/src/app/pages/workspace/workspace-list.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.spec.tsx
@@ -43,7 +43,7 @@ describe('WorkspaceList', () => {
     });
 
     userProfileStore.next({profile, reload, updateCache});
-    serverConfigStore.next({gsuiteDomain: 'abc'});
+    serverConfigStore.next({gsuiteDomain: 'abc', enableResearchReviewPrompt: true});
   });
 
   it('displays the correct number of workspaces', async() => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -1,5 +1,5 @@
 import {WorkspaceNavBarReact} from 'app/pages/workspace/workspace-nav-bar';
-import {currentWorkspaceStore, NavStore, urlParamsStore} from 'app/utils/navigation';
+import {currentWorkspaceStore, NavStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 import {mount} from 'enzyme';
 import * as React from 'react';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
@@ -17,6 +17,8 @@ describe('WorkspaceNavBarComponent', () => {
 
     currentWorkspaceStore.next(workspaceDataStub);
     urlParamsStore.next({ns: workspaceDataStub.namespace, wsid: workspaceDataStub.id});
+    serverConfigStore.next({
+      gsuiteDomain: 'fake-research-aou.org', enableResearchReviewPrompt: true});
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -5,6 +5,7 @@ import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams} from 'app/utils';
 import {NavStore} from 'app/utils/navigation';
 
+import {serverConfigStore} from 'app/utils/navigation';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
@@ -45,7 +46,7 @@ const tabs = [
 const navSeparator = <div style={styles.separator}/>;
 
 function restrictTab(workspace, tab) {
-  return workspace && workspace.accessLevel === 'OWNER'
+  return serverConfigStore.getValue().enableResearchReviewPrompt && workspace && workspace.accessLevel === 'OWNER'
       && workspace.researchPurpose.needsReviewPrompt && tab.name !== 'About';
 }
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -6,9 +6,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {ClarityModule} from '@clr/angular';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
-import {ServerConfigService} from 'app/services/server-config.service';
 import {registerApiClient, workspacesApi} from 'app/services/swagger-fetch-clients';
-import {urlParamsStore} from 'app/utils/navigation';
+import {serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 
 import {BugReportComponent} from 'app/components/bug-report';
 import {ConfirmDeleteModalComponent} from 'app/components/confirm-delete-modal';
@@ -21,7 +20,6 @@ import {UserService, WorkspaceAccessLevel} from 'generated';
 import {WorkspacesApi} from 'generated/fetch';
 
 import {ProfileStorageServiceStub} from 'testing/stubs/profile-storage-service-stub';
-import {ServerConfigServiceStub} from 'testing/stubs/server-config-service-stub';
 import {UserServiceStub} from 'testing/stubs/user-service-stub';
 import {WorkspacesServiceStub} from 'testing/stubs/workspace-service-stub';
 import {WorkspacesApiStub, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
@@ -66,13 +64,6 @@ describe('WorkspaceWrapperComponent', () => {
       providers: [
         {provide: ProfileStorageService, useValue: new ProfileStorageServiceStub()},
         {provide: UserService, useValue: new UserServiceStub()},
-        {
-          provide: ServerConfigService,
-          useValue: new ServerConfigServiceStub({
-            gsuiteDomain: 'fake-research-aou.org',
-            enableResearchReviewPrompt: true
-          })
-        },
       ]
     }).compileComponents().then(() => {
       registerApiClient(WorkspacesApi, new WorkspacesApiStub());
@@ -83,6 +74,8 @@ describe('WorkspaceWrapperComponent', () => {
         ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
         wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
       });
+      serverConfigStore.next({gsuiteDomain: 'fake-research-aou.org',
+        enableResearchReviewPrompt: true});
     });
   }));
 


### PR DESCRIPTION
As part of the story https://precisionmedicineinitiative.atlassian.net/browse/RW-2400
A prompt to review research purpose is displayed if the workspace attribute needs_research_purpose_prompt is set to true.

This PR adds Flag check in UI to restrict the prompt on PROD/STABLE/STAGING/PERF enviornment

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
