### PR TITLE
[RW-5111][risk=no] GA footer, support tracker callback on links

### DIFF
--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -303,13 +303,16 @@ export const Link = ({disabled = false, style = {}, children, ...props}) => {
   >{children}</Clickable>;
 };
 
-export const StyledAnchorTag = ({href, style = {}, children, ...props}) => {
+export const StyledAnchorTag = ({href, analyticsFn, style = {}, children, ...props}) => {
   const inlineAnchor = {
     display: 'inline-block',
     color: colors.accent
   };
   return <a href={href}
             onClick={e => {
+              if (analyticsFn) {
+                analyticsFn();
+              }
               // This does same page navigation iff there is no key pressed and target is not set.
               if (props.target === undefined && !href.startsWith('https://') && !href.startsWith('http://')) {
                 navigateAndPreventDefaultIfNoKeysPressed(e, href);

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -303,7 +303,7 @@ export const Link = ({disabled = false, style = {}, children, ...props}) => {
   >{children}</Clickable>;
 };
 
-export const StyledAnchorTag = ({href, analyticsFn, style = {}, children, ...props}) => {
+export const StyledAnchorTag = ({href, children, analyticsFn = null, style = {}, ...props}) => {
   const inlineAnchor = {
     display: 'inline-block',
     color: colors.accent

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -63,7 +63,21 @@ const NewTabFooterAnchorTag = ({style = {}, href, ...props}) => {
   return <FooterAnchorTag style={style} href={href} target='_blank' {...props}>{props.children}</FooterAnchorTag>;
 };
 
+const DataBrowserLink = (props) => (
+  <NewTabFooterAnchorTag href={environment.publicUiUrl}
+                         analyticsFn={AnalyticsTracker.Footer.DataBrowser}
+                         {...props}>
+    Data Browser
+  </NewTabFooterAnchorTag>
+);
 
+const ResearchHubLink = (props) => (
+  <NewTabFooterAnchorTag href='https://researchallofus.org'
+                         analyticsFn={AnalyticsTracker.Footer.ResearchHub}
+                         {...props}>
+    Research Hub
+  </NewTabFooterAnchorTag>
+);
 
 const FooterTemplate = ({style = {}, ...props}) => {
   return <div style={{...styles.footerTemplate, ...style}} {...props}>
@@ -176,22 +190,6 @@ const WorkbenchFooter = withUserProfile()(
       </FooterTemplate>;
     }
   });
-
-const DataBrowserLink = (props) => (
-  <NewTabFooterAnchorTag href={environment.publicUiUrl}
-                         analyticsFn={AnalyticsTracker.Footer.DataBrowser}
-                         {...props}>
-    Data Browser
-  </NewTabFooterAnchorTag>
-);
-
-const ResearchHubLink = (props) => (
-  <NewTabFooterAnchorTag href='https://researchallofus.org'
-                         analyticsFn={AnalyticsTracker.Footer.ResearchHub}
-                         {...props}>
-    Research Hub
-  </NewTabFooterAnchorTag>
-);
 
 const supportEmailAddress = 'support@researchallofus.org';
 

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -133,14 +133,8 @@ const WorkbenchFooter = withUserProfile()(
                 </FooterAnchorTag>
               </FlexColumn>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={environment.publicUiUrl}
-                                       analyticsFn={tracker.DataBrowser}>
-                  Data Browser
-                </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href='https://researchallofus.org'
-                                       analyticsFn={tracker.ResearchHub}>
-                  Research Hub
-                </NewTabFooterAnchorTag>
+                <DataBrowserLink />
+                <ResearchHubLink />
               </FlexColumn>
             </FlexRow>
           </FooterSection>
@@ -165,7 +159,7 @@ const WorkbenchFooter = withUserProfile()(
                   FAQs
                 </NewTabFooterAnchorTag>
                 <Link style={styles.footerAnchor} onClick={() => {
-                  tracker.ContactUs();
+                  tracker.ContactUs('Zendesk');
                   openZendeskWidget(
                     this.props.profileState.profile.givenName,
                     this.props.profileState.profile.familyName,
@@ -183,20 +177,33 @@ const WorkbenchFooter = withUserProfile()(
     }
   });
 
+const DataBrowserLink = (props) => (
+  <NewTabFooterAnchorTag href={environment.publicUiUrl}
+                         analyticsFn={AnalyticsTracker.Footer.DataBrowser}
+                         {...props}>
+    Data Browser
+  </NewTabFooterAnchorTag>
+);
+
+const ResearchHubLink = (props) => (
+  <NewTabFooterAnchorTag href='https://researchallofus.org'
+                         analyticsFn={AnalyticsTracker.Footer.ResearchHub}
+                         {...props}>
+    Research Hub
+  </NewTabFooterAnchorTag>
+);
+
 const supportEmailAddress = 'support@researchallofus.org';
 
 const RegistrationFooter = ({style = {}, ...props}) => {
   return <FooterTemplate {...props}>
     <FlexColumn>
       <FlexRow style={{...styles.footerSectionDivider, color: colors.white, width: '25rem'}}>
-        <NewTabFooterAnchorTag href={environment.publicUiUrl}>
-          Data Browser
-        </NewTabFooterAnchorTag>
-        <NewTabFooterAnchorTag style={{marginLeft: '1.5rem'}} href='https://researchallofus.org'>
-          Research Hub
-        </NewTabFooterAnchorTag>
+        <DataBrowserLink />
+        <ResearchHubLink style={{marginLeft: '1.5rem'}} />
         <div style={{fontSize: 12, marginLeft: '1.5rem'}}>
-          Contact Us: <FooterAnchorTag href={'mailto:' + supportEmailAddress}>
+          Contact Us: <FooterAnchorTag href={'mailto:' + supportEmailAddress}
+                                       analyticsFn={() => AnalyticsTracker.Footer.ContactUs('Email')}>
             {supportEmailAddress}
           </FooterAnchorTag>
         </div>

--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -5,6 +5,7 @@ import {SemiBoldHeader} from 'app/components/headers';
 import {AoU} from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {AnalyticsTracker} from 'app/utils/analytics';
 import {openZendeskWidget} from 'app/utils/zendesk';
 import { environment } from 'environments/environment';
 import * as React from 'react';
@@ -75,7 +76,9 @@ const FooterTemplate = ({style = {}, ...props}) => {
         {props.children}
         <div style={{...styles.footerAside, marginTop: '20px'}}>
           The <AoU/> logo is a service mark of the&nbsp;
-          <NewTabFooterAnchorTag href='https://www.hhs.gov'>
+          <NewTabFooterAnchorTag
+              href='https://www.hhs.gov'
+              analyticsFn={AnalyticsTracker.Footer.HHS}>
             U.S. Department of Health and Human Services
           </NewTabFooterAnchorTag>.<br/>
           The <AoU/> platform is for research only and does not provide medical advice, diagnosis or treatment. Copyright 2020.
@@ -110,20 +113,32 @@ const WorkbenchFooter = withUserProfile()(
     }
 
     render() {
+      const tracker = AnalyticsTracker.Footer;
       return <FooterTemplate>
         <FlexRow style={{justifyContent: 'flex-start', width: '100%'}}>
           <FooterSection style={styles.workbenchFooterItem} header='Quick Links'>
             <FlexRow>
               <FlexColumn style={{width: '50%'}}>
-                <FooterAnchorTag href='/'>Home</FooterAnchorTag>
-                <FooterAnchorTag href='library'>Featured Workspaces</FooterAnchorTag>
-                <FooterAnchorTag href='workspaces'>Your Workspaces</FooterAnchorTag>
+                <FooterAnchorTag href='/'
+                                 analyticsFn={tracker.Home}>
+                  Home
+                </FooterAnchorTag>
+                <FooterAnchorTag href='library'
+                                 analyticsFn={tracker.FeaturedWorkspaces}>
+                  Featured Workspaces
+                </FooterAnchorTag>
+                <FooterAnchorTag href='workspaces'
+                                 analyticsFn={tracker.YourWorkspaces}>
+                  Your Workspaces
+                </FooterAnchorTag>
               </FlexColumn>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={environment.publicUiUrl}>
+                <NewTabFooterAnchorTag href={environment.publicUiUrl}
+                                       analyticsFn={tracker.DataBrowser}>
                   Data Browser
                 </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href='https://researchallofus.org'>
+                <NewTabFooterAnchorTag href='https://researchallofus.org'
+                                       analyticsFn={tracker.ResearchHub}>
                   Research Hub
                 </NewTabFooterAnchorTag>
               </FlexColumn>
@@ -132,21 +147,25 @@ const WorkbenchFooter = withUserProfile()(
           <FooterSection style={styles.workbenchFooterItem} header='User Support'>
             <FlexRow>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={gettingStartedUrl}>
+                <NewTabFooterAnchorTag href={gettingStartedUrl} analyticsFn={tracker.GettingStarted}>
                   Getting Started
                 </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href={documentationUrl}>
+                <NewTabFooterAnchorTag href={documentationUrl}
+                                       analyticsFn={tracker.SupportDocs}>
                   Documentation
                 </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href={communityForumUrl}>
+                <NewTabFooterAnchorTag href={communityForumUrl}
+                                       analyticsFn={tracker.CommunityForum}>
                   Community Forum
                 </NewTabFooterAnchorTag>
               </FlexColumn>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={faqUrl}>
+                <NewTabFooterAnchorTag href={faqUrl}
+                                       analyticsFn={tracker.SupportFAQ}>
                   FAQs
                 </NewTabFooterAnchorTag>
                 <Link style={styles.footerAnchor} onClick={() => {
+                  tracker.ContactUs();
                   openZendeskWidget(
                     this.props.profileState.profile.givenName,
                     this.props.profileState.profile.familyName,

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -121,11 +121,11 @@ export const AnalyticsTracker = {
     FeaturedWorkspaces: () => triggerEvent(AnalyticsCategory.FOOTER, 'Featured workspaces', 'Featured workspaces'),
     ResearchHub: () => triggerEvent(AnalyticsCategory.FOOTER, 'Research Hub', 'Research Hub'),
     YourWorkspaces: () => triggerEvent(AnalyticsCategory.FOOTER, 'Your workspaces', 'Your workspaces'),
-    GettingStarted: () => triggerEvent(AnalyticsCategory.FOOTER, 'Getting started', 'Support-Getting started'),
-    SupportDocs: () => triggerEvent(AnalyticsCategory.FOOTER, 'Documentation', 'Support-Documentation'),
-    CommunityForum: () => triggerEvent(AnalyticsCategory.FOOTER, 'Community forum', 'Support-Community forum'),
-    SupportFAQ: () => triggerEvent(AnalyticsCategory.FOOTER, 'FAQ', 'Support-FAQ'),
-    ContactUs: () => triggerEvent(AnalyticsCategory.FOOTER, 'Contact Us', 'Support-Contact Us'),
+    GettingStarted: () => triggerEvent(AnalyticsCategory.FOOTER, 'Getting started', 'Support - Getting started'),
+    SupportDocs: () => triggerEvent(AnalyticsCategory.FOOTER, 'Documentation', 'Support - Documentation'),
+    CommunityForum: () => triggerEvent(AnalyticsCategory.FOOTER, 'Community forum', 'Support - Community forum'),
+    SupportFAQ: () => triggerEvent(AnalyticsCategory.FOOTER, 'FAQ', 'Support - FAQ'),
+    ContactUs: (suffix) => triggerEvent(AnalyticsCategory.FOOTER, 'Contact Us', `Support - Contact Us - ${suffix}`),
     HHS: () => triggerEvent(AnalyticsCategory.FOOTER, 'US Dept of Health & Human Svcs', 'hhs.gov')
   }
 };

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -29,66 +29,67 @@ export function triggerEvent(
   }
 }
 
-enum ANALYTICS_CATEGORIES {
+enum AnalyticsCategory {
   WORKSPACES = 'Workspaces',
   FEATURED_WORKSPACES = 'Featured Workspaces',
   DATASET_BUILDER = 'Dataset Builder',
   NOTEBOOKS = 'Notebooks',
   SIDEBAR = 'Sidebar Menu',
+  FOOTER = 'Footer',
   HELP = 'Help',
   WORKSPACE_UPDATE_PROMPT = 'Workspace update prompt'
 }
 
 export const AnalyticsTracker = {
   Workspaces: {
-    OpenCreatePage: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Create Page', getCurrentPageLabel()),
-    Create: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Create'),
-    OpenDuplicatePage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Duplicate Page', getCurrentPageLabel(suffix)),
-    Duplicate: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Duplicate'),
+    OpenCreatePage: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Open Create Page', getCurrentPageLabel()),
+    Create: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Create'),
+    OpenDuplicatePage: (suffix = '') => triggerEvent(AnalyticsCategory.WORKSPACES, 'Open Duplicate Page', getCurrentPageLabel(suffix)),
+    Duplicate: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Duplicate'),
     DuplicateFeatured: (name) =>
-      triggerEvent(ANALYTICS_CATEGORIES.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - Duplicate - ${name}`),
+      triggerEvent(AnalyticsCategory.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - Duplicate - ${name}`),
     NavigateToFeatured: (name) =>
-      triggerEvent(ANALYTICS_CATEGORIES.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - ${name}`),
-    OpenEditPage: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Edit Page', getCurrentPageLabel(suffix)),
-    Edit: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Edit'),
-    OpenShareModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Share Modal', getCurrentPageLabel(suffix)),
-    Share: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Share', getCurrentPageLabel()),
-    OpenDeleteModal: (suffix = '') => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Open Delete Modal', getCurrentPageLabel(suffix)),
-    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACES, 'Delete', getCurrentPageLabel()),
+      triggerEvent(AnalyticsCategory.FEATURED_WORKSPACES, 'Click', `Featured Workspace - Tile - ${name}`),
+    OpenEditPage: (suffix = '') => triggerEvent(AnalyticsCategory.WORKSPACES, 'Open Edit Page', getCurrentPageLabel(suffix)),
+    Edit: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Edit'),
+    OpenShareModal: (suffix = '') => triggerEvent(AnalyticsCategory.WORKSPACES, 'Open Share Modal', getCurrentPageLabel(suffix)),
+    Share: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Share', getCurrentPageLabel()),
+    OpenDeleteModal: (suffix = '') => triggerEvent(AnalyticsCategory.WORKSPACES, 'Open Delete Modal', getCurrentPageLabel(suffix)),
+    Delete: () => triggerEvent(AnalyticsCategory.WORKSPACES, 'Delete', getCurrentPageLabel()),
   },
   WorkspaceUpdatePrompt: {
-    LooksGood: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACE_UPDATE_PROMPT, 'Click \'Looks  Good\'', 'No Edits'),
-    UpdateWorkspace: () => triggerEvent(ANALYTICS_CATEGORIES.WORKSPACE_UPDATE_PROMPT, 'Click \'Update\'', 'Edit Workspace')
+    LooksGood: () => triggerEvent(AnalyticsCategory.WORKSPACE_UPDATE_PROMPT, 'Click \'Looks  Good\'', 'No Edits'),
+    UpdateWorkspace: () => triggerEvent(AnalyticsCategory.WORKSPACE_UPDATE_PROMPT, 'Click \'Update\'', 'Edit Workspace')
   },
   DatasetBuilder: {
-    OpenCreatePage: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Create Page'),
-    Save: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Save'),
-    SaveAndAnalyze: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Save and Analyze', suffix),
-    OpenEditPage: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Edit Page', suffix),
-    Update: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Update'),
-    UpdateAndAnalyze: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Update and Analyze', suffix),
-    SeeCodePreview: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'See Code Preview'),
-    OpenRenameModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Rename Modal'),
-    Rename: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Rename'),
-    OpenExportModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Export Modal'),
-    Export: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Export', suffix),
-    OpenDeleteModal: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Open Delete Modal'),
-    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'Delete'),
-    ViewPreviewTable: () => triggerEvent(ANALYTICS_CATEGORIES.DATASET_BUILDER, 'View Preview Table')
+    OpenCreatePage: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Open Create Page'),
+    Save: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Save'),
+    SaveAndAnalyze: (suffix) => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Save and Analyze', suffix),
+    OpenEditPage: (suffix) => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Open Edit Page', suffix),
+    Update: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Update'),
+    UpdateAndAnalyze: (suffix) => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Update and Analyze', suffix),
+    SeeCodePreview: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'See Code Preview'),
+    OpenRenameModal: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Open Rename Modal'),
+    Rename: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Rename'),
+    OpenExportModal: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Open Export Modal'),
+    Export: (suffix) => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Export', suffix),
+    OpenDeleteModal: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Open Delete Modal'),
+    Delete: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'Delete'),
+    ViewPreviewTable: () => triggerEvent(AnalyticsCategory.DATASET_BUILDER, 'View Preview Table')
   },
   Notebooks: {
-    OpenCreateModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Create Modal'),
-    Create: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Create', suffix),
-    OpenRenameModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Rename Modal'),
-    Rename: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Rename'),
-    Duplicate: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Duplicate'),
-    OpenCopyModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Copy Modal'),
-    Copy: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Copy'),
-    OpenDeleteModal: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Open Delete Modal'),
-    Delete: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Delete'),
-    Preview: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Preview'),
-    Edit: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Edit'),
-    Run: () => triggerEvent(ANALYTICS_CATEGORIES.NOTEBOOKS, 'Run (Playground Mode)')
+    OpenCreateModal: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Open Create Modal'),
+    Create: (suffix) => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Create', suffix),
+    OpenRenameModal: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Open Rename Modal'),
+    Rename: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Rename'),
+    Duplicate: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Duplicate'),
+    OpenCopyModal: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Open Copy Modal'),
+    Copy: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Copy'),
+    OpenDeleteModal: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Open Delete Modal'),
+    Delete: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Delete'),
+    Preview: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Preview'),
+    Edit: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Edit'),
+    Run: () => triggerEvent(AnalyticsCategory.NOTEBOOKS, 'Run (Playground Mode)')
   },
   Registration: {
     SignIn: () => triggerEvent('Registration', 'Click sign-in', 'Sign in'),
@@ -109,10 +110,23 @@ export const AnalyticsTracker = {
     TutorialVideo: () => triggerEvent('Home Page', 'Clicked on a tutorial video', 'Tutorial videos'),
   },
   Sidebar: {
-    OpenSidebar: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.SIDEBAR, 'Click', suffix),
-    Search: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.HELP, 'Search', `Help - Search - ${suffix}`),
-    ContactUs: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.HELP, 'Click', `Help - Contact Us - ${suffix}`),
-    UserSupport: (suffix) => triggerEvent(ANALYTICS_CATEGORIES.HELP, 'Click', `Help - User Support - ${suffix}`)
+    OpenSidebar: (suffix) => triggerEvent(AnalyticsCategory.SIDEBAR, 'Click', suffix),
+    Search: (suffix) => triggerEvent(AnalyticsCategory.HELP, 'Search', `Help - Search - ${suffix}`),
+    ContactUs: (suffix) => triggerEvent(AnalyticsCategory.HELP, 'Click', `Help - Contact Us - ${suffix}`),
+    UserSupport: (suffix) => triggerEvent(AnalyticsCategory.HELP, 'Click', `Help - User Support - ${suffix}`)
+  },
+  Footer: {
+    Home: () => triggerEvent(AnalyticsCategory.FOOTER, 'Home', 'Home'),
+    DataBrowser: () => triggerEvent(AnalyticsCategory.FOOTER, 'Data Browser', 'Data Browser'),
+    FeaturedWorkspaces: () => triggerEvent(AnalyticsCategory.FOOTER, 'Featured workspaces', 'Featured workspaces'),
+    ResearchHub: () => triggerEvent(AnalyticsCategory.FOOTER, 'Research Hub', 'Research Hub'),
+    YourWorkspaces: () => triggerEvent(AnalyticsCategory.FOOTER, 'Your workspaces', 'Your workspaces'),
+    GettingStarted: () => triggerEvent(AnalyticsCategory.FOOTER, 'Getting started', 'Support-Getting started'),
+    SupportDocs: () => triggerEvent(AnalyticsCategory.FOOTER, 'Documentation', 'Support-Documentation'),
+    CommunityForum: () => triggerEvent(AnalyticsCategory.FOOTER, 'Community forum', 'Support-Community forum'),
+    SupportFAQ: () => triggerEvent(AnalyticsCategory.FOOTER, 'FAQ', 'Support-FAQ'),
+    ContactUs: () => triggerEvent(AnalyticsCategory.FOOTER, 'Contact Us', 'Support-Contact Us'),
+    HHS: () => triggerEvent(AnalyticsCategory.FOOTER, 'US Dept of Health & Human Svcs', 'hhs.gov')
   }
 };
 


### PR DESCRIPTION
- Add GA tracking on footer links
- Support an analytics callback function on `StyledAnchorTag`
- Renamed GA enum to follow more standard naming conventions (originally, I'd thought I might export this.. happy to revert if this is too much for the PR)

Alternatives considered on property name:
- `onClick`: this seemed to ambiguous in combination with the standard onclick function (which runs first, etc)
- `sideEffect`: there's nothing GA specific about the callback parameter. However, this also left things a bit ambiguous as to when the side effect might actually run and I don't have any other ideas about what else could use this callback