### PR TITLE
[RW-5229][risk=no] Restrict special characters that break concept search

### DIFF
--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -137,6 +137,25 @@ describe('ConceptHomepage', () => {
 
   });
 
+  it('should show warning and not search if restricted characters have been enters', async() => {
+    const conceptSpy = jest.spyOn(conceptsApi(), 'searchConcepts');
+    const countSpy = jest.spyOn(conceptsApi(), 'domainCounts');
+    const surveySpy = jest.spyOn(conceptsApi(), 'searchSurveys');
+    const wrapper = mount(<ConceptHomepage />);
+    await waitOneTickAndUpdate(wrapper);
+    const termWithRestrictedChars = defaultSearchTerm + '@';
+    searchTable(termWithRestrictedChars, wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Test that it doesn't make any api calls
+    expect(countSpy).toHaveBeenCalledTimes(0);
+    expect(conceptSpy).toHaveBeenCalledTimes(0);
+    expect(surveySpy).toHaveBeenCalledTimes(0);
+
+    // Test that the forbidden character alert is displayed
+    expect(wrapper.find('[data-test-id="forbidden-character-alert"]').length).toBe(1);
+  });
+
   it('should change search criteria when standard only not checked', async() => {
     const spy = jest.spyOn(conceptsApi(), 'searchConcepts');
     const selectedDomain = DomainStubVariables.STUB_DOMAINS[1];

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -137,14 +137,14 @@ describe('ConceptHomepage', () => {
 
   });
 
-  it('should show warning and not search if restricted characters have been enters', async() => {
+  it('should show warning and not search if invalid characters have been entered', async() => {
     const conceptSpy = jest.spyOn(conceptsApi(), 'searchConcepts');
     const countSpy = jest.spyOn(conceptsApi(), 'domainCounts');
     const surveySpy = jest.spyOn(conceptsApi(), 'searchSurveys');
     const wrapper = mount(<ConceptHomepage />);
     await waitOneTickAndUpdate(wrapper);
-    const termWithRestrictedChars = defaultSearchTerm + '@';
-    searchTable(termWithRestrictedChars, wrapper);
+    const termWithInvalidChars = defaultSearchTerm + '(';
+    searchTable(termWithInvalidChars, wrapper);
     await waitOneTickAndUpdate(wrapper);
 
     // Test that it doesn't make any api calls
@@ -152,8 +152,8 @@ describe('ConceptHomepage', () => {
     expect(conceptSpy).toHaveBeenCalledTimes(0);
     expect(surveySpy).toHaveBeenCalledTimes(0);
 
-    // Test that the forbidden character alert is displayed
-    expect(wrapper.find('[data-test-id="forbidden-character-alert"]').length).toBe(1);
+    // Test that one input error alert is displayed with the proper message
+    expect(wrapper.find('[data-test-id="input-error-alert"]').text()).toBe('There is an unclosed ( in the search string');
   });
 
   it('should change search criteria when standard only not checked', async() => {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -588,7 +588,9 @@ export const ConceptHomepage = withCurrentWorkspace()(
                         onChange={() => this.handleCheckboxChange()}/>
             </div>
             {forbiddenCharactersEntered && <AlertDanger style={styles.inputAlert}>
-                The following characters are not allowed: ~ - @ ( ) [ ] | &lt; &gt;
+                <span data-test-id='forbidden-character-alert'>
+                  The following characters are not allowed: ~ - @ ( ) [ ] | &lt; &gt;
+                </span>
             </AlertDanger>}
             {showSearchError && <AlertDanger style={styles.inputAlert}>
                 Minimum concept search length is three characters.


### PR DESCRIPTION
Prevent calling the api when an invalid MySQL string been entered since they will break the api call.

Also restricting  `[ ] |`  since they will cause errors in the matching regex once the results are returned.
( `]` actually won't cause an error but seems weird to restrict `[` and not `]` )

Shows a warning message if the user tries to search with an invalid string.

Unclosed quote:
![Screen Shot 2020-08-05 at 11 10 14 AM](https://user-images.githubusercontent.com/40036095/89436974-96ee4b00-d70c-11ea-8950-95b7d15684ac.png)

Unclosed paren:
![Screen Shot 2020-08-05 at 11 10 26 AM](https://user-images.githubusercontent.com/40036095/89437046-ab324800-d70c-11ea-8e9a-c7f2eec01ffb.png)

Too many closing parens:
![Screen Shot 2020-08-05 at 11 10 43 AM](https://user-images.githubusercontent.com/40036095/89437094-b9806400-d70c-11ea-9365-43760ae50b51.png)

Trailing + or -:
![Screen Shot 2020-08-05 at 11 11 09 AM](https://user-images.githubusercontent.com/40036095/89437146-cb620700-d70c-11ea-95ab-3a2f6c46311b.png)

Forbidden special character:
![Screen Shot 2020-08-05 at 11 11 32 AM](https://user-images.githubusercontent.com/40036095/89437203-e16fc780-d70c-11ea-999d-88b40ba0682f.png)

The messages will also stack if there are multiple errors in the search string:
![Screen Shot 2020-08-05 at 11 29 24 AM](https://user-images.githubusercontent.com/40036095/89438951-167d1980-d70f-11ea-8769-68fc776492c7.png)



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
