### PR TITLE
DRAFT: use a client-supplied token instead of the login token

### DIFF
--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -2,14 +2,14 @@ import DataPage, {TabLabelAlias} from 'app/page/data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {EllipsisMenuAction} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
-import {findWorkspace, performActions, signIn} from 'utils/test-utils';
+import {findWorkspace, performActions, experimentalTestSignIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 
 
 describe('Editing workspace thru workspace card ellipsis menu', () => {
 
   beforeEach(async () => {
-    await signIn(page);
+    await experimentalTestSignIn(page);
   });
 
   /**

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -10,7 +10,7 @@ import * as fp from 'lodash/fp';
 import {ElementHandle, Page} from 'puppeteer';
 import {waitForText} from 'utils/waits-utils';
 import WorkspaceCard from 'app/component/workspace-card';
-import {WorkspaceAccessLevel} from 'app/text-labels';
+import {PageUrl, WorkspaceAccessLevel} from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {makeWorkspaceName} from './str-utils';
 
@@ -37,6 +37,24 @@ export async function signInAs(userId: string, passwd: string): Promise<Page> {
   await newPage.setDefaultNavigationTimeout(90000);
   await signIn(newPage, userId, passwd);
   return newPage;
+}
+
+export async function experimentalTestSignIn(page: Page): Promise<void> {
+  const homePage = new HomePage(page);
+  await homePage.gotoUrl(PageUrl.Home.toString());
+
+  // generate this token manually via:
+  // gcloud auth application-default login --no-launch-browser
+  // gcloud auth application-default print-access-token
+
+  // gcloud auth login user-email WILL NOT WORK
+
+  const actualToken = '[redacted]';
+  const cmd = 'window.useToken(\'' + actualToken + '\')';
+  await page.evaluate(cmd);
+
+  await homePage.gotoUrl(PageUrl.Home.toString());
+  await homePage.waitForLoad();
 }
 
 /**

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -43,6 +43,9 @@ export async function experimentalTestSignIn(page: Page): Promise<void> {
   const homePage = new HomePage(page);
   await homePage.gotoUrl(PageUrl.Home.toString());
 
+  let printToken = await page.evaluate('window.clientSuppliedToken');
+  console.log('window.clientSuppliedToken pre function call = ' + printToken);
+
   // generate this token manually via:
   // gcloud auth application-default login --no-launch-browser
   // gcloud auth application-default print-access-token
@@ -51,7 +54,11 @@ export async function experimentalTestSignIn(page: Page): Promise<void> {
 
   const actualToken = '[redacted]';
   const cmd = 'window.useToken(\'' + actualToken + '\')';
+  console.log('window.useToken function call = ' + cmd);
   await page.evaluate(cmd);
+
+  printToken = await page.evaluate('window.clientSuppliedToken');
+  console.log('window.clientSuppliedToken post function call = ' + printToken);
 
   await homePage.gotoUrl(PageUrl.Home.toString());
   await homePage.waitForLoad();

--- a/ui/src/app/services/sign-in.service.ts
+++ b/ui/src/app/services/sign-in.service.ts
@@ -102,12 +102,14 @@ export class SignInService {
 
   public get currentAccessToken() {
     if (window.clientSuppliedToken) {
+      console.log('[TEST-INJECTED] currentAccessToken = ' + window.clientSuppliedToken);
       return window.clientSuppliedToken;
     } else if (!gapi.auth2) {
       return null;
     } else {
       const authResponse = gapi.auth2.getAuthInstance().currentUser.get().getAuthResponse(true);
       if (authResponse !== null) {
+        console.log('[REAL AUTH FLOW] currentAccessToken = ' + authResponse.access_token);
         return authResponse.access_token;
       } else {
         return null;


### PR DESCRIPTION
Description:

Early draft for comments.

Inspired by https://github.com/DataBiosphere/terra-ui/pull/686 as a step toward Capcha-avoidance in automated testing for https://precisionmedicineinitiative.atlassian.net/browse/RW-5108 - seems like a much easier change for our codebase.

Basic local test: observe that setting `window.clientSuppliedToken` to nonsense in the JS Console will cause network calls to fail and the app to not work properly.  Setting it to a legitimate Access Token for my user caused everything to work again.  Unsetting it also caused the app to work again, reverting to the standard auth flow. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
