### PR TITLE
[no ticket][risk=no] circleci config change for pupppeteer-e2e-test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,7 +560,6 @@ jobs:
     parallelism: 3
     steps:
       - checkout_init_git
-      - halt_if_code_unchanged
       - browser-tools/install-browser-tools
       - run_e2e_test
 


### PR DESCRIPTION
skip check has a bug - job were skipped when PR contains changed `.sh`, `.rb` files. I need time to find solution. remove the check in meantime.