### PR TITLE
[RW-5166][risk=no] inject DataSetMapper into DataSetServiceImpl

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -35,7 +35,6 @@ import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapperImpl;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
-import org.pmiops.workbench.dataset.DataSetMapper;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.DataSetServiceImpl;
@@ -43,7 +42,6 @@ import org.pmiops.workbench.dataset.DatasetConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
-import org.pmiops.workbench.db.dao.DataDictionaryEntryDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
@@ -94,8 +92,6 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   @Autowired private CdrVersionService cdrVersionService;
   @Autowired private CohortDao cohortDao;
   @Autowired private ConceptSetDao conceptSetDao;
-  @Autowired private DataDictionaryEntryDao dataDictionaryEntryDao;
-  @Autowired private DataSetMapper dataSetMapper;
   @Autowired private DataSetService dataSetService;
   @Autowired private FireCloudService fireCloudService;
   @Autowired private NotebooksService notebooksService;
@@ -179,10 +175,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
         spy(
             new DataSetController(
                 bigQueryService,
-                CLOCK,
                 cdrVersionService,
-                dataDictionaryEntryDao,
-                dataSetMapper,
                 dataSetService,
                 fireCloudService,
                 notebooksService,

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -108,12 +108,13 @@ public class DataSetController implements DataSetApiDelegate {
       String workspaceNamespace, String workspaceFirecloudName, DataSetRequest dataSetRequest) {
     validateDataSetCreateRequest(dataSetRequest);
     final long workspaceId =
-      workspaceService
-        .getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-          workspaceNamespace, workspaceFirecloudName, WorkspaceAccessLevel.WRITER)
-        .getWorkspaceId();
+        workspaceService
+            .getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+                workspaceNamespace, workspaceFirecloudName, WorkspaceAccessLevel.WRITER)
+            .getWorkspaceId();
     dataSetRequest.setWorkspaceId(workspaceId);
-    return ResponseEntity.ok(dataSetService.saveDataSet(dataSetRequest, userProvider.get().getUserId()));
+    return ResponseEntity.ok(
+        dataSetService.saveDataSet(dataSetRequest, userProvider.get().getUserId()));
   }
 
   private void validateDataSetCreateRequest(DataSetRequest dataSetRequest) {
@@ -375,9 +376,12 @@ public class DataSetController implements DataSetApiDelegate {
     if (Strings.isNullOrEmpty(request.getEtag())) {
       throw new BadRequestException("missing required update field 'etag'");
     }
-    workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-        workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
-
+    long dataSetWorkspaceId =
+        workspaceService
+            .getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+                workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER)
+            .getWorkspaceId();
+    request.setWorkspaceId(dataSetWorkspaceId);
     return ResponseEntity.ok(dataSetService.updateDataSet(request, dataSetId));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.dataset;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,17 +49,17 @@ public interface DataSetMapper {
 
   @Mapping(target = "dataSetId", ignore = true)
   @Mapping(
-      target = "version",
-      source = "etag",
-      qualifiedByName = "etagToCdrVersion",
-      nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+    target = "version",
+    source = "etag",
+    qualifiedByName = "etagToCdrVersion",
+    nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
   @Mapping(target = "creatorId", ignore = true)
   @Mapping(target = "creationTime", ignore = true)
   @Mapping(target = "invalid", ignore = true)
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "prePackagedConceptSetEnum", ignore = true)
   @Mapping(target = "values", source = "domainValuePairs")
-  DbDataset dataSetRequestToDb(DataSetRequest dataSetRequest, @Context DbDataset dbDataSet);
+  DbDataset dataSetRequestToDb(DataSetRequest dataSetRequest);
 
   @Mapping(target = "id", source = "dataSetId")
   @Mapping(target = "conceptSets", source = "conceptSetIds")

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetMapper.java
@@ -2,8 +2,6 @@ package org.pmiops.workbench.dataset;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,17 +47,17 @@ public interface DataSetMapper {
 
   @Mapping(target = "dataSetId", ignore = true)
   @Mapping(
-    target = "version",
-    source = "etag",
-    qualifiedByName = "etagToCdrVersion",
-    nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+      target = "version",
+      source = "etag",
+      qualifiedByName = "etagToCdrVersion",
+      nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
   @Mapping(target = "creatorId", ignore = true)
   @Mapping(target = "creationTime", ignore = true)
   @Mapping(target = "invalid", ignore = true)
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "prePackagedConceptSetEnum", ignore = true)
   @Mapping(target = "values", source = "domainValuePairs")
-  DbDataset dataSetRequestToDb(DataSetRequest dataSetRequest);
+  DbDataset dataSetRequestToDb(DataSetRequest dataSetRequest, @Context DbDataset dbDataSet);
 
   @Mapping(target = "id", source = "dataSetId")
   @Mapping(target = "conceptSets", source = "conceptSetIds")
@@ -71,13 +69,14 @@ public interface DataSetMapper {
   @AfterMapping
   default void populateFromSourceDbObject(
       @MappingTarget DbDataset targetDb, @Context DbDataset dbDataSet) {
-    if (dbDataSet != null
-        && (targetDb.getConceptSetIds() == null || targetDb.getConceptSetIds().size() == 0)) {
+    targetDb.setInvalid(dbDataSet == null ? false : dbDataSet.getInvalid());
+    if (targetDb.getValues().isEmpty()) {
       // In case of rename, dataSetRequest does not have cohort/Concept ID information
       targetDb.setConceptSetIds(dbDataSet.getConceptSetIds());
       targetDb.setCohortIds(dbDataSet.getCohortIds());
       targetDb.setValues(dbDataSet.getValues());
       targetDb.setIncludesAllParticipants(dbDataSet.getIncludesAllParticipants());
+      targetDb.setPrePackagedConceptSet(dbDataSet.getPrePackagedConceptSet());
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
@@ -5,10 +5,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.DataDictionaryEntry;
+import org.pmiops.workbench.model.DataSet;
 import org.pmiops.workbench.model.DataSetPreviewRequest;
 import org.pmiops.workbench.model.DataSetRequest;
 import org.pmiops.workbench.model.KernelTypeEnum;
@@ -16,7 +19,11 @@ import org.pmiops.workbench.model.ResourceType;
 
 public interface DataSetService {
 
-  DbDataset saveDataSet(DbDataset dataset);
+  DataSet saveDataSet(DataSetRequest dataSetRequest, Long userId);
+
+  DataSet saveDataSet(DbDataset dataset);
+
+  DataSet updateDataSet(DataSetRequest dataSetRequest, Long DataSetId);
 
   QueryJobConfiguration previewBigQueryJobConfig(DataSetPreviewRequest dataSetPreviewRequest);
 
@@ -37,11 +44,13 @@ public interface DataSetService {
 
   List<DbCohort> getCohortsForDataset(DbDataset dataSet);
 
-  List<DbDataset> getDataSets(ResourceType resourceType, long resourceId);
+  List<DataSet> getDataSets(ResourceType resourceType, long resourceId);
 
-  void deleteDataSet(DbWorkspace dbWorkspace, Long dataSetId);
+  void deleteDataSet(Long dataSetId);
 
-  Optional<DbDataset> getDbDataSet(DbWorkspace dbWorkspace, Long dataSetId);
+  Optional<DataSet> getDbDataSet(Long dataSetId);
 
   void markDirty(ResourceType resourceType, long resourceId);
+
+  DataDictionaryEntry findDataDictionaryEntry(String fieldName, DbCdrVersion cdrVersion);
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.utils.mappers;
 import java.sql.Timestamp;
 import java.util.Optional;
 import javax.inject.Provider;
+import joptsimple.internal.Strings;
 import org.mapstruct.Named;
 import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -65,7 +66,7 @@ public class CommonMappers {
 
   @Named("etagToCdrVersion")
   public int etagToCdrVersion(String etag) {
-    return Etags.toVersion(etag);
+    return Strings.isNullOrEmpty(etag) ? 1 : Etags.toVersion(etag);
   }
 
   public BillingStatus checkBillingFeatureFlag(BillingStatus billingStatus) {

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -12,13 +12,16 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.cdr.CdrVersionService;
+import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetMapper;
 import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.dataset.DataSetMapperImpl;
-import org.pmiops.workbench.dataset.DataSetService;
+import org.pmiops.workbench.dataset.DataSetServiceImpl;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.DataDictionaryEntryDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
@@ -58,17 +61,20 @@ public class DataDictionaryTest {
   @TestConfiguration
   @Import({
     CdrVersionService.class,
+    CommonMappers.class,
     DataSetController.class,
-    DataSetMapperImpl.class,
-    CommonMappers.class
+    DataSetServiceImpl.class,
+    DataSetMapperImpl.class
   })
   @MockBean({
     BigQueryService.class,
+    CdrBigQuerySchemaConfigService.class,
     CohortService.class,
+    CohortQueryBuilder.class,
+    ConceptBigQueryService.class,
     ConceptSetService.class,
     ConceptService.class,
     ConceptSetMapper.class,
-    DataSetService.class,
     FireCloudService.class,
     NotebooksService.class,
     WorkspaceService.class

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -161,7 +161,7 @@ public class DataSetMapperTest {
     request.setConceptSetIds(conceptIds);
     request.setIncludesAllParticipants(false);
     request.setPrePackagedConceptSet(PrePackagedConceptSetEnum.NONE);
-    final DbDataset toDataSet = dataSetMapper.dataSetRequestToDb(request, null);
+    final DbDataset toDataSet = dataSetMapper.dataSetRequestToDb(request, dbDataset);
     assertThat(toDataSet.getName()).isEqualTo("New Name");
     assertThat(toDataSet.getCohortIds()).isEqualTo(cohortIds);
     assertThat(toDataSet.getIncludesAllParticipants()).isFalse();

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetMapperTest.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.model.DataDictionaryEntry;
 import org.pmiops.workbench.model.DataSet;
 import org.pmiops.workbench.model.DataSetRequest;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.DomainValuePair;
 import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,6 +81,7 @@ public class DataSetMapperTest {
     dbDataset.setIncludesAllParticipants(false);
     dbDataset.setDescription("All Blue-eyed Blondes");
     dbDataset.setLastModifiedTime(Timestamp.from(Instant.now()));
+    dbDataset.setInvalid(false);
     dbDataset.setWorkspaceId(1L);
     dbDataset.setPrePackagedConceptSet(
         DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE));
@@ -147,7 +149,7 @@ public class DataSetMapperTest {
         .isEqualTo(dbDataset.getIncludesAllParticipants());
     assertThat(toDataSet.getConceptSetIds()).isEqualTo(dbDataset.getConceptSetIds());
     assertThat(toDataSet.getValues()).isEqualTo(dbDataset.getValues());
-    assertThat(toDataSet.getPrePackagedConceptSet()).isEqualTo((short) 2);
+    assertThat(toDataSet.getPrePackagedConceptSet()).isEqualTo((short) 0);
   }
 
   @Test
@@ -155,18 +157,24 @@ public class DataSetMapperTest {
     List<Long> conceptIds = ImmutableList.of(4l, 5l, 6l);
     List<Long> cohortIds = ImmutableList.of(1l, 2l, 3l);
 
+    DomainValuePair domainValuePair = new DomainValuePair();
+    domainValuePair.setDomain(Domain.PERSON);
+    domainValuePair.setValue("person_id");
+
     DataSetRequest request = new DataSetRequest();
     request.setName("New Name");
     request.setCohortIds(cohortIds);
     request.setConceptSetIds(conceptIds);
     request.setIncludesAllParticipants(false);
     request.setPrePackagedConceptSet(PrePackagedConceptSetEnum.NONE);
+    request.setDomainValuePairs(ImmutableList.of(domainValuePair));
     final DbDataset toDataSet = dataSetMapper.dataSetRequestToDb(request, dbDataset);
     assertThat(toDataSet.getName()).isEqualTo("New Name");
     assertThat(toDataSet.getCohortIds()).isEqualTo(cohortIds);
     assertThat(toDataSet.getIncludesAllParticipants()).isFalse();
     assertThat(toDataSet.getConceptSetIds()).isEqualTo(conceptIds);
     assertThat(toDataSet.getPrePackagedConceptSet()).isEqualTo((short) 0);
+    assertThat(toDataSet.getValues().get(0).getDomainEnum()).isEqualTo(Domain.PERSON);
   }
 
   private void assertDbModelToClient(DataSet dataSet, DbDataset dbDataset) {


### PR DESCRIPTION
This PR addresses:
1. moving DataSetMapper from DataSetController to DataSetServiceImpl
2. moving DataDictionaryEntryDao from DataSetController to DataSetServiceImpl
3. updating affected test cases.