### PR TITLE
[risk=no] Swap linting order to allow ng lint flag passing

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "build": "ng build",
     "test": "ng test --source-map=false",
     "test-react": "jest",
-    "lint": "ng lint --type-check && yarn eslint src --ext ts,tsx",
+    "lint": "yarn eslint src --ext ts,tsx && ng lint --type-check",
     "e2e": "ng e2e",
     "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run codegen-swagger-fetch && yarn run post-codegen && yarn run notebooks-codegen-swagger && yarn run notebooks-codegen-swagger-fetch && yarn run notebooks-post-codegen",
     "codegen-clean": "rm -rf src/generated src/notebooks-generated",


### PR DESCRIPTION
This fixes `yarn lint --fix`, only one of the `&&`'d commands can get the extra arguments. If you want to pass `--fix` to eslint, you can just run `yarn eslint --fix`.

This won't matter once we're exclusively on eslint.