### PR TITLE
[RW-5341][risk=low] Optionally include demographics in metrics export

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1495,6 +1495,12 @@ def export_workspace_data(cmd_name, *args)
       String,
       ->(opts, v) { opts.export_filename = v},
       "Filename of export file to write to")
+  op.add_typed_option(
+      "--include-demographics=[include-demographics]",
+      TrueClass,
+      ->(opts, v) { opts.include_demographics = v},
+      "Whether to include sensitive researcher demographics in the export. Default is false"
+  )
 
   # Create a cloud context and apply the DB connection variables to the environment.
   # These will be read by Gradle and passed as Spring Boot properties to the command-line.
@@ -1505,6 +1511,9 @@ def export_workspace_data(cmd_name, *args)
   flags = ([
       ["--export-filename", op.opts.export_filename]
   ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
+  if op.opts.include_demographics
+    flags += [ "--include-demographics" ]
+  end
   flags.map! { |f| "'#{f}'" }
 
   with_cloud_proxy_and_db(gcc) do

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -300,26 +300,26 @@ public class ExportWorkspaceData {
     row.setDegrees(
         Optional.ofNullable(user.getDegreesEnum()).orElse(ImmutableList.of()).stream()
             .map(Degree::toString)
-            .collect(Collectors.joining(",")));
+            .collect(Collectors.joining(",\n")));
     DbDemographicSurvey demo = user.getDemographicSurvey();
     if (includeDemographics && demo != null) {
       row.setRace(
           Optional.ofNullable(demo.getRaceEnum()).orElse(ImmutableList.of()).stream()
               .map(Race::toString)
-              .collect(Collectors.joining(",")));
+              .collect(Collectors.joining(",\n")));
       row.setEthnicity(
           Optional.ofNullable(demo.getEthnicityEnum()).map(Ethnicity::toString).orElse(""));
       row.setGenderIdentity(
           Optional.ofNullable(demo.getGenderIdentityEnumList()).orElse(ImmutableList.of()).stream()
               .map(GenderIdentity::toString)
-              .collect(Collectors.joining(",")));
+              .collect(Collectors.joining(",\n")));
       row.setIdentifyAsLgbtq(
           Optional.ofNullable(demo.getIdentifiesAsLgbtq()).map(this::toYesNo).orElse(""));
       row.setLgbtqIdentity(Optional.ofNullable(demo.getLgbtqIdentity()).orElse(""));
       row.setSexAtBirth(
           Optional.ofNullable(demo.getSexAtBirthEnum()).orElse(ImmutableList.of()).stream()
               .map(SexAtBirth::toString)
-              .collect(Collectors.joining(",")));
+              .collect(Collectors.joining(",\n")));
       row.setYearOfBirth(
           Optional.ofNullable(demo.getYear_of_birth())
               .filter(i -> i > 0)

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.tools;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.opencsv.bean.BeanField;
 import com.opencsv.bean.ColumnPositionMappingStrategy;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.persistence.EntityManagerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -35,7 +37,9 @@ import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -44,7 +48,14 @@ import org.pmiops.workbench.firecloud.FireCloudConfig;
 import org.pmiops.workbench.firecloud.FirecloudRetryHandler;
 import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.firecloud.api.WorkspacesApi;
+import org.pmiops.workbench.model.Degree;
+import org.pmiops.workbench.model.Disability;
+import org.pmiops.workbench.model.Education;
+import org.pmiops.workbench.model.Ethnicity;
 import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.model.GenderIdentity;
+import org.pmiops.workbench.model.Race;
+import org.pmiops.workbench.model.SexAtBirth;
 import org.pmiops.workbench.monitoring.LogsBasedMetricServiceImpl;
 import org.pmiops.workbench.monitoring.MonitoringServiceImpl;
 import org.pmiops.workbench.monitoring.MonitoringSpringConfiguration;
@@ -62,6 +73,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.EntityManagerHolder;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /** A tool that will generate a CSV export of our workspace data */
 @Configuration
@@ -91,8 +104,14 @@ public class ExportWorkspaceData {
           .required()
           .hasArg()
           .build();
+  private static Option includeDemographicsOpt =
+      Option.builder()
+          .longOpt("include-demographics")
+          .desc("Whether to include researcher demographics in the export (sensitive)")
+          .build();
 
-  private static Options options = new Options().addOption(exportFilenameOpt);
+  private static Options options =
+      new Options().addOption(exportFilenameOpt).addOption(includeDemographicsOpt);
 
   // Short circuit the DI wiring here with a "mock" WorkspaceService
   // Importing the real one requires importing a large subtree of dependencies
@@ -126,6 +145,7 @@ public class ExportWorkspaceData {
 
   @Bean
   public CommandLineRunner run(
+      @Qualifier("entityManagerFactory") EntityManagerFactory emf,
       WorkspaceDao workspaceDao,
       CohortDao cohortDao,
       ConceptSetDao conceptSetDao,
@@ -150,7 +170,13 @@ public class ExportWorkspaceData {
     this.dateFormat.setTimeZone(TimeZone.getTimeZone("CST"));
 
     return (args) -> {
+      // Binding the EntityManager allows us to use lazy lookups. This simulates what is done on
+      // the server, where an entity manager is bound for the duration of a request.
+      EntityManagerHolder emHolder = new EntityManagerHolder(emf.createEntityManager());
+      TransactionSynchronizationManager.bindResource(emf, emHolder);
+
       CommandLine opts = new DefaultParser().parse(options, args);
+      boolean includeDemographics = opts.hasOption(includeDemographicsOpt.getLongOpt());
 
       log.info("collecting all users");
       List<WorkspaceExportRow> rows = new ArrayList<>();
@@ -159,7 +185,7 @@ public class ExportWorkspaceData {
 
       log.info("collecting / converting all workspaces");
       for (DbWorkspace workspace : this.workspaceDao.findAll()) {
-        rows.add(toWorkspaceExportRow(workspace));
+        rows.add(toWorkspaceExportRow(workspace, includeDemographics));
         usersWithoutWorkspaces.remove(workspace.getCreator());
 
         if (rows.size() % 10 == 0) {
@@ -169,7 +195,7 @@ public class ExportWorkspaceData {
 
       log.info("converting users without workspaces");
       for (DbUser user : usersWithoutWorkspaces) {
-        rows.add(toWorkspaceExportRow(user));
+        rows.add(toWorkspaceExportRow(user, includeDemographics));
       }
 
       final CustomMappingStrategy mappingStrategy = new CustomMappingStrategy();
@@ -186,11 +212,12 @@ public class ExportWorkspaceData {
     };
   }
 
-  private WorkspaceExportRow toWorkspaceExportRow(DbWorkspace workspace) {
-    WorkspaceExportRow row = toWorkspaceExportRow(workspace.getCreator());
+  private WorkspaceExportRow toWorkspaceExportRow(
+      DbWorkspace workspace, boolean includeDemographics) {
+    WorkspaceExportRow row = toWorkspaceExportRow(workspace.getCreator(), includeDemographics);
 
     row.setProjectId(workspace.getWorkspaceNamespace());
-    row.setName(workspace.getName());
+    row.setWorkspaceName(workspace.getName());
     row.setCreatedDate(dateFormat.format(workspace.getCreationTime()));
 
     try {
@@ -241,17 +268,18 @@ public class ExportWorkspaceData {
     return row;
   }
 
-  private WorkspaceExportRow toWorkspaceExportRow(DbUser user) {
-    String verifiedInstitutionName =
-        verifiedInstitutionalAffiliationDao
-            .findFirstByUser(user)
-            .map(via -> via.getInstitution().getDisplayName())
-            .orElse("");
+  private WorkspaceExportRow toWorkspaceExportRow(DbUser user, boolean includeDemographics) {
+    Optional<DbVerifiedInstitutionalAffiliation> verifiedAffiliation =
+        verifiedInstitutionalAffiliationDao.findFirstByUser(user);
 
     WorkspaceExportRow row = new WorkspaceExportRow();
     row.setCreatorContactEmail(user.getContactEmail());
     row.setCreatorUsername(user.getUsername());
-    row.setInstitution(verifiedInstitutionName);
+    row.setName(formatName(user));
+    row.setInstitution(
+        verifiedAffiliation.map(via -> via.getInstitution().getDisplayName()).orElse(""));
+    row.setInstitutionalRole(
+        verifiedAffiliation.map(via -> via.getInstitutionalRoleEnum().toString()).orElse(""));
     row.setCreatorFirstSignIn(
         Optional.ofNullable(user.getFirstSignInTime()).map(dateFormat::format).orElse(""));
     row.setTwoFactorAuthCompletionDate(
@@ -269,6 +297,39 @@ public class ExportWorkspaceData {
             .map(dateFormat::format)
             .orElse(""));
     row.setCreatorRegistrationState(user.getDataAccessLevelEnum().toString());
+    row.setDegrees(
+        Optional.ofNullable(user.getDegreesEnum()).orElse(ImmutableList.of()).stream()
+            .map(Degree::toString)
+            .collect(Collectors.joining(",")));
+    DbDemographicSurvey demo = user.getDemographicSurvey();
+    if (includeDemographics && demo != null) {
+      row.setRace(
+          Optional.ofNullable(demo.getRaceEnum()).orElse(ImmutableList.of()).stream()
+              .map(Race::toString)
+              .collect(Collectors.joining(",")));
+      row.setEthnicity(
+          Optional.ofNullable(demo.getEthnicityEnum()).map(Ethnicity::toString).orElse(""));
+      row.setGenderIdentity(
+          Optional.ofNullable(demo.getGenderIdentityEnumList()).orElse(ImmutableList.of()).stream()
+              .map(GenderIdentity::toString)
+              .collect(Collectors.joining(",")));
+      row.setIdentifyAsLgbtq(
+          Optional.ofNullable(demo.getIdentifiesAsLgbtq()).map(this::toYesNo).orElse(""));
+      row.setLgbtqIdentity(Optional.ofNullable(demo.getLgbtqIdentity()).orElse(""));
+      row.setSexAtBirth(
+          Optional.ofNullable(demo.getSexAtBirthEnum()).orElse(ImmutableList.of()).stream()
+              .map(SexAtBirth::toString)
+              .collect(Collectors.joining(",")));
+      row.setYearOfBirth(
+          Optional.ofNullable(demo.getYear_of_birth())
+              .filter(i -> i > 0)
+              .map(i -> Integer.toString(i))
+              .orElse(""));
+      row.setDisability(
+          Optional.ofNullable(demo.getDisabilityEnum()).map(Disability::toString).orElse(""));
+      row.setHighestEducation(
+          Optional.ofNullable(demo.getEducationEnum()).map(Education::toString).orElse(""));
+    }
 
     return row;
   }
@@ -279,6 +340,12 @@ public class ExportWorkspaceData {
 
   private String toYesNo(boolean b) {
     return b ? "Yes" : "No";
+  }
+
+  private String formatName(DbUser user) {
+    return Optional.ofNullable(user.getFamilyName()).orElse("")
+        + ", "
+        + Optional.ofNullable(user.getGivenName()).orElse("");
   }
 }
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/WorkspaceExportRow.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/WorkspaceExportRow.java
@@ -29,6 +29,18 @@ public class WorkspaceExportRow {
   @CsvBindByPosition(position = 1)
   private String creatorUsername;
 
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @CsvBindByName(column = "name")
+  @CsvBindByPosition(position = 2)
+  private String name;
+
   public String getInstitution() {
     return institution;
   }
@@ -38,8 +50,20 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Institution")
-  @CsvBindByPosition(position = 2)
+  @CsvBindByPosition(position = 3)
   private String institution;
+
+  public String getInstitutionalRole() {
+    return institutionalRole;
+  }
+
+  public void setInstitutionalRole(String institutionalRole) {
+    this.institutionalRole = institutionalRole;
+  }
+
+  @CsvBindByName(column = "Institutional role")
+  @CsvBindByPosition(position = 4)
+  private String institutionalRole;
 
   public String getCreatorFirstSignIn() {
     return creatorFirstSignIn;
@@ -50,7 +74,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "First Sign In")
-  @CsvBindByPosition(position = 3)
+  @CsvBindByPosition(position = 5)
   private String creatorFirstSignIn;
 
   public String getCreatorRegistrationState() {
@@ -62,7 +86,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Registration State")
-  @CsvBindByPosition(position = 4)
+  @CsvBindByPosition(position = 6)
   private String creatorRegistrationState;
 
   public String getTwoFactorAuthCompletionDate() {
@@ -74,7 +98,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "2fa Completion Time (CST)")
-  @CsvBindByPosition(position = 5)
+  @CsvBindByPosition(position = 7)
   private String twoFactorAuthCompletionDate;
 
   public String getEraCompletionDate() {
@@ -86,7 +110,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "eRA Completion Time (CST)")
-  @CsvBindByPosition(position = 6)
+  @CsvBindByPosition(position = 8)
   private String eraCompletionDate;
 
   public String getTrainingCompletionDate() {
@@ -98,7 +122,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Training Completion Time (CST)")
-  @CsvBindByPosition(position = 7)
+  @CsvBindByPosition(position = 9)
   private String trainingCompletionDate;
 
   public String getDuccCompletionDate() {
@@ -110,8 +134,128 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "DUCC Completion Time (CST)")
-  @CsvBindByPosition(position = 8)
+  @CsvBindByPosition(position = 10)
   private String duccCompletionDate;
+
+  public String getDegrees() {
+    return degrees;
+  }
+
+  public void setDegrees(String degrees) {
+    this.degrees = degrees;
+  }
+
+  @CsvBindByName(column = "Degrees")
+  @CsvBindByPosition(position = 11)
+  private String degrees;
+
+  public String getRace() {
+    return race;
+  }
+
+  public void setRace(String race) {
+    this.race = race;
+  }
+
+  @CsvBindByName(column = "Race")
+  @CsvBindByPosition(position = 12)
+  private String race;
+
+  public String getEthnicity() {
+    return ethnicity;
+  }
+
+  public void setEthnicity(String ethnicity) {
+    this.ethnicity = ethnicity;
+  }
+
+  @CsvBindByName(column = "Ethnicity")
+  @CsvBindByPosition(position = 13)
+  private String ethnicity;
+
+  public String getGenderIdentity() {
+    return genderIdentity;
+  }
+
+  public void setGenderIdentity(String genderIdentity) {
+    this.genderIdentity = genderIdentity;
+  }
+
+  @CsvBindByName(column = "Gender Identity")
+  @CsvBindByPosition(position = 14)
+  private String genderIdentity;
+
+  public String getIdentifyAsLgbtq() {
+    return identifyAsLgbtq;
+  }
+
+  public void setIdentifyAsLgbtq(String identifyAsLgbtq) {
+    this.identifyAsLgbtq = identifyAsLgbtq;
+  }
+
+  @CsvBindByName(column = "Identify as LGBTQ")
+  @CsvBindByPosition(position = 15)
+  private String identifyAsLgbtq;
+
+  public String getLgbtqIdentity() {
+    return lgbtqIdentity;
+  }
+
+  public void setLgbtqIdentity(String lgbtqIdentity) {
+    this.lgbtqIdentity = lgbtqIdentity;
+  }
+
+  @CsvBindByName(column = "LGBTQ Identity")
+  @CsvBindByPosition(position = 16)
+  private String lgbtqIdentity;
+
+  public String getSexAtBirth() {
+    return sexAtBirth;
+  }
+
+  public void setSexAtBirth(String sexAtBirth) {
+    this.sexAtBirth = sexAtBirth;
+  }
+
+  @CsvBindByName(column = "Sex at birth")
+  @CsvBindByPosition(position = 17)
+  private String sexAtBirth;
+
+  public String getYearOfBirth() {
+    return yearOfBirth;
+  }
+
+  public void setYearOfBirth(String yearOfBirth) {
+    this.yearOfBirth = yearOfBirth;
+  }
+
+  @CsvBindByName(column = "Year of birth")
+  @CsvBindByPosition(position = 18)
+  private String yearOfBirth;
+
+  public String getDisability() {
+    return disability;
+  }
+
+  public void setDisability(String disability) {
+    this.disability = disability;
+  }
+
+  @CsvBindByName(column = "Disability")
+  @CsvBindByPosition(position = 19)
+  private String disability;
+
+  public String getHighestEducation() {
+    return highestEducation;
+  }
+
+  public void setHighestEducation(String highestEducation) {
+    this.highestEducation = highestEducation;
+  }
+
+  @CsvBindByName(column = "HighestEducation")
+  @CsvBindByPosition(position = 20)
+  private String highestEducation;
 
   public String getProjectId() {
     return projectId;
@@ -122,20 +266,20 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Project ID")
-  @CsvBindByPosition(position = 9)
+  @CsvBindByPosition(position = 21)
   private String projectId;
 
-  public String getName() {
-    return name;
+  public String getWorkspaceName() {
+    return workspaceName;
   }
 
-  public void setName(String name) {
-    this.name = name;
+  public void setWorkspaceName(String workspaceName) {
+    this.workspaceName = workspaceName;
   }
 
   @CsvBindByName(column = "Workspace Name")
-  @CsvBindByPosition(position = 10)
-  private String name;
+  @CsvBindByPosition(position = 22)
+  private String workspaceName;
 
   public String getCreatedDate() {
     return createdDate;
@@ -146,7 +290,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Created Time (CST)")
-  @CsvBindByPosition(position = 11)
+  @CsvBindByPosition(position = 23)
   private String createdDate;
 
   public String getCollaborators() {
@@ -158,7 +302,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Other users in the workspace")
-  @CsvBindByPosition(position = 12)
+  @CsvBindByPosition(position = 24)
   private String collaborators;
 
   public String getCohortNames() {
@@ -170,7 +314,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Cohort Names")
-  @CsvBindByPosition(position = 13)
+  @CsvBindByPosition(position = 25)
   private String cohortNames;
 
   public String getCohortCount() {
@@ -182,7 +326,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Cohort Count")
-  @CsvBindByPosition(position = 14)
+  @CsvBindByPosition(position = 26)
   private String cohortCount;
 
   public String getConceptSetNames() {
@@ -194,7 +338,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Concept Set Names")
-  @CsvBindByPosition(position = 15)
+  @CsvBindByPosition(position = 27)
   private String conceptSetNames;
 
   public String getConceptSetCount() {
@@ -206,7 +350,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Concept Set Count")
-  @CsvBindByPosition(position = 16)
+  @CsvBindByPosition(position = 28)
   private String conceptSetCount;
 
   public String getDatasetNames() {
@@ -218,7 +362,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Dataset Names")
-  @CsvBindByPosition(position = 17)
+  @CsvBindByPosition(position = 29)
   private String datasetNames;
 
   public String getDatasetCount() {
@@ -230,7 +374,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Dataset Count")
-  @CsvBindByPosition(position = 18)
+  @CsvBindByPosition(position = 30)
   private String datasetCount;
 
   public String getNotebookNames() {
@@ -242,7 +386,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Notebook Names")
-  @CsvBindByPosition(position = 19)
+  @CsvBindByPosition(position = 31)
   private String notebookNames;
 
   public String getNotebooksCount() {
@@ -254,7 +398,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Notebook Count")
-  @CsvBindByPosition(position = 20)
+  @CsvBindByPosition(position = 32)
   private String notebooksCount;
 
   public String getWorkspaceSpending() {
@@ -266,7 +410,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Spending")
-  @CsvBindByPosition(position = 21)
+  @CsvBindByPosition(position = 33)
   private String workspaceSpending;
 
   public String getReviewForStigmatizingResearch() {
@@ -278,7 +422,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Review for Stigmatizing research (Y/N)")
-  @CsvBindByPosition(position = 22)
+  @CsvBindByPosition(position = 34)
   private String reviewForStigmatizingResearch;
 
   public String getWorkspaceLastUpdatedDate() {
@@ -290,7 +434,7 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Workspace Last Updated Time (CST)")
-  @CsvBindByPosition(position = 23)
+  @CsvBindByPosition(position = 35)
   private String workspaceLastUpdatedDate;
 
   public String getActive() {
@@ -302,6 +446,6 @@ public class WorkspaceExportRow {
   }
 
   @CsvBindByName(column = "Is Workspace active? (Y/N)")
-  @CsvBindByPosition(position = 24)
+  @CsvBindByPosition(position = 36)
   private String active;
 }


### PR DESCRIPTION
There is active work to move to a nightly reporting pipeline. For now though, this script is still being run manually to generate metrics. There is a high priority request for this information - however I do not wish to make it part of the standard export, since the nature of the data is sensitive.