### PR TITLE
[RW-4950][risk=low] Add x-frame-options SAMEORIGIN to UI responses

### DIFF
--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -21,6 +21,9 @@ handlers:
     Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
     X-XSS-Protection: 1
     X-Content-Type-Options: "nosniff"
+    # This can be removed once the below Content-Security-Policy is enforced, it
+    # is obsoleted by frame-ancestors.
+    X-Frame-Options: SAMEORIGIN
     # unsafe-inline is unfortunately required as the Incapsula WAF injects a
     # script onto the page when we're serving in production, for which we'd be
     # unable to precompute a hash.


### PR DESCRIPTION
This is a stop-gap until we have CSP enforced.

Tested manually:
- Pushed to https://calbach-dot-all-of-us-workbench-test.appspot.com/
- Verified TOS and DUA still render
- Verified notebook preview still renders