### PR TITLE
[risk=no] Try dropping FF puppeteer install for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,7 +575,8 @@ jobs:
     parallelism: 3
     steps:
       - checkout_init_git
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+        install-firefox: false
       - run_e2e_test
 
   # Deploy UI local server then run Puppeteer e2e tests on deployed "local" environment.
@@ -593,7 +594,8 @@ jobs:
           name: Halt job if not a pull request
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+        install-firefox: false
       - start_local_ui
       - run_e2e_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,7 +576,7 @@ jobs:
     steps:
       - checkout_init_git
       - browser-tools/install-browser-tools:
-        install-firefox: false
+          install-firefox: false
       - run_e2e_test
 
   # Deploy UI local server then run Puppeteer e2e tests on deployed "local" environment.
@@ -595,7 +595,7 @@ jobs:
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
       - browser-tools/install-browser-tools:
-        install-firefox: false
+          install-firefox: false
       - start_local_ui
       - run_e2e_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,6 +575,9 @@ jobs:
     parallelism: 3
     steps:
       - checkout_init_git
+      - run:
+          description: Install extra browser packages.
+          command: sudo apt-get install -y libgbm-dev
       - browser-tools/install-browser-tools:
           install-firefox: false
       - run_e2e_test
@@ -594,6 +597,9 @@ jobs:
           name: Halt job if not a pull request
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
+      - run:
+          description: Install extra browser packages.
+          command: sudo apt-get install -y libgbm-dev
       - browser-tools/install-browser-tools:
           install-firefox: false
       - start_local_ui


### PR DESCRIPTION
Firefox install via orb is currently failing. We don't actually need Firefox..

Follow-up investigation: see whether we can simply use an updated base image which has the appropriate browser versions.