### PR TITLE
[no ticket][risk=no] Puppeteer: modal clickButton function with optional waitFor parameters

### DIFF
--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -48,26 +48,17 @@ export default class Modal extends Container {
     const { waitForNav = false, waitForClose = false } = waitOptions;
     const button = await this.waitForButton(buttonLabel);
     await button.waitUntilEnabled();
-    if (waitForClose && waitForNav) {
-      await Promise.all([
-        this.waitUntilClose(),
-        this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
-        button.click(),
-      ]);
-    } else if (waitForClose) {
-      await Promise.all([
-        this.waitUntilClose(),
-        button.click(),
-      ]);
-    } else if (waitForNav) {
-      await Promise.all([
-        this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
-        button.click(),
-      ]);
-    } else {
-      return button.click();
+    const promisesArray = [];
+    if (waitForClose) {
+      promisesArray.push(this.waitUntilClose());
     }
-    
+    if (waitForNav) {
+      promisesArray.push(this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}));
+    }
+    await Promise.all([
+      promisesArray,
+      button.click(),
+    ]);
   }
 
   async waitForButton(buttonLabel: LinkText): Promise<Button> {

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -39,10 +39,35 @@ export default class Modal extends Container {
     return modalText.toString();
   }
 
-  async clickButton(buttonLabel: LinkText): Promise<void> {
+  /**
+   * Click a button.
+   * @param {string} buttonLabel The button text label.
+   * @param waitOptions Wait for navigation or/and modal close after click button.
+   */
+  async clickButton(buttonLabel: LinkText, waitOptions: {waitForNav?: boolean, waitForClose?: boolean} = {}): Promise<void> {
+    const { waitForNav = false, waitForClose = false } = waitOptions;
     const button = await this.waitForButton(buttonLabel);
     await button.waitUntilEnabled();
-    return button.click();
+    if (waitForClose && waitForNav) {
+      await Promise.all([
+        this.waitUntilClose(),
+        this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
+        button.click(),
+      ]);
+    } else if (waitForClose) {
+      await Promise.all([
+        this.waitUntilClose(),
+        button.click(),
+      ]);
+    } else if (waitForNav) {
+      await Promise.all([
+        this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
+        button.click(),
+      ]);
+    } else {
+      return button.click();
+    }
+    
   }
 
   async waitForButton(buttonLabel: LinkText): Promise<Button> {

--- a/e2e/app/component/share-modal.ts
+++ b/e2e/app/component/share-modal.ts
@@ -24,17 +24,14 @@ export default class ShareModal extends Modal {
     const ownerOpt = await this.waitForRoleOption(level);
     await ownerOpt.click();
 
-    await this.clickButton(LinkText.Save);
-    await this.waitUntilClose();
+    await this.clickButton(LinkText.Save, {waitForClose: true});
   }
 
   async removeUser(username: string): Promise<void> {
     const rmCollab = await this.page.waitForXPath(
       `${this.collabRowXPath(username)}//clr-icon[@shape="minus-circle"]`, {visible: true});
     await rmCollab.click();
-
-    await this.clickButton(LinkText.Save);
-    return this.waitUntilClose();
+    await this.clickButton(LinkText.Save, {waitForClose: true});
   }
 
   /**

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -71,10 +71,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     const descriptionTextarea = await modal.waitForTextarea('DESCRIPTION');
     await descriptionTextarea.type(description);
 
-    const saveButton = await Button.findByName(this.page, {name: LinkText.Save});
-    await saveButton.waitUntilEnabled();
-    await saveButton.click();
-    await modal.waitUntilClose();
+    await modal.clickButton(LinkText.Save, {waitForClose: true});
     await waitWhileLoading(this.page);
 
     return cohortName;
@@ -94,11 +91,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
   async deleteConfirmationDialog(): Promise<string> {
     const modal = new Modal(this.page);
     const contentText = await modal.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteCohort}, modal);
-    await Promise.all([
-      deleteButton.click(),
-      modal.waitUntilClose(),
-    ]);
+    await modal.clickButton(LinkText.DeleteCohort, {waitForClose: true});
     await waitWhileLoading(this.page);
     return contentText;
   }
@@ -110,12 +103,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
   async discardChangesConfirmationDialog(): Promise<string> {
     const modal = new Modal(this.page);
     const contentText = await modal.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DiscardChanges}, modal);
-    await Promise.all([
-      deleteButton.click(),
-      modal.waitUntilClose(),
-      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
-    ]);
+    await modal.clickButton(LinkText.DiscardChanges, {waitForNav: true, waitForClose: true});
     await waitWhileLoading(this.page);
     return contentText;
   }

--- a/e2e/app/page/cohort-criteria-modal.ts
+++ b/e2e/app/page/cohort-criteria-modal.ts
@@ -123,12 +123,8 @@ export default class CohortCriteriaModal extends Modal {
   /**
    * Click FINISH button.
    */
-  async clickFinishButton(opt: {waitUntilClosed?: boolean} = {}): Promise<void> {
-    const { waitUntilClosed = true } = opt
-    await this.clickButton(LinkText.Finish);
-    if (waitUntilClosed) {
-      await this.waitUntilClose();
-    }
+  async clickFinishButton(): Promise<void> {
+    return this.clickButton(LinkText.Finish, {waitForClose: true});
   }
 
   async waitForParticipantResult(): Promise<string> {

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -54,8 +54,7 @@ export default class CohortParticipantsGroup {
     const modal = new Modal(this.page);
     const textbox = await modal.waitForTextbox('New Name:');
     await textbox.type(newGroupName);
-    await modal.waitForButton(LinkText.Rename).then(b => b.click());
-    await modal.waitUntilClose();
+    await modal.clickButton(LinkText.Rename, {waitForClose: true});
   }
 
   /**

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -35,11 +35,7 @@ export default class ConceptsetPage extends AuthenticatedPage {
   async openCopyToWorkspaceModal(conceptName: string): Promise<ConceptsetCopyModal> {
     const ellipsis = this.getEllipsisMenu(conceptName);
     await ellipsis.clickAction(EllipsisMenuAction.CopyToAnotherWorkspace, {waitForNav: false});
-    const modal = new ConceptsetCopyModal(this.page);
-    await modal.waitUntilVisible();
-    await modal.getDestinationTextbox();
-    await modal.getNameTextbox();
-    return modal;
+    return new ConceptsetCopyModal(this.page);
   }
 
   // Get Concept Ellipsis dropdown menu

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -5,6 +5,7 @@ import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
 import Textarea from 'app/element/textarea';
 import {LinkText} from 'app/text-labels';
+import {waitWhileLoading} from 'utils/test-utils';
 import ConceptsetActionsPage from './conceptset-actions-page';
 
 const faker = require('faker/locale/en_US');
@@ -50,6 +51,7 @@ export default class ConceptsetSaveModal extends Modal {
 
     // Click SAVE button.
     await this.clickButton(LinkText.Save, {waitForClose: true});
+    await waitWhileLoading(this.page);
 
     const conceptActionPage = new ConceptsetActionsPage(this.page);
     await conceptActionPage.waitForLoad();

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -5,7 +5,6 @@ import RadioButton from 'app/element/radiobutton';
 import Textbox from 'app/element/textbox';
 import Textarea from 'app/element/textarea';
 import {LinkText} from 'app/text-labels';
-import {waitWhileLoading} from '../../utils/test-utils';
 import ConceptsetActionsPage from './conceptset-actions-page';
 
 const faker = require('faker/locale/en_US');
@@ -50,11 +49,7 @@ export default class ConceptsetSaveModal extends Modal {
     }
 
     // Click SAVE button.
-    await this.clickButton(LinkText.Save);
-    await Promise.all([
-      waitWhileLoading(this.page),
-      this.waitUntilClose(),
-    ]);
+    await this.clickButton(LinkText.Save, {waitForClose: true});
 
     const conceptActionPage = new ConceptsetActionsPage(this.page);
     await conceptActionPage.waitForLoad();

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -2,7 +2,6 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
-import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
@@ -136,11 +135,7 @@ export default class DataPage extends AuthenticatedPage {
 
     const modal = new Modal(this.page);
     const modalContentText = await modal.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteDataset}, modal);
-    await Promise.all([
-      deleteButton.click(),
-      modal.waitUntilClose(),
-    ]);
+    await modal.clickButton(LinkText.DeleteDataset, {waitForClose: true});
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Dataset "${datasetName}"`);
@@ -164,11 +159,7 @@ export default class DataPage extends AuthenticatedPage {
     const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, modal);
     await descriptionTextarea.type('Puppeteer automation rename dataset.');
 
-    const renameButton = await Button.findByName(this.page, {normalizeSpace: LinkText.RenameDataset}, modal);
-    await Promise.all([
-      renameButton.click(),
-      modal.waitUntilClose(),
-    ]);
+    await modal.clickButton(LinkText.RenameDataset, {waitForClose: true});
     await waitWhileLoading(this.page);
 
     console.log(`Renamed Dataset "${datasetName}" to "${newDatasetName}"`);
@@ -188,11 +179,7 @@ export default class DataPage extends AuthenticatedPage {
 
     const modal = new Modal(this.page);
     const modalTextContent = await modal.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteConceptSet}, modal);
-    await Promise.all([
-      deleteButton.click(),
-      modal.waitUntilClose(),
-    ]);
+    await modal.clickButton(LinkText.DeleteConceptSet, {waitForClose: true});
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Concept Set "${conceptsetName}"`);
@@ -209,8 +196,7 @@ export default class DataPage extends AuthenticatedPage {
     await newNameInput.type(newCohortName);
     const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description:'}, modal);
     await descriptionTextarea.type('Puppeteer automation rename cohort.');
-    await modal.clickButton(LinkText.Rename);
-    await modal.waitUntilClose();
+    await modal.clickButton(LinkText.Rename, {waitForClose: true});
     await waitWhileLoading(this.page);
     console.log(`Cohort "${cohortName}" renamed to "${newCohortName}"`);
   }

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -1,7 +1,6 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import NewNotebookModal from 'app/component/new-notebook-modal';
-import Button from 'app/element/button';
 import Link from 'app/element/link';
 import Textbox from 'app/element/textbox';
 import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
@@ -43,11 +42,7 @@ export default class WorkspaceAnalysisPage extends AuthenticatedPage {
 
     const modal = new Modal(this.page);
     const modalContentText = await modal.getContent();
-    const deleteButton = await Button.findByName(this.page, {normalizeSpace: LinkText.DeleteNotebook}, modal);
-    await Promise.all([
-      deleteButton.click(),
-      modal.waitUntilClose(),
-    ]);
+    await modal.clickButton(LinkText.DeleteNotebook, {waitForClose: true});
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Notebook "${notebookName}"`);
@@ -113,8 +108,7 @@ export default class WorkspaceAnalysisPage extends AuthenticatedPage {
     const modalTextContents = await modal.getContent();
     const newNameInput = new Textbox(this.page, `${modal.getXpath()}//*[@id="new-name"]`);
     await newNameInput.type(newNotebookName);
-    await modal.clickButton(LinkText.RenameNotebook);
-    await modal.waitUntilClose();
+    await modal.clickButton(LinkText.RenameNotebook, {waitForClose: true});
     await waitWhileLoading(this.page);
     console.log(`Notebook "${notebookName}" renamed to "${newNotebookName}"`);
     return modalTextContents;

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -391,11 +391,7 @@ export default class WorkspaceEditPage extends AuthenticatedPage {
     // confirm create in pop-up modal
     const modal = new Modal(this.page);
     const modalTextContent = await modal.getContent();
-    await Promise.all([
-      modal.clickButton(LinkText.Confirm),
-      modal.waitUntilClose(),
-      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0'], timeout: 60000}),
-    ]);
+    await modal.clickButton(LinkText.Confirm, {waitForClose: true, waitForNav: true});
     await waitWhileLoading(this.page);
     return modalTextContent;
   }

--- a/e2e/tests/notebook/notebook-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-actions.spec.ts
@@ -42,8 +42,8 @@ describe('Jupyter notebook tests', () => {
       expect(disabledButton).toBe(true);
 
       // Click "Cancel" button.
-      await modal.waitForButton(LinkText.Cancel).then( (butn) => butn.click());
-      await modal.waitUntilClose();
+      await modal.clickButton(LinkText.Cancel, {waitForClose: true});
+
       const modalExists = await modal.exists();
       expect(modalExists).toBe(false);
       // Page remain unchanged, still should be the Analysis page.

--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -47,7 +47,7 @@ describe('Jupyter notebook tests', () => {
            'print(sys.version)';
       const code1Output = await notebook.runCodeCell(1, {code: code1});
       // Python version is 3.7.6 at time of this writing. It can change.
-      expect(code1Output).toEqual(expect.stringContaining('3.7.6'));
+      expect(code1Output).toEqual(expect.stringContaining('3.7.8'));
 
       const code2 = '!jupyter kernelspec list';
       const code2Output = await notebook.runCodeCell(2, {code: code2});

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -43,7 +43,7 @@ describe('Jupyter notebook tests', () => {
       const code2 = 'sessionInfo()';
       const code2Output = await notebook.runCodeCell(2, {code: code2});
       // R version is 3.6.2 at time of this writing. It can change.
-      expect(code2Output).toMatch(/R version 3.6.2/);
+      expect(code2Output).toMatch(/R version 4.0.2/);
 
       // Delete R notebook
       const analysisPage = await notebook.goBackAnalysisPage();

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -203,6 +203,7 @@ export async function findWorkspace(page: Page, createNew: boolean = false): Pro
     await workspacesPage.createWorkspace(workspaceName);
     console.log(`Created workspace: "${workspaceName}"`);
     await workspacesPage.load();
+    await waitWhileLoading(page);
     return WorkspaceCard.findCard(page, workspaceName);
   }
 


### PR DESCRIPTION
Sometimes, click a button in modal should close the modal or/and causes page to change/navigate away. User has to remember to call `waitUntilClose` or/and `this.page.navigation` functions explicitly in order to keep test steps and UI in sync. The refactored`clickButton` function will make it easy to read and write lesser code when click a button in modal.
 
New function signature is `clickButton(buttonLabel: LinkText, waitOptions: {waitForNav?: boolean, waitForClose?: boolean} = {})`.

All tests verified to pass.
<img width="292" alt="Screen Shot 2020-07-27 at 2 58 00 PM" src="https://user-images.githubusercontent.com/35533885/88580484-a3dab280-d019-11ea-9919-bb73613ade15.png">
