### PR TITLE
[risk=no][RW-5120] Replace login component route with react

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -25,7 +25,6 @@ import {ConceptHomepageComponent} from './pages/data/concept/concept-homepage';
 import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-details';
 import {HomepageComponent} from './pages/homepage/homepage';
-import {SignInComponent} from './pages/login/sign-in';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -47,16 +47,15 @@ import {BreadcrumbType, NavStore} from './utils/navigation';
 declare let gtag: Function;
 
 const routes: Routes = [
-  {
-    path: 'login',
-    component: SignInComponent,
-    data: {title: 'Sign In'}
-  },
   // TODO(RW-5302): Reconcile react routes with angular guards, we cannot
   // have both ** under the sign in guard and ** in the signed out context.
   // Hardcoding all signed out paths here is a stop-gap.
   {
     path: 'cookie-policy',
+    component: AppRouting
+  },
+  {
+    path: 'login',
     component: AppRouting
   },
   {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -12,9 +12,9 @@ import { ReactWrapperBase } from 'app/utils';
 import {authStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {SignIn} from "./pages/login/sign-in";
-import {AnalyticsTracker} from "./utils/analytics";
-import {Redirect} from "react-router";
+import {Redirect} from 'react-router';
+import {SignIn} from './pages/login/sign-in';
+import {AnalyticsTracker} from './utils/analytics';
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -42,7 +42,6 @@ import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actio
 import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-details';
 import {HomepageComponent} from './pages/homepage/homepage';
 import {InitialErrorComponent} from './pages/initial-error/component';
-import {SignInComponent} from './pages/login/sign-in';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
@@ -160,7 +159,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     RoutingSpinnerComponent,
     SignedInComponent,
     NavBarComponent,
-    SignInComponent,
     TablePage,
     TextModalComponent,
     WorkspaceAboutComponent,

--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -32,7 +32,7 @@ describe('SignInReact', () => {
   beforeEach(() => {
     window.scrollTo = () => {};
     props = {
-      onInit: () => {},
+      onSignIn: () => {},
       signIn: signIn,
       windowSize: {width: 1700, height: 0},
       serverConfig: defaultConfig

--- a/ui/src/app/pages/login/sign-in.spec.tsx
+++ b/ui/src/app/pages/login/sign-in.spec.tsx
@@ -11,18 +11,18 @@ import {AccountCreationTos} from 'app/pages/login/account-creation/account-creat
 import InvitationKey from 'app/pages/login/invitation-key';
 import LoginReactComponent from 'app/pages/login/login';
 import {serverConfigStore} from 'app/utils/navigation';
-import {createEmptyProfile, SignInProps, SignInReact, SignInReactImpl, SignInStep} from './sign-in';
+import {createEmptyProfile, SignInProps, SignIn, SignInImpl, SignInStep} from './sign-in';
 
 describe('SignInReact', () => {
   let props: SignInProps;
 
   const signIn = jest.fn();
 
-  const component = () => mount(<SignInReact {...props}/>);
+  const component = () => mount(<SignIn {...props}/>);
 
   // To correctly shallow-render this component wrapped by two HOCs, we need to add two extra
   // .shallow() calls at the end.
-  const shallowComponent = () => shallow(<SignInReact {...props}/>).shallow().shallow();
+  const shallowComponent = () => shallow(<SignIn {...props}/>).shallow().shallow();
 
   const defaultConfig = {
     gsuiteDomain: 'researchallofus.org',
@@ -125,7 +125,7 @@ describe('SignInReact', () => {
     props.serverConfig = {...defaultConfig, requireInvitationKey: false};
 
     const wrapper = shallowComponent();
-    const signInImpl = wrapper.instance() as SignInReactImpl;
+    const signInImpl = wrapper.instance() as SignInImpl;
     const steps = signInImpl.getAccountCreationSteps();
     expect(steps).toEqual([
       SignInStep.LANDING,

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -1,5 +1,3 @@
-import {Component} from '@angular/core';
-import {Router} from '@angular/router';
 import * as fp from 'lodash/fp';
 
 import {PUBLIC_HEADER_IMAGE} from 'app/components/public-layout';
@@ -9,11 +7,9 @@ import {AccountCreationSurvey} from 'app/pages/login/account-creation/account-cr
 import {AccountCreationTos} from 'app/pages/login/account-creation/account-creation-tos';
 import {InvitationKey} from 'app/pages/login/invitation-key';
 import {LoginReactComponent} from 'app/pages/login/login';
-import {SignInService} from 'app/services/sign-in.service';
 import colors from 'app/styles/colors';
 import {
   reactStyles,
-  ReactWrapperBase,
   ServerConfigProps,
   WindowSizeProps,
   withServerConfig,
@@ -28,7 +24,6 @@ import {Footer, FooterTypeEnum} from 'app/components/footer';
 import {AccountCreationInstitution} from 'app/pages/login/account-creation/account-creation-institution';
 import {environment} from 'environments/environment';
 import * as React from 'react';
-import {Navigate} from "../../components/app-router";
 
 // A template function which returns the appropriate style config based on window size and
 // background images.

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -28,6 +28,7 @@ import {Footer, FooterTypeEnum} from 'app/components/footer';
 import {AccountCreationInstitution} from 'app/pages/login/account-creation/account-creation-institution';
 import {environment} from 'environments/environment';
 import * as React from 'react';
+import {Navigate} from "../../components/app-router";
 
 // A template function which returns the appropriate style config based on window size and
 // background images.
@@ -117,7 +118,7 @@ export const StepToImageConfig: Map<SignInStep, BackgroundImageConfig> = new Map
 
 export interface SignInProps extends ServerConfigProps, WindowSizeProps {
   initialStep?: SignInStep;
-  onInit: () => void;
+  onSignIn: () => void;
   signIn: () => void;
 }
 
@@ -168,12 +169,7 @@ export const createEmptyProfile = (): Profile => {
   return profile;
 };
 
-/**
- * The inner / implementation SignIn component. This class should only be rendered via the
- * SignInReact method, which wraps this with the expected higher-order components.
- */
-export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
-
+export const SignIn = fp.flow(withServerConfig(), withWindowSize())(class extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
@@ -190,7 +186,7 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
 
   componentDidMount() {
     document.body.style.backgroundColor = colors.light;
-    this.props.onInit();
+    this.props.onSignIn();
   }
 
   componentDidUpdate(prevProps: SignInProps, prevState: SignInState, snapshot) {
@@ -327,32 +323,4 @@ export class SignInReactImpl extends React.Component<SignInProps, SignInState> {
       {showFooter && <Footer type={FooterTypeEnum.Registration} />}
     </FlexColumn>;
   }
-}
-
-export const SignInReact = fp.flow(withServerConfig(), withWindowSize())(SignInReactImpl);
-
-@Component({
-  template: '<div #root></div>'
-})
-export class SignInComponent extends ReactWrapperBase {
-
-  constructor(private signInService: SignInService, private router: Router) {
-    super(SignInReact, ['onInit', 'signIn']);
-    this.onInit = this.onInit.bind(this);
-    this.signIn = this.signIn.bind(this);
-  }
-
-  onInit(): void {
-    this.signInService.isSignedIn$.subscribe((signedIn) => {
-      if (signedIn) {
-        this.router.navigateByUrl('/');
-      }
-    });
-  }
-
-  signIn(): void {
-    AnalyticsTracker.Registration.SignIn();
-    this.signInService.signIn();
-  }
-
-}
+});

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -164,7 +164,14 @@ export const createEmptyProfile = (): Profile => {
   return profile;
 };
 
-export const SignIn = fp.flow(withServerConfig(), withWindowSize())(class extends React.Component<SignInProps, SignInState> {
+/**
+ * The inner / implementation SignIn component. This class should only be rendered via the
+ * SignInReact method, which wraps this with the expected higher-order components.
+ *
+ * This impl is separated out for testing purposes.
+ */
+
+export class SignInImpl extends React.Component<SignInProps, SignInState> {
   constructor(props: SignInProps) {
     super(props);
     this.state = {
@@ -318,4 +325,6 @@ export const SignIn = fp.flow(withServerConfig(), withWindowSize())(class extend
       {showFooter && <Footer type={FooterTypeEnum.Registration} />}
     </FlexColumn>;
   }
-});
+}
+
+export const SignIn = fp.flow(withServerConfig(), withWindowSize())(SignInImpl);

--- a/ui/src/app/pages/session-expired.tsx
+++ b/ui/src/app/pages/session-expired.tsx
@@ -17,14 +17,14 @@ const styles = reactStyles({
   }
 });
 
-export class SessionExpired extends React.Component<{routeConfig: {signIn: Function}}> {
+export class SessionExpired extends React.Component<{signIn: Function}> {
   render() {
     return <PublicLayout>
       <BoldHeader>You have been signed out</BoldHeader>
       <section style={styles.textSection}>
         You were automatically signed out of your session due to inactivity
       </section>
-      <GoogleSignInButton signIn={() => this.props.routeConfig.signIn()}/>
+      <GoogleSignInButton signIn={() => this.props.signIn()}/>
     </PublicLayout>;
   }
 }

--- a/ui/src/app/pages/sign-in-again.tsx
+++ b/ui/src/app/pages/sign-in-again.tsx
@@ -25,14 +25,14 @@ const styles = reactStyles({
 
 const supportUrl = 'support@researchallofus.org';
 
-export class SignInAgain extends React.Component<{routeConfig: {signIn: Function}}> {
+export class SignInAgain extends React.Component<{signIn: Function}> {
   render() {
     return <PublicLayout contentStyle={{width: '500px'}}>
       <BoldHeader>You have been signed out</BoldHeader>
       <section style={styles.textSection}>
         You’ve been away for a while and we could not verify whether your session was still active.
       </section>
-      <GoogleSignInButton signIn={() => this.props.routeConfig.signIn()}/>
+      <GoogleSignInButton signIn={() => this.props.signIn()}/>
       <section style={styles.noteSection}>
         <strong>Note</strong>: You may have been redirected to this page immediately after attempting to sign in,
         if you did not explicitly sign out of your most recent session. If, after signing in


### PR DESCRIPTION
This also cleans up some passing of props in some React-routed components now that I know how to do it in a nicer way

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on this change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
