### PR TITLE
[RW-3851][risk=no] Disable Save Criteria button if no changes made

### DIFF
--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -156,7 +156,7 @@ function mapCriteria(crit: Selection) {
 }
 
 export interface Selection extends Criteria {
-  attributes: Array<Attribute>;
+  attributes?: Array<Attribute>;
   parameterId: string;
 }
 

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -17,7 +17,7 @@ import {
   serverConfigStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
-import {Criteria, DomainType} from 'generated/fetch';
+import {Attribute, Criteria, DomainType} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 
 const proIcons = {
@@ -141,7 +141,22 @@ const styles = reactStyles({
   },
 });
 
+function mapCriteria(crit: Selection) {
+  return {
+    attributes: crit.attributes,
+    code: crit.code,
+    domainId: crit.domainId,
+    group: crit.group,
+    hasAncestorData: crit.hasAncestorData,
+    isStandard: crit.isStandard,
+    name: crit.name,
+    parameterId: crit.parameterId,
+    type: crit.type
+  };
+}
+
 export interface Selection extends Criteria {
+  attributes: Array<Attribute>;
   parameterId: string;
 }
 
@@ -269,6 +284,7 @@ interface Props {
 
 interface State {
   attributesSelection: Criteria;
+  disableSave: boolean;
   modifierButtonText: string;
   showModifiersSlide: boolean;
 }
@@ -336,12 +352,17 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
       super(props);
       this.state = {
         attributesSelection: undefined,
+        disableSave: false,
         modifierButtonText: 'APPLY MODIFIERS',
         showModifiersSlide: false
       };
     }
 
     componentDidMount(): void {
+      if (!!this.props.cohortContext) {
+        // Check for disabling the Save Criteria button
+        this.checkCriteriaChanges();
+      }
       this.subscription = attributesSelectionStore.subscribe(attributesSelection => {
         this.setState({attributesSelection});
         if (!!attributesSelection) {
@@ -351,11 +372,16 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
-      if (!this.props.criteria && !!prevProps.criteria) {
+      const {cohortContext, criteria} = this.props;
+      if (!criteria && !!prevProps.criteria) {
         this.setState({
           modifierButtonText: 'APPLY MODIFIERS',
           showModifiersSlide: false
         });
+      }
+      if (!!cohortContext && !!criteria && criteria !== prevProps.criteria) {
+        // Each time the criteria changes, we check for disabling the Save Criteria button again
+        this.checkCriteriaChanges();
       }
     }
 
@@ -375,9 +401,15 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
       return index > 0 && selection.domainId !== DomainType.PERSON.toString();
     }
 
-    get criteriaUnchanged() {
+    checkCriteriaChanges() {
       const {cohortContext, criteria} = this.props;
-      return !!cohortContext && JSON.stringify(cohortContext.item.searchParameters) === JSON.stringify(criteria);
+      if (criteria.length === 0) {
+        this.setState({disableSave: true});
+      } else {
+        const mappedCriteriaString = JSON.stringify(criteria.map(mapCriteria));
+        const mappedParametersString = JSON.stringify(cohortContext.item.searchParameters.map(mapCriteria));
+        this.setState({disableSave: mappedCriteriaString === mappedParametersString});
+      }
     }
 
     renderCriteria() {
@@ -431,7 +463,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
 
     render() {
       const {back, criteria} = this.props;
-      const {attributesSelection, modifierButtonText, showModifiersSlide} = this.state;
+      const {attributesSelection, disableSave, modifierButtonText, showModifiersSlide} = this.state;
       return <div>
         <FlexRow style={styles.navIcons}>
           {this.showAttributesOrModifiers &&
@@ -465,7 +497,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
             <FlexRowWrap style={{flexDirection: 'row-reverse', marginTop: '2rem'}}>
               <Button type='primary'
                       style={styles.saveButton}
-                      disabled={this.criteriaUnchanged}
+                      disabled={disableSave}
                       onClick={() => saveCriteria()}>Save Criteria</Button>
               <Button type='link'
                       style={{color: colors.primary, marginRight: '0.5rem'}}

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -375,6 +375,11 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
       return index > 0 && selection.domainId !== DomainType.PERSON.toString();
     }
 
+    get criteriaUnchanged() {
+      const {cohortContext, criteria} = this.props;
+      return !!cohortContext && JSON.stringify(cohortContext.item.searchParameters) === JSON.stringify(criteria);
+    }
+
     renderCriteria() {
       const {criteria} = this.props;
       const g = fp.groupBy('isStandard', criteria);
@@ -460,6 +465,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
             <FlexRowWrap style={{flexDirection: 'row-reverse', marginTop: '2rem'}}>
               <Button type='primary'
                       style={styles.saveButton}
+                      disabled={this.criteriaUnchanged}
                       onClick={() => saveCriteria()}>Save Criteria</Button>
               <Button type='link'
                       style={{color: colors.primary, marginRight: '0.5rem'}}


### PR DESCRIPTION
When editing a search item, keep the Save Criteria button disabled until changes are made to the selections. This will prevent unnecessary count queries from running.


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
