### PR TITLE
[risk=no] Include timestamp in metrics export

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
@@ -93,8 +94,6 @@ public class ExportWorkspaceData {
 
   private static Options options = new Options().addOption(exportFilenameOpt);
 
-  private static SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
-
   // Short circuit the DI wiring here with a "mock" WorkspaceService
   // Importing the real one requires importing a large subtree of dependencies
   @Bean
@@ -123,6 +122,7 @@ public class ExportWorkspaceData {
   private UserDao userDao;
   private WorkspacesApi workspacesApi;
   private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
+  private SimpleDateFormat dateFormat;
 
   @Bean
   public CommandLineRunner run(
@@ -144,6 +144,10 @@ public class ExportWorkspaceData {
     this.userDao = userDao;
     this.workspacesApi = workspacesApi;
     this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
+    this.dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+    // Just pick a consistent Time Zone. Most of the reporting is handled in Central Time, so we
+    // just use that here.
+    this.dateFormat.setTimeZone(TimeZone.getTimeZone("CST"));
 
     return (args) -> {
       CommandLine opts = new DefaultParser().parse(options, args);

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/WorkspaceExportRow.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/WorkspaceExportRow.java
@@ -73,7 +73,7 @@ public class WorkspaceExportRow {
     this.twoFactorAuthCompletionDate = twoFactorAuthCompletionDate;
   }
 
-  @CsvBindByName(column = "2fa Completion Date")
+  @CsvBindByName(column = "2fa Completion Time (CST)")
   @CsvBindByPosition(position = 5)
   private String twoFactorAuthCompletionDate;
 
@@ -85,7 +85,7 @@ public class WorkspaceExportRow {
     this.eraCompletionDate = eraCompletionDate;
   }
 
-  @CsvBindByName(column = "eRA Completion Date")
+  @CsvBindByName(column = "eRA Completion Time (CST)")
   @CsvBindByPosition(position = 6)
   private String eraCompletionDate;
 
@@ -97,7 +97,7 @@ public class WorkspaceExportRow {
     this.trainingCompletionDate = trainingCompletionDate;
   }
 
-  @CsvBindByName(column = "Training Completion Date")
+  @CsvBindByName(column = "Training Completion Time (CST)")
   @CsvBindByPosition(position = 7)
   private String trainingCompletionDate;
 
@@ -109,7 +109,7 @@ public class WorkspaceExportRow {
     this.duccCompletionDate = duccCompletionDate;
   }
 
-  @CsvBindByName(column = "DUCC Completion Date")
+  @CsvBindByName(column = "DUCC Completion Time (CST)")
   @CsvBindByPosition(position = 8)
   private String duccCompletionDate;
 
@@ -145,7 +145,7 @@ public class WorkspaceExportRow {
     this.createdDate = createdDate;
   }
 
-  @CsvBindByName(column = "Workspace Created Date")
+  @CsvBindByName(column = "Workspace Created Time (CST)")
   @CsvBindByPosition(position = 11)
   private String createdDate;
 
@@ -289,7 +289,7 @@ public class WorkspaceExportRow {
     this.workspaceLastUpdatedDate = workspaceLastUpdatedDate;
   }
 
-  @CsvBindByName(column = "Workspace Last Updated Date")
+  @CsvBindByName(column = "Workspace Last Updated Time (CST)")
   @CsvBindByPosition(position = 23)
   private String workspaceLastUpdatedDate;
 


### PR DESCRIPTION
Per Karthik's request, include timestamp. I've just hardcoded it to CST since I didn't see a clear way to handle time zones in Google sheets. Karthik confirmed this was fine.