### PR TITLE
[RW-5218][risk=no] Adding is_deceased to the cloud CDR

### DIFF
--- a/api/config/cdr_versions_perf.json
+++ b/api/config/cdr_versions_perf.json
@@ -33,6 +33,6 @@
     "creationTime": "2020-05-07 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_1"
+    "cdrDbName": "synth_r_2019q4_2"
   }
 ]

--- a/api/config/cdr_versions_preprod.json
+++ b/api/config/cdr_versions_preprod.json
@@ -32,6 +32,6 @@
     "creationTime": "2020-05-07 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_1"
+    "cdrDbName": "synth_r_2019q4_2"
   }
 ]

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -59,6 +59,6 @@
     "creationTime": "2020-05-07 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_1"
+    "cdrDbName": "synth_r_2019q4_2"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -59,6 +59,6 @@
     "creationTime": "2020-05-07 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_1"
+    "cdrDbName": "synth_r_2019q4_2"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -33,6 +33,6 @@
     "creationTime": "2020-05-07 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_1"
+    "cdrDbName": "synth_r_2019q4_2"
   }
 ]

--- a/api/db-cdr/changelog-schema/db.changelog-36.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-36.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+  <changeSet author="brianfreeman" id="changelog-36">
+    <addColumn tableName="cb_person">
+      <column name="is_deceased" type="BOOL">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -42,4 +42,5 @@
   <include file="changelog-schema/db.changelog-33.xml"/>
   <include file="changelog-schema/db.changelog-34.xml"/>
   <include file="changelog-schema/db.changelog-35.xml"/>
+  <include file="changelog-schema/db.changelog-36.xml"/>
 </databaseChangeLog>

--- a/api/db-cdr/generate-cdr/bq-schemas/cb_person.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/cb_person.json
@@ -18,5 +18,10 @@
     "mode": "NULLABLE",
     "name": "age_at_cdr",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_deceased",
+    "type": "INTEGER"
   }
 ]

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -87,8 +87,8 @@ VALUES
 echo "Inserting cb_person"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "INSERT INTO \`$OUTPUT_PROJECT.$OUTPUT_DATASET.cb_person\`
-(person_id, dob, age_at_consent, age_at_cdr)
-SELECT person_id, dob, age_at_consent, age_at_cdr
+(person_id, dob, age_at_consent, age_at_cdr, is_deceased)
+SELECT person_id, dob, age_at_consent, age_at_cdr, is_deceased
 FROM \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`"
 
 # Populate cb_data_filter table

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
@@ -169,12 +169,12 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 0
-    and sad.concept_id = 903118"
+    and sad.concept_id = 903115"
 
 #####################################################################
 #   update source systolic pressure data into cb_search_all_events
 #####################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
+echo "Updating systolic pressure data into cb_search_all_events"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
 SET sad.systolic = meas.systolic
@@ -189,7 +189,7 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 0
-    and sad.concept_id = 903115"
+    and sad.concept_id = 903118"
 
 ################################################################
 #   insert standard measurement data into cb_search_all_events
@@ -238,12 +238,12 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 1
-    and sad.concept_id = 903118"
+    and sad.concept_id = 903115"
 
 #######################################################################
-#   update standard diastolic pressure data into cb_search_all_events
+#   update standard systolic pressure data into cb_search_all_events
 #######################################################################
-echo "Updating diastolic pressure data into cb_search_all_events"
+echo "Updating systolic pressure data into cb_search_all_events"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\` sad
 SET sad.systolic = meas.systolic
@@ -259,7 +259,7 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 1
-    and sad.concept_id = 903115"
+    and sad.concept_id = 903118"
 
 ##############################################################
 #   insert source observation data into cb_search_all_events

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
@@ -169,7 +169,8 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 0
-    and sad.concept_id = 903115"
+    -- this is intentional as we want to update diastolic on the systolic row
+    and sad.concept_id = 903118"
 
 #####################################################################
 #   update source systolic pressure data into cb_search_all_events
@@ -189,7 +190,8 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 0
-    and sad.concept_id = 903118"
+    -- this is intentional as we want to update systolic on the diastolic row
+    and sad.concept_id = 903115"
 
 ################################################################
 #   insert standard measurement data into cb_search_all_events
@@ -238,7 +240,8 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 1
-    and sad.concept_id = 903115"
+    -- this is intentional as we want to update diastolic on the systolic row
+    and sad.concept_id = 903118"
 
 #######################################################################
 #   update standard systolic pressure data into cb_search_all_events
@@ -259,7 +262,8 @@ FROM
 WHERE meas.person_id = sad.person_id
     and meas.measurement_datetime = sad.entry_datetime
     and sad.is_standard = 1
-    and sad.concept_id = 903118"
+    -- this is intentional as we want to update systolic on the diastolic row
+    and sad.concept_id = 903115"
 
 ##############################################################
 #   insert source observation data into cb_search_all_events

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -761,6 +761,7 @@ Common.register_command({
 })
 
 def make_bq_denormalized_tables(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   date = Time.new
   date = date.year.to_s + "-" + date.month.to_s + "-" + date.day.to_s
@@ -807,6 +808,7 @@ Generates big query denormalized tables for search and review. Used by cohort bu
 })
 
 def make_bq_denormalized_review(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.dry_run = false
   op.add_option(
@@ -839,6 +841,7 @@ Generates big query denormalized tables for review. Used by cohort builder. Must
 })
 
 def make_bq_denormalized_search_events(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.data_browser = false
   op.opts.dry_run = false
@@ -877,6 +880,7 @@ Generates big query denormalized search. Used by cohort builder. Must be run onc
 })
 
 def make_bq_denormalized_search_person(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.data_browser = false
   op.opts.dry_run = false
@@ -915,6 +919,7 @@ Generates big query denormalized search. Used by cohort builder. Must be run onc
 })
 
 def make_bq_denormalized_dataset(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.dry_run = false
   op.add_option(
@@ -947,6 +952,7 @@ Generates big query denormalized dataset tables. Used by Data Set Builder. Must 
 })
 
 def make_bq_dataset_linking(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.dry_run = false
   op.add_option(
@@ -1019,6 +1025,7 @@ Generates the criteria table in big query. Used by cohort builder. Must be run o
 })
 
 def generate_private_cdr_counts(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.add_option(
     "--bq-project [bq-project]",
@@ -1063,6 +1070,7 @@ Generates databases in bigquery with data from a de-identified cdr that will be 
 })
 
 def copy_bq_tables(cmd_name, *args)
+  ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)
   op.add_option(
     "--sa-project [sa-project]",


### PR DESCRIPTION
This PR does the following:
1. move the CDR version from `synth_r_2019q4_21` to `synth_r_2019q4_2` for test, staging, stable, perf and preprod
2. adds the `is_deceased` column to the `cb_person` table
3. fixes a bug with systolic and diastolic concept ids
4. adds `ensure_docker_sync()` to many of the CDR indexing commands in `devstart.rb`