### PR TITLE
[RW-5367][risk=no] Create feature flag for concept set search refactor

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": true
   },
   "actionAudit": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -107,6 +107,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false
   },
   "actionAudit": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false
   },
   "actionAudit": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false
   },
   "actionAudit": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false
   },
   "actionAudit": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false
   },
   "actionAudit": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -104,6 +104,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
     "enableCohortBuilderV2": false,
+    "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": true
   },
   "actionAudit": {

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -40,6 +40,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
             .useNewShibbolethService(config.featureFlags.useNewShibbolethService)
             .enableCohortBuilderV2(config.featureFlags.enableCohortBuilderV2)
+            .enableConceptSetSearchV2(config.featureFlags.enableConceptSetSearchV2)
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -259,6 +259,8 @@ public class WorkbenchConfig {
     public boolean enableResearchPurposePrompt;
     // Flag to indicate whether to use the new UI for cohort builder
     public boolean enableCohortBuilderV2;
+    // Flag to indicate whether to use new Concept Set Search
+    public boolean enableConceptSetSearchV2;
     // If true, reporting cron job will write data to configured BigQuery reporting dataset.
     public boolean enableReportingUploadCron;
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3830,6 +3830,10 @@ definitions:
         type: boolean
         default: false
         description: Whether to use the Cohort Builder UI.
+      enableConceptSetSearchV2:
+        type: boolean
+        default: false
+        description: Whether to use new Concept Search.
       enableResearchReviewPrompt:
         type: boolean
         default: false


### PR DESCRIPTION
Add a new feature flag "enableConceptSetSearchV2" in api to be used for new concept set search

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
