### PR TITLE
[risk=no][no ticket] Trim whitespace from Institution Display Name and Other Text

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -330,6 +330,7 @@ export class AdminInstitutionEditImpl extends React.Component<UrlParamsProps, In
                 inputStyle={{width: '16rem', marginTop: '0.3rem'}}
                 labelText='Institution Name'
                 onChange={v => this.setState(fp.set(['institution', 'displayName'], v))}
+                onBlur={v => this.setState(fp.set(['institution', 'displayName'], v.trim()))}
             />
             <div style={{color: colors.danger}} data-test-id='displayNameError'>
               {!this.isAddInstitutionMode && errors && errors.displayName}
@@ -341,10 +342,11 @@ export class AdminInstitutionEditImpl extends React.Component<UrlParamsProps, In
                       value={institution.organizationTypeEnum}
                       onChange={v => this.updateInstitutionRole(v.value)}/>
             <div style={{color: colors.danger}}>{!this.isAddInstitutionMode && errors && errors.organizationTypeEnum}</div>
-
-            {showOtherInstitutionTextBox && <TextInputWithLabel value={institution.organizationTypeOtherText}
-               onChange={v => this.setState(fp.set(['institution', 'organizationTypeOtherText'], v))}
-               inputStyle={{width: '16rem', marginTop: '0.8rem'}}/>}
+            {showOtherInstitutionTextBox && <TextInputWithLabel
+              value={institution.organizationTypeOtherText}
+              onChange={v => this.setState(fp.set(['institution', 'organizationTypeOtherText'], v))}
+              onBlur={v => this.setState(fp.set(['institution', 'displayName'], v.trim()))}
+              inputStyle={{width: '16rem', marginTop: '0.8rem'}}/>}
             <label style={styles.label}>Agreement Type</label>
             <Dropdown style={{width: '16rem'}} data-test-id='agreement-dropdown'
                       placeholder='Your Agreement'

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -345,7 +345,7 @@ export class AdminInstitutionEditImpl extends React.Component<UrlParamsProps, In
             {showOtherInstitutionTextBox && <TextInputWithLabel
               value={institution.organizationTypeOtherText}
               onChange={v => this.setState(fp.set(['institution', 'organizationTypeOtherText'], v))}
-              onBlur={v => this.setState(fp.set(['institution', 'displayName'], v.trim()))}
+              onBlur={v => this.setState(fp.set(['institution', 'organizationTypeOtherText'], v.trim()))}
               inputStyle={{width: '16rem', marginTop: '0.8rem'}}/>}
             <label style={styles.label}>Agreement Type</label>
             <Dropdown style={{width: '16rem'}} data-test-id='agreement-dropdown'

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -110,7 +110,7 @@ export class AccountCreationInstitution extends React.Component<Props, State> {
       const details = await institutionApi().getPublicInstitutionDetails();
       this.setState({
         loadingInstitutions: false,
-        institutions: fp.sortBy( institution => institution.displayName, details.institutions)
+        institutions: fp.sortBy( institution => institution.displayName.trim(), details.institutions)
       });
       // Check email and populate appropriate icon In case page is loaded :
       // after clicking PREVIOUS BUTTON from step 3 or


### PR DESCRIPTION
Description:

I noticed that UNC was oddly alphabetized first.  The reason was a leading space.  This was not immediately obvious because the Display Name is trimmed in the Dropdown.

<img width="657" alt="Screen Shot 2020-08-20 at 10 37 59 AM" src="https://user-images.githubusercontent.com/2701406/90789772-4b739980-e2d5-11ea-9792-83ef985032b2.png">

Trim these strings onBlur

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
