### PR TITLE
[RW-5322][risk=no] move ds_linking table to cloud sql

### DIFF
--- a/api/config/cdr_versions_perf.json
+++ b/api/config/cdr_versions_perf.json
@@ -33,6 +33,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_3"
+    "cdrDbName": "synth_r_2019q4_5"
   }
 ]

--- a/api/config/cdr_versions_preprod.json
+++ b/api/config/cdr_versions_preprod.json
@@ -9,7 +9,7 @@
     "creationTime": "2019-10-21 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 224143,
-    "cdrDbName": "r_2020q1_2"
+    "cdrDbName": "r_2020q3_1"
   },
   {
     "cdrVersionId": 2,
@@ -21,7 +21,7 @@
     "creationTime": "2020-04-16 00:00:00Z",
     "releaseNumber": 4,
     "numParticipants": 224001,
-    "cdrDbName": "r_2020q1_1"
+    "cdrDbName": "r_2020q3_2"
   },
   {
     "cdrVersionId": 3,
@@ -32,6 +32,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_3"
+    "cdrDbName": "synth_r_2019q4_5"
   }
 ]

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -57,6 +57,6 @@
     "creationTime": "2019-10-04 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 224143,
-    "cdrDbName": "r_2019q4_5"
+    "cdrDbName": "r_2019q4_6"
   }
 ]

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -59,6 +59,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_3"
+    "cdrDbName": "synth_r_2019q4_5"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -59,6 +59,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_3"
+    "cdrDbName": "synth_r_2019q4_5"
   }
 ]

--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -33,6 +33,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_4"
+    "cdrDbName": "synth_r_2019q4_5"
   }
 ]

--- a/api/db-cdr/changelog-data/db.changelog-1.xml
+++ b/api/db-cdr/changelog-data/db.changelog-1.xml
@@ -26,6 +26,7 @@
     <delete tableName="cb_criteria_ancestor"/>
     <delete tableName="cb_person"/>
     <delete tableName="cb_data_filter"/>
+    <delete tableName="ds_linking"/>
 
     <loadData tableName="domain_info" file="csv/domain_info.csv" encoding="UTF-8" quotchar='"'>
       <column name="concept_id" type="NUMERIC"/>
@@ -292,6 +293,15 @@
       <column name="data_filter_id" type="NUMERIC"/>
       <column name="display_name" type="STRING"/>
       <column name="name" type="STRING"/>
+    </loadData>
+
+    <loadData tableName="ds_linking" file="csv/ds_linking.csv" encoding="UTF-8"
+      quotchar='"'>
+      <column name="id" type="NUMERIC"/>
+      <column name="denormalized_name" type="STRING"/>
+      <column name="omop_sql" type="STRING"/>
+      <column name="join_value" type="STRING"/>
+      <column name="domain" type="STRING"/>
     </loadData>
 
   </changeSet>

--- a/api/db-cdr/changelog-schema/db.changelog-38.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-38.xml
@@ -19,7 +19,7 @@
         <constraints nullable="true"/>
       </column>
       <column name="domain" type="VARCHAR(80)">
-        <constraints nullable="true"/>
+        <constraints nullable="false"/>
       </column>
     </createTable>
 

--- a/api/db-cdr/changelog-schema/db.changelog-38.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-38.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet author="brianfreeman" id="changelog-38">
+    <createTable tableName="ds_linking">
+      <column name="id" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="denormalized_name" type="VARCHAR(400)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="omop_sql" type="VARCHAR(4000)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="join_value" type="VARCHAR(4000)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="domain" type="VARCHAR(80)">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+
+    <createIndex
+      indexName="idx_ds_linking_domain"
+      tableName="ds_linking"
+      unique="false">
+      <column name="domain"/>
+    </createIndex>
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -44,4 +44,5 @@
   <include file="changelog-schema/db.changelog-35.xml"/>
   <include file="changelog-schema/db.changelog-36.xml"/>
   <include file="changelog-schema/db.changelog-37.xml"/>
+  <include file="changelog-schema/db.changelog-38.xml"/>
 </databaseChangeLog>

--- a/api/db-cdr/generate-cdr/bq-schemas/ds_linking.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/ds_linking.json
@@ -1,0 +1,27 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "ID",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "DENORMALIZED_NAME",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "OMOP_SQL",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "JOIN_VALUE",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "DOMAIN",
+    "type": "STRING"
+  }
+]

--- a/api/db-cdr/generate-cdr/make-bq-data-dump.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data-dump.sh
@@ -17,7 +17,7 @@ echo "Dumping tables to csv from $BUCKET"
 # Note tables larger than 1 G need to be dumped into more than one file.
 # Namin scheme is table_name.*.csv.gz
 
-tables=(concept cb_criteria_relationship cb_criteria cb_criteria_attribute domain_info survey_module domain vocabulary cb_criteria_ancestor concept_synonym cb_person cb_data_filter)
+tables=(concept cb_criteria_relationship cb_criteria cb_criteria_attribute ds_linking domain_info survey_module domain vocabulary cb_criteria_ancestor concept_synonym cb_person cb_data_filter)
 
 for table in ${tables[@]}; do
   echo "Dumping table : $table"

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -43,7 +43,7 @@ cb_cri_anc_table_check=\\bcb_criteria_ancestor\\b
 
 # Create bq tables we have json schema for
 schema_path=generate-cdr/bq-schemas
-create_tables=(concept cb_criteria cb_criteria_attribute cb_criteria_relationship cb_criteria_ancestor domain_info survey_module domain vocabulary concept_synonym cb_person cb_data_filter)
+create_tables=(concept cb_criteria cb_criteria_attribute cb_criteria_relationship cb_criteria_ancestor ds_linking domain_info survey_module domain vocabulary concept_synonym cb_person cb_data_filter)
 
 for t in "${create_tables[@]}"
 do
@@ -99,6 +99,14 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 VALUES
 (1,'Only include participants with EHR data','has_ehr_data'),
 (2,'Only include participants with Physical Measurements','has_physical_measurement_data')"
+
+# Populate ds_linking table
+echo "Inserting ds_linking"
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$OUTPUT_PROJECT.$OUTPUT_DATASET.ds_linking\`
+(ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+SELECT ROW_NUMBER() OVER() ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN
+FROM \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
 
 # Populate some tables from cdr data
 ###############

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.cdr.dao.DSLinkingDao;
+import org.pmiops.workbench.cdr.model.DbDSLinking;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohorts.CohortCloningService;
 import org.pmiops.workbench.cohorts.CohortService;
@@ -92,6 +94,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   @Autowired private CdrVersionService cdrVersionService;
   @Autowired private CohortDao cohortDao;
   @Autowired private ConceptSetDao conceptSetDao;
+  @Autowired private DSLinkingDao dsLinkingDao;
   @Autowired private DataSetService dataSetService;
   @Autowired private FireCloudService fireCloudService;
   @Autowired private NotebooksService notebooksService;
@@ -111,6 +114,14 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   private DbConceptSet dbConditionConceptSet;
   private DbConceptSet dbProcedureConceptSet;
   private DbWorkspace dbWorkspace;
+  private DbDSLinking conditionLinking1;
+  private DbDSLinking conditionLinking2;
+  private DbDSLinking personLinking1;
+  private DbDSLinking personLinking2;
+  private DbDSLinking surveyLinking1;
+  private DbDSLinking surveyLinking2;
+  private DbDSLinking procedureLinking1;
+  private DbDSLinking procedureLinking2;
 
   @TestConfiguration
   @Import({
@@ -229,6 +240,74 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
     dbCohort2 = cohortDao.save(dbCohort2);
 
     when(controller.generateRandomEightCharacterQualifier()).thenReturn("00000000");
+
+    conditionLinking1 =
+        DbDSLinking.builder()
+            .addDenormalizedName("CORE_TABLE_FOR_DOMAIN")
+            .addOmopSql("CORE_TABLE_FOR_DOMAIN")
+            .addJoinValue("from `${projectId}.${dataSetId}.condition_occurrence` c_occurrence")
+            .addDomain("Condition")
+            .build();
+    dsLinkingDao.save(conditionLinking1);
+    conditionLinking2 =
+        DbDSLinking.builder()
+            .addDenormalizedName("PERSON_ID")
+            .addOmopSql("c_occurrence.PERSON_ID")
+            .addJoinValue("from `${projectId}.${dataSetId}.condition_occurrence` c_occurrence")
+            .addDomain("Condition")
+            .build();
+    dsLinkingDao.save(conditionLinking2);
+
+    personLinking1 =
+        DbDSLinking.builder()
+            .addDenormalizedName("CORE_TABLE_FOR_DOMAIN")
+            .addOmopSql("CORE_TABLE_FOR_DOMAIN")
+            .addJoinValue("FROM `${projectId}.${dataSetId}.person` person")
+            .addDomain("Person")
+            .build();
+    dsLinkingDao.save(personLinking1);
+    personLinking2 =
+        DbDSLinking.builder()
+            .addDenormalizedName("PERSON_ID")
+            .addOmopSql("person.PERSON_ID")
+            .addJoinValue("FROM `${projectId}.${dataSetId}.person` person")
+            .addDomain("Person")
+            .build();
+    dsLinkingDao.save(personLinking2);
+
+    surveyLinking1 =
+        DbDSLinking.builder()
+            .addDenormalizedName("CORE_TABLE_FOR_DOMAIN")
+            .addOmopSql("CORE_TABLE_FOR_DOMAIN")
+            .addJoinValue("FROM `${projectId}.${dataSetId}.ds_survey` answer")
+            .addDomain("Survey")
+            .build();
+    dsLinkingDao.save(surveyLinking1);
+    surveyLinking2 =
+        DbDSLinking.builder()
+            .addDenormalizedName("PERSON_ID")
+            .addOmopSql("answer.PERSON_ID")
+            .addJoinValue("")
+            .addDomain("Survey")
+            .build();
+    dsLinkingDao.save(surveyLinking2);
+
+    procedureLinking1 =
+        DbDSLinking.builder()
+            .addDenormalizedName("CORE_TABLE_FOR_DOMAIN")
+            .addOmopSql("CORE_TABLE_FOR_DOMAIN")
+            .addJoinValue("from `${projectId}.${dataSetId}.procedure_occurrence` procedure")
+            .addDomain("Procedure")
+            .build();
+    dsLinkingDao.save(procedureLinking1);
+    procedureLinking2 =
+        DbDSLinking.builder()
+            .addDenormalizedName("PERSON_ID")
+            .addOmopSql("procedure.PERSON_ID")
+            .addJoinValue("from `${projectId}.${dataSetId}.procedure_occurrence` procedure")
+            .addDomain("Procedure")
+            .build();
+    dsLinkingDao.save(procedureLinking2);
   }
 
   @After
@@ -239,6 +318,14 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
     conceptSetDao.delete(dbProcedureConceptSet.getConceptSetId());
     workspaceDao.delete(dbWorkspace.getWorkspaceId());
     cdrVersionDao.delete(dbCdrVersion.getCdrVersionId());
+    dsLinkingDao.delete(conditionLinking1);
+    dsLinkingDao.delete(conditionLinking2);
+    dsLinkingDao.delete(personLinking1);
+    dsLinkingDao.delete(personLinking2);
+    dsLinkingDao.delete(surveyLinking1);
+    dsLinkingDao.delete(surveyLinking2);
+    dsLinkingDao.delete(procedureLinking1);
+    dsLinkingDao.delete(procedureLinking2);
   }
 
   @Test

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/DSLinkingDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/DSLinkingDao.java
@@ -1,0 +1,12 @@
+package org.pmiops.workbench.cdr.dao;
+
+import java.util.List;
+import org.pmiops.workbench.cdr.model.DbDSLinking;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface DSLinkingDao extends CrudRepository<DbDSLinking, Long> {
+
+  List<DbDSLinking> findByDomainAndDenormalizedNameIn(
+      @Param("domain") String domain, @Param("names") List<String> names);
+}

--- a/api/src/main/java/org/pmiops/workbench/cdr/model/DbDSLinking.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/model/DbDSLinking.java
@@ -1,0 +1,142 @@
+package org.pmiops.workbench.cdr.model;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@Entity
+@Table(name = "ds_linking")
+public class DbDSLinking {
+  private long id;
+  private String denormalizedName;
+  private String omopSql;
+  private String joinValue;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  @Column(name = "denormalized_name")
+  public String getDenormalizedName() {
+    return denormalizedName;
+  }
+
+  public void setDenormalizedName(String denormalizedName) {
+    this.denormalizedName = denormalizedName;
+  }
+
+  @Column(name = "omop_sql")
+  public String getOmopSql() {
+    return omopSql;
+  }
+
+  public void setOmopSql(String omopSql) {
+    this.omopSql = omopSql;
+  }
+
+  @Column(name = "join_value")
+  public String getJoinValue() {
+    return joinValue;
+  }
+
+  public void setJoinValue(String joinValue) {
+    this.joinValue = joinValue;
+  }
+
+  @Column(name = "domain")
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(String domain) {
+    this.domain = domain;
+  }
+
+  private String domain;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DbDSLinking that = (DbDSLinking) o;
+    return Objects.equals(denormalizedName, that.denormalizedName)
+        && Objects.equals(omopSql, that.omopSql)
+        && Objects.equals(joinValue, that.joinValue)
+        && Objects.equals(domain, that.domain);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(denormalizedName, omopSql, joinValue, domain);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
+  }
+
+  public static DbDSLinking.Builder builder() {
+    return new DbDSLinking.Builder();
+  }
+
+  public static class Builder {
+    private long id;
+    private String denormalizedName;
+    private String omopSql;
+    private String joinValue;
+    private String domain;
+
+    private Builder() {}
+
+    public DbDSLinking.Builder addId(long id) {
+      this.id = id;
+      return this;
+    }
+
+    public DbDSLinking.Builder addDenormalizedName(String denormalizedName) {
+      this.denormalizedName = denormalizedName;
+      return this;
+    }
+
+    public DbDSLinking.Builder addOmopSql(String omopSql) {
+      this.omopSql = omopSql;
+      return this;
+    }
+
+    public DbDSLinking.Builder addJoinValue(String joinValue) {
+      this.joinValue = joinValue;
+      return this;
+    }
+
+    public DbDSLinking.Builder addDomain(String domain) {
+      this.domain = domain;
+      return this;
+    }
+
+    public DbDSLinking build() {
+      DbDSLinking dbDSLinking = new DbDSLinking();
+      dbDSLinking.setId(this.id);
+      dbDSLinking.setDenormalizedName(this.denormalizedName);
+      dbDSLinking.setOmopSql(this.omopSql);
+      dbDSLinking.setJoinValue(this.joinValue);
+      dbDSLinking.setDomain(this.domain);
+      return dbDSLinking;
+    }
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
@@ -1,0 +1,54 @@
+package org.pmiops.workbench.cdr.dao;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.cdr.model.DbDSLinking;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class DSLinkingDaoTest {
+
+  @Autowired private DSLinkingDao dsLinkingDao;
+  private DbDSLinking dbDSLinking1;
+  private DbDSLinking dbDSLinking2;
+
+  @Before
+  public void setUp() {
+    dbDSLinking1 =
+        dsLinkingDao.save(
+            DbDSLinking.builder()
+                .addDenormalizedName("CONDITION_CONCEPT_ID")
+                .addOmopSql("c_occurrence.CONDITION_CONCEPT_ID")
+                .addJoinValue("from `${projectId}.${dataSetId}.condition_occurrence` c_occurrence")
+                .addDomain("Condition")
+                .build());
+    dbDSLinking2 =
+        dsLinkingDao.save(
+            DbDSLinking.builder()
+                .addDenormalizedName("CONDITION_STATUS_CONCEPT_NAME")
+                .addOmopSql("c_status.concept_name as CONDITION_STATUS_CONCEPT_NAME")
+                .addJoinValue(
+                    "left join `${projectId}.${dataSetId}.concept` c_status on c_occurrence.CONDITION_STATUS_CONCEPT_ID = c_status.CONCEPT_ID")
+                .addDomain("Condition")
+                .build());
+  }
+
+  @Test
+  public void findByDomainAndDenormalizedNameIn() {
+    List<DbDSLinking> sqlParts =
+        dsLinkingDao.findByDomainAndDenormalizedNameIn(
+            "Condition", ImmutableList.of("CONDITION_CONCEPT_ID", "CONDITION_STATUS_CONCEPT_NAME"));
+    assertThat(sqlParts).hasSize(2);
+    assertThat(sqlParts).containsAllOf(dbDSLinking1, dbDSLinking2);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.cdr.dao.DSLinkingDao;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.dataset.DataSetMapper;
@@ -89,6 +90,7 @@ public class DataSetServiceTest {
   @Autowired private CohortQueryBuilder cohortQueryBuilder;
   @Autowired private DataDictionaryEntryDao dataDictionaryEntryDao;
   @Autowired private DataSetDao dataSetDao;
+  @Autowired private DSLinkingDao dsLinkingDao;
   @Autowired private DataSetMapper dataSetMapper;
 
   @MockBean private BigQueryService mockBigQueryService;
@@ -124,6 +126,7 @@ public class DataSetServiceTest {
             cohortQueryBuilder,
             dataDictionaryEntryDao,
             dataSetDao,
+            dsLinkingDao,
             dataSetMapper,
             CLOCK);
 


### PR DESCRIPTION
This PR moves the ds_linking table into our cloudsql CDR instance. Its more efficient to query this table in cloudsql rather than BQ. The following changes include

1. Updated the CDR indexing scripts to include `ds_linking` table (make-bq-data.sh and make-bq-data-dump.sh)
2. Added `ds_linking` table to our local liquibase build for development purposes
3. Created `DSLinkingDao` and db model `DbDSLinking` with new test case `DSLinkingDaoTest`
4. Updated `DataSetServiceImpl` to use `DSLinkingDao`
5. Bumped all cloudsql CDR versions to allow for using the `ds_linking` table