### PR TITLE
[RW-5233][risk=no] Fix styles for CB dropdown menu buttons

### DIFF
--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -104,6 +104,7 @@ const styles = reactStyles({
     padding: '3px 5px'
   },
   menuButton: {
+    background: colors.white,
     border: `1px solid ${colorWithWhiteness(colors.black, .8)}`,
     borderRadius: '0.125rem',
     color: colors.primary,

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -72,9 +72,11 @@ const styles = reactStyles({
     width: 'auto'
   },
   menuButton: {
+    background: colors.white,
     border: `1px solid ${colorWithWhiteness(colors.black, 0.75)}`,
     borderRadius: '0.125rem',
     color: colorWithWhiteness(colors.black, 0.45),
+    cursor: 'pointer',
     fontSize: '12px',
     fontWeight: 100,
     height: '1.5rem',

--- a/ui/src/app/cohort-search/search-group/search-group.component.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.tsx
@@ -82,9 +82,11 @@ const styles = reactStyles({
     padding: '0.5rem 0.25rem'
   },
   menuButton: {
+    background: colors.white,
     border: `1px solid ${colorWithWhiteness(colors.black, 0.75)}`,
     borderRadius: '0.125rem',
     color: colorWithWhiteness(colors.black, 0.45),
+    cursor: 'pointer',
     fontSize: '12px',
     fontWeight: 100,
     height: '1.5rem',


### PR DESCRIPTION
At some point, the backgrounds switched to gray but should be white.

Before:
<img width="1674" alt="Screen Shot 2020-07-14 at 3 31 45 PM" src="https://user-images.githubusercontent.com/40036095/87474545-df708800-c5e8-11ea-81ac-b1c13e4d0262.png">

After:
<img width="1674" alt="Screen Shot 2020-07-14 at 3 31 55 PM" src="https://user-images.githubusercontent.com/40036095/87474588-ed260d80-c5e8-11ea-8df9-e4c8c920ed47.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
