### PR TITLE
[RW-5329][RW-5333][risk=low] Bump aou Leo image to 1.0.4

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "",
     "shibbolethUiBaseUrl": ""

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "preprod-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_preprod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.4",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"


### PR DESCRIPTION
- Switches us back to main bigrquery package
- Installs new workbench-snippets library
- Upgrades R to 4.0
- Additional package updates in Leo base images, see changelogs under https://github.com/DataBiosphere/terra-docker for more details

Plan is to send out user communications along with this upgrade, but we're not expecting severe user impact from these upgrades. Per ongoing designs, we will plan to have a way of running older images for reproducibility in the future.

Manually tested: ran with this image locally, verified main dataset builder flows