### PR TITLE
[RW-1794][risk=low] Detect/warn on hotswap failure

### DIFF
--- a/api/buildSrc/src/main/groovy/org/pmiops/workbench/tooling/IncrementalHotSwapTask.groovy
+++ b/api/buildSrc/src/main/groovy/org/pmiops/workbench/tooling/IncrementalHotSwapTask.groovy
@@ -16,14 +16,32 @@ class IncrementalHotSwapTask extends DefaultTask {
         if (inputs.incremental) {
 
             inputs.outOfDate { change ->
+                // Take the modified class, attach to the live JVM debug port, and attempt to
+                // redefine the class via jdb.
                 String prefix = inputDir.path + "/"
                 String relativePath = change.file.path.substring(prefix.length())
                 String fqClassName = relativePath[0..-(".class".length() + 1)].replaceAll("/", ".")
-                printf "Hot swapping $fqClassName from $change.file.path..."
+                printf "Hot swapping $fqClassName from $change.file.path...\n"
                 def proc = "echo redefine $fqClassName $change.file.path".execute() \
-            | "${System.getenv('JAVA_HOME')}/bin/jdb -attach 8001".execute()
+                         | "${System.getenv('JAVA_HOME')}/bin/jdb -attach 8001".execute()
+                def jdbOutput = new StringBuffer()
+                proc.consumeProcessOutput(jdbOutput, System.err)
                 proc.waitFor()
-                println "done."
+
+                // Hacky, but from the shell we don't have a clear way of extracting a status of an
+                // "interactive" jdb command from the process exit status. Checking for output
+                // presence in general is not ideal, since it often reports some innocuous errors
+                // on launch. From experimentation, the jdb output typically looks like:
+                // "Error redefining <class name> ... schema change not implemented"
+                if (proc.exitValue() == 0 && !jdbOutput.contains("Error redefining")) {
+                    println "hot swap succeeded"
+                } else {
+                    println "hot swap failed; the code change you made may not be supported by " +
+                            "jdb redefine (for example, adding/renaming static variables), you " +
+                            "may need to restart your API server to pick this up. See the logs " +
+                            "below for more details"
+                    printf "\nhot swap jdb output:\n  $jdbOutput\n\n"
+                }
             }
 
             inputs.removed { change ->


### PR DESCRIPTION
As a stop-gap, this should make the current hotswap less treacherous. Remembered to clean this up from my earlier explorations.