### PR TITLE
[RW-4596][risk=no] Adding count to criteria search response

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -22,6 +22,7 @@ import org.pmiops.workbench.model.AgeType;
 import org.pmiops.workbench.model.AgeTypeCountListResponse;
 import org.pmiops.workbench.model.CriteriaAttributeListResponse;
 import org.pmiops.workbench.model.CriteriaListResponse;
+import org.pmiops.workbench.model.CriteriaListWithCountResponse;
 import org.pmiops.workbench.model.CriteriaMenuOptionsListResponse;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
@@ -120,14 +121,13 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   }
 
   @Override
-  public ResponseEntity<CriteriaListResponse> findCriteriaByDomainAndSearchTerm(
+  public ResponseEntity<CriteriaListWithCountResponse> findCriteriaByDomainAndSearchTerm(
       Long cdrVersionId, String domain, String term, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
     validateDomain(domain);
     validateTerm(term);
     return ResponseEntity.ok(
-        new CriteriaListResponse()
-            .items(cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, limit)));
+        cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, limit));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaLookup;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
@@ -160,7 +161,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
   @Query(
       value =
           "select c from DbCriteria c where domainId=:domain and type=:type and standard=:standard and code like upper(concat(:term,'%')) and match(synonyms, concat('+[', :domain, '_rank1]')) > 0 order by c.count desc")
-  List<DbCriteria> findCriteriaByDomainAndTypeAndCode(
+  Page<DbCriteria> findCriteriaByDomainAndTypeAndCode(
       @Param("domain") String domain,
       @Param("type") String type,
       @Param("standard") Boolean isStandard,
@@ -170,7 +171,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
   @Query(
       value =
           "select c from DbCriteria c where domainId=:domain and standard=:standard and code like upper(concat(:term,'%')) and match(synonyms, concat('+[', :domain, '_rank1]')) > 0 order by c.count desc")
-  List<DbCriteria> findCriteriaByDomainAndCode(
+  Page<DbCriteria> findCriteriaByDomainAndCode(
       @Param("domain") String domain,
       @Param("standard") Boolean isStandard,
       @Param("term") String term,
@@ -179,7 +180,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
   @Query(
       value =
           "select c from DbCriteria c where domainId=:domain and standard=:standard and match(synonyms, concat(:term, '+[', :domain, '_rank1]')) > 0 order by c.count desc, c.name asc")
-  List<DbCriteria> findCriteriaByDomainAndSynonyms(
+  Page<DbCriteria> findCriteriaByDomainAndSynonyms(
       @Param("domain") String domain,
       @Param("standard") Boolean isStandard,
       @Param("term") String term,

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -5,6 +5,7 @@ import org.pmiops.workbench.model.AgeType;
 import org.pmiops.workbench.model.AgeTypeCount;
 import org.pmiops.workbench.model.Criteria;
 import org.pmiops.workbench.model.CriteriaAttribute;
+import org.pmiops.workbench.model.CriteriaListWithCountResponse;
 import org.pmiops.workbench.model.CriteriaMenuOption;
 import org.pmiops.workbench.model.DataFilter;
 import org.pmiops.workbench.model.DemoChartInfo;
@@ -25,7 +26,8 @@ public interface CohortBuilderService {
 
   List<Criteria> findCriteriaBy(String domain, String type, Boolean standard, Long parentId);
 
-  List<Criteria> findCriteriaByDomainAndSearchTerm(String domain, String term, Integer limit);
+  CriteriaListWithCountResponse findCriteriaByDomainAndSearchTerm(
+      String domain, String term, Integer limit);
 
   List<CriteriaMenuOption> findCriteriaMenuOptions();
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3140,7 +3140,7 @@ paths:
         200:
           description: A collection of criteria
           schema:
-            "$ref": "#/definitions/CriteriaListResponse"
+            "$ref": "#/definitions/CriteriaListWithCountResponse"
   "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}/{conceptId}":
     parameters:
     - "$ref": "#/parameters/cdrVersionId"
@@ -6908,6 +6908,19 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/Criteria"
+  CriteriaListWithCountResponse:
+    type: object
+    required:
+    - items
+    - totalCount
+    properties:
+      items:
+        type: array
+        items:
+          "$ref": "#/definitions/Criteria"
+      totalCount:
+        type: integer
+        format: int64
   CriteriaMenuOptionsListResponse:
     type: object
     required:

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -186,7 +186,7 @@ public class CBCriteriaDaoTest {
 
   @Test
   public void findCriteriaByDomainAndTypeAndCode() {
-    PageRequest page = new PageRequest(0, 2);
+    PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> criteriaList =
         cbCriteriaDao
             .findCriteriaByDomainAndTypeAndCode(

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -186,14 +186,16 @@ public class CBCriteriaDaoTest {
 
   @Test
   public void findCriteriaByDomainAndTypeAndCode() {
-    PageRequest page = new PageRequest(0, 10);
+    PageRequest page = new PageRequest(0, 2);
     List<DbCriteria> criteriaList =
-        cbCriteriaDao.findCriteriaByDomainAndTypeAndCode(
-            DomainType.CONDITION.toString(),
-            CriteriaType.ICD9CM.toString(),
-            Boolean.FALSE,
-            "00",
-            page);
+        cbCriteriaDao
+            .findCriteriaByDomainAndTypeAndCode(
+                DomainType.CONDITION.toString(),
+                CriteriaType.ICD9CM.toString(),
+                Boolean.FALSE,
+                "00",
+                page)
+            .getContent();
     assertThat(criteriaList).containsExactly(icd9Criteria);
   }
 
@@ -201,8 +203,10 @@ public class CBCriteriaDaoTest {
   public void findCriteriaByDomainAndCode() {
     PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> criteriaList =
-        cbCriteriaDao.findCriteriaByDomainAndCode(
-            DomainType.CONDITION.toString(), Boolean.FALSE, "001", page);
+        cbCriteriaDao
+            .findCriteriaByDomainAndCode(
+                DomainType.CONDITION.toString(), Boolean.FALSE, "001", page)
+            .getContent();
     assertThat(criteriaList).containsExactly(icd9Criteria);
   }
 
@@ -210,8 +214,10 @@ public class CBCriteriaDaoTest {
   public void findCriteriaByDomainAndSynonyms() {
     PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> measurements =
-        cbCriteriaDao.findCriteriaByDomainAndSynonyms(
-            DomainType.MEASUREMENT.toString(), Boolean.TRUE, "001", page);
+        cbCriteriaDao
+            .findCriteriaByDomainAndSynonyms(
+                DomainType.MEASUREMENT.toString(), Boolean.TRUE, "001", page)
+            .getContent();
     assertThat(measurements).containsExactly(measurementCriteria);
   }
 


### PR DESCRIPTION
This PR creates a new response that adds criteria count

- Created a new response object `CriteriaListWithCountResponse`
- CBCriteriaDao now returns `Page` instead of `List` to allow for count
- Updated dao test