### PR TITLE
[no ticket][risk=no] Puppeteer dataset export to notebook

### DIFF
--- a/e2e/app/component/export-to-notebook-modal.ts
+++ b/e2e/app/component/export-to-notebook-modal.ts
@@ -6,7 +6,6 @@ import {Language, LinkText} from 'app/text-labels';
 import Modal from './modal';
 
 export default class ExportToNotebookModal extends Modal {
-   // data-test-id="notebook-name-input"
 
   constructor(page: Page, xpath?: string) {
     super(page, xpath);

--- a/e2e/app/component/export-to-notebook-modal.ts
+++ b/e2e/app/component/export-to-notebook-modal.ts
@@ -29,12 +29,12 @@ export default class ExportToNotebookModal extends Modal {
     return new Textbox(this.page, selector);
   }
 
-  getPythonRadiobutton(): RadioButton {
+  getPythonRadioButton(): RadioButton {
     const selector = `${this.getXpath()}//label[contains(normalize-space(),"Python")]//input[@type="radio"]`;
     return new RadioButton(this.page, selector);
   }
 
-  getRRadiobutton(): RadioButton {
+  getRRadioButton(): RadioButton {
     const selector = `${this.getXpath()}//label[contains(normalize-space(),"R")]//input[@type="radio"]`;
     return new RadioButton(this.page, selector);
   }
@@ -50,13 +50,8 @@ export default class ExportToNotebookModal extends Modal {
   async fillInModal(notebookName: string, language: Language = Language.Python): Promise<void> {
     const notebookNameInput = this.getNotebookNameInput();
     await notebookNameInput.type(notebookName);
-    if (language === Language.Python) {
-      const radio = this.getPythonRadiobutton();
-      await radio.select();
-    } else {
-      const radio = this.getRRadiobutton();
-      await radio.select();
-    }
+    const radio = language === Language.Python ? this.getPythonRadioButton() : this.getRRadioButton();
+    await radio.select();
     return this.clickButton(LinkText.ExportAndOpen, {waitForClose: true});
   }
 

--- a/e2e/app/component/export-to-notebook-modal.ts
+++ b/e2e/app/component/export-to-notebook-modal.ts
@@ -1,0 +1,63 @@
+import RadioButton from 'app/element/radiobutton';
+import Textbox from 'app/element/textbox';
+import {Page} from 'puppeteer';
+import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
+import {Language, LinkText} from 'app/text-labels';
+import Modal from './modal';
+
+export default class ExportToNotebookModal extends Modal {
+   // data-test-id="notebook-name-input"
+
+  constructor(page: Page, xpath?: string) {
+    super(page, xpath);
+  }
+
+  async waitForLoad(): Promise<this> {
+    try {
+      await super.waitForLoad();
+      await (this.getNotebookNameInput()).asElementHandle();
+    } catch (e) {
+      await savePageToFile(this.page);
+      await takeScreenshot(this.page);
+      throw new Error(`ExportToNotebookModal waitForLoad() encountered ${e}`);
+    }
+    return this;
+  }
+
+  getNotebookNameInput(): Textbox {
+    const selector = `${this.getXpath()}//*[@data-test-id="notebook-name-input"]`;
+    return new Textbox(this.page, selector);
+  }
+
+  getPythonRadiobutton(): RadioButton {
+    const selector = `${this.getXpath()}//label[contains(normalize-space(),"Python")]//input[@type="radio"]`;
+    return new RadioButton(this.page, selector);
+  }
+
+  getRRadiobutton(): RadioButton {
+    const selector = `${this.getXpath()}//label[contains(normalize-space(),"R")]//input[@type="radio"]`;
+    return new RadioButton(this.page, selector);
+  }
+
+  /**
+   * Fill out Export Notebook modal to create a new notebook:
+   * - Type notebook name.
+   * - Select notebook language.
+   * - Click "Export and Open" button.
+   * @param {string} notebookName Notebook name.
+   * @param {Language} language Notebook programming language. Default value is Python.
+   */
+  async fillInModal(notebookName: string, language: Language = Language.Python): Promise<void> {
+    const notebookNameInput = this.getNotebookNameInput();
+    await notebookNameInput.type(notebookName);
+    if (language === Language.Python) {
+      const radio = this.getPythonRadiobutton();
+      await radio.select();
+    } else {
+      const radio = this.getRRadiobutton();
+      await radio.select();
+    }
+    return this.clickButton(LinkText.ExportAndOpen, {waitForClose: true});
+  }
+
+}

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -7,9 +7,7 @@ import Checkbox from 'app/element/checkbox';
 import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
 import {LinkText} from 'app/text-labels';
 import {getPropValue} from 'utils/element-utils';
-
 import * as fp from 'lodash/fp';
-import {waitWhileLoading} from 'utils/test-utils';
 
 const Selector = {
   defaultDialog: '//*[@role="dialog"]',
@@ -23,10 +21,7 @@ export default class Modal extends Container {
 
   async waitForLoad(): Promise<this> {
     try {
-      await Promise.all([
-        this.waitUntilVisible(),
-        waitWhileLoading(this.page),
-      ]);
+      await this.waitUntilVisible();
     } catch (e) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -9,6 +9,7 @@ import {LinkText} from 'app/text-labels';
 import {getPropValue} from 'utils/element-utils';
 
 import * as fp from 'lodash/fp';
+import {waitWhileLoading} from 'utils/test-utils';
 
 const Selector = {
   defaultDialog: '//*[@role="dialog"]',
@@ -22,7 +23,10 @@ export default class Modal extends Container {
 
   async waitForLoad(): Promise<this> {
     try {
-      await this.waitUntilVisible();
+      await Promise.all([
+        this.waitUntilVisible(),
+        waitWhileLoading(this.page),
+      ]);
     } catch (e) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);

--- a/e2e/app/component/new-notebook-modal.ts
+++ b/e2e/app/component/new-notebook-modal.ts
@@ -40,13 +40,8 @@ export default class NewNotebookModal extends Modal {
    */
   async fillInModal(notebookName: string, language: Language): Promise<void> {
     await this.name().then( (textbox) => textbox.type(notebookName));
-    if (language === Language.Python) {
-      const radio = this.python3Radiobutton();
-      await radio.select();
-    } else {
-      const radio = this.RRadiobutton();
-      await radio.select();
-    }
+    const radio = language === Language.Python ? this.getPythonRadioButton() : this.getRRadioButton();
+    await radio.select();
     return this.clickButton(LinkText.CreateNotebook, {waitForClose: true, waitForNav: true});
   }
 
@@ -54,12 +49,12 @@ export default class NewNotebookModal extends Modal {
     return Textbox.findByName(this.page, {name: 'Name:'});
   }
 
-  python3Radiobutton(): RadioButton {
+  getPythonRadioButton(): RadioButton {
     const selector = '//*[@role="dialog"]//label[contains(normalize-space(),"Python 3")]//input[@type="radio"]';
     return new RadioButton(this.page, selector);
   }
 
-  RRadiobutton(): RadioButton {
+  getRRadioButton(): RadioButton {
     const selector = '//*[@role="dialog"]//label[contains(normalize-space(),"R")]//input[@type="radio"]';
     return new RadioButton(this.page, selector);
   }

--- a/e2e/app/page/data-page.ts
+++ b/e2e/app/page/data-page.ts
@@ -1,8 +1,9 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard from 'app/component/data-resource-card';
+import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
+import Link from 'app/element/link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
 import AuthenticatedPage from 'app/page/authenticated-page';
@@ -13,7 +14,6 @@ import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import Link from 'app/element/link';
 import CohortActionsPage from './cohort-actions-page';
 import CohortBuildPage from './cohort-build-page';
 import {Visits} from './cohort-criteria-modal';
@@ -106,6 +106,20 @@ export default class DataPage extends AuthenticatedPage {
   }
 
   /**
+   * Export Dataset to notebook thru the Ellipsis menu located inside the Dataset Resource card.
+   * @param {string} datasetName Dataset name.
+   * @param {string} notebookName Notebook name.
+   */
+  async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
+    const resourceCard = new DataResourceCard(this.page);
+    const datasetCard = await resourceCard.findCard(datasetName, CardType.Dataset);
+    await datasetCard.getEllipsis().clickAction(EllipsisMenuAction.exportToNotebook, {waitForNav: false});
+
+
+    console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
+  }
+
+  /**
    * Delete cohort by look up its name using Ellipsis menu.
    * @param {string} cohortName
    */
@@ -139,6 +153,7 @@ export default class DataPage extends AuthenticatedPage {
     await waitWhileLoading(this.page);
 
     console.log(`Deleted Dataset "${datasetName}"`);
+    await this.waitForLoad();
     return modalContentText;
   }
 

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -9,6 +9,7 @@ import {ElementType} from 'app/xpath-options';
 import AuthenticatedPage from './authenticated-page';
 import CohortBuildPage from './cohort-build-page';
 import ConceptsetSearchPage from './conceptset-search-page';
+import DatasetSaveModal from './dataset-save-modal';
 
 const PageTitle = 'Dataset Page';
 
@@ -88,11 +89,18 @@ export default class DatasetBuildPage extends AuthenticatedPage {
     }
   }
 
-  async clickSaveAndAnalyzeButton(): Promise<void> {
+  /**
+   * Click "Save and Analyze" button.
+   * @returns Instance of DatasetSaveModal.
+   */
+  async clickSaveAndAnalyzeButton(): Promise<DatasetSaveModal> {
     const saveButton = await Button.findByName(this.page, {name: 'Save and Analyze'});
     await saveButton.waitUntilEnabled();
     await saveButton.click();
     await waitWhileLoading(this.page);
+    const saveModal = new DatasetSaveModal(this.page);
+    await saveModal.waitForLoad();
+    return saveModal;
   }
 
   async clickAnalyzeButton(): Promise<void> {

--- a/e2e/app/page/dataset-save-modal.ts
+++ b/e2e/app/page/dataset-save-modal.ts
@@ -10,10 +10,6 @@ import {waitUntilChanged} from 'utils/element-utils';
 import {waitForPropertyExists} from 'utils/waits-utils';
 import Textarea from 'app/element/textarea';
 
-export const labelAlias = {
-  SeeCodePreview: 'See Code Preview'
-}
-
 export default class DatasetSaveModal extends Modal {
 
   constructor(page: Page) {
@@ -57,14 +53,11 @@ export default class DatasetSaveModal extends Modal {
     }
     await waitWhileLoading(this.page);
 
-    let finishButton: Button;
     if (isUpdate) {
-      finishButton = await this.waitForButton(LinkText.Update);
+      await this.clickButton(LinkText.Update, {waitForClose: true, waitForNav: true});
     } else {
-      finishButton = await this.waitForButton(LinkText.Save);
+      await this.clickButton(LinkText.Save, {waitForClose: true, waitForNav: true});
     }
-    await finishButton.waitUntilEnabled();
-    await finishButton.clickAndWait();
     await waitWhileLoading(this.page);
 
     if (isUpdate) {
@@ -83,7 +76,7 @@ export default class DatasetSaveModal extends Modal {
    */
   async previewCode(): Promise<string> {
     // Click 'See Code Preview' button.
-    const previewButton = await Button.findByName(this.page, {name: 'See Code Preview'}, this);
+    const previewButton = await Button.findByName(this.page, {name: LinkText.SeeCodePreview}, this);
     await previewButton.click();
     await waitUntilChanged(this.page, await previewButton.asElementHandle());
 

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -21,6 +21,7 @@ export enum EllipsisMenuAction {
    RenameDataset = 'Rename Dataset',
    Review = 'Review',
    Share = 'Share',
+   exportToNotebook = 'Export to Notebook',
 }
 
 export enum LinkText {
@@ -47,6 +48,7 @@ export enum LinkText {
    DeleteNotebook = 'Delete Notebook',
    DiscardChanges = 'Discard Changes',
    DuplicateWorkspace = 'Duplicate Workspace',
+   ExportAndOpen = 'Export and Open',
    Finish = 'Finish',
    GoToCopiedConceptSet = 'Go to Copied Concept Set',
    GoToCopiedNotebook = 'Go to Copied Notebook',
@@ -57,6 +59,7 @@ export enum LinkText {
    RenameNotebook = 'Rename Notebook',
    Save = 'Save',
    SaveCohort = 'Save Cohort',
+   SeeCodePreview = 'See Code Preview',
    StayHere = 'Stay Here',
    Submit = 'Submit',
    Update = 'Update',

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -2,7 +2,6 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import DatasetSaveModal from 'app/page/dataset-save-modal';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -145,9 +144,7 @@ describe('Create Concept Sets from Domains', () => {
     await conceptActionPage.clickCreateDatasetButton();
     await datasetBuildPage.selectCohorts(['All Participants']);
     await datasetBuildPage.selectConceptSets([conceptName1, conceptName2]);
-    await datasetBuildPage.clickSaveAndAnalyzeButton();
-
-    const saveModal = new DatasetSaveModal(page);
+    const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
     const datasetName = await saveModal.saveDataset();
 
     // Verify Dataset created successful.

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -2,7 +2,6 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import DatasetSaveModal from 'app/page/dataset-save-modal';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -31,9 +30,7 @@ describe('Create Dataset', () => {
 
     await datasetPage.selectCohorts(['All Participants']);
     await datasetPage.selectConceptSets(['Demographics', 'All Surveys']);
-    await datasetPage.clickSaveAndAnalyzeButton();
-
-    const saveModal = new DatasetSaveModal(page);
+    const saveModal = await datasetPage.clickSaveAndAnalyzeButton();
     const datasetName = await saveModal.saveDataset();
 
     // Verify create successful
@@ -106,9 +103,7 @@ describe('Create Dataset', () => {
 
     await datasetPage.selectCohorts([cohortName]);
     await datasetPage.selectConceptSets(['Demographics']);
-    await datasetPage.clickSaveAndAnalyzeButton();
-
-    const saveModal = new DatasetSaveModal(page);
+    const saveModal = await datasetPage.clickSaveAndAnalyzeButton();
     let datasetName = await saveModal.saveDataset({exportToNotebook: false});
 
     // Verify create successful.

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,0 +1,91 @@
+import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import Link from 'app/element/link';
+import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
+import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import NotebookPreviewPage from 'app/page/notebook-preview-page';
+import {makeRandomName} from 'utils/str-utils';
+import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
+import {waitForText} from 'utils/waits-utils';
+
+describe('Create Dataset', () => {
+
+  beforeEach(async () => {
+    await signIn(page);
+  });
+
+   /**
+    * Create new Dataset, export to notebook in Python language
+    * Finally delete Dataset.
+    */
+  test('Export dataset to notebook in Python language', async () => {
+    const workspaceCard = await findWorkspace(page);
+    await workspaceCard.clickWorkspaceName();
+
+    // Click Add Datasets button.
+    const dataPage = new DataPage(page);
+    const datasetBuildPage = await dataPage.clickAddDatasetButton();
+
+    await datasetBuildPage.selectCohorts(['All Participants']);
+    await datasetBuildPage.selectConceptSets(['Demographics']);
+
+    // Preview table exists and has one or more table rows.
+    const previewTable = await datasetBuildPage.getPreviewTable();
+    expect(await previewTable.exists()).toBe(true);
+    expect(await previewTable.getRowCount()).toBeGreaterThan(1);
+
+    const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
+    const newNotebookName = makeRandomName();
+    const newDatasetName = await saveModal.saveDataset({exportToNotebook: true, notebookName: newNotebookName});
+    await waitWhileLoading(page);
+
+    // Verify Notebook preview. Not going to start the Jupyter notebook.
+    const notebookPreviewPage = new NotebookPreviewPage(page);
+    await notebookPreviewPage.waitForLoad();
+    const currentPageUrl = page.url();
+    expect(currentPageUrl).toContain(`notebooks/preview/${newNotebookName}.ipynb`);
+
+    const previewTextVisible = await waitForText(page, 'Preview (Read-Only)', {xpath: '//*[text()="Preview (Read-Only)"]'});
+    expect(previewTextVisible).toBe(true);
+
+    const code = await notebookPreviewPage.getFormattedCode();
+    expect(code).toContain('import pandas');
+    expect(code).toContain('import os');
+
+    // Navigate to Workpace Notebooks page.
+    const notebooksLink = await Link.findByName(page, {name: 'Notebooks'});
+    await notebooksLink.clickAndWait();
+
+    const analysiPage = new WorkspaceAnalysisPage(page);
+    await analysiPage.waitForLoad();
+
+    // Verify new notebook exists.
+    const resourceCard = new DataResourceCard(page);
+    const notebookExists = await resourceCard.cardExists(newNotebookName, CardType.Notebook);
+    expect(notebookExists).toBe(true);
+
+    const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
+
+    // Delete notebook
+    await analysiPage.deleteNotebook(newNotebookName);
+
+    // Resource cards count decrease by 1.
+    const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
+    expect(newCardsCount).toBe(origCardsCount - 1);
+
+    // Delete Dataset.
+    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+
+    await dataPage.deleteDataset(newDatasetName);
+  });
+
+  /**
+   * Test:
+   * - Create dataset.
+   * - Export dataset to notebook thru the ellipsis menu.
+   */
+  test('Export dataset to notebook thru ellipsis menu', async () => {
+
+  });
+
+});

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,8 +1,6 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Link from 'app/element/link';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import DatasetSaveModal from 'app/page/dataset-save-modal';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -17,80 +15,12 @@ describe('Create Dataset', () => {
     await signIn(page);
   });
 
-   /**
-    * Create new Dataset, export to notebook in Python language
-    * Finally delete Dataset.
-    */
-  test('Export dataset to notebook in Python programming language', async () => {
-    const workspaceCard = await findWorkspace(page);
-    await workspaceCard.clickWorkspaceName();
-
-    // Click Add Datasets button.
-    const dataPage = new DataPage(page);
-    const datasetPage = await dataPage.clickAddDatasetButton();
-
-    await datasetPage.selectCohorts(['All Participants']);
-    await datasetPage.selectConceptSets(['Demographics']);
-
-    // Preview table exists and has one or more table rows.
-    const previewTable = await datasetPage.getPreviewTable();
-    expect(await previewTable.exists()).toBe(true);
-    expect(await previewTable.getRowCount()).toBeGreaterThan(1);
-
-    await datasetPage.clickSaveAndAnalyzeButton();
-
-    const saveModal = new DatasetSaveModal(page);
-    const newNotebookName = makeRandomName();
-    const newDatasetName = await saveModal.saveDataset({exportToNotebook: true, notebookName: newNotebookName});
-    await waitWhileLoading(page);
-
-    // Verify Notebook preview. Not going to start the Jupyter notebook.
-    const notebookPreviewPage = new NotebookPreviewPage(page);
-    await notebookPreviewPage.waitForLoad();
-    const currentPageUrl = page.url();
-    expect(currentPageUrl).toContain(`notebooks/preview/${newNotebookName}.ipynb`);
-
-    const previewTextVisible = await waitForText(page, 'Preview (Read-Only)', {xpath: '//*[text()="Preview (Read-Only)"]'});
-    expect(previewTextVisible).toBe(true);
-
-    const code = await notebookPreviewPage.getFormattedCode();
-    expect(code).toContain('import pandas');
-    expect(code).toContain('import os');
-
-    // Navigate to Workpace Notebooks page.
-    const notebooksLink = await Link.findByName(page, {name: 'Notebooks'});
-    await notebooksLink.clickAndWait();
-
-    const analysiPage = new WorkspaceAnalysisPage(page);
-    await analysiPage.waitForLoad();
-
-    // Verify new notebook exists.
-    const resourceCard = new DataResourceCard(page);
-    const notebookExists = await resourceCard.cardExists(newNotebookName, CardType.Notebook);
-    expect(notebookExists).toBe(true);
-
-    const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
-
-    // Delete notebook
-    await analysiPage.deleteNotebook(newNotebookName);
-
-    // Resource cards count decrease by 1.
-    const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
-    expect(newCardsCount).toBe(origCardsCount - 1);
-
-    // Delete Dataset.
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
-
-    await dataPage.deleteDataset(newDatasetName);
-  });
-
   /**
    * Create new Cohort thru Dataset Build page. Cohort built from demographics -> Ethnicity.
    * Create new Dataset with Cohort, then export to notebook in R language.
    * Delete Cohort, Dataset, and Notebook.
    */
-  test('Export dataset to notebook in R programming language', async () => {
+  test('Export dataset to notebook in R language', async () => {
     const workspaceCard = await findWorkspace(page);
     const workspaceName = await workspaceCard.clickWorkspaceName();
 
@@ -121,10 +51,8 @@ describe('Create Dataset', () => {
 
     await datasetBuildPage.selectCohorts([newCohortName]);
     await datasetBuildPage.selectConceptSets(['Demographics']);
-    await datasetBuildPage.clickSaveAndAnalyzeButton();
-
+    const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
     const newNotebookName = makeRandomName();
-    const saveModal = new DatasetSaveModal(page);
     const newDatasetName = await saveModal.saveDataset({
       exportToNotebook: true,
       notebookName: newNotebookName,


### PR DESCRIPTION
Break up `export-to-notebook.spec` test into `export-py-notebook.spec` and `export-r-notebook.spec` tests by programming language.
Reasons are:
- too many tests in single test suite takes a long time to finish.
- Add `Export dataset to notebook thru ellipsis menu` test in `export-py-notebook.spec` test to cover regression https://precisionmedicineinitiative.atlassian.net/browse/RW-5388.
