### PR TITLE
[risk=low][RW-5251] Validate email domains by constructing test addresses

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -111,7 +111,7 @@ describe('AdminInstitutionEditSpec', () => {
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
     wrapper.find('[data-test-id="emailAddressInput"]').first()
       .simulate('change', {target: {value: 'invalidEmail@domain@org,' +
-        '\ncorrectEmail@someDomain.org.com,\n invalidEmail,\n justDomain.org,' +
+        '\ncorrectEmail.123.hello@someDomain567.org.com,\n invalidEmail,\n justDomain.org,' +
         '\nsomeEmail@broadinstitute.org'}});
     wrapper.find('[data-test-id="emailAddressInput"]').first().simulate('blur');
     emailAddressError = wrapper.find('[data-test-id="emailAddressError"]');
@@ -149,7 +149,7 @@ describe('AdminInstitutionEditSpec', () => {
     // Multiple Entries with correct and incorrect Email Domain format
     wrapper.find('[data-test-id="emailDomainInput"]').first()
       .simulate('change', {target: {value: 'someEmailAddress@domain@org,' +
-        '\nsomeDomain.org.com,\n justSomeText,\njustDomain.org,\nbroadinstitute.org#wrongTest'}});
+        '\nsomeDomain123.org.com,\n justSomeText,\njustDomain.org,\nbroadinstitute.org#wrongTest'}});
     wrapper.find('[data-test-id="emailDomainInput"]').first().simulate('blur');
     emailAddressError = wrapper.find('[data-test-id="emailDomainError"]');
     expect(emailAddressError.first().props().children)

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -121,6 +121,7 @@ describe('AdminInstitutionEditSpec', () => {
           value:
             'invalidEmail@domain@org,\n' +
             'correctEmail@someDomain.org,\n' +
+            'correctEmail.123.hello@someDomain567.org.com\n' +
             ' invalidEmail   ,\n' +
             ' justDomain.org,\n' +
             'someEmail@broadinstitute.org'

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -1,4 +1,4 @@
-import {registerApiClient} from'app/services/swagger-fetch-clients';
+import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 import {mount} from 'enzyme';
 import {DuaType} from 'generated';
@@ -29,7 +29,7 @@ describe('AdminInstitutionEditSpec', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it('should throw error for existing Institution if display name is more than 80 characters', async () => {
+  it('should throw error for existing Institution if display name is more than 80 characters', async() => {
     urlParamsStore.next({
       institutionId: 'Verily'
     });
@@ -44,7 +44,7 @@ describe('AdminInstitutionEditSpec', () => {
       .toContain('Display name must be 80 characters or less');
   });
 
-  it('should default DUA to Master', async () => {
+  it('should default DUA to Master', async() => {
     urlParamsStore.next({
       institutionId: 'Verily'
     });
@@ -63,7 +63,11 @@ describe('AdminInstitutionEditSpec', () => {
     const testInput = fp.repeat(81, 'a');
 
     const agreementTypeDropDown = wrapper.find('[data-test-id="agreement-dropdown"]').instance() as Dropdown;
-    agreementTypeDropDown.props.onChange({originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
+    agreementTypeDropDown.props.onChange({
+      originalEvent: undefined,
+      value: DuaType.MASTER,
+      target: {name: 'name', id: '', value: DuaType.MASTER}
+    });
     await waitOneTickAndUpdate(wrapper);
 
     let emailAddressDiv = wrapper.find('[data-test-id="emailAddress"]');
@@ -75,8 +79,10 @@ describe('AdminInstitutionEditSpec', () => {
     expect(emailDomainLabel.props.children).toBe('Accepted Email Domains');
 
     agreementTypeDropDown.props.onChange(
-        {originalEvent: undefined, value: DuaType.RESTRICTED,
-          target: {name: 'name', id: '', value: DuaType.RESTRICTED}});
+      {
+        originalEvent: undefined, value: DuaType.RESTRICTED,
+        target: {name: 'name', id: '', value: DuaType.RESTRICTED}
+      });
     await waitOneTickAndUpdate(wrapper);
 
     emailAddressDiv = wrapper.find('[data-test-id="emailAddress"]');
@@ -90,7 +96,7 @@ describe('AdminInstitutionEditSpec', () => {
 
   });
 
-  it ('Should display error in case of invalid email Address Format', async() => {
+  it('Should display error in case of invalid email Address Format', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
@@ -98,7 +104,7 @@ describe('AdminInstitutionEditSpec', () => {
     expect(emailAddressError.length).toBe(0);
     const agreementTypeDropDown = wrapper.find('[data-test-id="agreement-dropdown"]').instance() as Dropdown;
     agreementTypeDropDown.props.onChange(
-        {originalEvent: undefined, value: DuaType.RESTRICTED, target: {name: 'name', id: '', value: DuaType.RESTRICTED}});
+      {originalEvent: undefined, value: DuaType.RESTRICTED, target: {name: 'name', id: '', value: DuaType.RESTRICTED}});
     await waitOneTickAndUpdate(wrapper);
 
     // In case of a single entry which is not in the correct format
@@ -110,9 +116,16 @@ describe('AdminInstitutionEditSpec', () => {
 
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
     wrapper.find('[data-test-id="emailAddressInput"]').first()
-      .simulate('change', {target: {value: 'invalidEmail@domain@org,' +
-        '\ncorrectEmail.123.hello@someDomain567.org.com,\n invalidEmail,\n justDomain.org,' +
-        '\nsomeEmail@broadinstitute.org'}});
+      .simulate('change', {
+        target: {
+          value:
+            'invalidEmail@domain@org,\n' +
+            'correctEmail@someDomain.org,\n' +
+            ' invalidEmail   ,\n' +
+            ' justDomain.org,\n' +
+            'someEmail@broadinstitute.org'
+        }
+      });
     wrapper.find('[data-test-id="emailAddressInput"]').first().simulate('blur');
     emailAddressError = wrapper.find('[data-test-id="emailAddressError"]');
     expect(emailAddressError.first().props().children)
@@ -127,7 +140,7 @@ describe('AdminInstitutionEditSpec', () => {
 
   });
 
-  it ('Should display error in case of invalid email Domain Format', async() => {
+  it('Should display error in case of invalid email Domain Format', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
@@ -135,7 +148,7 @@ describe('AdminInstitutionEditSpec', () => {
     expect(emailAddressError.length).toBe(0);
     const agreementTypeDropDown = wrapper.find('[data-test-id="agreement-dropdown"]').instance() as Dropdown;
     agreementTypeDropDown.props.onChange(
-        {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
+      {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
     await waitOneTickAndUpdate(wrapper);
 
     // Single Entry with incorrect Email Domain format
@@ -148,13 +161,17 @@ describe('AdminInstitutionEditSpec', () => {
 
     // Multiple Entries with correct and incorrect Email Domain format
     wrapper.find('[data-test-id="emailDomainInput"]').first()
-      .simulate('change', {target: {value: 'someEmailAddress@domain@org,' +
-        '\nsomeDomain123.org.com,\n justSomeText,\njustDomain.org,\nbroadinstitute.org#wrongTest'}});
+      .simulate('change', {
+        target: {
+          value: 'someEmailAddress@domain@org,' +
+            '\nsomeDomain123.org.com,\n justSomeText,\njustDomain.org,\nbroadinstitute.org#wrongTest'
+        }
+      });
     wrapper.find('[data-test-id="emailDomainInput"]').first().simulate('blur');
     emailAddressError = wrapper.find('[data-test-id="emailDomainError"]');
     expect(emailAddressError.first().props().children)
       .toBe('Following Email Domains are not valid : someEmailAddress@domain@org , ' +
-          'justSomeText , broadinstitute.org#wrongTest');
+        'justSomeText , broadinstitute.org#wrongTest');
 
 
     wrapper.find('[data-test-id="emailDomainInput"]').first()
@@ -165,13 +182,13 @@ describe('AdminInstitutionEditSpec', () => {
 
   });
 
-  it ('Should ignore empty string in email Domain', async() => {
+  it('Should ignore empty string in email Domain', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
     const agreementTypeDropDown = wrapper.find('[data-test-id="agreement-dropdown"]').instance() as Dropdown;
     agreementTypeDropDown.props.onChange(
-        {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
+      {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
     await waitOneTickAndUpdate(wrapper);
 
     // Single Entry with incorrect Email Domain format
@@ -182,20 +199,20 @@ describe('AdminInstitutionEditSpec', () => {
       .toBe('validEmail.com,\njustSomeRandom.domain');
   });
 
-  it ('Should ignore whitespaces in email address', async() => {
+  it('Should ignore whitespaces in email address', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
     const agreementTypeDropDown = wrapper.find('[data-test-id="agreement-dropdown"]').instance() as Dropdown;
     agreementTypeDropDown.props.onChange(
-        {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
+      {originalEvent: undefined, value: DuaType.MASTER, target: {name: 'name', id: '', value: DuaType.MASTER}});
     await waitOneTickAndUpdate(wrapper);
 
     // Single Entry with incorrect Email Domain format
     wrapper.find('[data-test-id="emailDomainInput"]').first()
-        .simulate('change', {target: {value: '  someDomain.com,\njustSomeRandom.domain   ,\n,'}});
+      .simulate('change', {target: {value: '  someDomain.com,\njustSomeRandom.domain   ,\n,'}});
     wrapper.find('[data-test-id="emailDomainInput"]').first().simulate('blur');
     expect(wrapper.find('[data-test-id="emailDomainInput"]').first().prop('value'))
-        .toBe('someDomain.com,\njustSomeRandom.domain');
+      .toBe('someDomain.com,\njustSomeRandom.domain');
   });
 });

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -121,16 +121,17 @@ describe('AdminInstitutionEditSpec', () => {
           value:
             'invalidEmail@domain@org,\n' +
             'correctEmail@someDomain.org,\n' +
-            'correctEmail.123.hello@someDomain567.org.com\n' +
+            ' correctEmail.123.hello@someDomain567.org.com   \n' +
             ' invalidEmail   ,\n' +
             ' justDomain.org,\n' +
-            'someEmail@broadinstitute.org'
+            'someEmail@broadinstitute.org\n' +
+            'nope@just#plain#wrong'
         }
       });
     wrapper.find('[data-test-id="emailAddressInput"]').first().simulate('blur');
     emailAddressError = wrapper.find('[data-test-id="emailAddressError"]');
     expect(emailAddressError.first().props().children)
-      .toBe('Following Email Addresses are not valid : invalidEmail@domain@org , invalidEmail , justDomain.org');
+      .toBe('Following Email Addresses are not valid : invalidEmail@domain@org , invalidEmail , justDomain.org , nope@just#plain#wrong');
 
     // Single correct format Email Address entries
     wrapper.find('[data-test-id="emailAddressInput"]').first()
@@ -164,8 +165,12 @@ describe('AdminInstitutionEditSpec', () => {
     wrapper.find('[data-test-id="emailDomainInput"]').first()
       .simulate('change', {
         target: {
-          value: 'someEmailAddress@domain@org,' +
-            '\nsomeDomain123.org.com,\n justSomeText,\njustDomain.org,\nbroadinstitute.org#wrongTest'
+          value:
+            'someEmailAddress@domain@org,\n' +
+            'someDomain123.org.com        ,\n' +
+            ' justSomeText,\n' +
+            ' justDomain.org,\n' +
+            'broadinstitute.org#wrongTest'
         }
       });
     wrapper.find('[data-test-id="emailDomainInput"]').first().simulate('blur');

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -133,12 +133,13 @@ export class AdminInstitutionEditImpl extends React.Component<UrlParamsProps, In
     this.setState(fp.set(['institution', 'emailDomains'], emailDomainsWithNoEmptyString));
 
     emailDomainsWithNoEmptyString.map(emailDomain => {
+      const dummyAddress = 'dummy@' + emailDomain;
       const errors = validate({
-        emailDomain
+        dummyAddress
       }, {
-        emailDomain: {format: {pattern: /[a-zA-z\-\.]+[.][a-zA-Z]+/i}}
+        dummyAddress: {email: true}
       });
-      if (errors && errors.emailDomain && errors.emailDomain.length > 0) {
+      if (errors && errors.dummyAddress && errors.dummyAddress.length > 0) {
         invalidEmailDomain.push(emailDomain);
       }
     });

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -133,13 +133,13 @@ export class AdminInstitutionEditImpl extends React.Component<UrlParamsProps, In
     this.setState(fp.set(['institution', 'emailDomains'], emailDomainsWithNoEmptyString));
 
     emailDomainsWithNoEmptyString.map(emailDomain => {
-      const dummyAddress = 'dummy@' + emailDomain;
+      const testAddress = 'test@' + emailDomain;
       const errors = validate({
-        dummyAddress
+        testAddress
       }, {
-        dummyAddress: {email: true}
+        testAddress: {email: true}
       });
-      if (errors && errors.dummyAddress && errors.dummyAddress.length > 0) {
+      if (errors && errors.testAddress && errors.testAddress.length > 0) {
         invalidEmailDomain.push(emailDomain);
       }
     });


### PR DESCRIPTION
Description:

Uses the email validator instead of homegrown regex
Allows numbers in domains before the TLD

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
