### PR TITLE
[RW-5089][risk=no] Centralize Zendesk urlset and correct sandbox URLs

### DIFF
--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -6,7 +6,7 @@ import {AoU} from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
-import {openZendeskWidget} from 'app/utils/zendesk';
+import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import { environment } from 'environments/environment';
 import * as React from 'react';
 
@@ -111,11 +111,6 @@ const FooterSection = ({style = {}, header, ...props}) => {
   </FlexColumn>;
 };
 
-const gettingStartedUrl = 'https://aousupporthelp.zendesk.com/hc/en-us/categories/360002157352-Getting-Started';
-const documentationUrl = 'https://aousupporthelp.zendesk.com/hc/en-us/categories/360002625291-Documentation';
-const communityForumUrl = 'https://aousupporthelp.zendesk.com/hc/en-us/community/topics';
-const faqUrl = 'https://aousupporthelp.zendesk.com/hc/en-us/categories/360002157532-Frequently-Asked-Questions';
-
 interface WorkbenchFooterProps {
   profileState;
 }
@@ -155,20 +150,20 @@ const WorkbenchFooter = withUserProfile()(
           <FooterSection style={styles.workbenchFooterItem} header='User Support'>
             <FlexRow>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={gettingStartedUrl} analyticsFn={tracker.GettingStarted}>
+                <NewTabFooterAnchorTag href={supportUrls.gettingStarted} analyticsFn={tracker.GettingStarted}>
                   Getting Started
                 </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href={documentationUrl}
+                <NewTabFooterAnchorTag href={supportUrls.tableOfContents}
                                        analyticsFn={tracker.SupportDocs}>
                   Documentation
                 </NewTabFooterAnchorTag>
-                <NewTabFooterAnchorTag href={communityForumUrl}
+                <NewTabFooterAnchorTag href={supportUrls.communityForum}
                                        analyticsFn={tracker.CommunityForum}>
                   Community Forum
                 </NewTabFooterAnchorTag>
               </FlexColumn>
               <FlexColumn style={{width: '50%'}}>
-                <NewTabFooterAnchorTag href={faqUrl}
+                <NewTabFooterAnchorTag href={supportUrls.faq}
                                        analyticsFn={tracker.SupportFAQ}>
                   FAQs
                 </NewTabFooterAnchorTag>

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -15,13 +15,12 @@ import {highlightSearchTerm, reactStyles, ReactWrapperBase, withCurrentWorkspace
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {NavStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {openZendeskWidget} from 'app/utils/zendesk';
+import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {environment} from 'environments/environment';
 import {ParticipantCohortStatus, WorkspaceAccessLevel} from 'generated/fetch';
 import {MenuItem, StyledAnchorTag} from './buttons';
 import {PopupTrigger} from './popups';
 
-const dataDictionaryUrl = 'https://aousupporthelp.zendesk.com/hc/en-us/articles/360033200232-Data-dictionary-for-Registered-Tier-Curated-Data-Repository-CDR-';
 const proIcons = {
   thunderstorm: '/assets/icons/thunderstorm-solid.svg'
 };
@@ -450,7 +449,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile())(
                        onMouseOver={() => this.setState({tooltipId: i})}
                        onMouseOut={() => this.setState({tooltipId: undefined})}>
                     {icon.id === 'dataDictionary'
-                      ? <a href={dataDictionaryUrl} target='_blank'>
+                      ? <a href={supportUrls.dataDictionary} target='_blank'>
                           <FontAwesomeIcon data-test-id={'help-sidebar-icon-' + i} icon={icon.faIcon} style={icon.style} />
                         </a>
                       : icon.faIcon === null

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -16,7 +16,6 @@ import {AnalyticsTracker} from 'app/utils/analytics';
 import {NavStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
-import {environment} from 'environments/environment';
 import {ParticipantCohortStatus, WorkspaceAccessLevel} from 'generated/fetch';
 import {MenuItem, StyledAnchorTag} from './buttons';
 import {PopupTrigger} from './popups';
@@ -501,7 +500,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile())(
             <div style={styles.footer}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
               <p style={styles.contentItem}>
-                Visit our <StyledAnchorTag href={environment.zendeskHelpCenterUrl}
+                Visit our <StyledAnchorTag href={supportUrls.helpCenter}
                                            target='_blank' onClick={() => this.analyticsEvent('UserSupport')}> User Support
                 </StyledAnchorTag> page or <span style={styles.link} onClick={() => this.openContactWidget()}> contact us</span>.
               </p>

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -3,8 +3,7 @@ import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles} from 'app/utils';
 import {navigate, navigateSignOut, signInStore} from 'app/utils/navigation';
-import {openZendeskWidget} from 'app/utils/zendesk';
-import {environment} from 'environments/environment';
+import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {Authority, Profile} from 'generated/fetch';
 import * as React from 'react';
 
@@ -236,7 +235,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
   }
 
   redirectToZendesk() {
-    window.open(environment.zendeskHelpCenterUrl, '_blank');
+    window.open(supportUrls.helpCenter, '_blank');
   }
 
   openContactWidget() {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -28,7 +28,7 @@ import {currentWorkspaceStore, navigateAndPreventDefaultIfNoKeysPressed} from 'a
 import {apiCallWithGatewayTimeoutRetries} from 'app/utils/retry';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
-import {openZendeskWidget} from 'app/utils/zendesk';
+import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {
   BillingStatus,
   Cohort,
@@ -1039,8 +1039,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                     width: '100%', height: '1.375rem', backgroundColor: colorWithWhiteness(colors.dark, 0.9),
                     color: colors.primary, paddingLeft: '0.4rem', fontSize: '13px', lineHeight: '16px',
                     alignItems: 'center'}}>
-                    <StyledAnchorTag href={'https://aousupporthelp.zendesk.com/hc/en-us/articles/' +
-                    '360033200232-Data-Dictionary-for-Registered-Tier-CDR'} target='_blank'>
+                    <StyledAnchorTag href={supportUrls.dataDictionary} target='_blank'>
                       Learn more
                     </StyledAnchorTag>&nbsp;in the data dictionary
                   </FlexRow>}

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -20,9 +20,9 @@ import {getRegistrationTasksMap, RegistrationDashboard} from 'app/pages/homepage
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
-import {supportUrls} from 'app/utils/zendesk';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
+import {supportUrls} from 'app/utils/zendesk';
 import {
   Profile,
 } from 'generated/fetch';

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -20,9 +20,9 @@ import {getRegistrationTasksMap, RegistrationDashboard} from 'app/pages/homepage
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {supportUrls} from 'app/utils/zendesk';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
-import {environment} from 'environments/environment';
 import {
   Profile,
 } from 'generated/fetch';
@@ -369,7 +369,7 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
                                         the left hand panel to browse through example workspaces.
                                       </CustomBulletListItem>
                                       <CustomBulletListItem bullet='→'>
-                                        Browse through our <StyledAnchorTag href={environment.zendeskHelpCenterUrl}
+                                        Browse through our <StyledAnchorTag href={supportUrls.helpCenter}
                                           target='_blank'>support materials</StyledAnchorTag> and forum topics.
                                       </CustomBulletListItem>
                                     </CustomBulletList>

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -22,6 +22,7 @@ import colors, {addOpacity} from 'app/styles/colors';
 import {hasRegisteredAccessFetch, reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
+import {environment} from 'environments/environment';
 import {
   Profile,
 } from 'generated/fetch';
@@ -368,7 +369,7 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
                                         the left hand panel to browse through example workspaces.
                                       </CustomBulletListItem>
                                       <CustomBulletListItem bullet='→'>
-                                        Browse through our <StyledAnchorTag href='https://aousupporthelp.zendesk.com/hc/en-us'
+                                        Browse through our <StyledAnchorTag href={environment.zendeskHelpCenterUrl}
                                           target='_blank'>support materials</StyledAnchorTag> and forum topics.
                                       </CustomBulletListItem>
                                     </CustomBulletList>

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -207,9 +207,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    // If we ever get a test Zendesk account,
-    // the key should be templated in using an environment variable.
-    initializeZendeskWidget(this.elementRef, environment.zendeskWidgetKey);
+    initializeZendeskWidget(this.elementRef);
   }
 
   ngOnDestroy() {

--- a/ui/src/app/pages/workspace/create-billing-account-modal.tsx
+++ b/ui/src/app/pages/workspace/create-billing-account-modal.tsx
@@ -6,7 +6,7 @@ import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {TextColumn} from 'app/components/text-column';
 import colors from 'app/styles/colors';
 import {withUserProfile} from 'app/utils';
-import {environment} from 'environments/environment';
+import {supportUrls} from 'app/utils/zendesk';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
 
@@ -34,7 +34,7 @@ export const CreateBillingAccountModal = withUserProfile() (
 
             <Button type='primary'
                     style={{fontWeight: 400, padding: '0 18px', height: '40px'}}
-                    onClick={() => window.open(environment.createBillingAccountHelpUrl, '_blank')}>
+                    onClick={() => window.open(supportUrls.createBillingAccount, '_blank')}>
               Read Instructions
             </Button>
           </FlexColumn>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -47,7 +47,7 @@ import {reportError} from 'app/utils/errors';
 import {currentWorkspaceStore, navigate, nextWorkspaceWarmupStore, serverConfigStore} from 'app/utils/navigation';
 import {getBillingAccountInfo} from 'app/utils/workbench-gapi-client';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {openZendeskWidget} from 'app/utils/zendesk';
+import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {
   ArchivalStatus,
   BillingAccount,
@@ -444,8 +444,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     renderBillingDescription() {
       return <div>
         The <AouTitle/> provides $300 in free credits per user. Please refer to
-        <StyledAnchorTag href={'https://aousupporthelp.zendesk.com/hc/en-us/sections' +
-        '/360008099991-Questions-About-Billing'} target='_blank'> &nbsp;this article
+        <StyledAnchorTag href={supportUrls.billing} target='_blank'> &nbsp;this article
         </StyledAnchorTag> to learn more about the free credit
         program and how it can be used. Once you have used up your free credits, you can request
         additional credits by <span style={styles.link} onClick={() => this.openContactWidget()}>
@@ -1025,7 +1024,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         <hr style={{marginTop: '1rem'}}/>
         <WorkspaceEditSection header={<FlexRow style={{alignItems: 'center'}}>
           <div>Research Use Statement Questions</div>
-          <StyledAnchorTag href='https://aousupporthelp.zendesk.com/hc/en-us/articles/360042673211-Examples-of-research-purpose-descriptions-'
+          <StyledAnchorTag href={supportUrls.researchPurpose}
                            target='_blank' style={{marginLeft: '1rem', fontSize: 14, lineHeight: '18px', fontWeight: 400}}>
             Best practices for Research Use Statement questions
           </StyledAnchorTag>

--- a/ui/src/app/utils/zendesk.ts
+++ b/ui/src/app/utils/zendesk.ts
@@ -1,4 +1,69 @@
 import {ElementRef} from '@angular/core';
+import {environment} from 'environments/environment';
+
+interface ZendeskUrls {
+  billing: string,
+  communityForum: string,
+  createBillingAccount: string,
+  dataDictionary: string,
+  faq: string,
+  gettingStarted: string,
+  tableOfContents: string,
+  researchPurpose: string,
+}
+
+/**
+ * A set of support URLs for the current environment. These need to be
+ * parameterized per environment since the Zendesk support content IDs are not
+ * stable across the prod and sandbox Zendesk instances.
+ */
+export const supportUrls: ZendeskUrls = ((baseUrl) => {
+  // We'll fallback to prod, if parsing fails. We don't want to throw here,
+  // since this is evaluated statically.
+  let host;
+  try {
+    host = new URL(baseUrl).host;
+  } catch (e) {
+    console.error('failed to parse zendesk support URL from env - assuming prod', e);
+  }
+
+  const prodHost = 'aousupporthelp.zendesk.com';
+  const article = (id) => `${baseUrl}/articles/${id}`;
+  const category = (id) => `${baseUrl}/categories/${id}`;
+  const section = (id) => `${baseUrl}/sections/${id}`;
+  const commonUrls = {
+    // This link in particular needs the "en-us" infix. The other urls will
+    // redirect according to detected locale, which is preferred.
+    communityForum: `${baseUrl}/en-us/community/topics`
+  };
+  const urls: {[key: string]: ZendeskUrls} = {
+    [prodHost]: {
+      ...commonUrls,
+      billing: section('360008099991'),
+      createBillingAccount: article('360039539411'),
+      dataDictionary: article('360033200232'),
+      faq: category('360002157532'),
+      gettingStarted: category('360002157352'),
+      tableOfContents: category('360002625291'),
+      researchPurpose: article('360042673211'),
+    },
+    'aousupporthelp1580753096.zendesk.com': {
+      ...commonUrls,
+      billing: section('360009142932'),
+      createBillingAccount: article('360044792211'),
+      dataDictionary: article('360044793611'),
+      faq: category('360003453651'),
+      gettingStarted: category('360003430652'),
+      tableOfContents: category('360003430672'),
+      researchPurpose: article('360044334652'),
+    }
+  };
+  if (!urls[host]) {
+    console.error(`no article IDs for Zendesk host ${host}, defaulting to prod`);
+    return urls[prodHost];
+  }
+  return urls[host];
+})(environment.zendeskHelpCenterUrl);
 
 // ideally this initialization would be done by including <script> tags in
 // the component template html file.  However, Angular does not allow this.

--- a/ui/src/app/utils/zendesk.ts
+++ b/ui/src/app/utils/zendesk.ts
@@ -3,15 +3,15 @@ import {environment} from 'environments/environment';
 import {ZendeskEnv} from 'environments/environment-type';
 
 interface ZendeskUrls {
-  billing: string,
-  communityForum: string,
-  createBillingAccount: string,
-  dataDictionary: string,
-  faq: string,
-  gettingStarted: string,
-  helpCenter: string,
-  tableOfContents: string,
-  researchPurpose: string,
+  billing: string;
+  communityForum: string;
+  createBillingAccount: string;
+  dataDictionary: string;
+  faq: string;
+  gettingStarted: string;
+  helpCenter: string;
+  tableOfContents: string;
+  researchPurpose: string;
 }
 
 const zendeskConfigs = {
@@ -23,7 +23,7 @@ const zendeskConfigs = {
     baseUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
     widgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9'
   }
-}
+};
 
 /**
  * A set of support URLs for the current environment. These need to be

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -43,7 +43,6 @@ export interface Environment {
   // The base URL for the Zendesk help center / user forum.
   // Example value: https://aousupporthelp.zendesk.com/hc/
   zendeskHelpCenterUrl: string;
-  createBillingAccountHelpUrl: string;
   // Zendesk Widget API key from the Zendesk admin console.
   zendeskWidgetKey: string;
 

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -1,3 +1,10 @@
+// The Zendesk environment instance. Note that sandbox is a mirror which has
+// different content IDs and separate SAML integration. See also app/utils/zendesk.ts.
+export enum ZendeskEnv {
+  Prod = 'prod',
+  Sandbox = 'sandbox'
+}
+
 export interface Environment {
   // Permanent environment variables.
   //
@@ -40,12 +47,8 @@ export interface Environment {
   // The url for Moodle integration
   // Example value: https://aoudev.nnlm.gov
   trainingUrl: string;
-  // The base URL for the Zendesk help center / user forum.
-  // Example value: https://aousupporthelp.zendesk.com/hc/
-  zendeskHelpCenterUrl: string;
-  // Zendesk Widget API key from the Zendesk admin console.
-  zendeskWidgetKey: string;
-
+  // The Zendesk environment corresponding to this deployment.
+  zendeskEnv: ZendeskEnv;
   inactivityTimeoutSeconds: number;
   inactivityWarningBeforeSeconds: number;
   // Whether users should be able to see the Published Workspaces

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -16,7 +16,6 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp1580753096.zendesk.com/hc/en-us/articles/360039550031-Instructions-to-Create-a-Billing-Account',
   zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 import {testEnvironmentBase} from 'environments/test-env-base';
 
 // This file is used for a local UI server pointed at a local API server
@@ -15,8 +15,7 @@ export const environment: Environment = {
   gaId: 'UA-112406425-5',
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
-  zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
+  zendeskEnv: ZendeskEnv.Sandbox,
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Perf',
@@ -14,8 +14,7 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
-  zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
+  zendeskEnv: ZendeskEnv.Sandbox,
   shibbolethUrl: 'https://shibboleth.dsde-perf.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -15,7 +15,6 @@ export const environment: Environment = {
   gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp1580753096.zendesk.com/hc/en-us/articles/360039550031-Instructions-to-Create-a-Billing-Account',
   zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
   shibbolethUrl: 'https://shibboleth.dsde-perf.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -13,7 +13,6 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp.zendesk.com/hc/en-us/articles/360039539411-How-to-Create-a-Billing-Account',
   zendeskWidgetKey: '5a7d70b9-37f9-443b-8d0e-c3bd3c2a55e3',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   trainingUrl: 'https://aou.nnlm.gov',

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'preprod',
@@ -12,8 +12,7 @@ export const environment: Environment = {
   gaId: 'UA-112406425-7',
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
-  zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
-  zendeskWidgetKey: '5a7d70b9-37f9-443b-8d0e-c3bd3c2a55e3',
+  zendeskEnv: ZendeskEnv.Prod,
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   trainingUrl: 'https://aou.nnlm.gov',
   inactivityTimeoutSeconds: 30 * 60,

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -13,7 +13,6 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp.zendesk.com/hc/en-us/articles/360039539411-How-to-Create-a-Billing-Account',
   zendeskWidgetKey: '5a7d70b9-37f9-443b-8d0e-c3bd3c2a55e3',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   trainingUrl: 'https://aou.nnlm.gov',

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: '',
@@ -12,8 +12,7 @@ export const environment: Environment = {
   gaId: 'UA-112406425-4',
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
-  zendeskHelpCenterUrl: 'http://aousupporthelp.zendesk.com/hc',
-  zendeskWidgetKey: '5a7d70b9-37f9-443b-8d0e-c3bd3c2a55e3',
+  zendeskEnv: ZendeskEnv.Prod,
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   trainingUrl: 'https://aou.nnlm.gov',
   inactivityTimeoutSeconds: 30 * 60,

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -13,7 +13,6 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp1580753096.zendesk.com/hc/en-us/articles/360039550031-Instructions-to-Create-a-Billing-Account',
   zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
   trainingUrl: 'https://aoudev.nnlm.gov',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Stable',
@@ -12,8 +12,7 @@ export const environment: Environment = {
   gaId: 'UA-112406425-3',
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
-  zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
+  zendeskEnv: ZendeskEnv.Sandbox,
   trainingUrl: 'https://aoudev.nnlm.gov',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -1,4 +1,4 @@
-import {Environment} from 'environments/environment-type';
+import {Environment, ZendeskEnv} from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Staging',
@@ -13,8 +13,7 @@ export const environment: Environment = {
   gaUserAgentDimension: 'dimension1',
   gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
-  zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
+  zendeskEnv: ZendeskEnv.Sandbox,
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -14,7 +14,6 @@ export const environment: Environment = {
   gaLoggedInDimension: 'dimension2',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp1580753096.zendesk.com/hc/en-us/articles/360039550031-Instructions-to-Create-a-Billing-Account',
   zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
   shibbolethUrl: 'https://shibboleth.dsde-prod.broadinstitute.org',
   inactivityTimeoutSeconds: 30 * 60,

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -13,7 +13,6 @@ export const testEnvironmentBase = {
   gaLoggedInDimension: 'dimension3',
   trainingUrl: 'https://aoudev.nnlm.gov',
   zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  createBillingAccountHelpUrl: 'https://aousupporthelp1580753096.zendesk.com/hc/en-us/articles/360039550031-Instructions-to-Create-a-Billing-Account&locale=en-us',
   zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   shouldShowDisplayTag: true,

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -1,3 +1,5 @@
+import {ZendeskEnv} from 'environments/environment-type';
+
 // The values are shared across the deployed test env as well as the local dev
 // environments.
 export const testEnvironmentBase = {
@@ -12,8 +14,7 @@ export const testEnvironmentBase = {
   gaUserAgentDimension: 'dimension2',
   gaLoggedInDimension: 'dimension3',
   trainingUrl: 'https://aoudev.nnlm.gov',
-  zendeskHelpCenterUrl: 'https://aousupporthelp1580753096.zendesk.com/hc',
-  zendeskWidgetKey: 'df0a2e39-f8a8-482b-baf5-af82e14d38f9',
+  zendeskEnv: ZendeskEnv.Sandbox,
   shibbolethUrl: 'http://mock-nih.dev.test.firecloud.org',
   shouldShowDisplayTag: true,
   inactivityTimeoutSeconds: 99999999999,


### PR DESCRIPTION
- ZD sandbox (used in lower environments), has different article IDs than in prod
- I decided to build the URLs statically to allow for static references in code

## Notes about Zendesk URLs

- the locale infix "/en-us/" is not necessary (except for the community forum URL). Better to leave this unset.
- the article ID is the only necessary part of the URL suffix, though when you click the URL via Zendesk it will include a sluggified title. My preference is to omit this, as those titles may change over time

## Alternative considered
Just linking the URLs directly into the environment.ts, but this felt like it might be overly complicated, for example:

```
cat environment.prod.ts
{
  ...,
  zendeskUrls: zendesk.prodUrls,
  ...

cat environment.stable.ts
{
  ...,
  zendeskUrls: zendesk.sandboxUrls,
  ...
```

where zendesk would need to be a hermetic package which environment.ts depends on. Could be convinced to explore this more.