### PR TITLE
[no ticket][risk=no] Puppeteeer: revert R and Python versions

### DIFF
--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -47,7 +47,7 @@ describe('Jupyter notebook tests', () => {
            'print(sys.version)';
       const code1Output = await notebook.runCodeCell(1, {code: code1});
       // Python version is 3.7.6 at time of this writing. It can change.
-      expect(code1Output).toEqual(expect.stringContaining('3.7.8'));
+      expect(code1Output).toEqual(expect.stringContaining('3.7.6'));
 
       const code2 = '!jupyter kernelspec list';
       const code2Output = await notebook.runCodeCell(2, {code: code2});

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -43,7 +43,7 @@ describe('Jupyter notebook tests', () => {
       const code2 = 'sessionInfo()';
       const code2Output = await notebook.runCodeCell(2, {code: code2});
       // R version is 3.6.2 at time of this writing. It can change.
-      expect(code2Output).toMatch(/R version 4.0.2/);
+      expect(code2Output).toMatch(/R version 3.6.2/);
 
       // Delete R notebook
       const analysisPage = await notebook.goBackAnalysisPage();


### PR DESCRIPTION
Change back R and Python versions due to reverted PR: https://github.com/all-of-us/workbench/pull/3861

Failed circleci job https://app.circleci.com/pipelines/github/all-of-us/workbench/2837/workflows/201d5932-3fb6-4fc3-9ea2-00402fac6b8e/jobs/93106