### PR TITLE
[RW-5218][risk=no] bumping cloud CDR version

### DIFF
--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -57,6 +57,6 @@
     "creationTime": "2019-10-04 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 224143,
-    "cdrDbName": "r_2020q1_2"
+    "cdrDbName": "r_2019q4_4"
   }
 ]


### PR DESCRIPTION
bumping cloud CDR version - change cloud cdr version(r_2019q4_4) to be inline with the BQ name(R2019Q4R3)