### PR TITLE
[RW-4588][risk=no] Update colors for graphs in CB

### DIFF
--- a/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
+++ b/ui/src/app/cohort-search/gender-chart/gender-chart.component.tsx
@@ -3,6 +3,7 @@ import HighchartsReact from 'highcharts-react-official';
 import * as React from 'react';
 
 import {getChartObj} from 'app/cohort-search/utils';
+import colors from 'app/styles/colors';
 
 highCharts.setOptions({
   lang: {
@@ -80,7 +81,6 @@ export class GenderChart extends React.Component<Props, State> {
       'F': 'Female',
       'No matching concept': 'Unknown'
     };
-    const colors = ['#a8385d', '#7aa3e5', '#a27ea8', '#aae3f5'];
     const chartData = data.reduce((acc, datum) => {
       const gender = !!genderCodes[datum.name] ? genderCodes[datum.name] : datum.name;
       if (!acc.categories.includes(gender)) {
@@ -90,7 +90,7 @@ export class GenderChart extends React.Component<Props, State> {
       if (index > -1) {
         acc.data[index].y += datum.count;
       } else {
-        acc.data.push({y: datum.count, name: gender, color: colors[acc.data.length]});
+        acc.data.push({y: datum.count, name: gender, color: colors.chartColors[acc.data.length]});
       }
       return acc;
     }, {categories: [], data: []});

--- a/ui/src/app/components/combo-chart.component.tsx
+++ b/ui/src/app/components/combo-chart.component.tsx
@@ -3,6 +3,7 @@ import HighchartsReact from 'highcharts-react-official';
 import * as React from 'react';
 
 import {getChartObj} from 'app/cohort-search/utils';
+import colors from 'app/styles/colors';
 
 interface Props {
   mode: string;
@@ -59,7 +60,7 @@ export class ComboChart extends React.Component<Props, State> {
           text: ''
         }
       },
-      colors: ['#adcded', '#aae3f5', '#a27ea8', '#7aa3e5', '#a8385d'],
+      colors: colors.chartColors,
       legend: {
         enabled: false
       },

--- a/ui/src/app/styles/colors.ts
+++ b/ui/src/app/styles/colors.ts
@@ -32,7 +32,8 @@ export default {
     'OWNER': '#4996A2',
     'READER': '#8F8E8F',
     'WRITER': '#92B572'
-  }
+  },
+  chartColors: ['#216FB4', '#6CACE4', '#8BC990', '#F8C954', '#F7981C', '#F0718B', '#F38D7A', '#A27DB7', '#CAB2D6']
 };
 
 class Rgba {


### PR DESCRIPTION
Adds a chartColors property in colors.ts based on [this Invision screen](https://projects.invisionapp.com/d/main?origin=v7#/console/12820961/423349542/preview?scrollOffset=25965), and uses the new colors in the cohort builder graphs. 

Approval given by Lou in a comment on [the ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-4588):
![Screen Shot 2020-08-05 at 2 43 21 PM](https://user-images.githubusercontent.com/40036095/89579766-f24a3700-d7f9-11ea-8948-d9cfbc7a3fc3.png)

![Screen Shot 2020-08-05 at 2 43 33 PM](https://user-images.githubusercontent.com/40036095/89579780-f8d8ae80-d7f9-11ea-933d-aaabb1a9ccb0.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
