### PR TITLE
[noTicket][risk=low]Removing extra closing bracket at the end of selected Cohort

### DIFF
--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -232,7 +232,7 @@ export class SelectionListModalVersion extends React.Component<Props> {
                            selection={selection}
                            removeSelection={() => removeSelection(selection)}/>
         )}
-      </div>}
+      </div>
       {!serverConfigStore.getValue().enableCohortBuilderV2 && <div style={styles.buttonContainer}>
         <Button type='link'
           style={{...styles.button, color: colors.dark, fontSize: '14px'}}

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -33,8 +33,7 @@ const styles = reactStyles({
     flex: 1,
     display: 'flex',
     flexFlow: 'row nowrap',
-    justifyContent: 'flex-start',
-    color: colors.accent
+    justifyContent: 'flex-start'
   },
   itemName: {
     flex: 1,
@@ -90,7 +89,13 @@ const styles = reactStyles({
     background: colorWithWhiteness(colors.black, 0.95),
     height: '100%',
     padding: '0.5rem 0 0 1rem',
-  }
+  },
+  selectionItemModal: {
+    display: 'flex',
+    fontSize: '14px',
+    padding: '0.2rem 0.5rem 0',
+    width: '100%',
+  },
 });
 
 export interface Selection extends Criteria {
@@ -139,7 +144,7 @@ export class SelectionInfoModal extends React.Component<SelectionInfoProps, Sele
       {this.showType && <strong>{typeDisplay(selection)}&nbsp;</strong>}
       {nameDisplay(selection)} {attributeDisplay(selection)}
     </React.Fragment>;
-    return <div style={styles.selectionItem}>
+    return <div style={styles.selectionItemModal}>
       <button style={styles.removeSelection} onClick={() => removeSelection()}>
         <ClrIcon shape='times-circle'/>
       </button>

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -5,7 +5,7 @@ import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
-import colors from 'app/styles/colors';
+import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {withCurrentCohortCriteria} from 'app/utils';
 import {reactStyles} from 'app/utils';
 import {currentCohortCriteriaStore, serverConfigStore} from 'app/utils/navigation';
@@ -75,6 +75,21 @@ const styles = reactStyles({
     color: colors.primary,
     margin: 0,
     padding: '0.5rem 0'
+  },
+  // Remove the following styles once enableCohortBuilderV2 is set to true
+  selectionContainerModal: {
+    background: colors.white,
+    border: `2px solid ${colors.primary}`,
+    borderRadius: '5px',
+    height: 'calc(100% - 150px)',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    width: '95%',
+  },
+  selectionPanelModal: {
+    background: colorWithWhiteness(colors.black, 0.95),
+    height: '100%',
+    padding: '0.5rem 0 0 1rem',
   }
 });
 
@@ -223,9 +238,9 @@ export class SelectionListModalVersion extends React.Component<Props> {
 
   render() {
     const {back, close, disableFinish, finish, removeSelection, selections, setView} = this.props;
-    return <div style={styles.selectionPanel}>
+    return <div style={styles.selectionPanelModal}>
       <h5 style={styles.selectionTitle}>Selected Criteria</h5>
-      <div style={styles.selectionContainer}>
+      <div style={styles.selectionContainerModal}>
         {selections.map((selection, s) =>
             <SelectionInfoModal key={s}
                            index={s}


### PR DESCRIPTION
I notice i left an extra } which is visible at the end of Selected Criteria 

<img width="1310" alt="Screen Shot 2020-08-04 at 12 31 03 AM" src="https://user-images.githubusercontent.com/34481816/89253148-c9535780-d5e9-11ea-8b92-bc95e9b9e51c.png">

After change: 
<img width="1338" alt="Screen Shot 2020-08-04 at 9 49 49 AM" src="https://user-images.githubusercontent.com/34481816/89302181-840a4680-d638-11ea-84f4-f257dc19e451.png">

<img width="1316" alt="Screen Shot 2020-08-04 at 10 25 10 AM" src="https://user-images.githubusercontent.com/34481816/89305600-d9485700-d63c-11ea-9334-be044fbb7970.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
