### PR TITLE
[risk=no] Pin Firefox to 78.0 to fix puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,7 +575,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout_init_git
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
           firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
       - run_e2e_test
 
@@ -594,7 +594,7 @@ jobs:
           name: Halt job if not a pull request
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
           firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
       - start_local_ui
       - run_e2e_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,6 +576,7 @@ jobs:
     steps:
       - checkout_init_git
       - browser-tools/install-browser-tools
+          firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
       - run_e2e_test
 
   # Deploy UI local server then run Puppeteer e2e tests on deployed "local" environment.
@@ -594,6 +595,7 @@ jobs:
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
       - browser-tools/install-browser-tools
+          firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
       - start_local_ui
       - run_e2e_test
 


### PR DESCRIPTION
The latest Firefox version (79.0) has issues installing via the CircleCI orb. Pin to 78.0 for now.