### PR TITLE
[no ticket][risk=no] Puppeteer variables rename and remove unnecessary function calls

### DIFF
--- a/e2e/app/component/concept-domain-card.ts
+++ b/e2e/app/component/concept-domain-card.ts
@@ -28,6 +28,7 @@ export default class ConceptDomainCard extends Container {
 
   async clickSelectConceptButton(): Promise<void> {
     const selectConceptButton = await this.getSelectConceptButton();
+    await selectConceptButton.waitUntilEnabled();
     await selectConceptButton.click();
     await this.page.waitForXPath('//*[@data-test-id="conceptTable"]', {visible: true});
     await waitWhileLoading(this.page);

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -12,7 +12,7 @@ const Selector = {
   defaultDialog: '//*[@role="dialog"]',
 }
 
-export default class Dialog extends Container {
+export default class Modal extends Container {
 
   constructor(page: Page, xpath: string = Selector.defaultDialog) {
     super(page, xpath);
@@ -25,16 +25,16 @@ export default class Dialog extends Container {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);
       const title = await this.page.title();
-      console.error(`${title}: dialog waitForLoad() encountered ${e}`);
+      console.error(`${title}: modal waitForLoad() encountered ${e}`);
       throw e;
     }
     return this;
   }
 
   async getContent(): Promise<string> {
-    const dialog = await this.page.waitForXPath(this.xpath, {visible: true});
-    const modalText = await (await dialog.getProperty('innerText')).jsonValue();
-    console.debug('dialog: \n' + modalText);
+    const modal = await this.page.waitForXPath(this.xpath, {visible: true});
+    const modalText = await (await modal.getProperty('innerText')).jsonValue();
+    console.debug('Modal: \n' + modalText);
     return modalText.toString();
   }
 
@@ -60,7 +60,7 @@ export default class Dialog extends Container {
     return Checkbox.findByName(this.page, {name: checkboxName}, this);
   }
 
-  async waitUntilDialogIsClosed(timeOut: number = 60000): Promise<void> {
+  async waitUntilClose(timeOut: number = 60000): Promise<void> {
     await this.page.waitForXPath(this.xpath, {hidden: true, timeout: timeOut});
   }
 

--- a/e2e/app/component/share-modal.ts
+++ b/e2e/app/component/share-modal.ts
@@ -1,11 +1,11 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {LinkText, WorkspaceAccessLevel} from 'app/text-labels';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import Textbox from 'app/element/textbox';
 import ClrIcon from 'app/element/clr-icon-link';
 
 
-export default class ShareModal extends Dialog {
+export default class ShareModal extends Modal {
 
   constructor(page: Page, xpath?: string) {
     super(page, xpath);
@@ -25,7 +25,7 @@ export default class ShareModal extends Dialog {
     await ownerOpt.click();
 
     await this.clickButton(LinkText.Save);
-    await this.waitUntilDialogIsClosed();
+    await this.waitUntilClose();
   }
 
   async removeUser(username: string): Promise<void> {
@@ -34,7 +34,7 @@ export default class ShareModal extends Dialog {
     await rmCollab.click();
 
     await this.clickButton(LinkText.Save);
-    return this.waitUntilDialogIsClosed();
+    return this.waitUntilClose();
   }
 
   /**

--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -6,7 +6,7 @@ import {Page} from 'puppeteer';
  */
 export default class Container {
 
-  constructor(protected readonly page: Page, protected xpath: string) { }
+  constructor(protected readonly page: Page, protected xpath?: string) { }
 
   getXpath(): string {
     return this.xpath;

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -1,6 +1,7 @@
 import {ClickOptions, ElementHandle, Page, WaitForSelectorOptions} from 'puppeteer';
 import Container from 'app/container';
 
+
 /**
  * BaseElement represents a web element in the DOM.
  * It implements useful methods for querying and interacting with this element.
@@ -15,7 +16,7 @@ export default class BaseElement extends Container {
 
   private element: ElementHandle;
 
-  constructor(protected readonly page: Page, xpath?: string) {
+  constructor(protected readonly page: Page, protected readonly xpath?: string) {
     super(page, xpath);
   }
 

--- a/e2e/app/element/button.ts
+++ b/e2e/app/element/button.ts
@@ -1,4 +1,4 @@
-import {JSHandle, Page, WaitForSelectorOptions} from 'puppeteer';
+import {JSHandle, Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -12,17 +12,15 @@ export default class Button extends BaseElement {
    * @param {Container} container Parent node if one exists. Normally, it is a Dialog or Modal window.
    * @param {WaitForSelectorOptions} waitOptions.
    */
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<Button> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Button> {
     xOpt.type = ElementType.Button;
     const butnXpath = buildXPath(xOpt, container);
     const button = new Button(page, butnXpath);
-    await button.waitForXPath(waitOptions);
     return button;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
   /**

--- a/e2e/app/element/checkbox.ts
+++ b/e2e/app/element/checkbox.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,17 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class Checkbox extends BaseElement {
    
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<Checkbox> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Checkbox> {
     xOpt.type = ElementType.Checkbox;
     const checkboxXpath = buildXPath(xOpt, container);
     const checkbox = new Checkbox(page, checkboxXpath);
-    await checkbox.waitForXPath(waitOptions);
     return checkbox;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
   /**

--- a/e2e/app/element/clr-icon-link.ts
+++ b/e2e/app/element/clr-icon-link.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,17 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class ClrIconLink extends BaseElement {
 
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<ClrIconLink> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<ClrIconLink> {
     xOpt.type = ElementType.Icon;
     const iconXpath = buildXPath(xOpt, container);
     const iconLink = new ClrIconLink(page, iconXpath);
-    await iconLink.waitForXPath(waitOptions);
     return iconLink;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
   /**

--- a/e2e/app/element/input-number.ts
+++ b/e2e/app/element/input-number.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,16 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class InputNumber extends BaseElement {
 
-  static async findByName(page: Page,
-                           xOpt: XPathOptions,
-                           container?: Container,
-                           waitOptions: WaitForSelectorOptions = {visible: true}): Promise<InputNumber> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<InputNumber> {
     xOpt.type = ElementType.Number;
     const xpath = buildXPath(xOpt, container);
     const input = new InputNumber(page, xpath);
-    await input.waitForXPath(waitOptions);
     return input;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
 }

--- a/e2e/app/element/link.ts
+++ b/e2e/app/element/link.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,18 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class Link extends BaseElement {
    
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<Link> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Link> {
     xOpt.type = ElementType.Link;
     const linkXpath = buildXPath(xOpt, container);
     const link = new Link(page, linkXpath);
-    await link.waitForXPath(waitOptions);
     return link;
   }
 
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
+  }
 
 }

--- a/e2e/app/element/radiobutton.ts
+++ b/e2e/app/element/radiobutton.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,17 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class RadioButton extends BaseElement {
    
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<RadioButton> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<RadioButton> {
     xOpt.type = ElementType.RadioButton;
     const radioButtonXpath = buildXPath(xOpt, container);
     const radioButton = new RadioButton(page, radioButtonXpath);
-    await radioButton.waitForXPath(waitOptions);
     return radioButton;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
   async isSelected(): Promise<boolean> {

--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -11,17 +11,15 @@ export default class Select extends BaseElement {
 
   private selectedOption;
    
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<Select> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Select> {
     xOpt.type = ElementType.Select;
     const selectXpath = buildXPath(xOpt, container);
     const select = new Select(page, selectXpath);
-    await select.waitForXPath(waitOptions);
     return select;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
   async selectOption(optionValue: string): Promise<string> {

--- a/e2e/app/element/textarea.ts
+++ b/e2e/app/element/textarea.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -6,17 +6,15 @@ import {buildXPath} from 'app/xpath-builders';
 
 export default class Textarea extends BaseElement {
 
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = { visible: true }): Promise<Textarea> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Textarea> {
     xOpt.type = ElementType.Textarea;
     const textareaXpath = buildXPath(xOpt, container);
     const textarea = new Textarea(page, textareaXpath);
-    await textarea.waitForXPath(waitOptions);
     return textarea;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
 }

--- a/e2e/app/element/textbox.ts
+++ b/e2e/app/element/textbox.ts
@@ -1,4 +1,4 @@
-import {Page, WaitForSelectorOptions} from 'puppeteer';
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import BaseElement from './base-element';
@@ -9,17 +9,15 @@ import {buildXPath} from 'app/xpath-builders';
  */
 export default class Textbox extends BaseElement {
 
-  static async findByName(
-     page: Page,
-     xOpt: XPathOptions,
-     container?: Container,
-     waitOptions: WaitForSelectorOptions = {visible: true}): Promise<Textbox> {
-
+  static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Textbox> {
     xOpt.type = ElementType.Textbox;
     const textboxXpath = buildXPath(xOpt, container);
     const textbox = new Textbox(page, textboxXpath);
-    await textbox.waitForXPath(waitOptions);
     return textbox;
+  }
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
   }
 
 }

--- a/e2e/app/page/analysis-page.ts
+++ b/e2e/app/page/analysis-page.ts
@@ -2,7 +2,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import Button from 'app/element/button';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
@@ -37,17 +37,17 @@ export default class AnalysisPage extends AuthenticatedPage {
     const menu = resourceCard.getEllipsis();
     await menu.clickAction(EllipsisMenuAction.Delete, {waitForNav: false});
 
-    const dialog = new Dialog(this.page);
-    const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteNotebook}, dialog);
+    const modal = new Modal(this.page);
+    const modalContentText = await modal.getContent();
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteNotebook}, modal);
     await Promise.all([
       deleteButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
     ]);
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Notebook "${notebookName}"`);
-    return dialogContentText;
+    return modalContentText;
   }
 
 }

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -1,5 +1,5 @@
 import {Page} from 'puppeteer';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import TieredMenu from 'app/component/tiered-menu';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
@@ -64,17 +64,17 @@ export default class CohortBuildPage extends AuthenticatedPage {
       description = faker.lorem.words(10);
     }
 
-    const dialog = new Dialog(this.page);
-    const nameTextbox = await dialog.waitForTextbox('COHORT NAME');
+    const modal = new Modal(this.page);
+    const nameTextbox = await modal.waitForTextbox('COHORT NAME');
     await nameTextbox.type(cohortName);
 
-    const descriptionTextarea = await dialog.waitForTextarea('DESCRIPTION');
+    const descriptionTextarea = await modal.waitForTextarea('DESCRIPTION');
     await descriptionTextarea.type(description);
 
     const saveButton = await Button.findByName(this.page, {name: LinkText.Save});
     await saveButton.waitUntilEnabled();
     await saveButton.click();
-    await dialog.waitUntilDialogIsClosed();
+    await modal.waitUntilClose();
     await waitWhileLoading(this.page);
 
     return cohortName;
@@ -92,12 +92,12 @@ export default class CohortBuildPage extends AuthenticatedPage {
    * @return {string} Dialog textContent.
    */
   async deleteConfirmationDialog(): Promise<string> {
-    const dialog = new Dialog(this.page);
-    const contentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteCohort}, dialog);
+    const modal = new Modal(this.page);
+    const contentText = await modal.getContent();
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteCohort}, modal);
     await Promise.all([
       deleteButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
     ]);
     await waitWhileLoading(this.page);
     return contentText;
@@ -108,12 +108,12 @@ export default class CohortBuildPage extends AuthenticatedPage {
    * @return {string} Dialog textContent.
    */
   async discardChangesConfirmationDialog(): Promise<string> {
-    const dialog = new Dialog(this.page);
-    const contentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DiscardChanges}, dialog);
+    const modal = new Modal(this.page);
+    const contentText = await modal.getContent();
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DiscardChanges}, modal);
     await Promise.all([
       deleteButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
       this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
     ]);
     await waitWhileLoading(this.page);

--- a/e2e/app/page/cohort-criteria-modal.ts
+++ b/e2e/app/page/cohort-criteria-modal.ts
@@ -1,5 +1,5 @@
 import {Page} from 'puppeteer';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import SelectMenu from 'app/component/select-menu';
 import Table from 'app/component/table';
 import ClrIconLink from 'app/element/clr-icon-link';
@@ -62,7 +62,7 @@ export enum FilterSign {
   Between = 'Between',
 }
 
-export default class CohortCriteriaModal extends Dialog {
+export default class CohortCriteriaModal extends Modal {
 
   constructor(page: Page, xpath: string = defaultXpath) {
     super(page, xpath);
@@ -126,7 +126,7 @@ export default class CohortCriteriaModal extends Dialog {
     const { waitUntilClosed = true } = opt
     await this.clickButton(LinkText.Finish);
     if (waitUntilClosed) {
-      await this.waitUntilDialogIsClosed();
+      await this.waitUntilClose();
     }
   }
 

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -1,6 +1,6 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {FieldSelector} from 'app/page/cohort-build-page';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 import CohortCriteriaModal, {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
@@ -51,11 +51,11 @@ export default class CohortParticipantsGroup {
   async editGroupName(newGroupName: string): Promise<void> {
     const menu = this.getGroupEllipsisMenu();
     await menu.clickParticipantsGroupAction(GroupAction.EditGroupName);
-    const dialog = new Dialog(this.page);
-    const textbox = await dialog.waitForTextbox('New Name:');
+    const modal = new Modal(this.page);
+    const textbox = await modal.waitForTextbox('New Name:');
     await textbox.type(newGroupName);
-    await dialog.waitForButton(LinkText.Rename).then(b => b.click());
-    await dialog.waitUntilDialogIsClosed();
+    await modal.waitForButton(LinkText.Rename).then(b => b.click());
+    await modal.waitUntilClose();
   }
 
   /**

--- a/e2e/app/page/cohort-review-modal.ts
+++ b/e2e/app/page/cohort-review-modal.ts
@@ -1,12 +1,12 @@
 import {Page} from 'puppeteer';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import InputNumber from 'app/element/input-number';
 
 const title = 'Create Review Set';
 
-export default class CohortReviewModal extends Dialog {
+export default class CohortReviewModal extends Modal {
 
   constructor(page: Page, xpath?: string) {
     super(page, xpath);

--- a/e2e/app/page/conceptset-copy-modal.ts
+++ b/e2e/app/page/conceptset-copy-modal.ts
@@ -1,10 +1,10 @@
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import Textbox from 'app/element/textbox';
 import {LinkText} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 
 
-export default class ConceptsetCopyModal extends Dialog {
+export default class ConceptsetCopyModal extends Modal {
 
   constructor(page: Page, xpath?: string) {
     super(page, xpath);

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -1,5 +1,5 @@
 import {Page} from 'puppeteer';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import {makeRandomName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
@@ -14,7 +14,7 @@ export enum SaveOption {
   ChooseExistingSet = 'Choose existing set',
 }
 
-export default class ConceptsetSaveModal extends Dialog {
+export default class ConceptsetSaveModal extends Modal {
 
   constructor(page: Page) {
     super(page);

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -31,8 +31,8 @@ export default class ConceptsetSearchPage extends AuthenticatedPage{
   }
 
   async saveConcept(saveOption?: SaveOption, existingConceptName?: string): Promise<string> {
-    const dialog = new ConceptsetSaveModal(this.page);
-    return dialog.fillOutSaveModal(saveOption, existingConceptName);
+    const modal = new ConceptsetSaveModal(this.page);
+    return modal.fillOutSaveModal(saveOption, existingConceptName);
   }
 
   async getAddToSetButton(): Promise<Button> {

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -1,5 +1,5 @@
 import DataResourceCard from 'app/component/data-resource-card';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
@@ -117,9 +117,9 @@ export default class DataPage extends AuthenticatedPage {
     }
     const menu = cohortCard.getEllipsis();
     await menu.clickAction(EllipsisMenuAction.Delete, {waitForNav: false});
-    const dialogContent = await (new CohortBuildPage(this.page)).deleteConfirmationDialog();
+    const modalContent = await (new CohortBuildPage(this.page)).deleteConfirmationDialog();
     console.log(`Deleted Cohort "${cohortName}"`);
-    return dialogContent;
+    return modalContent;
   }
 
   /**
@@ -134,17 +134,17 @@ export default class DataPage extends AuthenticatedPage {
     const menu = datasetCard.getEllipsis();
     await menu.clickAction(EllipsisMenuAction.Delete, {waitForNav: false});
 
-    const dialog = new Dialog(this.page);
-    const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteDataset}, dialog);
+    const modal = new Modal(this.page);
+    const modalContentText = await modal.getContent();
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteDataset}, modal);
     await Promise.all([
       deleteButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
     ]);
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Dataset "${datasetName}"`);
-    return dialogContentText;
+    return modalContentText;
   }
 
   /**
@@ -156,18 +156,18 @@ export default class DataPage extends AuthenticatedPage {
     const datasetCard = await DataResourceCard.findCard(this.page, datasetName);
     await datasetCard.getEllipsis().clickAction(EllipsisMenuAction.RenameDataset, {waitForNav: false});
 
-    const dialog = new Dialog(this.page);
+    const modal = new Modal(this.page);
 
-    const newNameTextbox = new Textbox(this.page, `${dialog.getXpath()}//*[@id="new-name"]`);
+    const newNameTextbox = new Textbox(this.page, `${modal.getXpath()}//*[@id="new-name"]`);
     await newNameTextbox.type(newDatasetName);
 
-    const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, dialog);
+    const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, modal);
     await descriptionTextarea.type('Puppeteer automation rename dataset.');
 
-    const renameButton = await Button.findByName(this.page, {normalizeSpace: LinkText.RenameDataset}, dialog);
+    const renameButton = await Button.findByName(this.page, {normalizeSpace: LinkText.RenameDataset}, modal);
     await Promise.all([
       renameButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
     ]);
     await waitWhileLoading(this.page);
 
@@ -186,31 +186,31 @@ export default class DataPage extends AuthenticatedPage {
     const menu = conceptSetCard.getEllipsis();
     await menu.clickAction(EllipsisMenuAction.Delete, {waitForNav: false});
 
-    const dialog = new Dialog(this.page);
-    const dialogContentText = await dialog.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteConceptSet}, dialog);
+    const modal = new Modal(this.page);
+    const modalTextContent = await modal.getContent();
+    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteConceptSet}, modal);
     await Promise.all([
       deleteButton.click(),
-      dialog.waitUntilDialogIsClosed(),
+      modal.waitUntilClose(),
     ]);
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Concept Set "${conceptsetName}"`);
-    return dialogContentText;
+    return modalTextContent;
   }
 
   async renameCohort(cohortName: string, newCohortName: string): Promise<void> {
     const cohortCard = await DataResourceCard.findCard(this.page, cohortName);
     const menu = cohortCard.getEllipsis();
     await menu.clickAction(EllipsisMenuAction.Rename, {waitForNav: false});
-    const dialog = new Dialog(this.page);
-    await dialog.getContent();
-    const newNameInput = new Textbox(this.page, `${dialog.getXpath()}//*[@id="new-name"]`);
+    const modal = new Modal(this.page);
+    await modal.getContent();
+    const newNameInput = new Textbox(this.page, `${modal.getXpath()}//*[@id="new-name"]`);
     await newNameInput.type(newCohortName);
-    const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, dialog);
+    const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, modal);
     await descriptionTextarea.type('Puppeteer automation rename cohort.');
-    await dialog.clickButton(LinkText.Rename);
-    await dialog.waitUntilDialogIsClosed();
+    await modal.clickButton(LinkText.Rename);
+    await modal.waitUntilClose();
     await waitWhileLoading(this.page);
     console.log(`Cohort "${cohortName}" renamed to "${newCohortName}"`);
   }

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -63,7 +63,6 @@ export default class DatasetBuildPage extends AuthenticatedPage {
   async clickAddConceptSetsButton(): Promise<ConceptsetSearchPage> {
     const addConceptSetsButton = await ClrIconLink.findByName(this.page, {name: LabelAlias.SelectConceptSets, ancestorLevel: 3, iconShape: 'plus-circle'});
     await addConceptSetsButton.clickAndWait();
-    await waitWhileLoading(this.page);
     const conceptPage = new ConceptsetSearchPage(this.page);
     await conceptPage.waitForLoad();
     return conceptPage;

--- a/e2e/app/page/dataset-save-modal.ts
+++ b/e2e/app/page/dataset-save-modal.ts
@@ -1,5 +1,5 @@
 import {Page} from 'puppeteer';
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import RadioButton from 'app/element/radiobutton';
@@ -12,7 +12,7 @@ export enum Language {
   R = 'R',
 }
 
-export default class DatasetSaveModal extends Dialog {
+export default class DatasetSaveModal extends Modal {
 
   constructor(page: Page) {
     super(page);

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -1,4 +1,4 @@
-import Dialog from 'app/component/dialog';
+import Modal from 'app/component/modal';
 import Button from 'app/element/button';
 import Checkbox from 'app/element/checkbox';
 import Select from 'app/element/select';
@@ -388,16 +388,16 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
     await button.focus(); // bring into viewport
     await button.click();
 
-    // confirm create in pop-up dialog
-    const dialog = new Dialog(this.page);
-    const dialogText = await dialog.getContent();
+    // confirm create in pop-up modal
+    const modal = new Modal(this.page);
+    const modalTextContent = await modal.getContent();
     await Promise.all([
-      dialog.clickButton(LinkText.Confirm),
-      dialog.waitUntilDialogIsClosed(),
+      modal.clickButton(LinkText.Confirm),
+      modal.waitUntilClose(),
       this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
     ]);
     await waitWhileLoading(this.page);
-    return dialogText;
+    return modalTextContent;
   }
 
   async clickShareWithCollaboratorsCheckbox() {

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -75,8 +75,6 @@ describe('User can create new Cohorts', () => {
     // Open Cohort details.
     const cohortLink = await Link.findByName(page, {name: cohortName});
     await cohortLink.clickAndWait();
-    // Wait for page ready
-    await waitWhileLoading(page);
     await waitForText(page, newTotalCount, {xpath: FieldSelector.TotalCount});
 
     // Modify Cohort: Edit Group 1 name successfully.
@@ -99,9 +97,9 @@ describe('User can create new Cohorts', () => {
     expect(newTotalCountInt2).toBe(newTotalCountInt);
 
     // Clean up: delete cohort
-    const dialogContent = await cohortPage.deleteCohort();
+    const modalContent = await cohortPage.deleteCohort();
     // Verify dialog content text
-    expect(dialogContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
+    expect(modalContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
     console.log(`Deleted Cohort "${cohortName}"`);
   });
 
@@ -204,12 +202,12 @@ describe('User can create new Cohorts', () => {
     expect(newCardsCount).toBe(origCardsCount + 1);
 
     // Delete duplicated cohort.
-    let dialogContent = await dataPage.deleteCohort(`Duplicate of ${cohortName}`);
-    expect(dialogContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
+    let modalTextContent = await dataPage.deleteCohort(`Duplicate of ${cohortName}`);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
 
     // Delete new cohort.
-    dialogContent = await dataPage.deleteCohort(cohortName);
-    expect(dialogContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
+    modalTextContent = await dataPage.deleteCohort(cohortName);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
 
   });
 

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,7 +1,7 @@
 import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
+import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
 import {makeRandomName} from 'utils/str-utils';
@@ -72,7 +72,6 @@ describe('User can create, modify, rename and delete Cohort', () => {
     // Click cohort link. Open cohort build page.
     const cohortLink = await Link.findByName(page, {name: cohortName});
     await cohortLink.clickAndWait();
-    await waitWhileLoading(page);
     await waitForText(page, totalCount, {xpath: FieldSelector.TotalCount});
 
     // Remove Exclude Group 3.
@@ -97,10 +96,10 @@ describe('User can create, modify, rename and delete Cohort', () => {
     expect(await DataResourceCard.findCard(page, newCohortName)).toBeTruthy();
 
     // Delete cohort.
-    const dialogContent = await dataPage.deleteCohort(newCohortName);
+    const modalTextContent = await dataPage.deleteCohort(newCohortName);
 
     // Verify Delete dialog content text
-    expect(dialogContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
 
     // Verify Delete successful.
     expect(await DataResourceCard.findCard(page, newCohortName, 5000)).toBeFalsy();

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -56,10 +56,10 @@ describe('Cohorts UI tests', () => {
     await dataPage.openTab(TabLabelAlias.About, {waitPageChange: false});
 
     // Don't save. Confirm Discard Changes
-    const dialogContent = await cohortPage.discardChangesConfirmationDialog();
+    const modalTextContent = await cohortPage.discardChangesConfirmationDialog();
     // Verify dialog content text
-    expect(dialogContent).toContain(`Your cohort has not been saved.`);
-    expect(dialogContent).toContain(`please click CANCEL and click CREATE COHORT to save your criteria.`);
+    expect(modalTextContent).toContain(`Your cohort has not been saved.`);
+    expect(modalTextContent).toContain(`please click CANCEL and click CREATE COHORT to save your criteria.`);
 
     // Check ABOUT tab is open
     const aboutPage = new WorkspaceAboutPage(page);

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -70,8 +70,8 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openTab(TabLabelAlias.Data);
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
 
-    const dialogTextContent = await dataPage.deleteConceptSet(conceptName);
-    expect(dialogTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}`);
+    const modalTextContent = await dataPage.deleteConceptSet(conceptName);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}`);
   });
 
   /**

--- a/e2e/tests/profile/profile-page.spec.ts
+++ b/e2e/tests/profile/profile-page.spec.ts
@@ -10,14 +10,14 @@ describe('Profile', () => {
   });
 
 
-  test('Click First and Last name fields on Profile page', async () => {
+  test('Check First and Last name fields on Profile page', async () => {
     const homePage = new HomePage(page);
     await homePage.waitForLoad();
     await navigation.navMenu(page, NavLink.PROFILE);
     const profilePage = new ProfilePage(page);
     const fname = await (await profilePage.getFirstName()).getValue();
     const lname = await (await profilePage.getLastName()).getValue();
-      // check last and first name textbox is not empty
+    // check last and first name textbox is not empty
     expect(fname).toMatch(new RegExp(/^[a-zA-Z]+/));
     expect(lname).toMatch(new RegExp(/^[a-zA-Z]+/));
     expect(lname).not.toEqual(fname);

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -18,13 +18,13 @@ describe('Creating new workspaces', () => {
     await workspacesPage.load();
 
     // create workspace with "No Review Requested" radiobutton selected
-    const dialogTextContent = await workspacesPage.createWorkspace(newWorkspaceName);
+    const modalTextContent = await workspacesPage.createWorkspace(newWorkspaceName);
 
     // Pick out few sentenses to verify
-    expect(dialogTextContent).toContain('Primary purpose of your project (Question 1)');
-    expect(dialogTextContent).toContain('Summary of research purpose (Question 2)');
-    expect(dialogTextContent).toContain('Will be displayed publicly to inform All of Us research participants.');
-    expect(dialogTextContent).toContain('You can also make changes to your answers after you create your workspace.');
+    expect(modalTextContent).toContain('Primary purpose of your project (Question 1)');
+    expect(modalTextContent).toContain('Summary of research purpose (Question 2)');
+    expect(modalTextContent).toContain('Will be displayed publicly to inform All of Us research participants.');
+    expect(modalTextContent).toContain('You can also make changes to your answers after you create your workspace.');
 
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });


### PR DESCRIPTION
This PR attempts to clean up unused code and give variables better names. No functional and test changes.

Renamed `dialog.ts` to `modal.ts`. Replaced `dialog` prefix in all variable names to `modal`.
Removed unnecessary call to `waitForXpath()` function in custom element wrapper classes: `Checkbox`, `Button`, `Link`, etc. 
Renamed `waitUntilDialogIsClosed()` function name in `modal.ts` to `waitUntilClose`. 
