### PR TITLE
[RW-5198][risk=low] PoC BigQuery Upload service

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",
@@ -119,5 +120,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": true
+  },
+  "reporting": {
+    "dataset": "reporting_local"
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -107,7 +107,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf",
@@ -122,5 +123,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": true
+  },
+  "reporting": {
+    "dataset": "reporting_perf"
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",
@@ -114,5 +115,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": false
+  },
+  "reporting": {
+    "dataset": "reporting_preprod"
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",
@@ -119,5 +120,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": false
+  },
+  "reporting": {
+    "dataset": "reporting_prod"
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",
@@ -119,5 +120,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": false
+  },
+  "reporting": {
+    "dataset": "reporting_stable"
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",
@@ -119,5 +120,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": true
+  },
+  "reporting": {
+    "dataset": "reporting_staging"
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -104,7 +104,8 @@
     "enableEventDateModifier": false,
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
-    "enableCohortBuilderV2": false
+    "enableCohortBuilderV2": false,
+    "enableReportingUploadCron": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",
@@ -119,5 +120,8 @@
   "captcha": {
     "enableCaptcha": true,
     "useTestCaptcha": true
+  },
+  "reporting": {
+    "dataset": "reporting_test"
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import javax.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.reporting.ReportingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -7,15 +9,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class OfflineReportingController implements OfflineReportingApiDelegate {
 
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final ReportingService reportingService;
 
-  public OfflineReportingController(ReportingService reportingService) {
+  public OfflineReportingController(
+      Provider<WorkbenchConfig> workbenchConfigProvider, ReportingService reportingService) {
+    this.workbenchConfigProvider = workbenchConfigProvider;
     this.reportingService = reportingService;
   }
 
   @Override
   public ResponseEntity<Void> uploadReportingSnapshot() {
-    reportingService.uploadSnapshot();
+    if (workbenchConfigProvider.get().featureFlags.enableReportingUploadCron) {
+      reportingService.takeAndUploadSnapshot();
+    }
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -27,6 +27,7 @@ public class WorkbenchConfig {
   public ActionAuditConfig actionAudit;
   public RdrExportConfig rdrExport;
   public CaptchaConfig captcha;
+  public ReportingConfig reporting;
 
   /** Creates a config with non-null-but-empty member variables, for use in testing. */
   public static WorkbenchConfig createEmptyConfig() {
@@ -50,6 +51,7 @@ public class WorkbenchConfig {
     config.actionAudit = new ActionAuditConfig();
     config.rdrExport = new RdrExportConfig();
     config.captcha = new CaptchaConfig();
+    config.reporting = new ReportingConfig();
     return config;
   }
 
@@ -259,6 +261,8 @@ public class WorkbenchConfig {
     public boolean enableResearchPurposePrompt;
     // Flag to indicate whether to use the new UI for cohort builder
     public boolean enableCohortBuilderV2;
+    // If true, reporting cron job will write data to configured BigQuery reporting dataset.
+    public boolean enableReportingUploadCron;
   }
 
   public static class ActionAuditConfig {
@@ -292,5 +296,9 @@ public class WorkbenchConfig {
   public static class CaptchaConfig {
     public boolean enableCaptcha;
     public boolean useTestCaptcha;
+  }
+
+  public static class ReportingConfig {
+    public String dataset;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -9,7 +9,6 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.model.BillingStatus;
-import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -77,7 +76,7 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long> {
           + "GROUP BY activeStatus, dataAccessLevel ORDER BY activeStatus, dataAccessLevel")
   List<ActiveStatusAndDataAccessLevelToCountResult> getActiveStatusAndDataAccessLevelToCount();
 
-  List<DbWorkspace> findAllByActiveStatusIn(WorkspaceActiveStatus workspaceActiveStatus);
+  List<DbWorkspace> findAllByActiveStatusIn(Short workspaceActiveStatusOrdinal);
 
   interface ActiveStatusAndDataAccessLevelToCountResult {
     Short getWorkspaceActiveStatus();

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingJobResult.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingJobResult.java
@@ -1,0 +1,8 @@
+package org.pmiops.workbench.reporting;
+
+public enum ReportingJobResult {
+  SUCCEEDED,
+  ABORTED,
+  PARTIAL_WRITE,
+  UNKNOWN
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingMapper.java
@@ -22,8 +22,8 @@ public interface ReportingMapper {
 
   List<ReportingResearcher> toReportingResearcherList(Collection<DbUser> dbUsers);
 
-  @Mapping(source = "creator", target = "creatorId")
-  @Mapping(target = "fakeSize", ignore = true) // not defined yet
+  @Mapping(source = "creator.userId", target = "creatorId")
+  @Mapping(target = "fakeSize", ignore = true) // temp column for testing; not in mapper
   ReportingWorkspace toModel(DbWorkspace dbWorkspace);
 
   List<ReportingWorkspace> toReportingWorkspaceList(Collection<DbWorkspace> dbWorkspace);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
@@ -1,11 +1,5 @@
 package org.pmiops.workbench.reporting;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.pmiops.workbench.model.ReportingSnapshot;
-
 public interface ReportingService {
-  @VisibleForTesting
-  ReportingSnapshot getSnapshot();
-
-  void uploadSnapshot();
+  ReportingJobResult takeAndUploadSnapshot();
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -1,63 +1,24 @@
 package org.pmiops.workbench.reporting;
 
-import java.time.Clock;
-import java.util.List;
-import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.model.ReportingResearcher;
 import org.pmiops.workbench.model.ReportingSnapshot;
-import org.pmiops.workbench.model.ReportingWorkspace;
-import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ReportingServiceImpl implements ReportingService {
 
-  private static final int MILLI_TO_MICRO = 1000;
-  private final Clock clock;
-  private final ReportingMapper reportingMapper;
-  private final UserService userService;
-  private final WorkspaceService workspaceService;
+  private final ReportingUploadService reportingUploadService;
+  private final ReportingSnapshotService reportingSnapshotService;
 
   public ReportingServiceImpl(
-      Clock clock,
-      ReportingMapper reportingMapper,
-      UserService userService,
-      WorkspaceService workspaceService) {
-    this.clock = clock;
-    this.reportingMapper = reportingMapper;
-    this.userService = userService;
-    this.workspaceService = workspaceService;
-  }
-
-  // The partition key must be an integer (can't use a timestamp),
-  // but we can certainly cast it into a BigQuery timestamp easily.
-  private long getBigQueryPartitionKey() {
-    return clock.millis() * MILLI_TO_MICRO;
+      ReportingUploadService reportingUploadService,
+      ReportingSnapshotService reportingSnapshotService) {
+    this.reportingUploadService = reportingUploadService;
+    this.reportingSnapshotService = reportingSnapshotService;
   }
 
   @Override
-  public ReportingSnapshot getSnapshot() {
-    return new ReportingSnapshot()
-        .captureTimestamp(clock.millis())
-        .researchers(getResearchers())
-        .workspaces(getWorkspaces());
-  }
-
-  @Override
-  public void uploadSnapshot() {
-    final ReportingSnapshot snapshot = getSnapshot();
-    // TODO: upload to BigQuery (or kick off task to upload).
-  }
-
-  private List<ReportingResearcher> getResearchers() {
-    final List<DbUser> users = userService.getAllUsers();
-    return reportingMapper.toReportingResearcherList(users);
-  }
-
-  private List<ReportingWorkspace> getWorkspaces() {
-    final List<DbWorkspace> workspaces = workspaceService.getAllActiveWorkspaces();
-    return reportingMapper.toReportingWorkspaceList(workspaces);
+  public ReportingJobResult takeAndUploadSnapshot() {
+    final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
+    return reportingUploadService.uploadSnapshot(snapshot);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotService.java
@@ -1,0 +1,7 @@
+package org.pmiops.workbench.reporting;
+
+import org.pmiops.workbench.model.ReportingSnapshot;
+
+public interface ReportingSnapshotService {
+  ReportingSnapshot takeSnapshot();
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
@@ -1,0 +1,62 @@
+package org.pmiops.workbench.reporting;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Random;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.ReportingResearcher;
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingWorkspace;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportingSnapshotServiceImpl implements ReportingSnapshotService {
+
+  private final Clock clock;
+  private final ReportingMapper reportingMapper;
+  private Random random;
+  private final UserService userService;
+  private final WorkspaceService workspaceService;
+
+  public ReportingSnapshotServiceImpl(
+      Clock clock,
+      ReportingMapper reportingMapper,
+      Random random,
+      UserService userService,
+      WorkspaceService workspaceService) {
+    this.clock = clock;
+    this.reportingMapper = reportingMapper;
+    this.random = random;
+    this.userService = userService;
+    this.workspaceService = workspaceService;
+  }
+
+  @Override
+  public ReportingSnapshot takeSnapshot() {
+    return new ReportingSnapshot()
+        .captureTimestamp(clock.millis())
+        .researchers(getResearchers())
+        .workspaces(getWorkspaces());
+  }
+
+  private List<ReportingResearcher> getResearchers() {
+    final List<DbUser> users = userService.getAllUsers();
+    return reportingMapper.toReportingResearcherList(users);
+  }
+
+  private List<ReportingWorkspace> getWorkspaces() {
+    final List<DbWorkspace> workspaces = workspaceService.getAllActiveWorkspaces();
+    final List<ReportingWorkspace> models = reportingMapper.toReportingWorkspaceList(workspaces);
+    for (ReportingWorkspace model : models) {
+      model.setFakeSize(getFakeSize());
+    }
+    return models;
+  }
+
+  private long getFakeSize() {
+    return random.nextLong();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
@@ -1,0 +1,9 @@
+package org.pmiops.workbench.reporting;
+
+import org.pmiops.workbench.model.ReportingSnapshot;
+
+// Declaring a service for hte BigQuery upload process will allow easaier testing side-by-side
+// of different upload strategies (e.g. batch vs chunked vs streaming).
+public interface ReportingUploadService {
+  ReportingJobResult uploadSnapshot(ReportingSnapshot reportingSnapshot);
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -1,0 +1,82 @@
+package org.pmiops.workbench.reporting;
+
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import javax.inject.Provider;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.ReportingResearcher;
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingWorkspace;
+import org.pmiops.workbench.reporting.insertion.ReportingInsertionJobBuilder;
+import org.pmiops.workbench.reporting.insertion.ResearcherParameter;
+import org.pmiops.workbench.reporting.insertion.WorkspaceParameter;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+public class ReportingUploadServiceImpl implements ReportingUploadService {
+  private static final Logger logger = Logger.getLogger("ReportingUploadServiceInsertQueryImpl");
+  private static final long MAX_WAIT_TIME = 10000;
+
+  private final BigQueryService bigQueryService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  private static final ReportingInsertionJobBuilder<ReportingResearcher> researcherJobBuilder =
+      ResearcherParameter::values;
+  private static final ReportingInsertionJobBuilder<ReportingWorkspace> workspaceJobBuilder =
+      WorkspaceParameter::values;
+
+  public ReportingUploadServiceImpl(
+      BigQueryService bigQueryService, Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.bigQueryService = bigQueryService;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  @Override
+  public ReportingJobResult uploadSnapshot(ReportingSnapshot reportingSnapshot) {
+    final List<QueryJobConfiguration> insertJobs = getJobs(reportingSnapshot);
+    final Map<QueryJobConfiguration, TableResult> insertResults =
+        insertJobs.stream()
+            .collect(ImmutableMap.toImmutableMap(Function.identity(), this::executeWithTimeout));
+
+    // TODO: pipe more useful diagnostic info to the log
+    insertResults.forEach(
+        (job, result) -> logger.info(String.format("Inserted %d rows", result.getTotalRows())));
+
+    return ReportingJobResult.SUCCEEDED;
+  }
+
+  private TableResult executeWithTimeout(QueryJobConfiguration job) {
+    return bigQueryService.executeQuery(job, MAX_WAIT_TIME);
+  }
+
+  private List<QueryJobConfiguration> getJobs(ReportingSnapshot reportingSnapshot) {
+    final QueryParameterValue snapshotTimestamp = getTimestampValue(reportingSnapshot);
+    return ImmutableList.of(
+        researcherJobBuilder.build(
+            qualifyTableName("researcher"), reportingSnapshot.getResearchers(), snapshotTimestamp),
+        workspaceJobBuilder.build(
+            qualifyTableName("workspace"), reportingSnapshot.getWorkspaces(), snapshotTimestamp));
+  }
+
+  private QueryParameterValue getTimestampValue(ReportingSnapshot reportingSnapshot) {
+    return QueryParameterValue.int64(reportingSnapshot.getCaptureTimestamp());
+  }
+
+  private String qualifyTableName(String tableName) {
+    return String.format(
+        "`%s.%s.%s`",
+        workbenchConfigProvider.get().server.projectId,
+        workbenchConfigProvider.get().reporting.dataset,
+        tableName);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/QueryParameterColumn.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/QueryParameterColumn.java
@@ -1,0 +1,18 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import com.google.cloud.bigquery.QueryParameterValue;
+import java.util.function.Function;
+
+public interface QueryParameterColumn<T> {
+
+  int MICROSECODNS_IN_MILLISECOND = 1000;
+
+  // parameter name (without any @ sign). Also matches column name
+  String getParameterName();
+
+  Function<T, QueryParameterValue> getQueryParameterValueFunction();
+
+  default QueryParameterValue toParameterValue(T target) {
+    return getQueryParameterValueFunction().apply(target);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/ReportingInsertionJobBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/ReportingInsertionJobBuilder.java
@@ -1,0 +1,82 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public interface ReportingInsertionJobBuilder<T> {
+
+  // Extending classes need only provide an  array of QueryParameterColumns, such
+  // as an enum class's values() array.
+  QueryParameterColumn<T>[] getQueryParameterColumns();
+
+  default String getColumnNameList() {
+    return Arrays.stream(getQueryParameterColumns())
+        .map(QueryParameterColumn::getParameterName)
+        .collect(Collectors.joining(", "));
+  }
+
+  default QueryJobConfiguration build(
+      String tableName, List<T> models, QueryParameterValue snapshotTimestamp) {
+    final List<String> columnNames =
+        Arrays.stream(getQueryParameterColumns())
+            .map(QueryParameterColumn::getParameterName)
+            .collect(ImmutableList.toImmutableList());
+    final String query =
+        "INSERT INTO "
+            + tableName
+            + " (snapshot_timestamp, "
+            + getColumnNameList()
+            + ")\n"
+            + createNamedParameterGridForInsertion(models.size(), columnNames)
+            + ";";
+    final Map<String, QueryParameterValue> keyToParameterValue =
+        getKeyToParameterValue(models, snapshotTimestamp);
+
+    return QueryJobConfiguration.newBuilder(query).setNamedParameters(keyToParameterValue).build();
+  }
+
+  default String createNamedParameterGridForInsertion(int rowCount, List<String> columnNames) {
+    return "VALUES\n"
+        + IntStream.range(0, rowCount)
+            .mapToObj(row -> writeNamedParameterValuesRow(row, columnNames))
+            .collect(Collectors.joining(",\n"));
+  }
+
+  // column count is number of  fields in the enum (no including timestamp)
+  default String writeNamedParameterValuesRow(int rowNum, List<String> columnNames) {
+    final String parameterNameList =
+        columnNames.stream()
+            .map(c -> "@" + parameterName(rowNum, c))
+            .collect(Collectors.joining(", "));
+    return "(@snapshot_timestamp, " + parameterNameList + ")";
+  }
+
+  default Map<String, QueryParameterValue> getKeyToParameterValue(
+      List<T> models, QueryParameterValue snapshotTimestamp) {
+    final ImmutableMap.Builder<String, QueryParameterValue> builder = ImmutableMap.builder();
+    builder.put("snapshot_timestamp", snapshotTimestamp); // same for all rows
+    for (int row = 0; row < models.size(); ++row) {
+      builder.putAll(toNamedParameterMap(models.get(row), row));
+    }
+    return builder.build();
+  }
+
+  default String parameterName(int rowNum, String columnName) {
+    return String.format("%s__%d", columnName, rowNum);
+  }
+
+  default Map<String, QueryParameterValue> toNamedParameterMap(T target, int rowIndex) {
+    return Arrays.stream(getQueryParameterColumns())
+        .collect(
+            ImmutableMap.toImmutableMap(
+                e -> parameterName(rowIndex, e.getParameterName()),
+                e -> e.toParameterValue(target)));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/ResearcherParameter.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/ResearcherParameter.java
@@ -1,0 +1,32 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import com.google.cloud.bigquery.QueryParameterValue;
+import java.util.function.Function;
+import org.pmiops.workbench.model.ReportingResearcher;
+
+public enum ResearcherParameter implements QueryParameterColumn<ReportingResearcher> {
+  RESEARCHER_ID("researcher_id", r -> QueryParameterValue.int64(r.getResearcherId())),
+  USERNAME("username", r -> QueryParameterValue.string(r.getUsername())),
+  FIRST_NAME("first_name", r -> QueryParameterValue.string(r.getFirstName())),
+  IS_DISABLED("is_disabled", r -> QueryParameterValue.bool(r.getIsDisabled()));
+
+  private final String parameterName;
+  private final Function<ReportingResearcher, QueryParameterValue> parameterValueFunction;
+
+  ResearcherParameter(
+      String parameterName,
+      Function<ReportingResearcher, QueryParameterValue> parameterValueFunction) {
+    this.parameterName = parameterName;
+    this.parameterValueFunction = parameterValueFunction;
+  }
+
+  @Override
+  public String getParameterName() {
+    return parameterName;
+  }
+
+  @Override
+  public Function<ReportingResearcher, QueryParameterValue> getQueryParameterValueFunction() {
+    return parameterValueFunction;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceParameter.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceParameter.java
@@ -1,0 +1,34 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import com.google.cloud.bigquery.QueryParameterValue;
+import java.util.function.Function;
+import org.pmiops.workbench.model.ReportingWorkspace;
+
+public enum WorkspaceParameter implements QueryParameterColumn<ReportingWorkspace> {
+  WORKSPACE_ID("workspace_id", w -> QueryParameterValue.int64(w.getWorkspaceId())),
+  CREATOR_ID("creator_id", w -> QueryParameterValue.int64(w.getCreatorId())),
+  FAKE_SIZE("fake_size", w -> QueryParameterValue.int64(w.getFakeSize())),
+  CREATION_TIME(
+      "creation_time",
+      w -> QueryParameterValue.timestamp(w.getCreationTime() * MICROSECODNS_IN_MILLISECOND));
+
+  private final String parameterName;
+  private final Function<ReportingWorkspace, QueryParameterValue> parameterValueFunction;
+
+  WorkspaceParameter(
+      String parameterName,
+      Function<ReportingWorkspace, QueryParameterValue> parameterValueFunction) {
+    this.parameterName = parameterName;
+    this.parameterValueFunction = parameterValueFunction;
+  };
+
+  @Override
+  public String getParameterName() {
+    return parameterName;
+  }
+
+  @Override
+  public Function<ReportingWorkspace, QueryParameterValue> getQueryParameterValueFunction() {
+    return parameterValueFunction;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -803,6 +803,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
 
   @Override
   public List<DbWorkspace> getAllActiveWorkspaces() {
-    return workspaceDao.findAllByActiveStatusIn(WorkspaceActiveStatus.ACTIVE);
+    return workspaceDao.findAllByActiveStatusIn(
+        DbStorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE));
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7805,9 +7805,12 @@ definitions:
           "$ref": "#/definitions/ReportingWorkspace"
   ReportingWorkspace:
     description: >
-      Workspace information for reporting.  Internal use only (not part of the API).
     type: object
     properties:
+      workspaceId:
+        description: PK for workspace table.
+        type: integer
+        format: int64
       creatorId:
         description: FK researcher ID for creator of workspace.
         type: integer

--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -85,4 +85,10 @@ cron:
   schedule: every day 21:00
   timezone: America/Chicago
   target: api
+- description: >
+    Compile a snapshot of workbench data for reporting and upload it to  BigQuery.
+  url: /v1/cron/uploadReportingSnapshot
+  schedule: every day 21:00
+  timezone: America/Chicago
+  target: api
 

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceTest.java
@@ -18,7 +18,9 @@ import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.ReportingResearcher;
 import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -44,6 +46,9 @@ public class ReportingSnapshotServiceTest {
   private static final String CURRENT_POSITION = "Tester";
   private static final String RESEARCH_PURPOSE = "To test things";
   private static final long NOW_EPOCH_MILLI = 1594404482000L;
+  private static final String USER_GIVEN_NAME_1 = "Marge";
+  private static final boolean USER_DISABLED_1 = false;
+  private static final long USER_ID_1 = 101L;
 
   @MockBean private Random mockRandom;
   @MockBean private UserService mockUserService;
@@ -108,16 +113,25 @@ public class ReportingSnapshotServiceTest {
     final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
     assertThat((double) snapshot.getCaptureTimestamp()).isWithin(100.0).of(NOW_EPOCH_MILLI);
     assertThat(snapshot.getResearchers()).hasSize(2);
-    assertThat(snapshot.getResearchers().get(0).getResearcherId()).isEqualTo(101);
-    assertThat(snapshot.getResearchers().get(0).getIsDisabled()).isFalse();
+    final ReportingResearcher researcher1 = snapshot.getResearchers().get(0);
+    assertThat(researcher1.getResearcherId()).isEqualTo(USER_ID_1);
+    assertThat(researcher1.getIsDisabled()).isEqualTo(USER_DISABLED_1);
+    assertThat(researcher1.getFirstName()).isEqualTo(USER_GIVEN_NAME_1);
+    assertThat(researcher1.getUsername()).isEqualTo(PRIMARY_EMAIL);
 
     assertThat(snapshot.getWorkspaces()).hasSize(2);
+    final ReportingWorkspace workspace1 = snapshot.getWorkspaces().get(0);
+    assertThat(workspace1.getWorkspaceId()).isEqualTo(101L);
+    assertThat(workspace1.getName()).isEqualTo("A Tale of Two Cities");
+    assertThat(workspace1.getFakeSize()).isEqualTo(100L);
+    assertThat(workspace1.getCreatorId()).isNull(); // not stubbed
   }
 
   private void mockUsers() {
     final List<DbUser> users =
         ImmutableList.of(
-            createFakeUser("Marge", false, 101L), createFakeUser("Homer", false, 102L));
+            createFakeUser(USER_GIVEN_NAME_1, USER_DISABLED_1, USER_ID_1),
+            createFakeUser("Homer", false, 102L));
     doReturn(users).when(mockUserService).getAllUsers();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceTest.java
@@ -1,0 +1,144 @@
+package org.pmiops.workbench.reporting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.Workspace;
+import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ReportingSnapshotServiceTest {
+  private static final String FAMILY_NAME = "Bobberson";
+  private static final String CONTACT_EMAIL = "bob@example.com";
+  private static final String PRIMARY_EMAIL = "bob@researchallofus.org";
+  private static final String ORGANIZATION = "Test";
+  private static final String CURRENT_POSITION = "Tester";
+  private static final String RESEARCH_PURPOSE = "To test things";
+  private static final long NOW_EPOCH_MILLI = 1594404482000L;
+
+  @MockBean private Random mockRandom;
+  @MockBean private UserService mockUserService;
+  @MockBean private WorkspaceService mockWorkspaceService;
+
+  @Autowired private ReportingSnapshotService reportingSnapshotService;
+
+  private static final TestMockFactory TEST_MOCK_FACTORY = new TestMockFactory();
+
+  @TestConfiguration
+  @Import({
+    CommonMappers.class,
+    ReportingMapperImpl.class,
+    ReportingSnapshotServiceImpl.class,
+    ReportingUploadServiceImpl.class
+  })
+  @MockBean({BigQueryService.class})
+  public static class config {
+    @Bean
+    public Clock getClock() {
+      return new FakeClock(Instant.ofEpochMilli(NOW_EPOCH_MILLI));
+    }
+  }
+
+  @Before
+  public void setup() {
+    // Return "random" numbers 100, 101, 102...
+    doAnswer(
+            new Answer<Long>() {
+              private long lastValue = 100;
+
+              public Long answer(InvocationOnMock invocation) {
+                return lastValue++;
+              }
+            })
+        .when(mockRandom)
+        .nextLong();
+  }
+
+  public void mockWorkspaces() {
+    final DbWorkspace dbWorkspace1 = stubDbWorkspace("aou-rw-123456", "A Tale of Two Cities", 101L);
+    final DbWorkspace dbWorkspace2 = stubDbWorkspace("aou-rw-789", "Moby Dick", 202L);
+
+    doReturn(ImmutableList.of(dbWorkspace1, dbWorkspace2))
+        .when(mockWorkspaceService)
+        .getAllActiveWorkspaces();
+  }
+
+  @Test
+  public void testGetSnapshot_noEntries() {
+    final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
+    assertThat(snapshot.getCaptureTimestamp()).isEqualTo(NOW_EPOCH_MILLI);
+    assertThat(snapshot.getResearchers()).isEmpty();
+    assertThat(snapshot.getWorkspaces()).isEmpty();
+  }
+
+  @Test
+  public void testGetSnapshot_someEntries() {
+    mockUsers();
+    mockWorkspaces();
+
+    final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
+    assertThat((double) snapshot.getCaptureTimestamp()).isWithin(100.0).of(NOW_EPOCH_MILLI);
+    assertThat(snapshot.getResearchers()).hasSize(2);
+    assertThat(snapshot.getResearchers().get(0).getResearcherId()).isEqualTo(101);
+    assertThat(snapshot.getResearchers().get(0).getIsDisabled()).isFalse();
+
+    assertThat(snapshot.getWorkspaces()).hasSize(2);
+  }
+
+  private void mockUsers() {
+    final List<DbUser> users =
+        ImmutableList.of(
+            createFakeUser("Marge", false, 101L), createFakeUser("Homer", false, 102L));
+    doReturn(users).when(mockUserService).getAllUsers();
+  }
+
+  private DbUser createFakeUser(String givenName, boolean disabled, long userId) {
+    DbUser user = new DbUser();
+    user.setUserId(userId);
+    user.setGivenName(givenName);
+    user.setFamilyName(FAMILY_NAME);
+    user.setUsername(PRIMARY_EMAIL);
+    user.setContactEmail(CONTACT_EMAIL);
+    user.setOrganization(ORGANIZATION);
+    user.setCurrentPosition(CURRENT_POSITION);
+    user.setAreaOfResearch(RESEARCH_PURPOSE);
+    user.setDisabled(disabled);
+    return user;
+  }
+
+  private DbWorkspace stubDbWorkspace(
+      String workspaceNamespace, String workspaceName, long workspaceId) {
+    final Workspace workspace1 =
+        TEST_MOCK_FACTORY.createWorkspace(workspaceNamespace, workspaceName);
+    return TestMockFactory.createDbWorkspaceStub(workspace1, workspaceId);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceInsertQueryImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceInsertQueryImplTest.java
@@ -1,0 +1,131 @@
+package org.pmiops.workbench.reporting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.bigquery.EmptyTableResult;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.common.collect.ImmutableList;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.cohortbuilder.util.QueryParameterValues;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.ReportingResearcher;
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingWorkspace;
+import org.pmiops.workbench.test.FakeClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ReportingUploadServiceInsertQueryImplTest {
+
+  private static final Instant NOW = Instant.parse("2000-01-01T00:00:00.00Z");
+  private static final Instant THEN = Instant.parse("1989-02-17T00:00:00.00Z");
+
+  private ReportingSnapshot reportingSnapshot;
+
+  @MockBean private BigQueryService mockBigQueryService;
+
+  @Autowired private ReportingUploadService reportingUploadService;
+  @Captor private ArgumentCaptor<QueryJobConfiguration> queryJobConfigurationCaptor;
+
+  @TestConfiguration
+  @Import({ReportingUploadServiceImpl.class})
+  public static class config {
+    @Bean
+    public Clock getClock() {
+      return new FakeClock(NOW);
+    }
+
+    @Bean
+    public WorkbenchConfig workbenchConfig() {
+      final WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
+      workbenchConfig.reporting.dataset = "wb_reporting";
+      workbenchConfig.server.projectId = "rw-wb-unit-test";
+      return workbenchConfig;
+    }
+  }
+
+  @Before
+  public void setup() {
+    reportingSnapshot =
+        new ReportingSnapshot()
+            .captureTimestamp(NOW.toEpochMilli())
+            .researchers(
+                ImmutableList.of(
+                    new ReportingResearcher()
+                        .username("bill@aou.biz")
+                        .firstName("Bill")
+                        .isDisabled(false)
+                        .researcherId(101L),
+                    new ReportingResearcher()
+                        .username("ted@aou.biz")
+                        .firstName("Ted")
+                        .isDisabled(true)
+                        .researcherId(202L),
+                    new ReportingResearcher()
+                        .username("socrates@aou.biz")
+                        .firstName("So-Crates")
+                        .isDisabled(false)
+                        .researcherId(303L)))
+            .workspaces(
+                ImmutableList.of(
+                    new ReportingWorkspace()
+                        .name("Circle K")
+                        .creationTime(THEN.toEpochMilli())
+                        .fakeSize(4444L)
+                        .creatorId(101L),
+                    new ReportingWorkspace()
+                        .name("Wyld Stallyns")
+                        .creationTime(THEN.toEpochMilli())
+                        .fakeSize(4444L)
+                        .creatorId(101L),
+                    new ReportingWorkspace()
+                        .name("You-us said what we-us are saying right now.")
+                        .creationTime(THEN.toEpochMilli())
+                        .fakeSize(4444L)
+                        .creatorId(202L)));
+    doReturn(new EmptyTableResult())
+        .when(mockBigQueryService)
+        .executeQuery(any(QueryJobConfiguration.class), anyLong());
+  }
+
+  @Test
+  public void testUploadSnapshot() {
+    reportingUploadService.uploadSnapshot(reportingSnapshot);
+    verify(mockBigQueryService, times(2))
+        .executeQuery(queryJobConfigurationCaptor.capture(), anyLong());
+
+    final List<QueryJobConfiguration> jobs = queryJobConfigurationCaptor.getAllValues();
+    assertThat(jobs).hasSize(2);
+
+    final QueryJobConfiguration job0 = jobs.get(0);
+    final String query0 = job0.getQuery();
+    assertThat(query0).isNotEmpty();
+
+    final String expandedQuery =
+        QueryParameterValues.formatQuery(QueryParameterValues.replaceNamedParameters(job0));
+
+    assertThat(expandedQuery).containsMatch("INSERT\\s+INTO");
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/utils/MatchersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/MatchersTest.java
@@ -72,6 +72,15 @@ public class MatchersTest {
   }
 
   @Test
+  public void testReplaceAll_multipleOccurrences() {
+    final String input = "And she'll have fun fun fun til her daddy takes the T-bird away.";
+    final Map<Pattern, String> patternToReplacement =
+        ImmutableMap.of(Pattern.compile("\\bfun\\b"), "cat");
+    final String updated = Matchers.replaceAllInMap(patternToReplacement, input);
+    assertThat(updated).contains("have cat cat cat");
+  }
+
+  @Test
   public void testReplaceAll_emptyMap() {
     final String input = "food is good for you!   2food3.";
     final String updated = Matchers.replaceAllInMap(Collections.emptyMap(), input);

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -11,6 +11,7 @@ import com.google.api.services.cloudbilling.model.BillingAccount;
 import com.google.api.services.cloudbilling.model.ListBillingAccountsResponse;
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -59,6 +60,7 @@ public class TestMockFactory {
         .billingAccountType(BillingAccountType.FREE_TIER)
         .creationTime(1588097211621L)
         .creator("jay@unit-test-research-aou.org")
+        .creationTime(Instant.parse("2000-01-01T00:00:00.00Z").toEpochMilli())
         .lastModifiedTime(1588097211621L)
         .published(false)
         .researchPurpose(


### PR DESCRIPTION
This batch of changes introduces the notion of a reporting snapshot with a common timestamp and an equal number of rows for several tables. There are a few interesting features:
* new feature flag to enable the cron to do its work (operating at the controller function level)
* pattern to specify column information and query parameter value info in an enum
* service to build the snapshot (independently of any dependency on BigQuery itself)
* Service for BQ upload with one implementation using DML insert queries. We can add implementations for streaming or GCS bulk load if needed without affecting anything else.
* Table and schema specifications are in https://github.com/all-of-us/workbench-devops/pull/51 in workbench-devops
* basic cron schedule for 24 hours.
* distinct dataset names for each environment. Technically everything except test/local could use the same dataset name, but it's better (1) to have a consistent schema across all projects and (2) it's really easy to be in the wrong project when working in the BigQuery console.
* Some Unit Test coverage, but most of the investment is in the framework & scaffolding.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
<img width="268" alt="Screen Shot 2020-08-06 at 12 28 21 PM" src="https://user-images.githubusercontent.com/53479492/89558061-bdca8100-d7e1-11ea-8c55-6095ee42b122.png">
<img width="621" alt="Screen Shot 2020-08-06 at 12 36 13 PM" src="https://user-images.githubusercontent.com/53479492/89558062-bdca8100-d7e1-11ea-8f2c-a40cf28930e6.png">
<img width="1095" alt="Screen Shot 2020-08-06 at 12 28 34 PM" src="https://user-images.githubusercontent.com/53479492/89558064-bdca8100-d7e1-11ea-8573-0202baca0735.png">
