### PR TITLE
[no ticket][risk = no] use configurable row limit for insert

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -122,6 +122,7 @@
     "useTestCaptcha": true
   },
   "reporting": {
-    "dataset": "reporting_local"
+    "dataset": "reporting_local",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -125,6 +125,7 @@
     "useTestCaptcha": true
   },
   "reporting": {
-    "dataset": "reporting_perf"
+    "dataset": "reporting_perf",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -117,6 +117,7 @@
     "useTestCaptcha": false
   },
   "reporting": {
-    "dataset": "reporting_preprod"
+    "dataset": "reporting_preprod",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -122,6 +122,7 @@
     "useTestCaptcha": false
   },
   "reporting": {
-    "dataset": "reporting_prod"
+    "dataset": "reporting_prod",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -122,6 +122,7 @@
     "useTestCaptcha": false
   },
   "reporting": {
-    "dataset": "reporting_stable"
+    "dataset": "reporting_stable",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -122,6 +122,7 @@
     "useTestCaptcha": true
   },
   "reporting": {
-    "dataset": "reporting_staging"
+    "dataset": "reporting_staging",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -122,6 +122,7 @@
     "useTestCaptcha": true
   },
   "reporting": {
-    "dataset": "reporting_test"
+    "dataset": "reporting_test",
+    "maxRowsPerInsert": 200
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -300,5 +300,6 @@ public class WorkbenchConfig {
 
   public static class ReportingConfig {
     public String dataset;
+    public Integer maxRowsPerInsert;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
@@ -62,6 +62,7 @@ public class ReportingUploadServiceTest {
     public WorkbenchConfig workbenchConfig() {
       final WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.reporting.dataset = "wb_reporting";
+      workbenchConfig.reporting.maxRowsPerInsert = 5;
       workbenchConfig.server.projectId = "rw-wb-unit-test";
       return workbenchConfig;
     }
@@ -138,7 +139,7 @@ public class ReportingUploadServiceTest {
     // inject it so that we don't need this many rows in the test, but I didn't think that was
     // necessarily a good enoughh reason to add configurable state.
     final List<ReportingResearcher> researchers =
-        IntStream.range(0, 2001)
+        IntStream.range(0, 21)
             .mapToObj(
                 id ->
                     new ReportingResearcher()
@@ -165,7 +166,7 @@ public class ReportingUploadServiceTest {
     final int researcherColumnCount = 4;
     final int workspaceColumnCount = 5;
 
-    assertThat(jobs.get(0).getNamedParameters()).hasSize(researcherColumnCount * 500 + 1);
+    assertThat(jobs.get(0).getNamedParameters()).hasSize(researcherColumnCount * 5 + 1);
     assertThat(jobs.get(4).getNamedParameters()).hasSize(researcherColumnCount + 1);
     assertThat(jobs.get(5).getNamedParameters()).hasSize(workspaceColumnCount + 1);
   }


### PR DESCRIPTION
Still seeing BigQuery errors that my insertion is too complex/long. Adding an environment config value with default of 200 (from 500).

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
