### PR TITLE
[RW-5088][risk=no] Sort institutions by display name

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.institution;
 
 import com.google.common.base.Strings;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -81,6 +82,7 @@ public class InstitutionServiceImpl implements InstitutionService {
   public List<Institution> getInstitutions() {
     return StreamSupport.stream(institutionDao.findAll().spliterator(), false)
         .map(this::toModel)
+        .sorted(Comparator.comparing(institution -> institution.getDisplayName()))
         .collect(Collectors.toList());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
@@ -75,13 +76,16 @@ public class InstitutionServiceTest {
     final Institution anotherInst =
         new Institution()
             .shortName("otherInst")
-            .displayName("The Institution of testing")
+            .displayName("An Institution for Testing")
             .emailDomains(Collections.emptyList())
             .emailAddresses(Collections.emptyList())
             .organizationTypeEnum(OrganizationType.INDUSTRY);
     assertThat(service.createInstitution(anotherInst)).isEqualTo(anotherInst);
 
     assertThat(service.getInstitutions()).containsExactly(roundTrippedTestInst, anotherInst);
+    Comparator<Institution> comparator =
+        Comparator.comparing(institution -> institution.getDisplayName());
+    assertThat(service.getInstitutions()).isStrictlyOrdered(comparator);
   }
 
   @Test


### PR DESCRIPTION
Does simple sorting on the server side. Tested locally by adding a "Greg" institution, which gets sorted correctly in the middle:

<img width="500" alt="Screen Shot 2020-07-08 at 4 25 23 PM" src="https://user-images.githubusercontent.com/51842/86966874-d474ae00-c137-11ea-974c-aa053e5c94fc.png">

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally