### PR TITLE
[no ticket][risk=no] Puppeteer remove setViewport

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -9,7 +9,6 @@ const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/5
  * - waitFor functions timeout
  */
 beforeEach(async () => {
-  await page.setViewport({ width: 0, height: 0 });
   await page.setUserAgent(userAgent);
   // See https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaultnavigationtimeouttimeout
   await page.setDefaultNavigationTimeout(90000);


### PR DESCRIPTION
Caused one test to fail in headless mode.
https://app.circleci.com/pipelines/github/all-of-us/workbench/2349/workflows/5fcb439c-f417-4dc4-b29a-c33033c7ba7d/jobs/90087/steps