### PR TITLE
[risk=no][no ticket] unify routeData approach

### DIFF
--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,7 +1,7 @@
 import {Component as AComponent} from '@angular/core';
 import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
-import {WorkspaceAuditPage} from 'app/pages/admin/admin-workspace-audit';
-import {UserAuditPage} from 'app/pages/admin/user-audit';
+import {WorkspaceAudit} from 'app/pages/admin/admin-workspace-audit';
+import {UserAudit} from 'app/pages/admin/user-audit';
 import {CookiePolicy} from 'app/pages/cookie-policy';
 import {DataUserCodeOfConduct} from 'app/pages/profile/data-user-code-of-conduct';
 import {SessionExpired} from 'app/pages/session-expired';
@@ -19,34 +19,52 @@ const signInGuard: Guard = {
   redirectPath: '/login'
 };
 
-const DUCC = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
-const UserAudit = withRouteData(UserAuditPage);
-const WorkspaceAudit = withRouteData(WorkspaceAuditPage);
+const CookiePolicyPage = withRouteData(CookiePolicy);
+const DataUserCodeOfConductPage = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
+const SessionExpiredPage = withRouteData(SessionExpired);
+const SignInAgainPage = withRouteData(SignInAgain);
+const UserAuditPage = withRouteData(UserAudit);
+const UserDisabledPage = withRouteData(UserDisabled);
+const WorkspaceAuditPage = withRouteData(WorkspaceAudit);
 
 export const AppRoutingComponent: React.FunctionComponent<{signIn: Function}> = ({signIn}) => {
   const {authLoaded = false} = useStore(authStore);
   return authLoaded && <AppRouter>
-    <AppRoute path='/cookie-policy' component={CookiePolicy}/>
-    <AppRoute path='/session-expired' data={{signIn: signIn}} component={SessionExpired}/>
-    <AppRoute path='/sign-in-again' data={{signIn: signIn}} component={SignInAgain}/>
-    <AppRoute path='/user-disabled' component={UserDisabled}/>
+    <AppRoute
+        path='/cookie-policy'
+        component={() => <CookiePolicyPage routeData={{title: 'Cookie Policy'}}/>}
+    />
+    <AppRoute
+        path='/session-expired'
+        data={{signIn: signIn}}
+        component={() => <SessionExpiredPage routeData={{title: 'You have been signed out'}}/>}
+    />
+    <AppRoute
+        path='/sign-in-again'
+        data={{signIn: signIn}}
+        component={() => <SignInAgainPage routeData={{title: 'You have been signed out'}}/>}
+    />
+    <AppRoute
+        path='/user-disabled'
+        component={() => <UserDisabledPage routeData={{title: 'Disabled'}}/>}
+    />
 
     <ProtectedRoutes guards={[signInGuard]}>
         <AppRoute
-        path='/data-code-of-conduct'
-          component={ () => <DUCC routeData={{
+          path='/data-code-of-conduct'
+          component={ () => <DataUserCodeOfConductPage routeData={{
             title: 'Data User Code of Conduct',
             minimizeChrome: true
           }} />}
         />
         <AppRoute path='/admin/user-audit'
-                  component={() => <UserAudit routeData={{title: 'User Audit'}}/>}/>
+                  component={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}/>
         <AppRoute path='/admin/user-audit/:username'
-                  component={() => <UserAudit routeData={{title: 'User Audit'}}/>}/>
+                  component={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}/>
         <AppRoute path='/admin/workspace-audit'
-                  component={() => <WorkspaceAudit routeData={{title: 'Workspace Audit'}}/>}/>
+                  component={() => <WorkspaceAuditPage routeData={{title: 'Workspace Audit'}}/>}/>
         <AppRoute path='/admin/workspace-audit/:workspaceNamespace'
-                  component={() => <WorkspaceAudit routeData={{title: 'Workspace Audit'}}/>}/>
+                  component={() => <WorkspaceAuditPage routeData={{title: 'Workspace Audit'}}/>}/>
     </ProtectedRoutes>
   </AppRouter>;
 };

--- a/ui/src/app/pages/admin/admin-workspace-audit.tsx
+++ b/ui/src/app/pages/admin/admin-workspace-audit.tsx
@@ -25,7 +25,7 @@ const getNextAuditPath = (subject: string) => {
   return `/admin/workspace-audit/${subject}`;
 };
 
-export const WorkspaceAuditPage = () => {
+export const WorkspaceAudit = () => {
   const {workspaceNamespace = ''} = useParams();
   return <AuditPageComponent auditSubjectType='Workspace'
                              buttonLabel='Workspace namespace (begins with aou-rw-)'

--- a/ui/src/app/pages/admin/user-audit.tsx
+++ b/ui/src/app/pages/admin/user-audit.tsx
@@ -38,7 +38,7 @@ const getNextAuditPath = (subject: string) => {
   return `/admin/user-audit/${subject}`;
 };
 
-export const UserAuditPage = () => {
+export const UserAudit = () => {
   const {username = ''} = useParams();
   return <AuditPageComponent auditSubjectType='User'
                              buttonLabel='Username without domain'

--- a/ui/src/app/pages/cookie-policy.tsx
+++ b/ui/src/app/pages/cookie-policy.tsx
@@ -48,10 +48,6 @@ const GOOGLE_PRIVACY_LINK = 'https://policies.google.com/privacy';
 const ZENDESK_PRIVACY_LINK = 'https://www.zendesk.com/company/customers-partners/privacy-policy/';
 
 export class CookiePolicy extends React.Component<{}, {}> {
-  componentDidMount() {
-    document.title = buildPageTitleForEnvironment('Cookie Policy');
-  }
-
   render() {
     return <PublicLayout>
       <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '100%', color: colors.primary}}>

--- a/ui/src/app/pages/cookie-policy.tsx
+++ b/ui/src/app/pages/cookie-policy.tsx
@@ -5,7 +5,6 @@ import {Header, SmallHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import {AouTitle} from 'app/components/text-wrappers';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
 
 const styles = {

--- a/ui/src/app/pages/session-expired.tsx
+++ b/ui/src/app/pages/session-expired.tsx
@@ -3,7 +3,6 @@ import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
-import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
 
 const styles = reactStyles({
@@ -19,10 +18,6 @@ const styles = reactStyles({
 });
 
 export class SessionExpired extends React.Component<{routeConfig: {signIn: Function}}> {
-  componentDidMount() {
-    document.title = buildPageTitleForEnvironment('You have been signed out');
-  }
-
   render() {
     return <PublicLayout>
       <BoldHeader>You have been signed out</BoldHeader>

--- a/ui/src/app/pages/sign-in-again.tsx
+++ b/ui/src/app/pages/sign-in-again.tsx
@@ -4,7 +4,6 @@ import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
-import {buildPageTitleForEnvironment} from 'app/utils/title';
 import * as React from 'react';
 
 const styles = reactStyles({

--- a/ui/src/app/pages/sign-in-again.tsx
+++ b/ui/src/app/pages/sign-in-again.tsx
@@ -27,10 +27,6 @@ const styles = reactStyles({
 const supportUrl = 'support@researchallofus.org';
 
 export class SignInAgain extends React.Component<{routeConfig: {signIn: Function}}> {
-  componentDidMount() {
-    document.title = buildPageTitleForEnvironment('You have been signed out');
-  }
-
   render() {
     return <PublicLayout contentStyle={{width: '500px'}}>
       <BoldHeader>You have been signed out</BoldHeader>

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -4,7 +4,6 @@ import {StyledAnchorTag} from 'app/components/buttons';
 import {BoldHeader} from 'app/components/headers';
 import {PublicLayout} from 'app/components/public-layout';
 import colors from 'app/styles/colors';
-import {buildPageTitleForEnvironment} from 'app/utils/title';
 
 const supportUrl = 'support@researchallofus.org';
 

--- a/ui/src/app/pages/user-disabled.tsx
+++ b/ui/src/app/pages/user-disabled.tsx
@@ -9,10 +9,6 @@ import {buildPageTitleForEnvironment} from 'app/utils/title';
 const supportUrl = 'support@researchallofus.org';
 
 export class UserDisabled extends React.Component {
-  componentDidMount() {
-    document.title = buildPageTitleForEnvironment('Disabled');
-  }
-
   render() {
     return <PublicLayout>
       <BoldHeader>Your account has been disabled</BoldHeader>


### PR DESCRIPTION
A while ago someone (I think @petesantos) introduced a `routeDataStore` atom that included some top level attributes like `title` (tab title prefix) and `minimizeChrome`. This change puts all the React routes that need to set a tab title prefix in a `withRouteData` wrapper and makes the wrapper naming convention in the React router consistent.