### PR TITLE
[RW-5324][risk=no] Move ConceptSetMapper into ConceptSetService

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -56,10 +56,10 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
     ConceptSet conceptSet =
-        conceptSetService.save(request, userProvider.get(), workspace.getWorkspaceId());
+        conceptSetService.createConceptSet(request, userProvider.get(), workspace.getWorkspaceId());
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), userProvider.get().getUserId(), conceptSet.getId());
-    return ResponseEntity.ok(conceptSetService.toHydratedConcepts(conceptSet));
+    return ResponseEntity.ok(conceptSet);
   }
 
   @Override
@@ -75,8 +75,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 
-    return ResponseEntity.ok(
-        conceptSetService.toHydratedConcepts(conceptSetService.findOne(conceptSetId)));
+    return ResponseEntity.ok(conceptSetService.getConceptSet(conceptSetId));
   }
 
   @Override
@@ -115,9 +114,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
-    return ResponseEntity.ok(
-        conceptSetService.toHydratedConcepts(
-            conceptSetService.updateConceptSet(conceptSetId, conceptSet)));
+    return ResponseEntity.ok(conceptSetService.updateConceptSet(conceptSetId, conceptSet));
   }
 
   @Override
@@ -132,9 +129,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
-    return ResponseEntity.ok(
-        conceptSetService.toHydratedConcepts(
-            conceptSetService.updateConceptSetConcepts(conceptSetId, request)));
+    return ResponseEntity.ok(conceptSetService.updateConceptSetConcepts(conceptSetId, request));
   }
 
   @Override
@@ -165,7 +160,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
             toWorkspace.getWorkspaceId());
     userRecentResourceService.updateConceptSetEntry(
         toWorkspace.getWorkspaceId(), userProvider.get().getUserId(), conceptSet.getId());
-    return ResponseEntity.ok(conceptSetService.toHydratedConcepts(conceptSet));
+    return ResponseEntity.ok(conceptSet);
   }
 
   private void validateCreateConceptSetRequest(CreateConceptSetRequest request) {

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -1,39 +1,22 @@
 package org.pmiops.workbench.api;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import java.sql.Timestamp;
-import java.time.Clock;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.apache.commons.collections4.CollectionUtils;
-import org.pmiops.workbench.cdr.CdrVersionContext;
-import org.pmiops.workbench.cdr.ConceptBigQueryService;
-import org.pmiops.workbench.cdr.model.DbConcept;
-import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
-import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
-import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.exceptions.ConflictException;
-import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.ConceptSetListResponse;
 import org.pmiops.workbench.model.CopyRequest;
 import org.pmiops.workbench.model.CreateConceptSetRequest;
-import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.Surveys;
 import org.pmiops.workbench.model.UpdateConceptSetRequest;
@@ -46,38 +29,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ConceptSetsController implements ConceptSetsApiDelegate {
 
-  private static final int MAX_CONCEPTS_PER_SET = 1000;
-  private static final String CONCEPT_CLASS_ID_QUESTION = "Question";
-  private static final int INITIAL_VERSION = 1;
-
   private final WorkspaceService workspaceService;
   private final ConceptSetService conceptSetService;
-  private final ConceptService conceptService;
   private final UserRecentResourceService userRecentResourceService;
-  private final ConceptBigQueryService conceptBigQueryService;
-  private final Clock clock;
-
   private final Provider<DbUser> userProvider;
-
-  @VisibleForTesting int maxConceptsPerSet;
 
   @Autowired
   ConceptSetsController(
       WorkspaceService workspaceService,
       ConceptSetService conceptSetService,
-      ConceptService conceptService,
-      ConceptBigQueryService conceptBigQueryService,
       UserRecentResourceService userRecentResourceService,
-      Provider<DbUser> userProvider,
-      Clock clock) {
+      Provider<DbUser> userProvider) {
     this.workspaceService = workspaceService;
     this.conceptSetService = conceptSetService;
-    this.conceptService = conceptService;
-    this.conceptBigQueryService = conceptBigQueryService;
     this.userRecentResourceService = userRecentResourceService;
     this.userProvider = userProvider;
-    this.clock = clock;
-    this.maxConceptsPerSet = MAX_CONCEPTS_PER_SET;
   }
 
   @Override
@@ -89,9 +55,8 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
         workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
-    DbConceptSet dbConceptSet = fromClientConceptSet(request, workspace.getWorkspaceId());
-
-    ConceptSet conceptSet = conceptSetService.save(dbConceptSet, );
+    ConceptSet conceptSet =
+        conceptSetService.save(request, userProvider.get(), workspace.getWorkspaceId());
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), userProvider.get().getUserId(), conceptSet.getId());
     return ResponseEntity.ok(conceptSetService.toHydratedConcepts(conceptSet));
@@ -121,15 +86,11 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
         workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 
-    List<ConceptSet> conceptSets = conceptSetService.findByWorkspaceId(workspace.getWorkspaceId());
-    ConceptSetListResponse response = new ConceptSetListResponse();
-    // Concept sets in the list response will *not* have concepts under them, as this could be
-    // a lot of data... you need to open up a concept set to see what concepts are within it.
-    response.setItems(
-        conceptSets.stream()
+    List<ConceptSet> conceptSets =
+        conceptSetService.findByWorkspaceId(workspace.getWorkspaceId()).stream()
             .sorted(Comparator.comparing(ConceptSet::getName))
-            .collect(Collectors.toList()));
-    return ResponseEntity.ok(response);
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(new ConceptSetListResponse().items(conceptSets));
   }
 
   @Override
@@ -140,27 +101,20 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     short surveyId = DbStorageEnums.surveysToStorage(Surveys.fromValue(surveyName.toUpperCase()));
     List<ConceptSet> conceptSets =
-        conceptSetService.findByWorkspaceIdAndSurvey(workspace.getWorkspaceId(), surveyId);
-    ConceptSetListResponse response =
-        new ConceptSetListResponse()
-            .items(
-                conceptSets.stream()
-                    .sorted(Comparator.comparing(ConceptSet::getName))
-                    .collect(Collectors.toList()));
-    return ResponseEntity.ok(response);
+        conceptSetService.findByWorkspaceIdAndSurvey(workspace.getWorkspaceId(), surveyId).stream()
+            .sorted(Comparator.comparing(ConceptSet::getName))
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(new ConceptSetListResponse().items(conceptSets));
   }
 
   @Override
   public ResponseEntity<ConceptSet> updateConceptSet(
       String workspaceNamespace, String workspaceId, Long conceptSetId, ConceptSet conceptSet) {
     // Fail fast if etag isn't provided
-    if (Strings.isNullOrEmpty(conceptSet.getEtag())) {
-      throw new BadRequestException("missing required update field 'etag'");
-    }
+    validateUpdateConceptSet(conceptSet);
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
-    validateAndUpdateDbConceptSet(dbConceptSet, conceptSet);
     return ResponseEntity.ok(
         conceptSetService.toHydratedConcepts(
             conceptSetService.updateConceptSet(conceptSetId, conceptSet)));
@@ -172,189 +126,46 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
       String workspaceId,
       Long conceptSetId,
       UpdateConceptSetRequest request) {
-    // Fail fast if etag isn't provided
-    if (Strings.isNullOrEmpty(request.getEtag())) {
-      throw new BadRequestException("missing required update field 'etag'");
-    }
+    // Fail fast if request isn't valid
+    validateUpdateConceptSetConcepts(request);
 
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.WRITER);
 
-    validateAndUpdateDbConceptSetConcept(dbConceptSet, request);
     return ResponseEntity.ok(
         conceptSetService.toHydratedConcepts(
             conceptSetService.updateConceptSetConcepts(conceptSetId, request)));
   }
 
   @Override
-  // TODO: Refactor this -> https://precisionmedicineinitiative.atlassian.net/browse/RW-5428
   public ResponseEntity<ConceptSet> copyConceptSet(
       String fromWorkspaceNamespace,
       String fromWorkspaceId,
       String fromConceptSetId,
       CopyRequest copyRequest) {
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    workspaceService.enforceWorkspaceAccessLevelAndRegisteredAuthDomain(
-        fromWorkspaceNamespace, fromWorkspaceId, WorkspaceAccessLevel.READER);
+    DbWorkspace fromWorkspace =
+        workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+            fromWorkspaceNamespace, fromWorkspaceId, WorkspaceAccessLevel.READER);
     DbWorkspace toWorkspace =
-        workspaceService.get(
-            copyRequest.getToWorkspaceNamespace(), copyRequest.getToWorkspaceName());
-    DbWorkspace fromWorkspace = workspaceService.get(fromWorkspaceNamespace, fromWorkspaceId);
-    workspaceService.enforceWorkspaceAccessLevelAndRegisteredAuthDomain(
-        toWorkspace.getWorkspaceNamespace(),
-        toWorkspace.getFirecloudName(),
-        WorkspaceAccessLevel.WRITER);
-    CdrVersionContext.setCdrVersionNoCheckAuthDomain(toWorkspace.getCdrVersion());
+        workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+            copyRequest.getToWorkspaceNamespace(),
+            copyRequest.getToWorkspaceName(),
+            WorkspaceAccessLevel.WRITER);
     if (toWorkspace.getCdrVersion().getCdrVersionId()
         != fromWorkspace.getCdrVersion().getCdrVersionId()) {
       throw new BadRequestException(
           "Target workspace does not have the same CDR version as current workspace");
     }
-    final DbConceptSet existingConceptSet =
-        conceptSetService
-            .findDbConceptSet(Long.valueOf(fromConceptSetId))
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format("Concept set %s does not exist", fromConceptSetId)));
-    DbConceptSet newConceptSet = new DbConceptSet(existingConceptSet);
 
-    newConceptSet.setName(copyRequest.getNewName());
-    newConceptSet.setCreator(userProvider.get());
-    newConceptSet.setWorkspaceId(toWorkspace.getWorkspaceId());
-    newConceptSet.setCreationTime(now);
-    newConceptSet.setLastModifiedTime(now);
-    newConceptSet.setVersion(INITIAL_VERSION);
-
-    ConceptSet conceptSet = conceptSetService.save(newConceptSet, );
+    ConceptSet conceptSet =
+        conceptSetService.copyAndSave(
+            Long.valueOf(fromConceptSetId),
+            copyRequest.getNewName(),
+            userProvider.get(),
+            toWorkspace.getWorkspaceId());
     userRecentResourceService.updateConceptSetEntry(
         toWorkspace.getWorkspaceId(), userProvider.get().getUserId(), conceptSet.getId());
     return ResponseEntity.ok(conceptSetService.toHydratedConcepts(conceptSet));
-  }
-
-  private void addConceptsToSet(DbConceptSet dbConceptSet, List<Long> addedIds) {
-    Domain domainEnum = dbConceptSet.getDomainEnum();
-    Iterable<DbConcept> concepts = conceptService.findAll(addedIds);
-    List<DbConcept> mismatchedConcepts =
-        ImmutableList.copyOf(concepts).stream()
-            .filter(concept -> !concept.getConceptClassId().equals(CONCEPT_CLASS_ID_QUESTION))
-            .filter(
-                concept -> {
-                  Domain domain =
-                      Domain.PHYSICALMEASUREMENT.equals(domainEnum)
-                          ? Domain.PHYSICALMEASUREMENT
-                          : DbStorageEnums.domainIdToDomain(concept.getDomainId());
-                  return !domainEnum.equals(domain);
-                })
-            .collect(Collectors.toList());
-    if (!mismatchedConcepts.isEmpty()) {
-      String mismatchedConceptIds =
-          Joiner.on(", ")
-              .join(
-                  mismatchedConcepts.stream()
-                      .map(DbConcept::getConceptId)
-                      .collect(Collectors.toList()));
-      throw new BadRequestException(
-          String.format("Concepts [%s] are not in domain %s", mismatchedConceptIds, domainEnum));
-    }
-
-    dbConceptSet.getConceptIds().addAll(addedIds);
-  }
-
-  private DbConceptSet fromClientConceptSet(CreateConceptSetRequest request, long workspaceId) {
-    ConceptSet conceptSet = request.getConceptSet();
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    DbConceptSet dbConceptSet = new DbConceptSet();
-    dbConceptSet.setDomainEnum(conceptSet.getDomain());
-    if (conceptSet.getSurvey() != null) {
-      dbConceptSet.setSurveysEnum(conceptSet.getSurvey());
-    }
-    if (dbConceptSet.getDomainEnum() == null) {
-      throw new BadRequestException(
-          "Domain " + conceptSet.getDomain() + " is not allowed for concept sets");
-    }
-    Optional.ofNullable(conceptSet.getEtag())
-        .ifPresent(etag -> dbConceptSet.setVersion(Etags.toVersion(etag)));
-    dbConceptSet.setDescription(conceptSet.getDescription());
-    dbConceptSet.setName(conceptSet.getName());
-    dbConceptSet.setCreator(userProvider.get());
-    dbConceptSet.setWorkspaceId(workspaceId);
-    dbConceptSet.setCreationTime(now);
-    dbConceptSet.setLastModifiedTime(now);
-    dbConceptSet.setVersion(INITIAL_VERSION);
-    addConceptsToSet(dbConceptSet, request.getAddedIds());
-    if (dbConceptSet.getConceptIds().size() > maxConceptsPerSet) {
-      throw new BadRequestException("Exceeded " + maxConceptsPerSet + " in concept set");
-    }
-    String omopTable = BigQueryTableInfo.getTableName(request.getConceptSet().getDomain());
-    dbConceptSet.setParticipantCount(
-        conceptBigQueryService.getParticipantCountForConcepts(
-            dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
-    return dbConceptSet;
-  }
-
-  private void validateAndUpdateDbConceptSet(DbConceptSet dbConceptSet, ConceptSet conceptSet) {
-    if (Strings.isNullOrEmpty(conceptSet.getEtag())) {
-      throw new BadRequestException("missing required update field 'etag'");
-    }
-    int version = Etags.toVersion(conceptSet.getEtag());
-    if (dbConceptSet.getVersion() != version) {
-      throw new ConflictException("Attempted to modify outdated concept set version");
-    }
-    if (conceptSet.getName() != null) {
-      dbConceptSet.setName(conceptSet.getName());
-    }
-    if (conceptSet.getDescription() != null) {
-      dbConceptSet.setDescription(conceptSet.getDescription());
-    }
-    if (conceptSet.getDomain() != null && conceptSet.getDomain() != dbConceptSet.getDomainEnum()) {
-      throw new BadRequestException("Cannot modify the domain of an existing concept set");
-    }
-    // In case of rename ConceptDet does not have concepts
-    if (!CollectionUtils.isEmpty(conceptSet.getConcepts())) {
-      validateCreateConceptSetRequest(
-          dbConceptSet,
-          conceptSet.getConcepts().stream()
-              .map(Concept::getConceptId)
-              .collect(Collectors.toList()));
-    }
-  }
-
-  private void validateAndUpdateDbConceptSetConcept(
-      DbConceptSet dbConceptSet, UpdateConceptSetRequest request) {
-    Set<Long> allConceptSetIds = dbConceptSet.getConceptIds();
-    if (request.getAddedIds() != null) {
-      allConceptSetIds.addAll(request.getAddedIds());
-    }
-    int sizeOfAllConceptSetIds = allConceptSetIds.size();
-    if (request.getRemovedIds() != null
-        && request.getRemovedIds().size() == sizeOfAllConceptSetIds) {
-      throw new BadRequestException("Concept Set must have at least one concept");
-    }
-
-    if (Strings.isNullOrEmpty(request.getEtag())) {
-      throw new BadRequestException("missing required update field 'etag'");
-    }
-    int version = Etags.toVersion(request.getEtag());
-    if (dbConceptSet.getVersion() != version) {
-      throw new ConflictException("Attempted to modify outdated concept set version");
-    }
-
-    if (request.getAddedIds() != null) {
-      addConceptsToSet(dbConceptSet, request.getAddedIds());
-    }
-    if (request.getRemovedIds() != null) {
-      dbConceptSet.getConceptIds().removeAll(request.getRemovedIds());
-    }
-    if (dbConceptSet.getConceptIds().isEmpty()) {
-      dbConceptSet.setParticipantCount(0);
-    } else {
-      String omopTable = BigQueryTableInfo.getTableName(dbConceptSet.getDomainEnum());
-      dbConceptSet.setParticipantCount(
-          conceptBigQueryService.getParticipantCountForConcepts(
-              dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
-    }
-    validateCreateConceptSetRequest(dbConceptSet, new ArrayList<>(dbConceptSet.getConceptIds()));
   }
 
   private void validateCreateConceptSetRequest(CreateConceptSetRequest request) {
@@ -362,6 +173,20 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
         .orElseThrow(() -> new BadRequestException("Domain cannot be null"));
     if (CollectionUtils.isEmpty(request.getAddedIds())) {
       throw new BadRequestException("Cannot create a concept set with no concepts");
+    }
+  }
+
+  private void validateUpdateConceptSet(ConceptSet conceptSet) {
+    if (Strings.isNullOrEmpty(conceptSet.getEtag())) {
+      throw new BadRequestException("missing required update field 'etag'");
+    }
+    Optional.ofNullable(conceptSet.getDomain())
+        .orElseThrow(() -> new BadRequestException("Domain cannot be null"));
+  }
+
+  private void validateUpdateConceptSetConcepts(UpdateConceptSetRequest request) {
+    if (Strings.isNullOrEmpty(request.getEtag())) {
+      throw new BadRequestException("missing required update field 'etag'");
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdrselector/WorkspaceResourcesServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdrselector/WorkspaceResourcesServiceImpl.java
@@ -10,11 +10,11 @@ import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbCohortReview;
-import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.ResourceType;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceResource;
@@ -81,14 +81,14 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
               .collect(Collectors.toList()));
     }
     if (resourceTypes.contains(ResourceType.CONCEPT_SET)) {
-      List<DbConceptSet> conceptSets =
+      List<ConceptSet> conceptSets =
           conceptSetService.findByWorkspaceId(dbWorkspace.getWorkspaceId());
       workspaceResources.addAll(
           conceptSets.stream()
               .map(
-                  dbConceptSet ->
-                      workspaceMapper.dbWorkspaceAndDbConceptSetToWorkspaceResource(
-                          dbWorkspace, workspaceAccessLevel, dbConceptSet))
+                  conceptSet ->
+                      workspaceMapper.dbWorkspaceSetToWorkspaceResource(
+                          dbWorkspace, workspaceAccessLevel, conceptSet))
               .collect(Collectors.toList()));
     }
     if (resourceTypes.contains(ResourceType.DATASET)) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -12,7 +12,7 @@ import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper;
-import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper.MapperContext;
+import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper.ConceptSetContext;
 import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.model.DbConceptSet;
@@ -63,8 +63,8 @@ public class ConceptSetService {
                     new NotFoundException(
                         String.format("Concept set %s does not exist", fromConceptSetId)));
     final Timestamp now = Timestamp.from(clock.instant());
-    MapperContext mapperContext =
-        new MapperContext.Builder()
+    ConceptSetContext conceptSetContext =
+        new ConceptSetContext.Builder()
             .name(newConceptSetName)
             .creator(creator)
             .workspaceId(toWorkspaceId)
@@ -73,7 +73,7 @@ public class ConceptSetService {
             .version(CONCEPT_SET_VERSION)
             .build();
     DbConceptSet dbConceptSetCopy =
-        conceptSetMapper.dbModelToDbModel(existingConceptSet, mapperContext);
+        conceptSetMapper.dbModelToDbModel(existingConceptSet, conceptSetContext);
 
     try {
       return conceptSetMapper.dbModelToClient(conceptSetDao.save(dbConceptSetCopy));
@@ -209,8 +209,8 @@ public class ConceptSetService {
   @Transactional
   public DbConceptSet cloneConceptSetAndConceptIds(
       DbConceptSet dbConceptSet, DbWorkspace targetWorkspace, boolean cdrVersionChanged) {
-    MapperContext mapperContext =
-        new MapperContext.Builder()
+    ConceptSetContext conceptSetContext =
+        new ConceptSetContext.Builder()
             .name(dbConceptSet.getName())
             .creator(targetWorkspace.getCreator())
             .workspaceId(targetWorkspace.getWorkspaceId())
@@ -219,7 +219,8 @@ public class ConceptSetService {
             .version(CONCEPT_SET_VERSION)
             .build();
 
-    DbConceptSet dbConceptSetClone = conceptSetMapper.dbModelToDbModel(dbConceptSet, mapperContext);
+    DbConceptSet dbConceptSetClone =
+        conceptSetMapper.dbModelToDbModel(dbConceptSet, conceptSetContext);
     if (cdrVersionChanged) {
       String omopTable = BigQueryTableInfo.getTableName(dbConceptSet.getDomainEnum());
       dbConceptSetClone.setParticipantCount(

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -52,7 +52,7 @@ public class ConceptSetService {
     this.clock = clock;
   }
 
-  public ConceptSet save(DbConceptSet dbConceptSet) {
+  public ConceptSet save(DbConceptSet dbConceptSet, Long WorkspaceId) {
     try {
       return conceptSetMapper.dbModelToClient(conceptSetDao.save(dbConceptSet));
     } catch (DataIntegrityViolationException e) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -57,7 +57,7 @@ public class ConceptSetService {
   public ConceptSet copyAndSave(
       Long fromConceptSetId, String newConceptSetName, DbUser creator, Long toWorkspaceId) {
     final DbConceptSet existingConceptSet =
-        findDbConceptSet(fromConceptSetId)
+        Optional.ofNullable(conceptSetDao.findOne(fromConceptSetId))
             .orElseThrow(
                 () ->
                     new NotFoundException(
@@ -181,10 +181,6 @@ public class ConceptSetService {
   public List<ConceptSet> findAll(List<Long> conceptSetIds) {
     return ((List<DbConceptSet>) conceptSetDao.findAll(conceptSetIds))
         .stream().map(conceptSetMapper::dbModelToClient).collect(Collectors.toList());
-  }
-
-  public Optional<DbConceptSet> findDbConceptSet(Long conceptSetId) {
-    return Optional.of(conceptSetDao.findOne(conceptSetId));
   }
 
   public List<ConceptSet> findByWorkspaceId(long workspaceId) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -1,17 +1,29 @@
 package org.pmiops.workbench.conceptset;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Ordering;
+import java.sql.Timestamp;
+import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.persistence.OptimisticLockException;
+import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
+import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper;
 import org.pmiops.workbench.dataset.BigQueryTableInfo;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.Concept;
 import org.pmiops.workbench.model.ConceptSet;
+import org.pmiops.workbench.model.UpdateConceptSetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,30 +31,116 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConceptSetService {
 
   private static final int CONCEPT_SET_VERSION = 1;
+  @VisibleForTesting public static int MAX_CONCEPTS_PER_SET = 1000;
   private final ConceptSetDao conceptSetDao;
   private final ConceptBigQueryService conceptBigQueryService;
+  private final ConceptService conceptService;
   private final ConceptSetMapper conceptSetMapper;
+  private final Clock clock;
 
   @Autowired
   public ConceptSetService(
       ConceptSetDao conceptSetDao,
       ConceptBigQueryService conceptBigQueryService,
-      ConceptSetMapper conceptSetMapper) {
+      ConceptService conceptService,
+      ConceptSetMapper conceptSetMapper,
+      Clock clock) {
     this.conceptSetDao = conceptSetDao;
     this.conceptBigQueryService = conceptBigQueryService;
+    this.conceptService = conceptService;
     this.conceptSetMapper = conceptSetMapper;
+    this.clock = clock;
   }
 
-  public DbConceptSet save(DbConceptSet dbConceptSet) {
-    return conceptSetDao.save(dbConceptSet);
+  public ConceptSet save(DbConceptSet dbConceptSet) {
+    try {
+      return conceptSetMapper.dbModelToClient(conceptSetDao.save(dbConceptSet));
+    } catch (DataIntegrityViolationException e) {
+      throw new ConflictException(
+          String.format("Concept set %s already exists.", dbConceptSet.getName()));
+    }
+  }
+
+  public ConceptSet updateConceptSet(Long conceptSetId, ConceptSet conceptSet) {
+    DbConceptSet dbConceptSet =
+        Optional.ofNullable(conceptSetDao.findOne(conceptSetId))
+            .orElseThrow(
+                () ->
+                    new NotFoundException("ConceptSet not found for concept id: " + conceptSetId));
+    int version = Etags.toVersion(conceptSet.getEtag());
+    if (dbConceptSet.getVersion() != version) {
+      throw new ConflictException("Attempted to modify outdated concept set version");
+    }
+    if (conceptSet.getName() != null) {
+      dbConceptSet.setName(conceptSet.getName());
+    }
+    if (conceptSet.getDescription() != null) {
+      dbConceptSet.setDescription(conceptSet.getDescription());
+    }
+    if (conceptSet.getDomain() != null && conceptSet.getDomain() != dbConceptSet.getDomainEnum()) {
+      throw new BadRequestException("Cannot modify the domain of an existing concept set");
+    }
+    final Timestamp now = Timestamp.from(clock.instant());
+    dbConceptSet.setLastModifiedTime(now);
+    try {
+      // TODO: add recent resource entry for concept sets [RW-1129]
+      return conceptSetMapper.dbModelToClient(conceptSetDao.save(dbConceptSet));
+    } catch (OptimisticLockException e) {
+      throw new ConflictException("Failed due to concurrent concept set modification");
+    }
+  }
+
+  public ConceptSet updateConceptSetConcepts(Long conceptSetId, UpdateConceptSetRequest request) {
+    DbConceptSet dbConceptSet =
+        Optional.ofNullable(conceptSetDao.findOne(conceptSetId))
+            .orElseThrow(
+                () ->
+                    new NotFoundException("ConceptSet not found for concept id: " + conceptSetId));
+
+    int version = Etags.toVersion(request.getEtag());
+    if (dbConceptSet.getVersion() != version) {
+      throw new ConflictException("Attempted to modify outdated concept set version");
+    }
+
+    if (request.getAddedIds() != null) {
+      dbConceptSet.getConceptIds().addAll(request.getAddedIds());
+    }
+    if (request.getRemovedIds() != null) {
+      dbConceptSet.getConceptIds().removeAll(request.getRemovedIds());
+    }
+    if (dbConceptSet.getConceptIds().size() > MAX_CONCEPTS_PER_SET) {
+      throw new ConflictException("Exceeded " + MAX_CONCEPTS_PER_SET + " in concept set");
+    }
+    if (dbConceptSet.getConceptIds().isEmpty()) {
+      dbConceptSet.setParticipantCount(0);
+    } else {
+      dbConceptSet.setParticipantCount(
+          conceptBigQueryService.getParticipantCountForConcepts(
+              dbConceptSet.getDomainEnum(),
+              BigQueryTableInfo.getTableName(dbConceptSet.getDomainEnum()),
+              dbConceptSet.getConceptIds()));
+    }
+
+    dbConceptSet.setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()));
+    try {
+      return conceptSetMapper.dbModelToClient(conceptSetDao.save(dbConceptSet));
+      // TODO: add recent resource entry for concept sets [RW-1129]
+    } catch (OptimisticLockException e) {
+      throw new ConflictException("Failed due to concurrent concept set modification");
+    }
   }
 
   public void delete(Long conceptSetId) {
     conceptSetDao.delete(conceptSetId);
   }
 
-  public Optional<DbConceptSet> findOne(Long conceptSetId) {
-    return Optional.of(conceptSetDao.findOne(conceptSetId));
+  public ConceptSet findOne(Long conceptSetId) {
+    DbConceptSet dbConceptSet =
+        Optional.ofNullable(conceptSetDao.findOne(conceptSetId))
+            .orElseThrow(
+                () ->
+                    new NotFoundException("ConceptSet not found for concept id: " + conceptSetId));
+    return conceptSetMapper.dbModelToClient(dbConceptSet);
   }
 
   public List<ConceptSet> findAll(List<Long> conceptSetIds) {
@@ -50,23 +148,27 @@ public class ConceptSetService {
         .stream().map(conceptSetMapper::dbModelToClient).collect(Collectors.toList());
   }
 
-  public DbConceptSet findOne(Long conceptSetId, DbWorkspace workspace) {
-    return conceptSetDao
-        .findByConceptSetIdAndWorkspaceId(conceptSetId, workspace.getWorkspaceId())
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    String.format(
-                        "No concept set with ID %s in workspace %s.",
-                        conceptSetId, workspace.getFirecloudName())));
+  public Optional<DbConceptSet> findDbConceptSet(Long conceptSetId) {
+    return Optional.of(conceptSetDao.findOne(conceptSetId));
   }
 
-  public List<DbConceptSet> findByWorkspaceId(long workspaceId) {
-    return conceptSetDao.findByWorkspaceId(workspaceId);
+  public List<ConceptSet> findByWorkspaceId(long workspaceId) {
+    return conceptSetDao.findByWorkspaceId(workspaceId).stream()
+        .map(conceptSetMapper::dbModelToClient)
+        .collect(Collectors.toList());
   }
 
-  public List<DbConceptSet> findByWorkspaceIdAndSurvey(long workspaceId, short surveyId) {
-    return conceptSetDao.findByWorkspaceIdAndSurvey(workspaceId, surveyId);
+  public List<ConceptSet> findByWorkspaceIdAndSurvey(long workspaceId, short surveyId) {
+    return conceptSetDao.findByWorkspaceIdAndSurvey(workspaceId, surveyId).stream()
+        .map(conceptSetMapper::dbModelToClient)
+        .collect(Collectors.toList());
+  }
+
+  public ConceptSet toHydratedConcepts(ConceptSet conceptSet) {
+    return conceptSet.concepts(
+        conceptService.findAll(
+            conceptSetDao.findOne(conceptSet.getId()).getConceptIds(),
+            Ordering.from(String.CASE_INSENSITIVE_ORDER).onResultOf(Concept::getConceptName)));
   }
 
   @Transactional

--- a/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
@@ -34,17 +34,18 @@ public interface ConceptSetMapper {
   @Mapping(target = "creationTime", ignore = true)
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "version", ignore = true)
-  DbConceptSet dbModelToDbModel(DbConceptSet dbConceptSet, @Context MapperContext mapperContext);
+  DbConceptSet dbModelToDbModel(
+      DbConceptSet dbConceptSet, @Context ConceptSetContext conceptSetContext);
 
   @AfterMapping
   default void afterMappingDbModelToDbModel(
-      @MappingTarget DbConceptSet dbConceptSet, @Context MapperContext mapperContext) {
-    dbConceptSet.setName(mapperContext.getName());
-    dbConceptSet.setCreator(mapperContext.getCreator());
-    dbConceptSet.setWorkspaceId(mapperContext.getWorkspaceId());
-    dbConceptSet.setCreationTime(mapperContext.getCreationTime());
-    dbConceptSet.setLastModifiedTime(mapperContext.getLastModifiedTime());
-    dbConceptSet.setVersion(mapperContext.getVersion());
+      @MappingTarget DbConceptSet dbConceptSet, @Context ConceptSetContext conceptSetContext) {
+    dbConceptSet.setName(conceptSetContext.getName());
+    dbConceptSet.setCreator(conceptSetContext.getCreator());
+    dbConceptSet.setWorkspaceId(conceptSetContext.getWorkspaceId());
+    dbConceptSet.setCreationTime(conceptSetContext.getCreationTime());
+    dbConceptSet.setLastModifiedTime(conceptSetContext.getLastModifiedTime());
+    dbConceptSet.setVersion(conceptSetContext.getVersion());
   }
 
   @Mapping(target = "conceptSetId", source = "conceptSet.id")
@@ -95,7 +96,7 @@ public interface ConceptSetMapper {
    * and lastModifiedTime are the offending properties. This is an attempt to work around this
    * issue.
    */
-  class MapperContext {
+  class ConceptSetContext {
     private String name;
     private DbUser creator;
     private Long workspaceId;
@@ -103,7 +104,7 @@ public interface ConceptSetMapper {
     private Timestamp lastModifiedTime;
     private int version;
 
-    public MapperContext(Builder builder) {
+    public ConceptSetContext(Builder builder) {
       this.name = builder.name;
       this.creator = builder.creator;
       this.workspaceId = builder.workspaceId;
@@ -174,8 +175,8 @@ public interface ConceptSetMapper {
         return this;
       }
 
-      public MapperContext build() {
-        return new MapperContext(this);
+      public ConceptSetContext build() {
+        return new ConceptSetContext(this);
       }
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.conceptset.mapper;
 
+import java.sql.Timestamp;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -25,6 +26,26 @@ public interface ConceptSetMapper {
   @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
   @Mapping(target = "concepts", ignore = true)
   ConceptSet dbModelToClient(DbConceptSet source);
+
+  @Mapping(target = "conceptSetId", ignore = true)
+  @Mapping(target = "name", ignore = true)
+  @Mapping(target = "creator", ignore = true)
+  @Mapping(target = "workspaceId", ignore = true)
+  @Mapping(target = "creationTime", ignore = true)
+  @Mapping(target = "lastModifiedTime", ignore = true)
+  @Mapping(target = "version", ignore = true)
+  DbConceptSet dbModelToDbModel(DbConceptSet dbConceptSet, @Context MapperContext mapperContext);
+
+  @AfterMapping
+  default void afterMappingDbModelToDbModel(
+      @MappingTarget DbConceptSet dbConceptSet, @Context MapperContext mapperContext) {
+    dbConceptSet.setName(mapperContext.getName());
+    dbConceptSet.setCreator(mapperContext.getCreator());
+    dbConceptSet.setWorkspaceId(mapperContext.getWorkspaceId());
+    dbConceptSet.setCreationTime(mapperContext.getCreationTime());
+    dbConceptSet.setLastModifiedTime(mapperContext.getLastModifiedTime());
+    dbConceptSet.setVersion(mapperContext.getVersion());
+  }
 
   @Mapping(target = "conceptSetId", source = "conceptSet.id")
   @Mapping(target = "domainEnum", source = "conceptSet.domain")
@@ -53,7 +74,7 @@ public interface ConceptSetMapper {
       @Context ConceptBigQueryService conceptBigQueryService);
 
   @AfterMapping
-  default void updateConceptSetFields(
+  default void afterMappingClientToDbModel(
       CreateConceptSetRequest source,
       @Context Long workspaceId,
       @Context DbUser creator,
@@ -66,5 +87,96 @@ public interface ConceptSetMapper {
     dbConceptSet.setParticipantCount(
         conceptBigQueryService.getParticipantCountForConcepts(
             dbConceptSet.getDomainEnum(), omopTable, dbConceptSet.getConceptIds()));
+  }
+
+  /**
+   * Mapstruct throws an error(The types of @Context parameters must be unique) when you have 2 or
+   * more of the same types using the @Context annotation. The 2 Timestamp objects for creationTime
+   * and lastModifiedTime are the offending properties. This is an attempt to work around this
+   * issue.
+   */
+  class MapperContext {
+    private String name;
+    private DbUser creator;
+    private Long workspaceId;
+    private Timestamp creationTime;
+    private Timestamp lastModifiedTime;
+    private int version;
+
+    public MapperContext(Builder builder) {
+      this.name = builder.name;
+      this.creator = builder.creator;
+      this.workspaceId = builder.workspaceId;
+      this.creationTime = builder.creationTime;
+      this.lastModifiedTime = builder.lastModifiedTime;
+      this.version = builder.version;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public DbUser getCreator() {
+      return creator;
+    }
+
+    public Long getWorkspaceId() {
+      return workspaceId;
+    }
+
+    public Timestamp getCreationTime() {
+      return creationTime;
+    }
+
+    public Timestamp getLastModifiedTime() {
+      return lastModifiedTime;
+    }
+
+    public int getVersion() {
+      return version;
+    }
+
+    public static class Builder {
+      private String name;
+      private DbUser creator;
+      private Long workspaceId;
+      private Timestamp creationTime;
+      private Timestamp lastModifiedTime;
+      private int version;
+
+      public Builder name(String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Builder creator(DbUser creator) {
+        this.creator = creator;
+        return this;
+      }
+
+      public Builder workspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+        return this;
+      }
+
+      public Builder creationTime(Timestamp creationTime) {
+        this.creationTime = creationTime;
+        return this;
+      }
+
+      public Builder lastModifiedTime(Timestamp lastModifiedTime) {
+        this.lastModifiedTime = lastModifiedTime;
+        return this;
+      }
+
+      public Builder version(int version) {
+        this.version = version;
+        return this;
+      }
+
+      public MapperContext build() {
+        return new MapperContext(this);
+      }
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbConceptSet.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbConceptSet.java
@@ -22,7 +22,7 @@ import org.pmiops.workbench.model.Surveys;
 @Entity
 @Table(name = "concept_set")
 public class DbConceptSet {
-  private static final int INITIAL_VERSION = 1;
+  public static final int INITIAL_VERSION = 1;
 
   private long conceptSetId;
   private int version;

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -68,8 +68,7 @@ public interface WorkspaceMapper {
     return toApiWorkspaceResponse(
         toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()),
         firecloudWorkspaceResponse.getAccessLevel());
-  }
-  ;
+  };
 
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -12,13 +12,13 @@ import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper;
 import org.pmiops.workbench.dataset.mapper.DataSetMapper;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbCohortReview;
-import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.CdrVersion;
+import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.Workspace;
@@ -68,7 +68,8 @@ public interface WorkspaceMapper {
     return toApiWorkspaceResponse(
         toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()),
         firecloudWorkspaceResponse.getAccessLevel());
-  };
+  }
+  ;
 
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")
@@ -170,16 +171,16 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "permission", source = "accessLevel")
-  @Mapping(target = "conceptSet", source = "dbConceptSet")
+  @Mapping(target = "conceptSet", source = "conceptSet")
   // All workspaceResources have one object and all others are null.
   @Mapping(target = "cohort", ignore = true)
   @Mapping(target = "cohortReview", ignore = true)
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
   // This should be set when the resource is set
-  @Mapping(target = "modifiedTime", source = "dbConceptSet.lastModifiedTime")
-  WorkspaceResource dbWorkspaceAndDbConceptSetToWorkspaceResource(
-      DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbConceptSet dbConceptSet);
+  @Mapping(target = "modifiedTime", source = "conceptSet.lastModifiedTime")
+  WorkspaceResource dbWorkspaceSetToWorkspaceResource(
+      DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, ConceptSet conceptSet);
 
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -15,7 +15,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
-import javax.inject.Provider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,14 +41,10 @@ import org.pmiops.workbench.config.WorkbenchConfig.BillingConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
-import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
-import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -80,7 +75,6 @@ import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
-import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -180,62 +174,30 @@ public class ConceptSetsControllerTest {
   private static DbUser currentUser;
   private Workspace workspace;
   private Workspace workspace2;
-  private TestMockFactory testMockFactory;
 
   @Autowired BillingProjectBufferService billingProjectBufferService;
-
-  @Autowired WorkspaceService workspaceService;
-
-  @Autowired ConceptSetDao conceptSetDao;
 
   @Autowired CdrVersionDao cdrVersionDao;
 
   @Autowired ConceptDao conceptDao;
 
-  @Autowired ConceptSetService conceptSetService;
-
-  @Autowired ConceptService conceptService;
-
-  @Autowired DataSetService dataSetService;
-
-  @Autowired WorkspaceDao workspaceDao;
-
   @Autowired UserDao userDao;
-
-  @Autowired CloudStorageService cloudStorageService;
-
-  @Autowired NotebooksService notebooksService;
-
-  @Autowired UserService userService;
 
   @Autowired FireCloudService fireCloudService;
 
   @Autowired ConceptSetsController conceptSetsController;
 
-  @Autowired UserRecentResourceService userRecentResourceService;
-
   @Autowired ConceptBigQueryService conceptBigQueryService;
-
-  @Autowired Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired WorkspacesController workspacesController;
 
-  @Autowired WorkspaceAuditor workspaceAuditor;
-
   @TestConfiguration
   @Import({
-    CohortCloningService.class,
-    CohortFactoryImpl.class,
-    CohortMapperImpl.class,
-    CohortReviewMapperImpl.class,
-    CohortReviewServiceImpl.class,
     CommonMappers.class,
     ConceptService.class,
     ConceptSetMapperImpl.class,
     ConceptSetsController.class,
     ConceptSetService.class,
-    DataSetMapperImpl.class,
-    FirecloudMapperImpl.class,
     LogsBasedMetricServiceFakeImpl.class,
     UserMapperImpl.class,
     UserServiceTestConfiguration.class,
@@ -246,10 +208,17 @@ public class ConceptSetsControllerTest {
   })
   @MockBean({
     BillingProjectBufferService.class,
+    CohortCloningService.class,
+    CohortFactoryImpl.class,
+    CohortMapperImpl.class,
+    CohortReviewMapperImpl.class,
+    CohortReviewServiceImpl.class,
     CloudStorageService.class,
     ComplianceService.class,
     ConceptBigQueryService.class,
     CohortService.class,
+    DataSetMapperImpl.class,
+    FirecloudMapperImpl.class,
     DataSetService.class,
     DirectoryService.class,
     FireCloudService.class,
@@ -293,11 +262,11 @@ public class ConceptSetsControllerTest {
   }
 
   @Before
-  public void setUp() throws Exception {
-    testMockFactory = new TestMockFactory();
+  public void setUp() {
+    TestMockFactory testMockFactory = new TestMockFactory();
 
     testMockFactory.stubBufferBillingProject(billingProjectBufferService);
-    testMockFactory.stubCreateFcWorkspace(fireCloudService);
+    TestMockFactory.stubCreateFcWorkspace(fireCloudService);
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);
@@ -332,14 +301,10 @@ public class ConceptSetsControllerTest {
 
     workspace = workspacesController.createWorkspace(workspace).getBody();
     workspace2 = workspacesController.createWorkspace(workspace2).getBody();
-    stubGetWorkspace(
-        workspace.getNamespace(), WORKSPACE_NAME, USER_EMAIL, WorkspaceAccessLevel.OWNER);
-    stubGetWorkspaceAcl(
-        workspace.getNamespace(), WORKSPACE_NAME, USER_EMAIL, WorkspaceAccessLevel.OWNER);
-    stubGetWorkspace(
-        workspace2.getNamespace(), WORKSPACE_NAME_2, USER_EMAIL, WorkspaceAccessLevel.OWNER);
-    stubGetWorkspaceAcl(
-        workspace2.getNamespace(), WORKSPACE_NAME_2, USER_EMAIL, WorkspaceAccessLevel.OWNER);
+    stubGetWorkspace(workspace.getNamespace(), WORKSPACE_NAME);
+    stubGetWorkspaceAcl(workspace.getNamespace(), WORKSPACE_NAME);
+    stubGetWorkspace(workspace2.getNamespace(), WORKSPACE_NAME_2);
+    stubGetWorkspaceAcl(workspace2.getNamespace(), WORKSPACE_NAME_2);
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.name());
@@ -446,7 +411,7 @@ public class ConceptSetsControllerTest {
 
   @Test(expected = NotFoundException.class)
   public void testGetSurveyConceptSetWrongConceptId() {
-    ConceptSet conceptSet = makeSurveyConceptSet1();
+    makeSurveyConceptSet1();
     conceptSetsController.getConceptSet(workspace2.getNamespace(), WORKSPACE_NAME_2, 99L);
   }
 
@@ -476,7 +441,7 @@ public class ConceptSetsControllerTest {
 
   @Test(expected = NotFoundException.class)
   public void testGetConceptSetWrongConceptSetId() {
-    ConceptSet conceptSet = makeConceptSet1();
+    makeConceptSet1();
     conceptSetsController.getConceptSet(workspace2.getNamespace(), WORKSPACE_NAME_2, 99L);
   }
 
@@ -524,7 +489,7 @@ public class ConceptSetsControllerTest {
         .isEmpty();
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test(expected = ConflictException.class)
   public void testUpdateConceptSetDomainChange() {
     ConceptSet conceptSet = makeConceptSet1();
     conceptSet.setDescription("new description");
@@ -587,7 +552,7 @@ public class ConceptSetsControllerTest {
   @Test
   public void testUpdateConceptSetConceptsAddMany() {
     saveConcepts();
-    conceptSetService.MAX_CONCEPTS_PER_SET = 1000;
+    ConceptSetService.MAX_CONCEPTS_PER_SET = 1000;
     when(conceptBigQueryService.getParticipantCountForConcepts(
             Domain.CONDITION,
             "condition_occurrence",
@@ -661,7 +626,7 @@ public class ConceptSetsControllerTest {
   public void testUpdateConceptSetConceptsAddTooMany() {
     saveConcepts();
     ConceptSet conceptSet = makeConceptSet1();
-    conceptSetService.MAX_CONCEPTS_PER_SET = 2;
+    ConceptSetService.MAX_CONCEPTS_PER_SET = 2;
     conceptSetsController
         .updateConceptSetConcepts(
             workspace.getNamespace(),
@@ -689,7 +654,7 @@ public class ConceptSetsControllerTest {
   @Test
   public void testDeleteConceptSet() {
     saveConcepts();
-    conceptSetService.MAX_CONCEPTS_PER_SET = 1000;
+    ConceptSetService.MAX_CONCEPTS_PER_SET = 1000;
     ConceptSet conceptSet1 = makeConceptSet1();
     ConceptSet conceptSet2 = makeConceptSet2();
     ConceptSet updatedConceptSet =
@@ -796,25 +761,23 @@ public class ConceptSetsControllerTest {
         .getBody();
   }
 
-  private void stubGetWorkspace(String ns, String name, String creator, WorkspaceAccessLevel access)
-      throws Exception {
+  private void stubGetWorkspace(String ns, String name) {
     FirecloudWorkspace fcWorkspace = new FirecloudWorkspace();
     fcWorkspace.setNamespace(ns);
     fcWorkspace.setName(name);
-    fcWorkspace.setCreatedBy(creator);
+    fcWorkspace.setCreatedBy(USER_EMAIL);
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(fcWorkspace);
-    fcResponse.setAccessLevel(access.toString());
+    fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
     when(fireCloudService.getWorkspace(ns, name)).thenReturn(fcResponse);
   }
 
-  private void stubGetWorkspaceAcl(
-      String ns, String name, String creator, WorkspaceAccessLevel access) {
+  private void stubGetWorkspaceAcl(String ns, String name) {
     FirecloudWorkspaceACL workspaceAccessLevelResponse = new FirecloudWorkspaceACL();
     FirecloudWorkspaceAccessEntry accessLevelEntry =
-        new FirecloudWorkspaceAccessEntry().accessLevel(access.toString());
+        new FirecloudWorkspaceAccessEntry().accessLevel(WorkspaceAccessLevel.OWNER.toString());
     Map<String, FirecloudWorkspaceAccessEntry> userEmailToAccessEntry =
-        ImmutableMap.of(creator, accessLevelEntry);
+        ImmutableMap.of(USER_EMAIL, accessLevelEntry);
     workspaceAccessLevelResponse.setAcl(userEmailToAccessEntry);
     when(fireCloudService.getWorkspaceAclAsService(ns, name))
         .thenReturn(workspaceAccessLevelResponse);

--- a/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/ConceptSetServiceTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.conceptset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.time.Clock;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,7 +39,7 @@ public class ConceptSetServiceTest {
 
   @TestConfiguration
   @Import({ConceptSetService.class, ConceptService.class, ConceptSetMapperImpl.class})
-  @MockBean({CommonMappers.class, ConceptBigQueryService.class})
+  @MockBean({CommonMappers.class, ConceptBigQueryService.class, Clock.class})
   static class Configuration {}
 
   @Test


### PR DESCRIPTION
This PR finalizes separation of logic between ConceptSetController and ConceptSetService

- ConceptSetController only has access to services and only throws request level exceptions(BadRequestException)
- ConceptSetService has all daos and mappers and only throws service level/db level exceptions

Also added `ConceptSetMapper#dbModelToDbModel` for copy/clone of ConceptSets. Had to add an inner class `ConceptSetContext` to `ConceptSetMapper` to work around a problem with Mapstruct that throws an error: The types of `@Context` parameters must be unique. This was caused by having two `Timestamp` objects as parameters to the `@afterMapping` method. 


