### PR TITLE
[no ticket][risk=no] Use 24h display for audit event dates

### DIFF
--- a/ui/src/app/components/admin/audit-card-list-view.tsx
+++ b/ui/src/app/components/admin/audit-card-list-view.tsx
@@ -183,7 +183,7 @@ const AuditActionCard = (props: { action: AuditAction }) => {
   // Something in the codegen is wonky here. the actionTime field is typed as a Date,
   // but turns out to be a number for some reason here. In other contexts it appears
   // to format itself happily though.
-  const timeString = moment(new Date(action.actionTime)).format('YYYY-MM-DD h:mm:ss');
+  const timeString = moment(new Date(action.actionTime)).format('YYYY-MM-DD hh:mm:ss');
   const actionTypes = fp.flow(
     fp.map(fp.get('header.actionType')),
     fp.sortedUniq,


### PR DESCRIPTION
This caused me quite some confusion when investigating RW-5373 (I though the event was 06:35, it was actually 18:35).

I haven't validated this fix locally, but I'm pretty sure it's correct per the [momentjs docs](https://momentjs.com/docs/#/parsing/string-formats/).