### PR TITLE
[RW-5320][risk=no] Adding sex at birth to response model

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -311,7 +311,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   private List<ConceptIdName> buildConceptIdNameList(
       List<DbCriteria> criteriaList, FilterColumns columnName) {
     return criteriaList.stream()
-        .filter(c -> c.getType().equals(columnName.toString()))
+        .filter(c -> columnName.toString().startsWith(c.getType()))
         .map(
             c -> new ConceptIdName().conceptId(new Long(c.getConceptId())).conceptName(c.getName()))
         .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.cohortbuilder;
 import static org.pmiops.workbench.model.FilterColumns.ETHNICITY;
 import static org.pmiops.workbench.model.FilterColumns.GENDER;
 import static org.pmiops.workbench.model.FilterColumns.RACE;
+import static org.pmiops.workbench.model.FilterColumns.SEX_AT_BIRTH;
 
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.QueryJobConfiguration;
@@ -264,7 +265,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     return new ParticipantDemographics()
         .genderList(buildConceptIdNameList(criteriaList, GENDER))
         .raceList(buildConceptIdNameList(criteriaList, RACE))
-        .ethnicityList(buildConceptIdNameList(criteriaList, ETHNICITY));
+        .ethnicityList(buildConceptIdNameList(criteriaList, ETHNICITY))
+        .sexAtBirthList(buildConceptIdNameList(criteriaList, SEX_AT_BIRTH));
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6448,6 +6448,7 @@ definitions:
     - BIRTHDATE
     - RACE
     - ETHNICITY
+    - SEX_AT_BIRTH
     - DECEASED
     - START_DATETIME
     - STANDARD_CODE
@@ -7489,6 +7490,7 @@ definitions:
     - genderList
     - raceList
     - ethnicityList
+    - sexAtBirthList
     properties:
       genderList:
         type: array
@@ -7499,6 +7501,10 @@ definitions:
         items:
           "$ref": "#/definitions/ConceptIdName"
       ethnicityList:
+        type: array
+        items:
+          "$ref": "#/definitions/ConceptIdName"
+      sexAtBirthList:
         type: array
         items:
           "$ref": "#/definitions/ConceptIdName"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -27,11 +27,13 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.elasticsearch.ElasticSearchService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.google.CloudStorageService;
+import org.pmiops.workbench.model.ConceptIdName;
 import org.pmiops.workbench.model.Criteria;
 import org.pmiops.workbench.model.CriteriaAttribute;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
@@ -497,7 +499,7 @@ public class CohortBuilderControllerTest {
   }
 
   @Test
-  public void getDrugBrandOrIngredientByName() {
+  public void findDrugBrandOrIngredientByName() {
     DbCriteria drugATCCriteria =
         DbCriteria.builder()
             .addDomainId(DomainType.DRUG.toString())
@@ -574,6 +576,57 @@ public class CohortBuilderControllerTest {
             .getItems();
     assertTrue(attrs.contains(createResponseCriteriaAttribute(criteriaAttributeMin)));
     assertTrue(attrs.contains(createResponseCriteriaAttribute(criteriaAttributeMax)));
+  }
+
+  @Test
+  public void findParticipantDemographics() {
+    cbCriteriaDao.save(
+        DbCriteria.builder()
+            .addDomainId(DomainType.PERSON.toString())
+            .addType(CriteriaType.GENDER.toString())
+            .addName("Male")
+            .addStandard(true)
+            .addConceptId("1")
+            .addParentId(1)
+            .build());
+    cbCriteriaDao.save(
+        DbCriteria.builder()
+            .addDomainId(DomainType.PERSON.toString())
+            .addType(CriteriaType.RACE.toString())
+            .addName("African American")
+            .addStandard(true)
+            .addConceptId("2")
+            .addParentId(1)
+            .build());
+    cbCriteriaDao.save(
+        DbCriteria.builder()
+            .addDomainId(DomainType.PERSON.toString())
+            .addType(CriteriaType.ETHNICITY.toString())
+            .addName("Not Hispanic or Latino")
+            .addStandard(true)
+            .addConceptId("3")
+            .addParentId(1)
+            .build());
+    cbCriteriaDao.save(
+        DbCriteria.builder()
+            .addDomainId(DomainType.PERSON.toString())
+            .addType(CriteriaType.SEX.toString())
+            .addName("Male")
+            .addStandard(true)
+            .addConceptId("4")
+            .addParentId(1)
+            .build());
+    ParticipantDemographics demos = controller.findParticipantDemographics(1L).getBody();
+    assertEquals(
+        new ConceptIdName().conceptId(1L).conceptName("Male"), demos.getGenderList().get(0));
+    assertEquals(
+        new ConceptIdName().conceptId(2L).conceptName("African American"),
+        demos.getRaceList().get(0));
+    assertEquals(
+        new ConceptIdName().conceptId(3L).conceptName("Not Hispanic or Latino"),
+        demos.getEthnicityList().get(0));
+    assertEquals(
+        new ConceptIdName().conceptId(4L).conceptName("Male"), demos.getSexAtBirthList().get(0));
   }
 
   @Test

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -70,7 +70,7 @@ export class CohortBuilderServiceStub extends CohortBuilderApi {
   }
 
   findParticipantDemographics(): Promise<ParticipantDemographics> {
-    return new Promise<ParticipantDemographics>(resolve => resolve({genderList: [], ethnicityList: [], raceList: []}));
+    return new Promise<ParticipantDemographics>(resolve => resolve({genderList: [], ethnicityList: [], raceList: [], sexAtBirthList: []}));
   }
 
   findCriteriaMenuOptions(): Promise<CriteriaMenuOptionsListResponse> {


### PR DESCRIPTION
Adding sex at birth to response model

- Updated CohortBuilderServiceImpl#findParticipantDemographics to include sex at birth
- Updated workbench-api.yaml to include sexAtBirthList and sex_at_birth filter column
- Added/Fixed API/UI test