### PR TITLE
[RW-5358][risk=no] Tool to update sex at birth in existing reviews.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -828,6 +828,16 @@ task updateCdrVersions(type: JavaExec) {
   }
 }
 
+// This should be run directly
+task updateReviewDemographics(type: JavaExec) {
+    classpath sourceSets.__tools__.runtimeClasspath
+    main = "org.pmiops.workbench.tools.UpdateReviewDemographics"
+    systemProperties = commandLineSpringProperties
+    if (project.hasProperty("appArgs")) {
+        args Eval.me(appArgs)
+    }
+}
+
 // This can be run directly or via the deploy command.
 task loadDataDictionary(type: JavaExec) {
   classpath sourceSets.__tools__.runtimeClasspath

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2021,6 +2021,32 @@ Common.register_command({
   :fn => ->(*args) { update_cdr_versions_local("update-cdr-versions-local", *args)}
 })
 
+def update_review_demographics_for_project(versions_file, dry_run)
+  common = Common.new
+  common.run_inline %W{
+    gradle updateReviewDemographics
+   -PappArgs=['#{versions_file}',#{dry_run}]}
+end
+
+def update_review_demographics(cmd_name, *args)
+  ensure_docker cmd_name, args
+  op = update_cdr_version_options(cmd_name, args)
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate
+
+  common = Common.new
+  common.run_inline %W{
+    gradle updateReviewDemographics
+    -PappArgs=[#{op.opts.dry_run}]}
+end
+
+Common.register_command({
+  :invocation => "update-review-demographics",
+  :description => "Update demographics concept ids",
+  :fn => ->(*args) { update_review_demographics("update-review-demographics", *args)}
+})
+
 def get_test_service_account()
   ServiceAccountContext.new(TEST_PROJECT).run do
     print "Service account key is now in sa-key.json"

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2021,13 +2021,6 @@ Common.register_command({
   :fn => ->(*args) { update_cdr_versions_local("update-cdr-versions-local", *args)}
 })
 
-def update_review_demographics_for_project(versions_file, dry_run)
-  common = Common.new
-  common.run_inline %W{
-    gradle updateReviewDemographics
-   -PappArgs=['#{versions_file}',#{dry_run}]}
-end
-
 def update_review_demographics(cmd_name, *args)
   ensure_docker cmd_name, args
   op = update_cdr_version_options(cmd_name, args)
@@ -2035,10 +2028,12 @@ def update_review_demographics(cmd_name, *args)
   op.parse.validate
   gcc.validate
 
-  common = Common.new
-  common.run_inline %W{
-    gradle updateReviewDemographics
-    -PappArgs=[#{op.opts.dry_run}]}
+  with_cloud_proxy_and_db(gcc) do
+      common = Common.new
+      common.run_inline %W{
+        gradle updateReviewDemographics
+        -PappArgs=[#{op.opts.dry_run}]}
+  end
 end
 
 Common.register_command({

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
@@ -11,6 +11,8 @@ public interface CohortReviewDao extends JpaRepository<DbCohortReview, Long> {
 
   Set<DbCohortReview> findAllByCohortId(long cohortId);
 
+  List<DbCohortReview> findAllByCdrVersionId(@Param("cdrVersionId") long cdrVersionId);
+
   DbCohortReview findCohortReviewByCohortIdAndCdrVersionId(
       @Param("cohortId") long cohortId, @Param("cdrVersionId") long cdrVersionId);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -39,15 +39,20 @@ public interface ParticipantCohortStatusDao
       value =
           "UPDATE participant_cohort_status"
               + " SET sex_at_birth_concept_id = :conceptId"
-              + " WHERE participant_id in (:personIds)",
+              + " WHERE participant_id in (:personIds)"
+              + " AND cohort_review_id = :cohortReviewId",
       nativeQuery = true)
   @Transactional
-  void bulkUpdateSexAtBirthByParticipantId(
-      @Param("conceptId") long conceptId, @Param("personIds") List<Long> personIds);
+  int bulkUpdateSexAtBirthByParticipantId(
+      @Param("conceptId") long conceptId,
+      @Param("personIds") List<Long> personIds,
+      @Param("cohortReviewId") Long cohortReviewId);
 
   DbParticipantCohortStatus findByParticipantKey_CohortReviewIdAndParticipantKey_ParticipantId(
       @Param("cohortReviewId") long cohortReviewId, @Param("participantId") long participantId);
 
   List<DbParticipantIdAndCohortStatus> findByParticipantKey_CohortReviewIdAndStatusIn(
       Long cohortReviewId, List<Short> cohortStatuses);
+
+  List<DbParticipantCohortStatus> findByParticipantKey_CohortReviewId(Long cohortReviewId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -43,7 +43,7 @@ public interface ParticipantCohortStatusDao
               + " AND cohort_review_id = :cohortReviewId",
       nativeQuery = true)
   @Transactional
-  int bulkUpdateSexAtBirthByParticipantId(
+  int bulkUpdateSexAtBirthByParticipantAndCohortReviewId(
       @Param("conceptId") long conceptId,
       @Param("personIds") List<Long> personIds,
       @Param("cohortReviewId") Long cohortReviewId);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDao.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ParticipantCohortStatusDao
     extends CrudRepository<DbParticipantCohortStatus, Long>, ParticipantCohortStatusDaoCustom {
@@ -32,6 +33,17 @@ public interface ParticipantCohortStatusDao
       nativeQuery = true)
   void bulkCopyByCohortReview(
       @Param("fromCrId") long fromCohortReviewId, @Param("toCrId") long toCohortReviewId);
+
+  @Modifying
+  @Query(
+      value =
+          "UPDATE participant_cohort_status"
+              + " SET sex_at_birth_concept_id = :conceptId"
+              + " WHERE participant_id in (:personIds)",
+      nativeQuery = true)
+  @Transactional
+  void bulkUpdateSexAtBirthByParticipantId(
+      @Param("conceptId") long conceptId, @Param("personIds") List<Long> personIds);
 
   DbParticipantCohortStatus findByParticipantKey_CohortReviewIdAndParticipantKey_ParticipantId(
       @Param("cohortReviewId") long cohortReviewId, @Param("participantId") long participantId);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -184,6 +184,14 @@ public class ParticipantCohortStatusDaoTest {
   }
 
   @Test
+  public void findByParticipantKeyCohortReviewId() {
+    List<DbParticipantCohortStatus> results =
+        participantCohortStatusDao.findByParticipantKey_CohortReviewId(COHORT_REVIEW_ID);
+
+    assertEquals(2, results.size());
+  }
+
+  @Test
   public void findAllNoSearchCriteria() {
     PageRequest pageRequest =
         new PageRequest()

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -11,6 +11,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class UpdateReviewDemographics {
 
+  private static final String DISTINCT_CONCEPT_IDS =
+      "select distinct sex_at_birth_concept_id FROM `${}.${}.person`";
+
   @Bean
   public CommandLineRunner run(
       BigQueryService bigQueryService,

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -122,7 +122,8 @@ public class UpdateReviewDemographics {
                             dbCohortReview.getCohortReviewId());
                 logger.info(
                     String.format(
-                        "%d participant(s) %s with sex at birth concept id %d - review id %d - CDR v: %d name: %s project: %s dataset: %s r#: %d",
+                        "%d participant(s) %s with sex at birth concept id %d - review id %d - "
+                            + "CDR v: %d name: %s project: %s dataset: %s r#: %d",
                         personCount,
                         dryRun ? "pending update" : "updated",
                         sexAtBirthConceptId,

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -1,7 +1,25 @@
 package org.pmiops.workbench.tools;
 
+import java.util.Arrays;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.db.dao.ParticipantCohortStatusDaoCustom;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** Backfill script to adjust cohort reviews that don't include sex at birth. */
 @Configuration
-public class UpdateReviewDemographics {}
+public class UpdateReviewDemographics {
+
+  @Bean
+  public CommandLineRunner run(
+      BigQueryService bigQueryService,
+      ParticipantCohortStatusDaoCustom participantCohortStatusDaoCustom) {
+    return (args) -> {
+      if (args.length != 1) {
+        throw new IllegalArgumentException("Expected 1 args (dry_run). Got " + Arrays.asList(args));
+      }
+      boolean dryRun = Boolean.parseBoolean(args[0]);
+    };
+  }
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -1,0 +1,7 @@
+package org.pmiops.workbench.tools;
+
+import org.springframework.context.annotation.Configuration;
+
+/** Backfill script to adjust cohort reviews that don't include sex at birth. */
+@Configuration
+public class UpdateReviewDemographics {}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -1,8 +1,22 @@
 package org.pmiops.workbench.tools;
 
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableResult;
 import java.util.Arrays;
-import org.pmiops.workbench.api.BigQueryService;
-import org.pmiops.workbench.db.dao.ParticipantCohortStatusDaoCustom;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.ParticipantCohortStatusDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,18 +25,76 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class UpdateReviewDemographics {
 
-  private static final String DISTINCT_CONCEPT_IDS =
-      "select distinct sex_at_birth_concept_id FROM `${}.${}.person`";
+  private static final Logger logger = Logger.getLogger(UpdateReviewDemographics.class.getName());
+
+  private BigQuery bigQueryService;
+  private String projectId;
+  private String datasetId;
+  private static final String PARAM_NAME = "p0";
+  private static final String SELECT_DISTINCT_SEX_AT_BIRTH =
+      "SELECT DISTINCT sex_at_birth_concept_id\n FROM `${projectId}.${datasetId}.person`";
+  private static final String SELECT_PERSON_IDS =
+      "SELECT person_id\n"
+          + "FROM `${projectId}.${datasetId}.person`\n"
+          + "WHERE sex_at_birth_concept_id = @"
+          + PARAM_NAME;
 
   @Bean
   public CommandLineRunner run(
-      BigQueryService bigQueryService,
-      ParticipantCohortStatusDaoCustom participantCohortStatusDaoCustom) {
+      CdrVersionDao cdrVersionDao, ParticipantCohortStatusDao participantCohortStatusDao) {
     return (args) -> {
       if (args.length != 1) {
         throw new IllegalArgumentException("Expected 1 args (dry_run). Got " + Arrays.asList(args));
       }
       boolean dryRun = Boolean.parseBoolean(args[0]);
+
+      for (DbCdrVersion cdrVersion : cdrVersionDao.findAll()) {
+        if (cdrVersion.getIsDefault()) {
+          projectId = cdrVersion.getBigqueryProject();
+          datasetId = cdrVersion.getBigqueryDataset();
+        }
+      }
+      Optional.ofNullable(projectId)
+          .orElseThrow(() -> new IllegalArgumentException("No Default CDR version exists."));
+      bigQueryService = BigQueryOptions.newBuilder().setProjectId(projectId).build().getService();
+
+      final List<Long> sexAtBirthConceptIds =
+          StreamSupport.stream(
+                  executeQuery(SELECT_DISTINCT_SEX_AT_BIRTH, null).getValues().spliterator(), false)
+              .map(fieldValues -> fieldValues.get("sex_at_birth_concept_id").getLongValue())
+              .collect(Collectors.toList());
+
+      for (Long sexAtBirthConceptId : sexAtBirthConceptIds) {
+        Map<String, QueryParameterValue> params = new HashMap<>();
+        params.put(PARAM_NAME, QueryParameterValue.int64(sexAtBirthConceptId));
+
+        final List<Long> personIds =
+            StreamSupport.stream(
+                    executeQuery(SELECT_PERSON_IDS, params).getValues().spliterator(), false)
+                .map(fieldValues -> fieldValues.get("person_id").getLongValue())
+                .collect(Collectors.toList());
+
+        logger.info(String.format("Processing sex at birth concept id: %d", sexAtBirthConceptId));
+        participantCohortStatusDao.bulkUpdateSexAtBirthByParticipantId(
+            sexAtBirthConceptId, personIds);
+      }
     };
+  }
+
+  private TableResult executeQuery(String query, Map<String, QueryParameterValue> params)
+      throws InterruptedException {
+    return bigQueryService
+        .create(
+            JobInfo.of(
+                QueryJobConfiguration.newBuilder(
+                        query.replace("${projectId}", projectId).replace("${datasetId}", datasetId))
+                    .setUseLegacySql(false)
+                    .setNamedParameters(params)
+                    .build()))
+        .getQueryResults(BigQuery.QueryResultsOption.maxWaitTime(300000L));
+  }
+
+  public static void main(String[] args) throws Exception {
+    CommandLineToolConfig.runCommandLine(UpdateReviewDemographics.class, args);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/UpdateReviewDemographics.java
@@ -116,10 +116,11 @@ public class UpdateReviewDemographics {
                 int personCount =
                     dryRun
                         ? personIdsToUpdate.size()
-                        : participantCohortStatusDao.bulkUpdateSexAtBirthByParticipantId(
-                            sexAtBirthConceptId,
-                            personIdsToUpdate,
-                            dbCohortReview.getCohortReviewId());
+                        : participantCohortStatusDao
+                            .bulkUpdateSexAtBirthByParticipantAndCohortReviewId(
+                                sexAtBirthConceptId,
+                                personIdsToUpdate,
+                                dbCohortReview.getCohortReviewId());
                 logger.info(
                     String.format(
                         "%d participant(s) %s with sex at birth concept id %d - review id %d - "


### PR DESCRIPTION
UpdateReviewDemographics is a tool that will backfill sex at birth in existing reviews across each env.

To Run: `./project.rb update-review-demographics --project all-of-us-workbench-test --dry-run true`

- **project** the project to run the updates 
- **dry-run** (optional) if true will output what data will get updated