### PR TITLE
[RW-5304][risk=no] Fix missing info in egress alert description

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
+import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.model.InstitutionUserInstructions;
@@ -118,6 +119,7 @@ public interface InstitutionService {
    */
   Optional<Institution> getFirstMatchingInstitution(final String contactEmail);
 
+  Optional<Institution> getByUser(DbUser user);
   /**
    * Deprecated because it refers to old-style Institutional Affiliations, to be deleted in RW-4362
    * The new-style equivalent is VerifiedInstitutionalAffiliationMapper.modelToDbWithoutUser()

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -277,7 +277,8 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   @Override
   public Optional<Institution> getByUser(DbUser user) {
-    return verifiedInstitutionalAffiliationDao.findFirstByUser(user)
+    return verifiedInstitutionalAffiliationDao
+        .findFirstByUser(user)
         .map(DbVerifiedInstitutionalAffiliation::getInstitution)
         .map(dbi -> institutionMapper.dbToModel(dbi, this));
   }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionUserInstructions;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
+import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
@@ -82,7 +83,7 @@ public class InstitutionServiceImpl implements InstitutionService {
   public List<Institution> getInstitutions() {
     return StreamSupport.stream(institutionDao.findAll().spliterator(), false)
         .map(this::toModel)
-        .sorted(Comparator.comparing(institution -> institution.getDisplayName()))
+        .sorted(Comparator.comparing(Institution::getDisplayName))
         .collect(Collectors.toList());
   }
 
@@ -272,6 +273,13 @@ public class InstitutionServiceImpl implements InstitutionService {
   public boolean validateOperationalUser(DbInstitution institution) {
     return institution != null
         && institution.getShortName().equals(OPERATIONAL_USER_INSTITUTION_SHORT_NAME);
+  }
+
+  @Override
+  public Optional<Institution> getByUser(DbUser user) {
+    return verifiedInstitutionalAffiliationDao.findFirstByUser(user)
+        .map(DbVerifiedInstitutionalAffiliation::getInstitution)
+        .map(dbi -> institutionMapper.dbToModel(dbi, this));
   }
 
   private Institution toModel(DbInstitution dbInstitution) {

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.actionaudit.auditors.EgressEventAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.EgressEvent;
@@ -179,9 +178,8 @@ public class EgressEventServiceImpl implements EgressEventService {
    */
   @Transient
   public String getAdminDescription(DbUser dbUser) {
-    final String institution = institutionService.getByUser(dbUser)
-        .map(Institution::getDisplayName)
-        .orElse("not found");
+    final String institution =
+        institutionService.getByUser(dbUser).map(Institution::getDisplayName).orElse("not found");
     return String.format(
         "%s %s - Username: %s\n" + "user_id: %d, Institution: %s, Account Age: %d days",
         dbUser.getGivenName(),

--- a/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
@@ -21,7 +21,9 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.EgressEvent;
+import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceUserAdminView;
@@ -37,6 +39,7 @@ public class EgressEventServiceImpl implements EgressEventService {
   private static final String USER_ID_GROUP_NAME = "userid";
   private final Clock clock;
   private final EgressEventAuditor egressEventAuditor;
+  private final InstitutionService institutionService;
   private final Provider<AlertApi> alertApiProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final UserService userService;
@@ -46,12 +49,14 @@ public class EgressEventServiceImpl implements EgressEventService {
   public EgressEventServiceImpl(
       Clock clock,
       EgressEventAuditor egressEventAuditor,
+      InstitutionService institutionService,
       Provider<AlertApi> alertApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       UserService userService,
       WorkspaceAdminService workspaceAdminService) {
     this.clock = clock;
     this.egressEventAuditor = egressEventAuditor;
+    this.institutionService = institutionService;
     this.alertApiProvider = alertApiProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.userService = userService;
@@ -174,17 +179,16 @@ public class EgressEventServiceImpl implements EgressEventService {
    */
   @Transient
   public String getAdminDescription(DbUser dbUser) {
-    final String institutions =
-        dbUser.getInstitutionalAffiliations().stream()
-            .map(DbInstitutionalAffiliation::getInstitution)
-            .collect(Collectors.joining(", "));
+    final String institution = institutionService.getByUser(dbUser)
+        .map(Institution::getDisplayName)
+        .orElse("not found");
     return String.format(
-        "%s %s - Username: %s\n" + "user_id: %d, Institutions: [ %s ], Account Age: %d days",
+        "%s %s - Username: %s\n" + "user_id: %d, Institution: %s, Account Age: %d days",
         dbUser.getGivenName(),
         dbUser.getFamilyName(),
         dbUser.getUsername(),
         dbUser.getUserId(),
-        institutions,
+        institution,
         getAgeInDays(dbUser.getCreationTime()));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -194,6 +194,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
     return new WorkspaceAdminView()
         .workspace(workspaceMapper.toApiWorkspace(dbWorkspace, firecloudWorkspace))
+        .workspaceDatabaseId(dbWorkspace.getWorkspaceId())
         .collaborators(collaborators)
         .resources(adminWorkspaceResources);
   }


### PR DESCRIPTION
Due to a testing gap I missed the DB ID, and I believe we weren't using the most up-to-date affiliation system. It's now singular instead of plural.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
