### PR TITLE
[no ticket][risk=no] Puppeteer: parameterize getPropValue function

### DIFF
--- a/e2e/app/component/concept-domain-card.ts
+++ b/e2e/app/component/concept-domain-card.ts
@@ -2,6 +2,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import Button from 'app/element/button';
 import Container from 'app/container';
+import {getPropValue} from 'utils/element-utils';
 
 export enum Domain {
    Conditions = 'Conditions',
@@ -56,10 +57,9 @@ export default class ConceptDomainCard extends Container {
 
   private async extractConceptsCount(selector: string): Promise<string> {
     const elemt = await this.page.waitForXPath(selector, {visible: true});
-    const textContent = await elemt.getProperty('textContent');
-    const value = (await textContent.jsonValue()).toString();
+    const textContent = await getPropValue<string>(elemt, 'textContent');
     const regex = new RegExp(/\d{1,3}(,?\d{3})*/); // Match numbers with comma
-    return (regex.exec(value))[0];
+    return (regex.exec(textContent))[0];
   }
 
   private async getSelectConceptButton(): Promise<Button> {

--- a/e2e/app/component/data-resource-card.ts
+++ b/e2e/app/component/data-resource-card.ts
@@ -2,6 +2,7 @@ import {ElementHandle, Page} from 'puppeteer';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import * as fp from 'lodash/fp';
 import {waitWhileLoading} from 'utils/test-utils';
+import {getPropValue} from 'utils/element-utils';
 
 const DataResourceCardSelector = {
   cardRootXpath: '//*[@data-test-id="card"]',
@@ -96,10 +97,7 @@ export default class DataResourceCard {
 
   async getResourceName(): Promise<string> {
     const elemt = await this.cardElement.$x(`.//*[${DataResourceCardSelector.cardNameXpath}]`);
-    const jHandle = await elemt[0].getProperty('innerText');
-    const name = await jHandle.jsonValue();
-    await jHandle.dispose();
-    return name.toString();
+    return getPropValue<string>(elemt[0], 'innerText');
   }
 
   asElementHandle(): ElementHandle {
@@ -113,9 +111,9 @@ export default class DataResourceCard {
   /**
    * Find card type: Cohort, Datasets or Concept Sets.
    */
-  async getCardType() : Promise<unknown> {
+  async getCardType() : Promise<string> {
     const [element] = await this.cardElement.$x(DataResourceCardSelector.cardTypeXpath);
-    return (await element.getProperty('innerText')).jsonValue();
+    return getPropValue<string>(element, 'innerText');
   }
 
   /**

--- a/e2e/app/component/data-table.ts
+++ b/e2e/app/component/data-table.ts
@@ -1,5 +1,6 @@
 import {Page} from 'puppeteer';
 import Container from 'app/container';
+import {getPropValue} from 'utils/element-utils';
 import Table from './table';
 
 
@@ -34,17 +35,16 @@ export default class DataTable extends Table {
 
   async getNumRecords(): Promise<number[]> {
     const selector = `${this.getPaginatorXpath()}/*[@class="p-paginator-current"]`;
-    let value;
+    let textContent;
     try {
       const elemt = await this.page.waitForXPath(selector);
-      const textContent = await elemt.getProperty('textContent');
-      value = await textContent.jsonValue();
+      textContent = await getPropValue<string>(elemt, 'textContent');
     } catch (e) {
       return [0, 0, 0];
     }
 
     // parse for total records. expected string format is "76 - 100 of 100 records".
-    const [start, end, total] = value.toString().match(/\d+/g);
+    const [start, end, total] = textContent.match(/\d+/g);
     return [start, end, total];
   }
 

--- a/e2e/app/component/ellipsis-menu.ts
+++ b/e2e/app/component/ellipsis-menu.ts
@@ -2,6 +2,7 @@ import {ElementHandle, Page} from 'puppeteer';
 import {EllipsisMenuAction} from 'app/text-labels';
 import {GroupAction} from 'app/page/cohort-participants-group';
 import Link from 'app/element/link';
+import {getPropValue} from 'utils/element-utils';
 import TieredMenu from './tiered-menu';
 
 export default class EllipsisMenu {
@@ -22,7 +23,7 @@ export default class EllipsisMenu {
     const elements = await this.page.$x(selector);
     const actionTextsArray = [];
     for (const elem of elements) {
-      actionTextsArray.push(await (await elem.getProperty('textContent')).jsonValue());
+      actionTextsArray.push(await getPropValue<string>(elem, 'textContent'));
       await elem.dispose();
     }
     return actionTextsArray;

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -6,6 +6,8 @@ import Textarea from 'app/element/textarea';
 import Checkbox from 'app/element/checkbox';
 import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
 import {LinkText} from 'app/text-labels';
+import {getPropValue} from 'utils/element-utils';
+
 import * as fp from 'lodash/fp';
 
 const Selector = {
@@ -34,7 +36,7 @@ export default class Modal extends Container {
     // xpath that excludes button labels and spans
     // '//*[@role="dialog"]//div[normalize-space(text()) and not(@role="button")]'
     const modal = await this.waitUntilVisible();
-    const modalText = await (await modal.getProperty('innerText')).jsonValue();
+    const modalText = await getPropValue<string>(modal, 'innerText');
     console.debug('Modal: \n' + modalText);
     return modalText.toString();
   }

--- a/e2e/app/component/select-menu.ts
+++ b/e2e/app/component/select-menu.ts
@@ -3,6 +3,7 @@ import BaseElement from 'app/element/base-element';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import {Page} from 'puppeteer';
+import {getPropValue} from 'utils/element-utils';
 
 export default class SelectMenu extends Container {
 
@@ -57,11 +58,10 @@ export default class SelectMenu extends Container {
   /**
    * Returns selected value in Select.
    */
-  async getSelectedValue(): Promise<unknown> {
+  async getSelectedValue(): Promise<string> {
     const selector = this.xpath + '/label';
     const displayedValue = await this.page.waitForXPath(selector, { visible: true });
-    const innerText = await displayedValue.getProperty('innerText');
-    return await innerText.jsonValue();
+    return getPropValue<string>(displayedValue, 'innerText');
   }
 
   /**
@@ -92,11 +92,11 @@ export default class SelectMenu extends Container {
     await dropdownTrigger.dispose();
   }
 
-  private async isOpen() {
+  private async isOpen(): Promise<boolean> {
     const selector = this.xpath + '/*[contains(concat(" ", normalize-space(@class), " "), " p-dropdown-panel ")]';
     try {
       const panel = await this.page.waitForXPath(selector);
-      const classNameString = await (await panel.getProperty('className')).jsonValue();
+      const classNameString = await getPropValue<string>(panel, 'className');
       const splits = classNameString.toString().split(' ');
       await panel.dispose();
       return splits.includes('p-input-overlay-visible');

--- a/e2e/app/component/table.ts
+++ b/e2e/app/component/table.ts
@@ -1,5 +1,6 @@
 import {ElementHandle, Page} from 'puppeteer';
 import Container from 'app/container';
+import {getPropValue} from 'utils/element-utils';
 
 // Table column names
 export enum TableColumn {
@@ -45,8 +46,7 @@ export default class Table extends Container {
 
   async getCellValue(rowIndex: number, columnIndex: number): Promise<string> {
     const handle = await this.getCell(rowIndex, columnIndex);
-    const prop = await handle.getProperty('innerText')
-    return (await prop.jsonValue()).toString();
+    return getPropValue<string>(handle, 'innerText');
   }
 
   async getRows(): Promise<ElementHandle[]> {
@@ -86,9 +86,8 @@ export default class Table extends Container {
     const columns = await this.getColumns();
     const columnNames = [];
     for (const column of columns) {
-      const textContent = await column.getProperty('innerText');
-      const value = await textContent.jsonValue();
-      columnNames.push(value.toString());
+      const textContent = await getPropValue<string>(column, 'innerText');
+      columnNames.push(textContent);
       await column.dispose();
     }
     return columnNames;

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -3,6 +3,7 @@ import {WorkspaceAccessLevel} from 'app/text-labels';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import * as fp from 'lodash/fp';
 import DataPage from 'app/page/data-page';
+import {getPropValue} from 'utils/element-utils';
 
 const WorkspaceCardSelector = {
   cardRootXpath: '//*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -83,10 +84,7 @@ export default class WorkspaceCard {
 
   async getWorkspaceName(): Promise<string> {
     const workspaceNameElemt = await this.cardElement.$x(`.//*[${WorkspaceCardSelector.cardNameXpath}]`);
-    const jHandle = await workspaceNameElemt[0].getProperty('innerText');
-    const name = await jHandle.jsonValue();
-    await jHandle.dispose();
-    return name.toString();
+    return getPropValue<string>(workspaceNameElemt[0], 'innerText');
   }
 
   asElementHandle(): ElementHandle {
@@ -101,9 +99,9 @@ export default class WorkspaceCard {
    * Find workspace access level.
    * @param workspaceName
    */
-  async getWorkspaceAccessLevel() : Promise<unknown> {
+  async getWorkspaceAccessLevel() : Promise<string> {
     const [element] = await this.cardElement.$x(WorkspaceCardSelector.accessLevelXpath);
-    return (await element.getProperty('innerText')).jsonValue();
+    return getPropValue<string>(element, 'innerText');
   }
 
   /**
@@ -132,8 +130,7 @@ export default class WorkspaceCard {
    */
   async clickWorkspaceName(waitForDataPage: boolean = true): Promise<string> {
     const [elemt] = await this.asElementHandle().$x(`.//*[${WorkspaceCardSelector.cardNameXpath}]`);
-    const textProp = await elemt.getProperty('textContent');
-    const name = await textProp.jsonValue();
+    const name = await getPropValue<string>(elemt, 'textContent');
     await Promise.all([
       this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
       elemt.click(),
@@ -142,7 +139,7 @@ export default class WorkspaceCard {
       const dataPage = new DataPage(this.page);
       await dataPage.waitForLoad();
     }
-    return name.toString();
+    return name;
   }
 
   private asCard(elementHandle: ElementHandle): WorkspaceCard {

--- a/e2e/app/element/checkbox.ts
+++ b/e2e/app/element/checkbox.ts
@@ -21,7 +21,7 @@ export default class Checkbox extends BaseElement {
    * Checked means element does not have "checked" property.
    */
   async isChecked(): Promise<boolean> {
-    return !!(await this.getProperty('checked'));
+    return this.getProperty<boolean>('checked');
   }
 
   /**

--- a/e2e/app/element/radiobutton.ts
+++ b/e2e/app/element/radiobutton.ts
@@ -19,8 +19,7 @@ export default class RadioButton extends BaseElement {
 
   async isSelected(): Promise<boolean> {
     await this.focus();
-    const is = await this.getProperty('checked');
-    return !!is;
+    return this.getProperty<boolean>('checked');
   }
 
   /**

--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -1,6 +1,7 @@
 import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
+import {getPropValue} from 'utils/element-utils';
 import BaseElement from './base-element';
 import {buildXPath} from 'app/xpath-builders';
 
@@ -9,7 +10,7 @@ import {buildXPath} from 'app/xpath-builders';
  */
 export default class Select extends BaseElement {
 
-  private selectedOption;
+  private selectedOption: string;
    
   static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Select> {
     xOpt.type = ElementType.Select;
@@ -23,7 +24,7 @@ export default class Select extends BaseElement {
   }
 
   async selectOption(optionValue: string): Promise<string> {
-    this.selectedOption = await (await this.asElementHandle()).select(optionValue);
+    [this.selectedOption] = await (await this.asElementHandle()).select(optionValue);
     return this.selectedOption;
   }
 
@@ -33,9 +34,7 @@ export default class Select extends BaseElement {
   async getSelectedOption(): Promise<string> {
     const selector = this.xpath + '/parent::*/following-sibling::label';
     const displayedValue = await this.page.waitForXPath(selector, { visible: true });
-    const innerText = await displayedValue.getProperty('innerText');
-    this.selectedOption = (await innerText.jsonValue()).toString();
-    return this.selectedOption;
+    return this.selectedOption = await getPropValue<string>(displayedValue, 'innerText');
   }
 
 }

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -2,6 +2,7 @@ import {Page} from 'puppeteer';
 import {PageUrl} from 'app/text-labels';
 import BasePage from 'app/page/base-page';
 import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
+import {getPropValue} from 'utils/element-utils';
 
 const signedInIndicator = 'app-signed-in';
 
@@ -57,12 +58,10 @@ export default abstract class AuthenticatedPage extends BasePage {
   /**
    * Find the actual displayed User name string in sidenav dropdown.
    */
-  async getUsername(): Promise<unknown> {
+  async getUsername(): Promise<string> {
     const xpath = `//*[child::clr-icon[@shape="angle"]/*[@role="img"]]`;
     const username = (await this.page.$x(xpath))[0];
-    const p = await username.getProperty('innerText');
-    const value = await p.jsonValue();
-    return value;
+    return getPropValue<string>(username, 'innerText');
   }
 
 

--- a/e2e/app/page/cohort-review-page.ts
+++ b/e2e/app/page/cohort-review-page.ts
@@ -4,6 +4,7 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import DataTable from 'app/component/data-table';
 import Button from 'app/element/button';
 import {LinkText} from 'app/text-labels';
+import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 
 const PageTitle = 'Review Cohort Participants';
@@ -45,11 +46,10 @@ export default class CohortReviewPage extends AuthenticatedPage {
     const dataTable = this.getDataTable();
     const bodyTable = dataTable.getBodyTable();
     const cell = await bodyTable.getCell(rowIndex, colIndex);
-    const textProp = await cell.getProperty('textContent');
-    const cellTextContent = await textProp.jsonValue();
+    const textContent = await getPropValue<string>(cell, 'textContent');
     await cell.click();
     await waitWhileLoading(this.page);
-    return cellTextContent.toString();
+    return textContent;
   }
 
 }

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -7,6 +7,7 @@ import {ElementType} from 'app/xpath-options';
 import {EllipsisMenuAction} from 'app/text-labels';
 import Button from 'app/element/button';
 import Textbox from 'app/element/textbox';
+import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 import ConceptsetCopyModal from './conceptset-copy-modal';
 
@@ -47,8 +48,7 @@ export default class ConceptsetPage extends AuthenticatedPage {
   async getConceptName(): Promise<string> {
     const xpath = `//*[@data-test-id="concept-set-title"]`;
     const title = await this.page.waitForXPath(xpath, {visible: true});
-    const value = await (await title.getProperty('innerText')).jsonValue();
-    return value.toString();
+    return getPropValue<string>(title, 'innerText');
   }
 
   async edit(newConceptName?: string, newDescription?: string): Promise<void> {

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -5,6 +5,7 @@ import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
 import Textarea from 'app/element/textarea';
 import {LinkText} from 'app/text-labels';
+import {getPropValue} from 'utils/element-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import ConceptsetActionsPage from './conceptset-actions-page';
 
@@ -31,7 +32,7 @@ export default class ConceptsetSaveModal extends Modal {
     const createNewSetRadioButton = await RadioButton.findByName(this.page, {name: saveOption}, this);
     await createNewSetRadioButton.select();
 
-    let conceptName;
+    let conceptName: string;
 
     if (saveOption === SaveOption.CreateNewSet) {
       // Generate a random name as new Concept name.
@@ -45,8 +46,7 @@ export default class ConceptsetSaveModal extends Modal {
     } else {
       const [selectedValue] = await this.page.select('[data-test-id="add-to-existing"] select', existingConceptName);
       const elem = await this.page.waitForSelector(`[data-test-id="add-to-existing"] select option[value="${selectedValue}"]`);
-      const value = await (await elem.getProperty('textContent')).jsonValue();
-      conceptName = value.toString();
+      conceptName = await getPropValue<string>(elem, 'textContent');
     }
 
     // Click SAVE button.

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -4,7 +4,7 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import Textbox from 'app/element/textbox';
 import DataTable from 'app/component/data-table';
 import Button from 'app/element/button';
-import {waitUntilChanged} from 'utils/element-utils';
+import {getPropValue, waitUntilChanged} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 import ConceptsetSaveModal, {SaveOption} from './conceptset-save-modal';
 
@@ -71,23 +71,19 @@ export default class ConceptsetSearchPage extends AuthenticatedPage{
 
     // Name column #2
     const nameCell = await bodyTable.getCell(rowIndex, 2);
-    let textProp = await nameCell.getProperty('textContent');
-    const nameValue = (await textProp.jsonValue()).toString();
+    const nameValue = await getPropValue<string>(nameCell, 'textContent');
 
     // Code column #3
     const codeCell = await bodyTable.getCell(rowIndex, 3);
-    textProp = await codeCell.getProperty('textContent');
-    const codeValue = (await textProp.jsonValue()).toString();
+    const codeValue = await getPropValue<string>(codeCell, 'textContent');
 
     // Vocabulary column #4
     const vocabularyCell = await bodyTable.getCell(rowIndex, 4);
-    textProp = await vocabularyCell.getProperty('textContent');
-    const vocabValue = (await textProp.jsonValue()).toString();
+    const vocabValue = await getPropValue<string>(vocabularyCell, 'textContent');
 
     // Participant Count column #5
     const participantCountCell = await bodyTable.getCell(rowIndex, 5);
-    textProp = await participantCountCell.getProperty('textContent');
-    const partiCountValue = (await textProp.jsonValue()).toString();
+    const partiCountValue = await getPropValue<string>(participantCountCell, 'textContent');
 
     const selectCheckCell = await bodyTable.getCell(rowIndex, selctionColumnIndex);
     const elemt = (await selectCheckCell.$x('.//*[@role="checkbox"]'))[0];

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -13,6 +13,7 @@ import {config} from 'resources/workbench-config';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import {LinkText} from 'app/text-labels';
+import {getPropValue} from 'utils/element-utils';
 
 const faker = require('faker/locale/en_US');
 
@@ -133,9 +134,9 @@ export default class CreateAccountPage extends BasePage {
     return await Textarea.findByName(this.page, {normalizeSpace: LabelAlias.ResearchBackground});
   }
 
-  async getUsernameDomain(): Promise<unknown> {
+  async getUsernameDomain(): Promise<string> {
     const elem = await this.page.waitForXPath('//*[./input[@id="username"]]/i');
-    return await (await elem.getProperty('innerText')).jsonValue();
+    return getPropValue<string>(elem, 'innerText');
   }
 
   async fillInFormFields(fields: { label: string; value: string; }[]): Promise<string> {

--- a/e2e/app/page/notebook-code-cell.ts
+++ b/e2e/app/page/notebook-code-cell.ts
@@ -85,7 +85,7 @@ export default class CodeCell {
    */
   private async getOutputTexts(index: number, timeOut: number): Promise<string> {
     const outputElement = await this.findOutputArea(index, timeOut);
-    const value = await getPropValue(outputElement, 'innerHTML');
+    const value = await getPropValue<string>(outputElement, 'innerHTML');
     await outputElement.dispose();
     return value;
   }
@@ -96,7 +96,7 @@ export default class CodeCell {
    */
   private async getOutputError(index: number, timeOut: number): Promise<string> {
     const outputElement = await this.findOutputAreaError(index, timeOut);
-    const value = await getPropValue(outputElement, 'innerHTML');
+    const value = await getPropValue<string>(outputElement, 'innerHTML');
     await outputElement.dispose();
     return value;
   }

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -108,7 +108,7 @@ export default class NotebookPage extends AuthenticatedPage {
 
   async kernelStatus(): Promise<KernelStatus | null> {
     const elemt = await this.frame().then( (frame) => frame.waitForSelector(CssSelector.kernelIcon, {visible: true}));
-    const value = await getPropValue(elemt, 'title');
+    const value = await getPropValue<string>(elemt, 'title');
     await elemt.dispose();
     Object.keys(KernelStatus).forEach(key => {
       if (KernelStatus[key] === value) {
@@ -121,7 +121,7 @@ export default class NotebookPage extends AuthenticatedPage {
   async getKernelName(): Promise<string> {
     const frame = await this.frame();
     const elemt = await frame.waitForSelector(CssSelector.kernelName, {visible: true});
-    const value = await getPropValue(elemt, 'textContent');
+    const value = await getPropValue<string>(elemt, 'textContent');
     await elemt.dispose();
     return value;
   }
@@ -145,7 +145,7 @@ export default class NotebookPage extends AuthenticatedPage {
   async findCodeCellInput(cellIndex: number): Promise<string> {
     const codeCell = new CodeCell(await this.frame());
     const elemt = await codeCell.findCellInput(cellIndex);
-    return getPropValue(elemt, 'outerText');
+    return getPropValue<string>(elemt, 'outerText');
   }
 
   async findCodeCellOutput(cellIndex: number): Promise<string> {

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -1,6 +1,7 @@
 import {ElementHandle, Frame, Page, WaitForSelectorOptions} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import Link from 'app/element/link';
+import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 import NotebookPage from './notebook-page';
 
@@ -46,8 +47,7 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
 
   async getFormattedCode(): Promise<string> {
     const codeContent = await this.waitForCssSelector('#notebook-container pre');
-    const textContentProperty = await codeContent.getProperty('textContent');
-    return (await textContentProperty.jsonValue()).toString();
+    return getPropValue<string>(codeContent, 'textContent');
   }
 
   private async waitForCssSelector(selector: string, options?: WaitForSelectorOptions): Promise<ElementHandle> {

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -4,6 +4,7 @@ import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils'
 import {buildXPath} from 'app/xpath-builders';
 import {WorkspaceAccessLevel} from 'app/text-labels';
 import {ElementType} from 'app/xpath-options';
+import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 import {TabLabelAlias} from './data-page';
 import Button from 'app/element/button';
@@ -44,7 +45,7 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
     // Fetch all of the collabs so we can string match and parse text content.
     const collabs = await this.page.$x(collabXPath);
     for (const c of collabs) {
-      let collabLine = await (await c.getProperty('textContent')).jsonValue() as string;
+      let collabLine = await getPropValue<string>(c, 'textContent');
       collabLine = collabLine.toLowerCase().trim();
       if (collabLine.includes(username.toLowerCase())) {
         for (const level of [
@@ -73,22 +74,19 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
   async getCdrVersion(): Promise<string> {
     const cdrVerXpath = '//*[@data-test-id="cdrVersion"]';
     const cdr = await this.page.waitForXPath(cdrVerXpath, {visible: true});
-    const cdrValue = await (await cdr.getProperty('innerText')).jsonValue();
-    return cdrValue.toString();
+    return getPropValue<string>(cdr, 'innerText');
   }
 
   async getCreationDate(): Promise<string> {
     const creationDateXpath = '//*[@data-test-id="creationDate"]/*[last()]';
     const creationDate = await this.page.waitForXPath(creationDateXpath, {visible: true});
-    const dateValue = await (await creationDate.getProperty('innerText')).jsonValue();
-    return dateValue.toString();
+    return getPropValue<string>(creationDate, 'innerText');
   }
 
   async getLastUpdatedDate(): Promise<string> {
     const lastUpdatedDateXpath = '//*[@data-test-id="lastUpdated"]/*[last()]';
     const lastUpdatedDate = await this.page.waitForXPath(lastUpdatedDateXpath, {visible: true});
-    const dateValue = await (await lastUpdatedDate.getProperty('innerText')).jsonValue();
-    return dateValue.toString();
+    return getPropValue<string>(lastUpdatedDate, 'innerText');
   }
 
 }

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -67,7 +67,7 @@ export default class WorkspaceAnalysisPage extends AuthenticatedPage {
     // Log page heading.
     const pageHeadingXpath = '//*[@data-test-id="notebook-redirect"]/h2';
     const pageHeading = await this.page.waitForXPath(pageHeadingXpath, {visible: true});
-    console.log(await getPropValue(pageHeading, 'textContent'));
+    console.log(await getPropValue<string>(pageHeading, 'textContent'));
 
     // Wait for existances of important messages.
     const warningTexts = 'You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench.';

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -15,8 +15,8 @@ const timeOut = parseInt(process.env.PUPPETEER_TIMEOUT, 10) || 90000;
 beforeEach(async () => {
   await page.setUserAgent(userAgent);
   // See https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaultnavigationtimeouttimeout
-  await page.setDefaultNavigationTimeout(navTimeOut);
-  await page.setDefaultTimeout(timeOut);
+  page.setDefaultNavigationTimeout(navTimeOut);
+  page.setDefaultTimeout(timeOut);
 });
 
 /**

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -121,7 +121,7 @@ describe('User can create new Cohorts', () => {
     const dataPage = new DataPage(page);
 
     // Save url
-    const workspaceDataUrl = await page.url();
+    const workspaceDataUrl = page.url();
 
     // Click Add Cohorts button
     const addCohortsButton = await dataPage.getAddCohortsButton();

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -6,6 +6,7 @@ import CohortReviewModal from 'app/page/cohort-review-modal';
 import CohortReviewPage from 'app/page/cohort-review-page';
 import DataPage from 'app/page/data-page';
 import {waitForText} from 'utils/waits-utils';
+import {getPropValue} from 'utils/element-utils';
 
 describe('Cohort review tests', () => {
 
@@ -46,9 +47,9 @@ describe('Cohort review tests', () => {
     const participantsTable = cohortReviewPage.getDataTable();
     const records = await participantsTable.getNumRecords();
     // Table records page numbering is in "1 - 25 of 100 records" format.
-    expect(Number(records[0])).toBe(1);
-    expect(Number(records[1])).toBe(25);
-    expect(Number(records[2])).toBe(reviewSetNumberOfParticipants);
+    expect(Number(records[0])).toEqual(1);
+    expect(Number(records[1])).toEqual(25);
+    expect(Number(records[2])).toEqual(reviewSetNumberOfParticipants);
 
     // Verify table column names match.
     const columns = ['Participant ID', 'Date of Birth', 'Deceased', 'Gender', 'Race', 'Ethnicity', 'Status'];
@@ -58,9 +59,9 @@ describe('Cohort review tests', () => {
 
     // Get Date of Birth in row 2.
     const dobCell = await participantsTable.getCell(2, 2);
-    const cellValue = await (await dobCell.getProperty('textContent')).jsonValue();
+    const cellValue = await getPropValue<string>(dobCell, 'textContent');
     // Check birth date is valid format.
-    isValidDate(cellValue.toString());
+    isValidDate(cellValue);
 
     // Check table row link navigation works. Click ParticipantId link in the second row.
     await cohortReviewPage.clickParticipantLink(2);

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -9,6 +9,7 @@ import {LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import Link from 'app/element/link';
+import {getPropValue} from 'utils/element-utils';
 
 
 describe('Editing and Copying Concept Sets', () => {
@@ -150,8 +151,8 @@ describe('Editing and Copying Concept Sets', () => {
       const conceptCard = await conceptCards[0];
       conceptName = await conceptCard.getResourceName();
       const nameLink = await conceptCard.getLink();
-      const value = await (await nameLink.getProperty('textContent')).jsonValue();
-      expect(conceptName).toBe(value.toString());
+      const value = await getPropValue<string>(nameLink, 'textContent');
+      expect(conceptName).toEqual(value);
       await nameLink.click();
     }
 
@@ -170,7 +171,7 @@ describe('Editing and Copying Concept Sets', () => {
     // Verify GoTo works
     await dataPage.waitForLoad();
 
-    const url = await page.url();
+    const url = page.url();
     expect(url).toContain(copyToWorkspace.replace(/-/g, ''));
 
     const resourceCard = new DataResourceCard(page);

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -47,7 +47,7 @@ describe('Create Dataset', () => {
     // Verify Notebook preview. Not going to start the Jupyter notebook.
     const notebookPreviewPage = new NotebookPreviewPage(page);
     await notebookPreviewPage.waitForLoad();
-    const currentPageUrl = await page.url();
+    const currentPageUrl = page.url();
     expect(currentPageUrl).toContain(`notebooks/preview/${newNotebookName}.ipynb`);
 
     const previewTextVisible = await waitForText(page, 'Preview (Read-Only)', {xpath: '//*[text()="Preview (Read-Only)"]'});
@@ -135,7 +135,7 @@ describe('Create Dataset', () => {
     // Verify Notebook preview. Not going to start the Jupyter notebook.
     const notebookPreviewPage = new NotebookPreviewPage(page);
     await notebookPreviewPage.waitForLoad();
-    const currentPageUrl = await page.url();
+    const currentPageUrl = page.url();
     expect(currentPageUrl).toContain(`notebooks/preview/${newNotebookName}.ipynb`);
 
     const code = await notebookPreviewPage.getFormattedCode();

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -72,7 +72,7 @@ describe('Home page ui tests', () => {
     const homePage = new HomePage(page);
     const plusIcon = await homePage.getCreateNewWorkspaceLink();
     expect(plusIcon).toBeTruthy();
-    const classname = await plusIcon.getProperty('className');
+    const classname = await plusIcon.getProperty<string>('className');
     expect(classname).toBe('is-solid');
     const shape = await plusIcon.getAttribute('shape');
     expect(shape).toBe('plus-circle');

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -36,14 +36,14 @@ describe('Clone workspace', () => {
       const dataPage = new DataPage(page);
       await dataPage.waitForLoad();
       // save Data page URL for comparison
-      const workspaceDataUrl1 = await page.url();
+      const workspaceDataUrl1 = page.url();
 
       // verify new workspace was created and now can be opened successfully
       await workspacesPage.load();
       const workspaceLink = await workspaceCard.getWorkspaceNameLink(cloneWorkspaceName);
       await workspaceLink.click();
       await dataPage.waitForLoad();
-      const workspaceDataUrl2 = await page.url();
+      const workspaceDataUrl2 = page.url();
 
       expect(workspaceDataUrl1).toEqual(workspaceDataUrl2);
     });
@@ -73,7 +73,7 @@ describe('Clone workspace', () => {
       // wait for Data page
       await dataPage.waitForLoad();
       // save Data page URL for comparison after sign out then sign in back
-      const workspaceDataUrl = await page.url();
+      const workspaceDataUrl = page.url();
       // strips out dash from workspace name
       expect(workspaceDataUrl).toContain(cloneWorkspaceName.replace(/-/g, ''));
 

--- a/e2e/utils/element-utils.ts
+++ b/e2e/utils/element-utils.ts
@@ -7,7 +7,7 @@ import {ElementHandle, JSHandle, Page} from 'puppeteer';
  * @param {string} attribute Attribute name.
  */
 export const getAttrValue = async (page: Page, element: ElementHandle, attribute: string): Promise<string> => {
-  return page.evaluate((link, attr) => {return link.getAttribute(attr)}, element, attribute);
+  return page.evaluate((elemt, attr) => {return elemt.getAttribute(attr)}, element, attribute);
 }
 
 /**
@@ -25,6 +25,6 @@ export async function getPropValue<T> (element: ElementHandle, property: string)
  * @param {Page} page Instance of Puppeteer page object.
  * @param {ElementHandle} element Element.
  */
-export const waitUntilChanged = async (page: Page, element: ElementHandle): Promise<JSHandle> => {
+export async function waitUntilChanged (page: Page, element: ElementHandle): Promise<JSHandle> {
   return page.waitForFunction(elemt => !elemt.ownerDocument.contains(elemt), {polling: 'raf'}, element);
 }

--- a/e2e/utils/element-utils.ts
+++ b/e2e/utils/element-utils.ts
@@ -7,7 +7,7 @@ import {ElementHandle, JSHandle, Page} from 'puppeteer';
  * @param {string} attribute Attribute name.
  */
 export const getAttrValue = async (page: Page, element: ElementHandle, attribute: string): Promise<string> => {
-  return page.evaluate((link, attr) => link.getAttribute(attr), element, attribute);
+  return page.evaluate((link, attr) => {return link.getAttribute(attr)}, element, attribute);
 }
 
 /**
@@ -15,9 +15,9 @@ export const getAttrValue = async (page: Page, element: ElementHandle, attribute
  * @param {ElementHandle} element Element.
  * @param {string} property Property name.
  */
-export const getPropValue = async (element: ElementHandle, property: string): Promise<string> => {
+export async function getPropValue<T> (element: ElementHandle, property: string): Promise<T> {
   const value = await element.getProperty(property).then((prop) => prop.jsonValue());
-  return value.toString().trim();
+  return value as T;
 }
 
 /*
@@ -25,6 +25,6 @@ export const getPropValue = async (element: ElementHandle, property: string): Pr
  * @param {Page} page Instance of Puppeteer page object.
  * @param {ElementHandle} element Element.
  */
-export async function waitUntilChanged(page: Page, element: ElementHandle): Promise<JSHandle> {
+export const waitUntilChanged = async (page: Page, element: ElementHandle): Promise<JSHandle> => {
   return page.waitForFunction(elemt => !elemt.ownerDocument.contains(elemt), {polling: 'raf'}, element);
 }


### PR DESCRIPTION
Code improvement:
- Parameterize `getPropValue<T>()` function in `element-utils.ts` so it can be used widely to reduce code duplication.
- Get rid of `Promise<unknown>` as functions' return type.

Unrelated code mistake fix:
- Removed `await` from non-async calls like `page.url()`.

No change to tests and functions' behavior.