### PR TITLE
triallelic randomize

### DIFF
--- a/api/genomics/src/main/java/org/pmiops/workbench/genomics/RandomizeVcf.java
+++ b/api/genomics/src/main/java/org/pmiops/workbench/genomics/RandomizeVcf.java
@@ -140,30 +140,49 @@ public class RandomizeVcf extends VariantWalker {
      */
     List<Allele> alleles = new ArrayList<>();
     double genotypeTypeIndex = random.nextDouble();
-    if (genotypeTypeIndex < .0145) {
-      // double no-call
-      return alleles;
-    } else if (genotypeTypeIndex < .8095) {
-      // homref
-      alleles.add(variantContext.getReference());
-      alleles.add(variantContext.getReference());
-    } else if (genotypeTypeIndex < .8654) {
-      // 0/1 het
-      alleles.add(variantContext.getReference());
-      alleles.add(variantContext.getAlternateAllele(0));
-    } else if (genotypeTypeIndex < .9268) {
-      // 1/0 het
-      alleles.add(variantContext.getAlternateAllele(0));
-      alleles.add(variantContext.getReference());
-    } else if (genotypeTypeIndex < .9994
-        || (genotypeTypeIndex >= .9994 && variantContext.getAlternateAlleles().size() == 1)) {
-      // homvar
-      alleles.add(variantContext.getAlternateAllele(0));
-      alleles.add(variantContext.getAlternateAllele(0));
+    if (variantContext.getAlternateAlleles().size() == 1) {
+      if (genotypeTypeIndex < .0145) {
+        // double no-call
+        alleles.add(Allele.NO_CALL);
+        alleles.add(Allele.NO_CALL);
+        return alleles;
+      } else if (genotypeTypeIndex < .8095) {
+        // homref
+        alleles.add(variantContext.getReference());
+        alleles.add(variantContext.getReference());
+      } else if (genotypeTypeIndex < .8654) {
+        // 0/1 het
+        alleles.add(variantContext.getReference());
+        alleles.add(variantContext.getAlternateAllele(0));
+      } else if (genotypeTypeIndex < .9268) {
+        // 1/0 het
+        alleles.add(variantContext.getAlternateAllele(0));
+        alleles.add(variantContext.getReference());
+      } else {
+        // homvar
+        alleles.add(variantContext.getAlternateAllele(0));
+        alleles.add(variantContext.getAlternateAllele(0));
+      }
     } else {
-      // homvar, but the rarer alt
-      alleles.add(variantContext.getAlternateAllele(1));
-      alleles.add(variantContext.getAlternateAllele(1));
+      // sum of probabilities of bi-allelic no-call / homref
+      if (genotypeTypeIndex < .8240) {
+        // double no-call (or ref, if we're at a tri-allelic site, but we don't differentiate)
+        alleles.add(Allele.NO_CALL);
+        alleles.add(Allele.NO_CALL);
+        return alleles;
+      } else if (genotypeTypeIndex < .8654) {
+        // 1/2 het
+        alleles.add(variantContext.getAlternateAllele(0));
+        alleles.add(variantContext.getAlternateAllele(1));
+      } else if (genotypeTypeIndex < .9268) {
+        // 2/1 het
+        alleles.add(variantContext.getAlternateAllele(1));
+        alleles.add(variantContext.getAlternateAllele(0));
+      } else {
+        // homvar, but the rarer alt
+        alleles.add(variantContext.getAlternateAllele(1));
+        alleles.add(variantContext.getAlternateAllele(1));
+      }
     }
     return alleles;
   }

--- a/api/genomics/src/main/java/org/pmiops/workbench/genomics/RandomizeVcf.java
+++ b/api/genomics/src/main/java/org/pmiops/workbench/genomics/RandomizeVcf.java
@@ -140,7 +140,27 @@ public class RandomizeVcf extends VariantWalker {
      */
     List<Allele> alleles = new ArrayList<>();
     double genotypeTypeIndex = random.nextDouble();
-    if (variantContext.getAlternateAlleles().size() == 1) {
+    if (variantContext.getAlternateAlleles().size() == 2) {
+      // sum of probabilities of bi-allelic no-call / homref
+      if (genotypeTypeIndex < .8240) {
+        // double no-call (or ref, if we're at a tri-allelic site, but we don't differentiate)
+        alleles.add(Allele.NO_CALL);
+        alleles.add(Allele.NO_CALL);
+        return alleles;
+      } else if (genotypeTypeIndex < .8654) {
+        // 1/2 het
+        alleles.add(variantContext.getAlternateAllele(0));
+        alleles.add(variantContext.getAlternateAllele(1));
+      } else if (genotypeTypeIndex < .9268) {
+        // 2/1 het
+        alleles.add(variantContext.getAlternateAllele(1));
+        alleles.add(variantContext.getAlternateAllele(0));
+      } else {
+        // homvar, but the rarer alt
+        alleles.add(variantContext.getAlternateAllele(1));
+        alleles.add(variantContext.getAlternateAllele(1));
+      }
+    } else {
       if (genotypeTypeIndex < .0145) {
         // double no-call
         alleles.add(Allele.NO_CALL);
@@ -162,26 +182,6 @@ public class RandomizeVcf extends VariantWalker {
         // homvar
         alleles.add(variantContext.getAlternateAllele(0));
         alleles.add(variantContext.getAlternateAllele(0));
-      }
-    } else {
-      // sum of probabilities of bi-allelic no-call / homref
-      if (genotypeTypeIndex < .8240) {
-        // double no-call (or ref, if we're at a tri-allelic site, but we don't differentiate)
-        alleles.add(Allele.NO_CALL);
-        alleles.add(Allele.NO_CALL);
-        return alleles;
-      } else if (genotypeTypeIndex < .8654) {
-        // 1/2 het
-        alleles.add(variantContext.getAlternateAllele(0));
-        alleles.add(variantContext.getAlternateAllele(1));
-      } else if (genotypeTypeIndex < .9268) {
-        // 2/1 het
-        alleles.add(variantContext.getAlternateAllele(1));
-        alleles.add(variantContext.getAlternateAllele(0));
-      } else {
-        // homvar, but the rarer alt
-        alleles.add(variantContext.getAlternateAllele(1));
-        alleles.add(variantContext.getAlternateAllele(1));
       }
     }
     return alleles;


### PR DESCRIPTION
In this array, we don't look for the ref in triallelic sites, we just no-call if it's not one of the alts. So I'm now handling randomizing at triallelic sites differently than biallelic sites. I'm combining the no-call probability with the homref probability and just writing 1/2 and 2/1 where I'd otherwise write 0/1 or 1/0.