### PR TITLE
[RW-5309][risk=medium] [P1] RDR Export:Workbench not exporting deleted workspaces

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -271,7 +272,7 @@ public class RdrExportServiceImplTest {
     when(rdrMapper.toRdrModel(mockDeletedWorkspace)).thenReturn(rdrWorkspace);
 
     rdrExportService.exportWorkspaces(workspaceID);
-    verify(mockWorkspaceService)
+    verify(mockWorkspaceService, never())
         .getFirecloudUserRoles(
             mockDeletedWorkspace.getWorkspaceNamespace(), mockDeletedWorkspace.getFirecloudName());
     verify(rdrExportDao, times(1)).save(anyList());


### PR DESCRIPTION
**Issue**: When a workspace is deleted the from workbench , it is also removed from Firecloud as well. Hence while exporting the deleted workspaces to RDR, _workspaceService.getFirecloudUserRole_ would throw an error ,because of which the deleted workspace will be skipped from export.

**Fix**: Skip the call to get collaborators list  if the workspace is deleted. 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
