### PR TITLE
[RW-5295][risk=low] Consolidate field masking, fix mapper

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -274,7 +274,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       resource.setWorkspaceBillingStatus(BillingStatus.ACTIVE);
     }
     resource.setPermission(
-        firecloudMapper.fcWorkspaceResponseToApiWorkspaceAccessLevel(workspaceDetails).toString());
+        firecloudMapper.fcToApiWorkspaceAccessLevel(workspaceDetails.getAccessLevel()).toString());
     resource.setWorkspaceNamespace(workspaceDetails.getWorkspace().getNamespace());
     resource.setWorkspaceFirecloudName(workspaceDetails.getWorkspace().getName());
     return resource;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -88,7 +88,7 @@ public interface FireCloudService {
 
   Optional<FirecloudWorkspaceResponse> getWorkspace(DbWorkspace dbWorkspace);
 
-  List<FirecloudWorkspaceResponse> getWorkspaces(List<String> fields);
+  List<FirecloudWorkspaceResponse> getWorkspaces();
 
   void deleteWorkspace(String projectName, String workspaceName);
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -93,7 +93,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   // All options are defined in this document:
   // https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#
-  public static final List<String> FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS =
+  public static final List<String> FIRECLOUD_WORKSPACE_REQUIRED_FIELDS =
       ImmutableList.of(
           "accessLevel",
           "workspace.workspaceId",
@@ -377,7 +377,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     return retryHandler.run(
         (context) ->
             workspacesApi.getWorkspace(
-                projectName, workspaceName, FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS));
+                projectName, workspaceName, FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override
@@ -387,7 +387,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     return retryHandler.run(
         (context) ->
             workspacesApi.getWorkspace(
-                projectName, workspaceName, FIRECLOUD_GET_WORKSPACE_REQUIRED_FIELDS));
+                projectName, workspaceName, FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override
@@ -410,9 +410,10 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public List<FirecloudWorkspaceResponse> getWorkspaces(List<String> fields)
-      throws WorkbenchException {
-    return retryHandler.run((context) -> endUserWorkspacesApiProvider.get().listWorkspaces(fields));
+  public List<FirecloudWorkspaceResponse> getWorkspaces() throws WorkbenchException {
+    return retryHandler.run(
+        (context) ->
+            endUserWorkspacesApiProvider.get().listWorkspaces(FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/FirecloudMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/FirecloudMapper.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.utils.mappers;
 
 import org.mapstruct.Mapper;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
-import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.ClusterStatus;
 import org.pmiops.workbench.model.ListClusterResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -23,12 +22,11 @@ public interface FirecloudMapper {
     return WorkspaceAccessLevel.fromValue(acl.getAccessLevel());
   }
 
-  default WorkspaceAccessLevel fcWorkspaceResponseToApiWorkspaceAccessLevel(
-      FirecloudWorkspaceResponse fcResponse) {
-    if (fcResponse.getAccessLevel().equals(WorkspaceService.PROJECT_OWNER_ACCESS_LEVEL)) {
+  default WorkspaceAccessLevel fcToApiWorkspaceAccessLevel(String accessLevel) {
+    if (WorkspaceService.PROJECT_OWNER_ACCESS_LEVEL.equals(accessLevel)) {
       return WorkspaceAccessLevel.OWNER;
     } else {
-      return WorkspaceAccessLevel.fromValue(fcResponse.getAccessLevel());
+      return WorkspaceAccessLevel.fromValue(accessLevel);
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
 import org.pmiops.workbench.cohortreview.CohortReviewMapper;
 import org.pmiops.workbench.cohorts.CohortMapper;
 import org.pmiops.workbench.conceptset.ConceptSetMapper;
@@ -61,10 +62,14 @@ public interface WorkspaceMapper {
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
   Workspace toApiWorkspace(DbWorkspace dbWorkspace);
 
-  @Mapping(target = "workspace", source = "dbWorkspace")
-  @Mapping(target = "accessLevel", source = "firecloudWorkspaceResponse")
-  WorkspaceResponse toApiWorkspaceResponse(
-      DbWorkspace dbWorkspace, FirecloudWorkspaceResponse firecloudWorkspaceResponse);
+  default WorkspaceResponse toApiWorkspaceResponse(
+      DbWorkspace dbWorkspace, FirecloudWorkspaceResponse firecloudWorkspaceResponse) {
+    FirecloudMapper fcMapper = Mappers.getMapper(FirecloudMapper.class);
+    return new WorkspaceResponse()
+        .accessLevel(
+            fcMapper.fcWorkspaceResponseToApiWorkspaceAccessLevel(firecloudWorkspaceResponse))
+        .workspace(toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()));
+  };
 
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -6,7 +6,6 @@ import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
 import org.pmiops.workbench.cohortreview.CohortReviewMapper;
 import org.pmiops.workbench.cohorts.CohortMapper;
 import org.pmiops.workbench.conceptset.ConceptSetMapper;
@@ -62,13 +61,13 @@ public interface WorkspaceMapper {
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
   Workspace toApiWorkspace(DbWorkspace dbWorkspace);
 
+  WorkspaceResponse toApiWorkspaceResponse(Workspace workspace, String accessLevel);
+
   default WorkspaceResponse toApiWorkspaceResponse(
       DbWorkspace dbWorkspace, FirecloudWorkspaceResponse firecloudWorkspaceResponse) {
-    FirecloudMapper fcMapper = Mappers.getMapper(FirecloudMapper.class);
-    return new WorkspaceResponse()
-        .accessLevel(
-            fcMapper.fcWorkspaceResponseToApiWorkspaceAccessLevel(firecloudWorkspaceResponse))
-        .workspace(toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()));
+    return toApiWorkspaceResponse(
+        toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()),
+        firecloudWorkspaceResponse.getAccessLevel());
   };
 
   @Mapping(target = "timeReviewed", ignore = true)

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -187,16 +187,15 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
 
   @Override
   public List<WorkspaceResponse> getWorkspacesAndPublicWorkspaces() {
-    Map<String, FirecloudWorkspaceResponse> fcWorkspaces = getFirecloudWorkspaces();
-    List<DbWorkspace> dbWorkspaces = workspaceDao.findAllByFirecloudUuidIn(fcWorkspaces.keySet());
-
-    System.out.println(fcWorkspaces.values().iterator().next().getWorkspace().getBucketName());
+    Map<String, FirecloudWorkspaceResponse> fcWorkspacesByUuid = getFirecloudWorkspaces();
+    List<DbWorkspace> dbWorkspaces =
+        workspaceDao.findAllByFirecloudUuidIn(fcWorkspacesByUuid.keySet());
     return dbWorkspaces.stream()
         .filter(DbWorkspace::isActive)
         .map(
             dbWorkspace ->
                 workspaceMapper.toApiWorkspaceResponse(
-                    dbWorkspace, fcWorkspaces.get(dbWorkspace.getFirecloudUuid())))
+                    dbWorkspace, fcWorkspacesByUuid.get(dbWorkspace.getFirecloudUuid())))
         .collect(Collectors.toList());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -187,10 +187,10 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
 
   @Override
   public List<WorkspaceResponse> getWorkspacesAndPublicWorkspaces() {
-    Map<String, FirecloudWorkspaceResponse> fcWorkspaces =
-        getFirecloudWorkspaces(ImmutableList.of("accessLevel", "workspace.workspaceId"));
+    Map<String, FirecloudWorkspaceResponse> fcWorkspaces = getFirecloudWorkspaces();
     List<DbWorkspace> dbWorkspaces = workspaceDao.findAllByFirecloudUuidIn(fcWorkspaces.keySet());
 
+    System.out.println(fcWorkspaces.values().iterator().next().getWorkspace().getBucketName());
     return dbWorkspaces.stream()
         .filter(DbWorkspace::isActive)
         .map(
@@ -242,10 +242,10 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
     return workspaceResponse;
   }
 
-  private Map<String, FirecloudWorkspaceResponse> getFirecloudWorkspaces(List<String> fields) {
+  private Map<String, FirecloudWorkspaceResponse> getFirecloudWorkspaces() {
     // fields must include at least "workspace.workspaceId", otherwise
     // the map creation will fail
-    return fireCloudService.getWorkspaces(fields).stream()
+    return fireCloudService.getWorkspaces().stream()
         .collect(
             Collectors.toMap(
                 fcWorkspace -> fcWorkspace.getWorkspace().getWorkspaceId(),

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -503,9 +503,9 @@ public class WorkspacesControllerTest {
     doReturn(fcResponse)
         .when(fireCloudService)
         .getWorkspace(fcWorkspace.getNamespace(), fcWorkspace.getName());
-    List<FirecloudWorkspaceResponse> workspaceResponses = fireCloudService.getWorkspaces(any());
+    List<FirecloudWorkspaceResponse> workspaceResponses = fireCloudService.getWorkspaces();
     workspaceResponses.add(fcResponse);
-    doReturn(workspaceResponses).when(fireCloudService).getWorkspaces(any());
+    doReturn(workspaceResponses).when(fireCloudService).getWorkspaces();
   }
 
   /**
@@ -594,7 +594,7 @@ public class WorkspacesControllerTest {
         testMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces(any());
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
 
     assertThat(workspacesController.getWorkspaces().getBody().getItems().size()).isEqualTo(1);
   }
@@ -2467,7 +2467,7 @@ public class WorkspacesControllerTest {
 
   @Test
   public void testEmptyFireCloudWorkspaces() {
-    when(fireCloudService.getWorkspaces(any())).thenReturn(new ArrayList<>());
+    when(fireCloudService.getWorkspaces()).thenReturn(new ArrayList<>());
     try {
       ResponseEntity<org.pmiops.workbench.model.WorkspaceResponseListResponse> response =
           workspacesController.getWorkspaces();
@@ -2753,7 +2753,7 @@ public class WorkspacesControllerTest {
         testMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces(any());
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
 
     assertThat(workspacesController.getPublishedWorkspaces().getBody().getItems().size())
         .isEqualTo(1);
@@ -2773,7 +2773,7 @@ public class WorkspacesControllerTest {
         testMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces(any());
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
 
     assertThat(workspacesController.getWorkspaces().getBody().getItems().size()).isEqualTo(1);
   }
@@ -2792,7 +2792,7 @@ public class WorkspacesControllerTest {
         testMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.WRITER.toString());
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces(any());
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
 
     assertThat(workspacesController.getWorkspaces().getBody().getItems().size()).isEqualTo(1);
   }
@@ -2811,7 +2811,7 @@ public class WorkspacesControllerTest {
         testMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.READER.toString());
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces(any());
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
 
     assertThat(workspacesController.getWorkspaces().getBody().getItems().size()).isEqualTo(0);
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -25,13 +25,16 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.Workspace;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
+import org.pmiops.workbench.model.WorkspaceResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -173,6 +176,24 @@ public class WorkspaceMapperTest {
 
     assertThat(ws.getCreationTime()).isEqualTo(DB_CREATION_TIMESTAMP.toInstant().toEpochMilli());
     assertThat(ws.getPublished()).isEqualTo(sourceDbWorkspace.getPublished());
+  }
+
+  @Test
+  public void testConvertsFirecloudResponseToApiResponse() {
+    final WorkspaceResponse resp =
+        workspaceMapper.toApiWorkspaceResponse(
+            sourceDbWorkspace,
+            new FirecloudWorkspaceResponse()
+                .workspace(sourceFirecloudWorkspace)
+                .accessLevel("PROJECT_OWNER"));
+
+    assertThat(resp.getAccessLevel()).isEqualTo(WorkspaceAccessLevel.OWNER);
+
+    // Verify data came from the DB workspace.
+    assertThat(resp.getWorkspace().getBillingAccountName()).isEqualTo(BILLING_ACCOUNT_NAME);
+
+    // Verify data came from the Firecloud workspace.
+    assertThat(resp.getWorkspace().getGoogleBucketName()).isEqualTo(FIRECLOUD_BUCKET_NAME);
   }
 
   private void assertResearchPurposeMatches(ResearchPurpose rp) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -155,7 +154,7 @@ public class WorkspaceServiceTest {
         WorkspaceAccessLevel.OWNER,
         WorkspaceActiveStatus.ACTIVE);
 
-    doReturn(firecloudWorkspaceResponses).when(mockFireCloudService).getWorkspaces(any());
+    doReturn(firecloudWorkspaceResponses).when(mockFireCloudService).getWorkspaces();
 
     currentUser = new DbUser();
     currentUser.setUsername(DEFAULT_USERNAME);


### PR DESCRIPTION
Bug: getWorkspaces() was not returning googleBucketName. See https://github.com/all-of-us/workbench-snippets/pull/50#discussion_r454547600 for where this mattered. Our UI currently doesn't care.

Fix1: consolidate the field masks (request more from getWorkspaces). There should be no performance delta here given the metadata we're requesting.
Fix2: have the mapper use the Firecloud workspace

I used a custom mapper as I didn't see another way, this is pretty ugly - mapstruct experts please advise.