### PR TITLE
[risk=low][RW-4956] enable free credit limit override UX

### DIFF
--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -90,7 +90,6 @@ const ToggleWithLabelAndToggledText = ({label, initialValue, disabled, onToggle,
   </FlexColumn>;
 };
 
-
 const EmailValidationErrorMessage = ({emailValidationResponse, updatedProfile, verifiedInstitutionOptions}) => {
   if (updatedProfile && updatedProfile.verifiedInstitutionalAffiliation) {
     if (emailValidationResponse.isValidMember) {
@@ -111,6 +110,31 @@ const EmailValidationErrorMessage = ({emailValidationResponse, updatedProfile, v
     }
   }
   return null;
+};
+
+const FreeCreditsUsage = ({aboveLimit, usage}) => {
+  const inputStyle = aboveLimit ?
+  {...styles.textInput,
+    backgroundColor: colorWithWhiteness(colors.danger, .95),
+    borderColor: colors.danger,
+    color: colors.danger,
+  } :
+  {...styles.textInput,
+    ...styles.backgroundColorDark,
+    borderColor: colors.disabled,
+    color: colors.disabled};
+
+  return <React.Fragment>
+    <TextInputWithLabel
+      labelText={'Free credits used'}
+      value={usage}
+      inputId={'freeTierUsage'}
+      disabled={true}
+      inputStyle={inputStyle}
+      containerStyle={styles.textInputContainer}
+    />
+    {aboveLimit && <div style={{color: colors.danger}}>Update free credit limit</div>}
+  </React.Fragment>;
 };
 
 interface Props {
@@ -220,6 +244,16 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
     // gotcha: JS sorts numbers lexicographically by default
     const numericallySorted = defaultsPlusMaybeOverride.sort((a, b) => a - b);
     return fp.map((limit) => ({label: renderUSD(limit), value: limit}), numericallySorted);
+  }
+
+  getFreeCreditUsage(): string {
+    const {updatedProfile: {freeTierDollarQuota, freeTierUsage}} = this.state;
+    return `${renderUSD(freeTierUsage)} used of ${renderUSD(freeTierDollarQuota)} limit`;
+  }
+
+  usageIsAboveLimit(): boolean {
+    const {updatedProfile: {freeTierDollarQuota, freeTierUsage}} = this.state;
+    return freeTierDollarQuota < freeTierUsage;
   }
 
   async getInstitutions() {
@@ -501,13 +535,9 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
                 containerStyle={styles.textInputContainer}
                 onChange={email => this.setContactEmail(email)}
             />
-            <TextInputWithLabel
-                labelText={'Free credits used'}
-                placeholder={renderUSD(updatedProfile.freeTierUsage)}
-                inputId={'freeTierUsage'}
-                disabled={true}
-                inputStyle={{width: '6.5rem', ...styles.backgroundColorDark}}
-                containerStyle={styles.textInputContainer}
+            <FreeCreditsUsage
+              aboveLimit={this.usageIsAboveLimit()}
+              usage={this.getFreeCreditUsage()}
             />
           </FlexColumn>
           <FlexColumn style={{width: '33%'}}>

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -217,7 +217,9 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
   getFreeCreditLimitOptions() {
     const {oldProfile: {freeTierDollarQuota}} = this.state;
     const defaultsPlusMaybeOverride = Array.from(freeCreditLimitDefaultOptions.add(freeTierDollarQuota));
-    return fp.map((limit) => ({label: renderUSD(limit), value: limit}), defaultsPlusMaybeOverride.sort());
+    // gotcha: JS sorts numbers lexicographically by default
+    const numericallySorted = defaultsPlusMaybeOverride.sort((a, b) => a - b);
+    return fp.map((limit) => ({label: renderUSD(limit), value: limit}), numericallySorted);
   }
 
   async getInstitutions() {

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -133,9 +133,9 @@ const FreeCreditsUsage = ({isAboveLimit, usage}: FreeCreditsProps) => {
 
   return <React.Fragment>
     <TextInputWithLabel
-      labelText={'Free credits used'}
+      labelText='Free credits used'
       value={usage}
-      inputId={'freeTierUsage'}
+      inputId='freeTierUsage'
       disabled={true}
       inputStyle={inputStyle}
       containerStyle={styles.textInputContainer}

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -14,10 +14,10 @@ import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   displayDateWithoutHours,
+  formatFreeCreditsUSD,
   isBlank,
   reactStyles,
   ReactWrapperBase,
-  renderUSD,
   withUrlParams
 } from 'app/utils';
 
@@ -248,12 +248,12 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
     const defaultsPlusMaybeOverride = Array.from(freeCreditLimitDefaultOptions.add(freeTierDollarQuota));
     // gotcha: JS sorts numbers lexicographically by default
     const numericallySorted = defaultsPlusMaybeOverride.sort((a, b) => a - b);
-    return fp.map((limit) => ({label: renderUSD(limit), value: limit}), numericallySorted);
+    return fp.map((limit) => ({label: formatFreeCreditsUSD(limit), value: limit}), numericallySorted);
   }
 
   getFreeCreditUsage(): string {
     const {updatedProfile: {freeTierDollarQuota, freeTierUsage}} = this.state;
-    return `${renderUSD(freeTierUsage)} used of ${renderUSD(freeTierDollarQuota)} limit`;
+    return `${formatFreeCreditsUSD(freeTierUsage)} used of ${formatFreeCreditsUSD(freeTierDollarQuota)} limit`;
   }
 
   usageIsAboveLimit(): boolean {

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -112,8 +112,13 @@ const EmailValidationErrorMessage = ({emailValidationResponse, updatedProfile, v
   return null;
 };
 
-const FreeCreditsUsage = ({aboveLimit, usage}) => {
-  const inputStyle = aboveLimit ?
+interface FreeCreditsProps {
+  isAboveLimit: boolean;
+  usage: string;
+}
+
+const FreeCreditsUsage = ({isAboveLimit, usage}: FreeCreditsProps) => {
+  const inputStyle = isAboveLimit ?
   {...styles.textInput,
     backgroundColor: colorWithWhiteness(colors.danger, .95),
     borderColor: colors.danger,
@@ -133,7 +138,7 @@ const FreeCreditsUsage = ({aboveLimit, usage}) => {
       inputStyle={inputStyle}
       containerStyle={styles.textInputContainer}
     />
-    {aboveLimit && <div style={{color: colors.danger}}>Update free credit limit</div>}
+    {isAboveLimit && <div style={{color: colors.danger}}>Update free credit limit</div>}
   </React.Fragment>;
 };
 
@@ -536,7 +541,7 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
                 onChange={email => this.setContactEmail(email)}
             />
             <FreeCreditsUsage
-              aboveLimit={this.usageIsAboveLimit()}
+              isAboveLimit={this.usageIsAboveLimit()}
               usage={this.getFreeCreditUsage()}
             />
           </FlexColumn>

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -121,8 +121,8 @@ const FreeCreditsUsage = ({aboveLimit, usage}) => {
   } :
   {...styles.textInput,
     ...styles.backgroundColorDark,
-    borderColor: colors.disabled,
-    color: colors.disabled};
+    color: colors.disabled,
+  };
 
   return <React.Fragment>
     <TextInputWithLabel

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -512,8 +512,8 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
             <DropdownWithLabel
                 label={'Free credit limit'}
                 options={this.getFreeCreditLimitOptions()}
-                initialValue={updatedProfile.freeTierDollarQuota}
                 onChange={async(event) => this.setFreeTierCreditDollarLimit(event.value)}
+                initialValue={updatedProfile.freeTierDollarQuota}
                 dropdownStyle={{width: '4.5rem'}}
                 dataTestId={'freeTierDollarQuota'}
             />

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -57,7 +57,9 @@ const styles = reactStyles({
   }
 });
 
-const freeCreditLimitDefaultOptions = new Set([300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800]);
+const CREDIT_LIMIT_DEFAULT_MIN = 300;
+const CREDIT_LIMIT_DEFAULT_MAX = 800;
+const CREDIT_LIMIT_DEFAULT_STEP = 50;
 
 const DropdownWithLabel = ({label, options, initialValue, onChange, disabled= false, dataTestId, dropdownStyle = {}}) => {
   return <FlexColumn data-test-id={dataTestId} style={{marginTop: '1rem'}}>
@@ -245,9 +247,16 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
 
   getFreeCreditLimitOptions() {
     const {oldProfile: {freeTierDollarQuota}} = this.state;
-    const defaultsPlusMaybeOverride = Array.from(freeCreditLimitDefaultOptions.add(freeTierDollarQuota));
+
+    const defaultsPlusMaybeOverride = new Set(
+      // gotcha: argument order for rangeStep is (step, start, end)
+      // IntelliJ incorrectly believes takes the order is (start, end, step)
+      fp.rangeStep(CREDIT_LIMIT_DEFAULT_STEP, CREDIT_LIMIT_DEFAULT_MIN, CREDIT_LIMIT_DEFAULT_MAX))
+      .add(freeTierDollarQuota);
+
     // gotcha: JS sorts numbers lexicographically by default
-    const numericallySorted = defaultsPlusMaybeOverride.sort((a, b) => a - b);
+    const numericallySorted = Array.from(defaultsPlusMaybeOverride).sort((a, b) => a - b);
+
     return fp.map((limit) => ({label: formatFreeCreditsUSD(limit), value: limit}), numericallySorted);
   }
 

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -501,7 +501,7 @@ const AdminUser = withUrlParams()(class extends React.Component<Props, State> {
             />
             <TextInputWithLabel
                 labelText={'Free credits used'}
-                placeholder={updatedProfile.freeTierUsage}
+                placeholder={renderUSD(updatedProfile.freeTierUsage)}
                 inputId={'freeTierUsage'}
                 disabled={true}
                 inputStyle={{width: '6.5rem', ...styles.backgroundColorDark}}

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -21,7 +21,8 @@ import {isBlank, reactStyles} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {reportError} from 'app/utils/errors';
 import {
-  getRoleOptions, MasterDuaEmailMismatchErrorMessage,
+  getRoleOptions,
+  MasterDuaEmailMismatchErrorMessage,
   RestrictedDuaEmailMismatchErrorMessage,
   validateEmail
 } from 'app/utils/institutions';

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -21,9 +21,9 @@ import {institutionApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   displayDateWithoutHours,
+  formatFreeCreditsUSD,
   reactStyles,
   ReactWrapperBase,
-  renderUSD,
   withUserProfile
 } from 'app/utils';
 import {convertAPIError, reportError} from 'app/utils/errors';
@@ -577,8 +577,8 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
                     <div>Remaining <i>All of Us</i> free credits:</div>
                 </FlexColumn>
                 <FlexColumn style={{alignItems: 'flex-end', marginLeft: '1.0rem'}}>
-                  <div style={{marginTop: '0.4rem', fontWeight: 600}}>{renderUSD(profile.freeTierUsage)}</div>
-                  <div style={{fontWeight: 600}}>{renderUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}</div>
+                  <div style={{marginTop: '0.4rem', fontWeight: 600}}>{formatFreeCreditsUSD(profile.freeTierUsage)}</div>
+                  <div style={{fontWeight: 600}}>{formatFreeCreditsUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}</div>
                 </FlexColumn>
             </FlexRow>}
             <div style={styles.title}>

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -577,8 +577,8 @@ export const ProfilePage = withUserProfile()(class extends React.Component<
                     <div>Remaining <i>All of Us</i> free credits:</div>
                 </FlexColumn>
                 <FlexColumn style={{alignItems: 'flex-end', marginLeft: '1.0rem'}}>
-                    <div style={{marginTop: '0.4rem'}}>{renderUSD(profile.freeTierUsage)}</div>
-                  {renderUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}
+                  <div style={{marginTop: '0.4rem', fontWeight: 600}}>{renderUSD(profile.freeTierUsage)}</div>
+                  <div style={{fontWeight: 600}}>{renderUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}</div>
                 </FlexColumn>
             </FlexRow>}
             <div style={styles.title}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -33,9 +33,9 @@ import {WorkspaceResearchSummary} from 'app/pages/workspace/workspace-research-s
 import {userApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
+  formatFreeCreditsUSD,
   reactStyles,
   ReactWrapperBase,
-  renderUSD,
   sliceByHalfLength,
   withCdrVersions,
   withCurrentWorkspace,
@@ -1014,7 +1014,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             </div>
             <OverlayPanel ref={(me) => freeTierBalancePanel = me} dismissable={true} appendTo={document.body}>
               <div style={styles.freeCreditsBalanceOverlay}>
-                FREE CREDIT BALANCE {renderUSD(freeTierCreditsBalance)}
+                FREE CREDIT BALANCE {formatFreeCreditsUSD(freeTierCreditsBalance)}
               </div>
             </OverlayPanel>
             <FlexRow>

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -531,7 +531,7 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
 
 // render a float value as US currency, rounded to cents: 255.372793 -> $255.37
 // negative values are rendered as $0
-export function renderUSD(value: number) {
+export function renderUSD(value: number): string {
   value = value || 0.0;
   if (value < 0.0) {
     return '$0';

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -531,7 +531,7 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
 
 // render a float value as US currency, rounded to cents: 255.372793 -> $255.37
 // negative values are rendered as $0
-export function renderUSD(value: number): string {
+export function formatFreeCreditsUSD(value: number): string {
   value = value || 0.0;
   if (value < 0.0) {
     return '$0';

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -534,9 +534,9 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
 export function renderUSD(value: number) {
   value = value || 0.0;
   if (value < 0.0) {
-    return <div style={{fontWeight: 600}}>$0</div>;
+    return '$0';
   } else {
-    return <div style={{fontWeight: 600}}>${(value).toFixed(2)}</div>;
+    return '$' + value.toFixed(2).toString();
   }
 }
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -533,7 +533,7 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
 // negative values are rendered as $0
 export function formatFreeCreditsUSD(value: number): string {
   value = value || 0.0;
-  if (value < 0.0) {
+  if (value <= 0.0) {
     return '$0';
   } else {
     return '$' + value.toFixed(2).toString();

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -44,7 +44,7 @@ export const getRoleOptions = (institutions: Array<PublicInstitutionDetails>, in
     const {shortName} = institution;
     return shortName === institutionShortName;
   }, institutions);
-  if (matchedInstitution === null || matchedInstitution === undefined) {
+  if (matchedInstitution === undefined) {
     return [];
   }
 

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -44,6 +44,10 @@ export const getRoleOptions = (institutions: Array<PublicInstitutionDetails>, in
     const {shortName} = institution;
     return shortName === institutionShortName;
   }, institutions);
+  if (matchedInstitution === null || matchedInstitution === undefined) {
+    return [];
+  }
+
   const {organizationTypeEnum} = matchedInstitution;
   const availableRoles: Array<InstitutionalRole> =
       AccountCreationOptions.institutionalRolesByOrganizationType


### PR DESCRIPTION
Description:

Default case (no free tier credit limit override has been set yet) -> default values of 300-800 in dropdown
![no-override](https://user-images.githubusercontent.com/2701406/91206421-1dc39180-e6d5-11ea-9e14-48217f1f0993.gif)

Existing override = 400 -> value of 400 is preselected, using the same default values
![over-400](https://user-images.githubusercontent.com/2701406/91206564-5d8a7900-e6d5-11ea-979f-e35be71f4115.gif)

Existing override is not one of the default values -> this value is preselected and added to the dropdown choices, sorted appropriately. Examples for $234.50 and $1500
![override-234 50](https://user-images.githubusercontent.com/2701406/91206592-6713e100-e6d5-11ea-9696-628b68a52a84.gif)
![over-1500](https://user-images.githubusercontent.com/2701406/91206737-9aef0680-e6d5-11ea-93dc-9ba848b2500a.gif)





---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
