### PR TITLE
[RW-5013][risk=no] Backfill tool fixes: id lists and 1ppw projects

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1319,6 +1319,7 @@ def fix_desynchronized_billing_project_owners(cmd_name, *args)
       ->(opts, v) { opts.billing_project_ids = v},
       "Optional billing projects IDs to update. By default all projects are considered")
 
+  op.opts.billing_project_ids = ''
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate()
@@ -1332,8 +1333,7 @@ def fix_desynchronized_billing_project_owners(cmd_name, *args)
   flags = ([
       ["--fc-base-url", fc_config["baseUrl"]],
       ["--researcher-domain", domain]
-    ] + (op.opts.billing_project_ids ?
-         ["--billing-project-ids", op.opts.billing_project_ids] : [])
+    ] + op.opts.billing_project_ids.split(',').map{ |bp| ["--billing-project-ids", bp] }
     ).map { |kv| "#{kv[0]}=#{kv[1]}" }
   if op.opts.dry_run
     flags += ["--dry-run"]

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FixDesynchronizedBillingProjectOwners.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FixDesynchronizedBillingProjectOwners.java
@@ -97,7 +97,7 @@ public class FixDesynchronizedBillingProjectOwners {
         workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS);
     log.info(String.format("found %d workspaces", workspaces.size()));
 
-    // 1PPW workspaces still exist and need to be filtered out - this script depends on the
+    // Non-1PPW workspaces still exist and need to be filtered out - this script depends on the
     // assumption that workspace ACLs are synchronized to project ACLs, which doesn't hold when
     // there are multiple workspaces per project.
     Set<String> singleWorkspaceProjects =

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/FixDesynchronizedBillingProjectOwners.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/FixDesynchronizedBillingProjectOwners.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -91,8 +92,27 @@ public class FixDesynchronizedBillingProjectOwners {
       throws ApiException {
     int ownersRemoved = 0;
     int ownersAdded = 0;
-    for (FirecloudWorkspaceResponse resp :
-        workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS)) {
+
+    List<FirecloudWorkspaceResponse> workspaces =
+        workspacesApi.listWorkspaces(FIRECLOUD_LIST_WORKSPACES_REQUIRED_FIELDS);
+    log.info(String.format("found %d workspaces", workspaces.size()));
+
+    // 1PPW workspaces still exist and need to be filtered out - this script depends on the
+    // assumption that workspace ACLs are synchronized to project ACLs, which doesn't hold when
+    // there are multiple workspaces per project.
+    Set<String> singleWorkspaceProjects =
+        workspaces.stream()
+            // Count entries by billing project ID.
+            .map(w -> w.getWorkspace().getNamespace())
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+            .entrySet()
+            .stream()
+            // Only take projects which conform to 1PPW.
+            .filter(e -> e.getValue() == 1)
+            .map(Entry::getKey)
+            .collect(Collectors.toSet());
+
+    for (FirecloudWorkspaceResponse resp : workspaces) {
       FirecloudWorkspace w = resp.getWorkspace();
       if (!billingProjectIds.isEmpty() && !billingProjectIds.contains(w.getNamespace())) {
         continue;
@@ -104,6 +124,11 @@ public class FixDesynchronizedBillingProjectOwners {
             String.format(
                 "service account has '%s' access to workspace '%s'; skipping",
                 resp.getAccessLevel(), id));
+        continue;
+      }
+
+      if (!singleWorkspaceProjects.contains(w.getNamespace())) {
+        log.info(String.format("skipping workspace '%s', doesn't conform to 1PPW", id));
         continue;
       }
 


### PR DESCRIPTION
- Fix yet another issue with the "id list" flag approach
- Filter out 1ppw projects. These cause thrashing with the tool, as it can lead to  adding/removing the same person from a billing project repeatedly (one project may be encountered multiple times during iteration).

This tool has already run successfully, these changes are included for posterity.