### PR TITLE
[RW-4319][risk=no] Drop all usages of sendFreeTierAlertEmails (1/2)

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -242,8 +242,7 @@ public class WorkbenchConfig {
     // as opposed to reading service account private keys from GCS.
     // See RW-2840.
     public boolean useKeylessDelegatedCredentials;
-    // Whether we send emails to users after they pass Free Tier usage thresholds
-    // Blocked by RW-4135: do not enable in an environment where contact_email can be NULL
+    // Deprecated. Removal pending: RW-4319.
     public boolean sendFreeTierAlertEmails;
     // Flag to indicate whether to use the new Moodle badges API
     // https://precisionmedicineinitiative.atlassian.net/browse/RW-2957

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -120,26 +120,24 @@ public class MailServiceImpl implements MailService {
             user.getUsername(), threshold, currentUsage, remainingBalance);
     log.info(logMsg);
 
-    if (workbenchConfig.featureFlags.sendFreeTierAlertEmails) {
-      final String msgHtml =
-          buildHtml(
-              FREE_TIER_DOLLAR_THRESHOLD_RESOURCE,
-              freeTierDollarThresholdSubstitutionMap(user, currentUsage, remainingBalance));
-      final String subject =
-          String.format(
-              "Reminder - %s Free credit usage in All of Us Researcher Workbench",
-              formatPercentage(threshold));
+    final String msgHtml =
+        buildHtml(
+            FREE_TIER_DOLLAR_THRESHOLD_RESOURCE,
+            freeTierDollarThresholdSubstitutionMap(user, currentUsage, remainingBalance));
+    final String subject =
+        String.format(
+            "Reminder - %s Free credit usage in All of Us Researcher Workbench",
+            formatPercentage(threshold));
 
-      final MandrillMessage msg =
-          new MandrillMessage()
-              .to(Collections.singletonList(validatedRecipient(user.getContactEmail())))
-              .html(msgHtml)
-              .subject(subject)
-              .fromEmail(workbenchConfig.mandrill.fromEmail);
+    final MandrillMessage msg =
+        new MandrillMessage()
+            .to(Collections.singletonList(validatedRecipient(user.getContactEmail())))
+            .html(msgHtml)
+            .subject(subject)
+            .fromEmail(workbenchConfig.mandrill.fromEmail);
 
-      sendWithRetries(
-          msg, String.format("User %s passed a free tier dollar threshold", user.getUsername()));
-    }
+    sendWithRetries(
+        msg, String.format("User %s passed a free tier dollar threshold", user.getUsername()));
   }
 
   @Override
@@ -150,22 +148,20 @@ public class MailServiceImpl implements MailService {
         String.format("Free credits have expired for User %s", user.getUsername());
     log.info(logMsg);
 
-    if (workbenchConfig.featureFlags.sendFreeTierAlertEmails) {
-      final String msgHtml =
-          buildHtml(FREE_TIER_EXPIRATION_RESOURCE, freeTierExpirationSubstitutionMap(user));
+    final String msgHtml =
+        buildHtml(FREE_TIER_EXPIRATION_RESOURCE, freeTierExpirationSubstitutionMap(user));
 
-      final String subject = "Alert - Free credit expiration in All of Us Researcher Workbench";
+    final String subject = "Alert - Free credit expiration in All of Us Researcher Workbench";
 
-      final MandrillMessage msg =
-          new MandrillMessage()
-              .to(Collections.singletonList(validatedRecipient(user.getContactEmail())))
-              .html(msgHtml)
-              .subject(subject)
-              .fromEmail(workbenchConfig.mandrill.fromEmail);
+    final MandrillMessage msg =
+        new MandrillMessage()
+            .to(Collections.singletonList(validatedRecipient(user.getContactEmail())))
+            .html(msgHtml)
+            .subject(subject)
+            .fromEmail(workbenchConfig.mandrill.fromEmail);
 
-      sendWithRetries(
-          msg, String.format("Free tier credits have expired for user %s", user.getUsername()));
-    }
+    sendWithRetries(
+        msg, String.format("Free tier credits have expired for user %s", user.getUsername()));
   }
 
   @Override


### PR DESCRIPTION
Part 1: remove all usage of the feature flag
Part 2 (next PR): remove the feature flag

Process which we should formalize: https://github.com/all-of-us/workbench/pull/2920#discussion_r356808233