### PR TITLE
[RW-5263][risk=no] DatSetServiceImpl.updateDataSet: Use dataSetMapper, After Mapping to set values to databaseObject

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
-import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -222,11 +221,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   @Override
   public DataSet saveDataSet(DataSetRequest dataSetRequest, Long userId) {
-    final Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    DbDataset dbDataset = dataSetMapper.dataSetRequestToDb(dataSetRequest, null);
-    dbDataset.setCreationTime(now);
+    DbDataset dbDataset = dataSetMapper.dataSetRequestToDb(dataSetRequest, null, clock);
     dbDataset.setCreatorId(userId);
-    dbDataset.setInvalid(false);
     return saveDataSet(dbDataset);
   }
 
@@ -249,12 +245,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     if (dbDataSet.getVersion() != version) {
       throw new ConflictException("Attempted to modify outdated data set version");
     }
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    DbDataset dbMappingConvert = dataSetMapper.dataSetRequestToDb(request, dbDataSet);
-    dbMappingConvert.setCreatorId(dbDataSet.getCreatorId());
-    dbMappingConvert.setCreationTime(dbDataSet.getCreationTime());
-    dbMappingConvert.setDataSetId(dbDataSet.getDataSetId());
-    dbMappingConvert.setLastModifiedTime(now);
+    DbDataset dbMappingConvert = dataSetMapper.dataSetRequestToDb(request, dbDataSet, clock);
     return saveDataSet(dbMappingConvert);
   }
 


### PR DESCRIPTION
Move the following setters from DataSetServiceImpl to AfterMapper function of DataSetMapper :
  CreationTime, LastModifiedTime, invalid and CreatorId ( for update) 

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
