### PR TITLE
[RW-5329][risk=low] Attempt to upgrade the notebook image again

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "local-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "perf-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "",
     "shibbolethUiBaseUrl": ""

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "preprod-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_preprod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_prod",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "stable-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_stable",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "staging-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "test-AoU-RW",
     "vpcServicePerimeterName": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:0.0.1",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"


### PR DESCRIPTION
- Update to newer TensorFlow python package.
- Update numpy to match documented version (this fixes pandas_profiling in our tests).
- Reinstall AoU fork of bigrquery (new patch taken from ahead of the main package)

Manual testing:
- Ran a local bash shell with the new docker image
- Opened python3 and executed Alex's new test content (derived from manual QA notebook): https://github.com/all-of-us/workbench/blob/0d68c9bfd3420206f0df277b85b757a0175a8385/e2e/resources/python-code/import-libs.py 
- Opened R and executed Alex's new test content: https://github.com/all-of-us/workbench/blob/0d68c9bfd3420206f0df277b85b757a0175a8385/e2e/resources/r-code/import-libs.R