### PR TITLE
[no ticket][risk=no] Puppeteer: log failed requests in debug mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ commands:
           # parallelism used to run e2e tests
           command: |
             circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings > /tmp/tests-to-run
-            yarn test:ci:debug $(cat /tmp/tests-to-run)
+            yarn test:ci $(cat /tmp/tests-to-run)
           no_output_timeout: 15m
       - store_artifacts:
           path: e2e/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ commands:
           # parallelism used to run e2e tests
           command: |
             circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings > /tmp/tests-to-run
-            yarn test:ci $(cat /tmp/tests-to-run)
+            yarn test:ci:debug $(cat /tmp/tests-to-run)
           no_output_timeout: 15m
       - store_artifacts:
           path: e2e/logs

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -3,7 +3,7 @@ const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/5
 
 const navTimeOut = parseInt(process.env.PUPPETEER_NAVIGATION_TIMEOUT, 10) || 90000;
 const timeOut = parseInt(process.env.PUPPETEER_TIMEOUT, 10) || 90000;
-
+const isDebugMode = process.argv.includes('--debug');
 
 /**
  * Set up page common properties:
@@ -42,10 +42,10 @@ beforeAll(async () => {
     // to improve page load performance, block network requests unrelated to application.
     try {
       if (host === 'www.google-analytics.com'
-         || host === 'accounts.youtube.com'
-         || host === 'static.zdassets.com'
-         || host === 'play.google.com'
-         || request.url().endsWith('content-security-index-report')) {
+           || host === 'accounts.youtube.com'
+           || host === 'static.zdassets.com'
+           || host === 'play.google.com'
+           || request.url().endsWith('content-security-index-report')) {
         request.abort();
       } else {
         request.continue();
@@ -54,6 +54,17 @@ beforeAll(async () => {
       console.error(err);
     }
   });
+  if (isDebugMode) {
+    // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
+    page.on('requestfailed', request => {
+      console.error(`❌ Failed request => ${request.method()} ${request.url()}`);
+      request.continue();
+    });
+    // Emitted when the page crashed
+    page.on('error', error => console.error(`❌ ${error}`));
+    // Emitted when a script has uncaught exception
+    page.on('pageerror', error => console.error(`❌ ${error}`));
+  }
 });
 
 afterAll(async () => {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,7 @@
     "test-local": "cross-env WORKBENCH_ENV=local DEBUG=true jest --maxWorkers=2",
     "test-local:debug": "cross-env WORKBENCH_ENV=local PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=2",
     "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2",
+    "test:ci:debug": "cross-env NODE_ENV=development CI=true jest --ci --debug --maxWorkers=1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
     "test-local": "cross-env WORKBENCH_ENV=local DEBUG=true jest --maxWorkers=2",
     "test-local:debug": "cross-env WORKBENCH_ENV=local PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=2",
     "test:ci": "cross-env NODE_ENV=development CI=true jest --ci --maxWorkers=2",
-    "test:ci:debug": "cross-env NODE_ENV=development CI=true jest --ci --debug --maxWorkers=1",
+    "test:ci:debug": "cross-env NODE_ENV=development CI=true jest --ci --debug --maxWorkers=1 --bail 1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",


### PR DESCRIPTION
To make it easier to troubleshoot test failures by print out failed network requests to console. This is useful for circleci test failures investigation.

`--debug` mode circleci e2e-test job results example:
https://app.circleci.com/pipelines/github/all-of-us/workbench/2806/workflows/23bf50ec-c462-4dee-910a-b224923330d1/jobs/92891
