### PR TITLE
[RW-4847][RW-5405][risk=low] Upgrade remaining Leo client-side usages

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -25,7 +25,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
-import org.pmiops.workbench.notebooks.api.NotebooksApi;
+import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
 import org.pmiops.workbench.notebooks.model.StorageLink;
@@ -45,7 +45,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private final Provider<RuntimesApi> runtimesApiProvider;
   private final Provider<RuntimesApi> serviceRuntimesApiProvider;
-  private final Provider<NotebooksApi> notebooksApiProvider;
+  private final Provider<ProxyApi> proxyApiProvider;
   private final Provider<ServiceInfoApi> serviceInfoApiProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final Provider<DbUser> userProvider;
@@ -58,7 +58,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
       @Qualifier(NotebooksConfig.USER_RUNTIMES_API) Provider<RuntimesApi> runtimesApiProvider,
       @Qualifier(NotebooksConfig.SERVICE_RUNTIMES_API)
           Provider<RuntimesApi> serviceRuntimesApiProvider,
-      Provider<NotebooksApi> notebooksApiProvider,
+      Provider<ProxyApi> proxyApiProvider,
       Provider<ServiceInfoApi> serviceInfoApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       Provider<DbUser> userProvider,
@@ -67,7 +67,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
       WorkspaceService workspaceService) {
     this.runtimesApiProvider = runtimesApiProvider;
     this.serviceRuntimesApiProvider = serviceRuntimesApiProvider;
-    this.notebooksApiProvider = notebooksApiProvider;
+    this.proxyApiProvider = proxyApiProvider;
     this.serviceInfoApiProvider = serviceInfoApiProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.userProvider = userProvider;
@@ -205,10 +205,10 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                                 .sourceUri(e.getValue())
                                 .localDestinationPath(e.getKey()))
                     .collect(Collectors.toList()));
-    NotebooksApi notebooksApi = notebooksApiProvider.get();
+    ProxyApi proxyApi = proxyApiProvider.get();
     notebooksRetryHandler.run(
         (context) -> {
-          notebooksApi.welderLocalize(googleProject, runtimeName, welderReq);
+          proxyApi.welderLocalize(googleProject, runtimeName, welderReq);
           return null;
         });
   }
@@ -216,9 +216,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   @Override
   public StorageLink createStorageLink(
       String googleProject, String runtime, StorageLink storageLink) {
-    NotebooksApi notebooksApi = notebooksApiProvider.get();
+    ProxyApi proxyApi = proxyApiProvider.get();
     return notebooksRetryHandler.run(
-        (context) -> notebooksApi.welderCreateStorageLink(googleProject, runtime, storageLink));
+        (context) -> proxyApi.welderCreateStorageLink(googleProject, runtime, storageLink));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksConfig.java
@@ -11,7 +11,7 @@ import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.api.ServiceInfoApi;
 import org.pmiops.workbench.notebooks.api.JupyterApi;
-import org.pmiops.workbench.notebooks.api.NotebooksApi;
+import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -88,8 +88,8 @@ public class NotebooksConfig {
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public NotebooksApi notebooksApi(@Qualifier(USER_NOTEBOOKS_CLIENT) ApiClient apiClient) {
-    NotebooksApi api = new NotebooksApi();
+  public ProxyApi proxyApi(@Qualifier(USER_NOTEBOOKS_CLIENT) ApiClient apiClient) {
+    ProxyApi api = new ProxyApi();
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1,6 +1,6 @@
 # This file is a hand-crafted combination of Leo and its proxy APIs.
-#  - A subset of Welder (modified for cluster/path prefix): https://github.com/DataBiosphere/welder/blob/master/server/src/main/resources/api-docs.yaml
-#  - A subset of Jupyter (modified for cluster/path prefix): https://github.com/jupyter/notebook/blob/master/notebook/services/api/api.yaml
+#  - A subset of Welder (modified for runtime/path prefix): https://github.com/DataBiosphere/welder/blob/master/server/src/main/resources/api-docs.yaml
+#  - A subset of Jupyter (modified for runtime/path prefix): https://github.com/jupyter/notebook/blob/master/notebook/services/api/api.yaml
 #  - Subset of Leo API used client-side (downgraded to Swagger2): https://github.com/broadinstitute/leonardo/blob/develop/src/main/resources/swagger/api-docs.yaml
 
 swagger: '2.0'
@@ -18,9 +18,9 @@ basePath: /
 produces:
   - application/json
 tags:
-  - name: test
-    description: Test API
-  - name: runtime
+  - name: notebooks
+    description: Notebooks Welder API
+  - name: runtimes
     description: Runtimes API
   - name: proxy
     description: Notebook proxy API
@@ -135,12 +135,12 @@ paths:
               schema:
                 $ref: "#/definitions/ErrorReport"
 
-  "/proxy/{googleProject}/{clusterName}/setCookie":
+  "/proxy/{googleProject}/{runtimeName}/setCookie":
     get:
       summary: Sets a browser cookie needed to authorize connections to a Dataproc
-        cluster
+        runtime
       description: >
-        If using Google token-based authorization to a cluster, the Leo proxy
+        If using Google token-based authorization to a runtime, the Leo proxy
         accepts a
 
         Google token passed as a cookie value. This endpoint facilitates setting that cookie.
@@ -155,8 +155,8 @@ paths:
           required: true
           type: string
         - in: path
-          name: clusterName
-          description: clusterName
+          name: runtimeName
+          description: runtimeName
           required: true
           type: string
       responses:
@@ -169,7 +169,7 @@ paths:
               schema:
                 $ref: "#/definitions/ErrorReport"
         "404":
-          description: Cluster not found
+          description: Runtime not found
           content:
             application/json:
               schema:
@@ -209,7 +209,7 @@ paths:
 ## https://github.com/DataBiosphere/welder/blob/master/server/src/main/resources/api-docs.yaml
 ##########################################################################################
 
-  '/proxy/{googleProject}/{clusterName}/welder/objects':
+  '/proxy/{googleProject}/{runtimeName}/welder/objects':
     parameters:
       - in: path
         name: googleProject
@@ -217,8 +217,8 @@ paths:
         required: true
         type: string
       - in: path
-        name: clusterName
-        description: clusterName
+        name: runtimeName
+        description: runtimeName
         required: true
         type: string
     post:
@@ -240,7 +240,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/WelderErrorReport'
-  '/proxy/{googleProject}/{clusterName}/welder/storageLinks':
+  '/proxy/{googleProject}/{runtimeName}/welder/storageLinks':
     parameters:
       - in: path
         name: googleProject
@@ -248,12 +248,12 @@ paths:
         required: true
         type: string
       - in: path
-        name: clusterName
-        description: clusterName
+        name: runtimeName
+        description: runtimeName
         required: true
         type: string
     post:
-      summary: 'creates the specified storage link configuration for the cluster'
+      summary: 'creates the specified storage link configuration for the runtime'
       operationId: welderCreateStorageLink
       tags:
         - notebooks
@@ -280,7 +280,7 @@ paths:
   # "workspaces/..." fragment into a single "path" var, as is used in Jupyter's
   # own Swagger definition. Note: this does not initialize any parent
   # directories. The Leo proxy localize API can be used for this purpose.
-  /notebooks/{googleProject}/{clusterName}/api/contents/{fileName}:
+  /notebooks/{googleProject}/{runtimeName}/api/contents/{fileName}:
     parameters:
       - in: path
         name: googleProject
@@ -288,8 +288,8 @@ paths:
         required: true
         type: string
       - in: path
-        name: clusterName
-        description: clusterName
+        name: runtimeName
+        description: runtimeName
         required: true
         type: string
       - in: path
@@ -347,7 +347,7 @@ paths:
             $ref: '#/definitions/JupyterContents'
         500:
           description: Model key error
-  /notebooks/{googleProject}/{clusterName}/api/contents/workspaces/{workspaceDir}:
+  /notebooks/{googleProject}/{runtimeName}/api/contents/workspaces/{workspaceDir}:
     parameters:
       - in: path
         name: googleProject
@@ -355,8 +355,8 @@ paths:
         required: true
         type: string
       - in: path
-        name: clusterName
-        description: clusterName
+        name: runtimeName
+        description: runtimeName
         required: true
         type: string
       - in: path
@@ -406,7 +406,7 @@ paths:
               reason:
                 type: string
                 description: Explanation of error reason
-  /notebooks/{googleProject}/{clusterName}/api/contents/workspaces/{workspaceDir}/{fileName}:
+  /notebooks/{googleProject}/{runtimeName}/api/contents/workspaces/{workspaceDir}/{fileName}:
     parameters:
       - in: path
         name: googleProject
@@ -414,8 +414,8 @@ paths:
         required: true
         type: string
       - in: path
-        name: clusterName
-        description: clusterName
+        name: runtimeName
+        description: runtimeName
         required: true
         type: string
       - in: path
@@ -477,32 +477,6 @@ paths:
 ## DEFINITIONS
 ##########################################################################################
 definitions:
-  ClusterStatus:
-    type: string
-    enum: &CLUSTERSTATUS
-      - Creating
-      - Running
-      - Updating
-      - Error
-      - Stopping
-      - Stopped
-      - Starting
-      - Deleting
-      - Deleted
-      - Unknown
-
-  InstanceStatus:
-    type: string
-    enum: &INSTANCESTATUS
-      - Provisioning
-      - Staging
-      - Running
-      - Stopping
-      - Stopped
-      - Suspending
-      - Suspended
-      - Terminated
-
   ErrorReport:
     description: ''
     required:
@@ -555,419 +529,6 @@ definitions:
         type: integer
         description: line number
 
-  Cluster:
-    description: ''
-    required:
-      - id
-      - clusterName
-      - googleProject
-      - googleServiceAccount
-      - machineConfig
-      - status
-      - createdDate
-      - labels
-      - dateAccessed
-      - autopauseThreshold
-      - defaultClientId
-      - scopes
-    properties:
-      id:
-        type: string
-        description: The internally-referenced ID of the cluster
-      clusterName:
-        type: string
-        description: The user-supplied name for the cluster
-      googleId:
-        type: string
-        description: Google's UUID for the cluster
-      googleProject:
-        type: string
-        description: The Google Project used to create the cluster
-      googleServiceAccount:
-        type: string
-        description: The Google Service Account used to create the cluster
-      machineConfig:
-        description: The machine configurations for the master and worker nodes
-        $ref: '#/definitions/MachineConfig'
-      operationName:
-        type: string
-        description: Google's operation ID for the cluster
-      status:
-        $ref: "#/definitions/ClusterStatus"
-      hostIp:
-        type: string
-        description: The IP address of the cluster master node
-      createdDate:
-        type: string
-        description: The date and time the cluster was created, in ISO-8601 format
-      destroyedDate:
-        type: string
-        description: The date and time the cluster was destroyed, in ISO-8601 format
-      labels:
-        type: object
-        description: The labels to be placed on the cluster. Of type Map[String,String]
-      errors:
-        type: array
-        description: The list of errors that were encountered on cluster create. Each error consists of the error message, code and timestamp
-        items:
-          $ref: "#/definitions/ClusterError"
-      instances:
-        description: Array of instances belonging to this cluster
-        type: array
-        items:
-          $ref: '#/definitions/Instance'
-      dateAccessed:
-        type: string
-        description: |
-          The date and time the cluster was last accessed, in ISO-8601 format.
-          Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
-      autopauseThreshold:
-        type: integer
-        description: The number of minutes of idle time to elapse before the cluster is autopaused. A value of 0 is equivalent to autopause being turned off.
-      defaultClientId:
-        type: string
-        description: The default Google Client ID.
-      scopes:
-        type: array
-        items:
-          type: string
-        description: The scopes for the cluster.
-      stagingBucket:
-        type: string
-        description: Bucket name containing logs and staging resources for the cluster.
-
-
-  ListClusterResponse:
-    description: ''
-    required:
-      - clusterName
-      - googleProject
-      - googleServiceAccount
-      - machineConfig
-      - status
-      - createdDate
-      - labels
-      - dateAccessed
-      - autopauseThreshold
-      - defaultClientId
-    properties:
-      internalId:
-        type: string
-        description: Internal resource ID of the cluster
-      clusterName:
-        type: string
-        description: The user-supplied name for the cluster
-      googleId:
-        type: string
-        description: Google's UUID for the cluster
-      googleProject:
-        type: string
-        description: The Google Project used to create the cluster
-      googleServiceAccount:
-        type: string
-        description: The Google Service Account used to create the cluster
-      machineConfig:
-        description: The machine configurations for the master and worker nodes
-        $ref: '#/definitions/MachineConfig'
-      operationName:
-        type: string
-        description: Google's operation ID for the cluster
-      status:
-        $ref: "#/definitions/ClusterStatus"
-      hostIp:
-        type: string
-        description: The IP address of the cluster master node
-      createdDate:
-        type: string
-        description: The date and time the cluster was created, in ISO-8601 format
-      destroyedDate:
-        type: string
-        description: The date and time the cluster was destroyed, in ISO-8601 format
-      labels:
-        type: object
-        description: The labels to be placed on the cluster. Of type Map[String,String]
-      instances:
-        description: Array of instances belonging to this cluster
-        type: array
-        items:
-          $ref: '#/definitions/Instance'
-      dateAccessed:
-        type: string
-        description: |
-          The date and time the cluster was last accessed, in ISO-8601 format.
-          Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
-      autopauseThreshold:
-        type: integer
-        description: The number of minutes of idle time to elapse before the cluster is autopaused. A value of 0 is equivalent to autopause being turned off.
-      defaultClientId:
-        type: string
-        description: The default Google Client ID.
-
-  InstanceKey:
-    description: ''
-    required:
-      - project
-      - zone
-      - name
-    properties:
-      project:
-        type: string
-        description: The Google Project the instance belongs to
-      zone:
-        type: string
-        description: The Google zone the instance belongs to
-      name:
-        type: string
-        description: The name of the instance
-
-  Instance:
-    description: ''
-    required:
-      - key
-      - googleId
-      - status
-    properties:
-      key:
-        description: Unique identifier of (project, zone, name) for this instance
-        $ref: '#/definitions/InstanceKey'
-      googleId:
-        type: string
-        description: Google's unique id for this instance
-      status:
-        $ref: "#/definitions/InstanceStatus"
-      ip:
-        type: string
-        description: The public IP address of the instance, if any
-      dataprocRole:
-        type: string
-        description: The dataproc role (master, worker, preemptible worker) of this instance, if any
-      createdDate:
-        type: string
-        description: The date and time the instance was created, in ISO-8601 format
-
-  ClusterRequest:
-    description: ''
-    properties:
-      labels:
-        type: object
-        description: The labels to be placed on the cluster. Of type Map[String,String]
-      userJupyterExtensionConfig:
-        $ref: "#/definitions/UserJupyterExtensionConfig"
-        description: Jupyter extensions to be installed in the notebook
-      jupyterUserScriptUri:
-        type: string
-        description: |
-          Optional GCS object URI to a bash script the user wishes to run inside their jupyter
-          docker. This script runs exactly once when the cluster is first initialized. Logs from
-          this script can be found in the Leo staging bucket for the cluster. Script is run as root
-          and docker --privileged.
-      jupyterStartUserScriptUri:
-        type: string
-        description: |
-          Optional GCS object URI to a bash script the user wishes to run on cluster start inside
-          the jupyter docker. In contrast to jupyterUserScriptUri, this always runs before starting
-          Jupyter, both on initial cluster creation and on cluster resume (jupyterUserScriptUri runs
-          once on cluster creation). This script may be used to launch background processes which
-          would not otherwise survive a cluster stop/start.
-          The script is pulled once at cluster creation time; subsequent client changes to the user
-          script at this URI do not affect the cluster. Timestamped logs for this script can be
-          found in the Leo staging bucket for the cluster. Script is run as root and docker --privileged.
-      machineConfig:
-        description: The machine configurations for the master and worker nodes
-        $ref: '#/definitions/MachineConfig'
-      properties:
-        description: >
-          Example {"spark:spark.executor.memory": "10g"}. See https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties for allowed property settings
-        type: object
-        additionalProperties:
-          type: string
-      stopAfterCreation:
-        description: |
-          If true, Leo will immediately stop the cluster once it's created, with the end result being a
-          a cluster in Stopped state. Otherwise, the end result will be a cluster in Running state.
-          Defaults to false.
-        type: boolean
-        default: false
-      autopause:
-        type: boolean
-        description: Whether autopause feature is enabled for this specific cluster. If unset, autopause will be enabled and a system default threshold will be used.
-      autopauseThreshold:
-        type: integer
-        description: The number of minutes of idle time to elapse before the cluster is autopaused. If autopause is set to false, this value is disregarded. A value of 0 is equivalent to autopause being turned off. If autopause is enabled and this is unset, a system default threshold will be used.
-      defaultClientId:
-        type: string
-        description: The default Google Client ID.
-      toolDockerImage:
-        type: string
-        description: The tool docker image to install. May be Dockerhub or GCR. If not set, a default Jupyter image will be installed.
-      welderDockerImage:
-        type: string
-        description: |
-          The Welder docker image to install. Only takes effect if the tool being installed supports welder.
-          May be Dockerhub or GCR. If not set, then a default Welder image will be installed.
-      scopes:
-        type: array
-        items:
-          type: string
-        description: >
-          The scopes for the cluster. Defaults (userinfo.email, userinfo.profile, bigquery, source.read_only) will be used if left blank. Important: If you choose to specify custom scopes, the defaults will be overwritten. Thus, if you need the defaults, you will need to include the default scopes in your custom list of scopes.
-        default: ["https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/bigquery", "https://www.googleapis.com/auth/source.read_only"]
-      enableWelder:
-        type: boolean
-        description: If set to true, sets up welder on the cluster. If unset, welder will not be put on the cluster.
-        default: false
-      customClusterEnvironmentVariables:
-        type: object
-        description: A collection of key/value pairs of environment variable names and their desired value to be set in the cluster.
-        additionalProperties:
-          type: string
-
-  ClusterError:
-    description: 'Errors encountered on cluster create'
-    properties:
-      errorMessage:
-        type: string
-        description: Error message
-      errorCode:
-        type: integer
-        description: Error code
-      timestamp:
-        type: string
-        description: timestamp for error in ISO 8601 format
-
-  LeonardoVersion:
-    type: object
-    properties:
-      version:
-        type: string
-
-  MachineConfig:
-    description: 'The configuration for a single Dataproc cluster'
-    properties:
-      numberOfWorkers:
-        type: integer
-        description: |
-          Optional, number of workers in the cluster. Can be 0 (default), 2 or more. Google Dataproc does not allow 1 worker.
-      masterMachineType:
-        type: string
-        description: |
-          Optional, the machine type determines the number of CPUs and memory for the master node. For example "n1-standard-16"
-          or "n1-highmem-64". If unspecified, defaults to creating a "n1-standard-4" machine. To decide which is right for you,
-          see https://cloud.google.com/compute/docs/machine-types
-      masterDiskSize:
-        type: integer
-        description: |
-          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
-      workerMachineType:
-        type: string
-        description: |
-          Optional, the machine type determines the number of CPUs and memory for the worker nodes. For example "n1-standard-16"
-          or "n1-highmem-64". If unspecified, defaults to creating a "n1-standard-4" machine. To decide which is right for you,
-          see https://cloud.google.com/compute/docs/machine-types. Ignored if numberOfWorkers is 0.
-      workerDiskSize:
-        type: integer
-        description: |
-          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
-          Ignored if numberOfWorkers is 0.
-      numberOfWorkerLocalSSDs:
-        type: integer
-        description: |
-          Optional, the number of local solid state disks for workers. If unspecified, the default number is 0.
-          Ignored if numberOfWorkers is 0.
-      numberOfPreemptibleWorkers:
-        type: integer
-        description: |
-          Optional, the number of preemptible workers. If unspecified, the default number is 0. Ignored if numberOfWorkers is 0.
-          For more information, see https://cloud.google.com/compute/docs/instances/preemptible
-
-  UserJupyterExtensionConfig:
-    description: 'Specification of Jupyter Extensions to be installed on the cluster'
-    properties:
-      nbExtensions:
-        type: object
-        description: |
-          Optional, map of extension name and nbExtension. The nbExtension can either be a tar.gz or .js file, either on google storage or at a URL, or a python package.
-          An archive must not include a parent directory, and must have an entry point named 'main'.
-          For more information on notebook extensions, see http://jupyter-notebook.readthedocs.io/en/latest/extending/frontend_extensions.html.
-          Example, {"ext1":"gs://bucket/extension.tar.gz", "ext2":"python-package",  "ext3":"http://foo.com/extension.js"}
-      serverExtensions:
-        type: object
-        description: |
-          Optional, map of extension name and server extension. The serverExtensions can either be a tar.gz file on google storage or a python package.
-          Example, {"ext1":"gs://bucket/extension.tar.gz", "ext2":"python-package"}
-      combinedExtensions:
-        type: object
-        description: |
-          Optional, map of extension name and notebook plus server extension. The extension can either be a tar.gz file on google storage or a python package.
-          Example, {"ext1":"gs://bucket/extension.tar.gz", "ext2":"python-package"}
-      labExtensions:
-        type: object
-        description: |
-          Optional, map of extension name and lab extension. The extension should be a verified jupyterlab extension that is uploaded to npm (list of public extensions here: https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories), a gzipped tarball made using 'npm pack', a folder structured by 'jlpm build', a JS file to be inserted into an JL extension template (see https://github.com/jupyterlab/extension-cookiecutter-js), or a URL to one of the last three options.
-
-  SubsystemStatus:
-    description: status of a subsystem Leonardo depends on
-    type: object
-    required:
-      - ok
-    properties:
-      ok:
-        type: boolean
-        description: whether this system is up or down from Leonardo's point of view
-      messages:
-        type: array
-        items:
-          type: string
-
-  SystemStatus:
-    description: status of each subsystem Leonardo depends on
-    type: object
-    required:
-      - ok
-      - systems
-    properties:
-      ok:
-        type: boolean
-        description: true if everything is ok, false if anything is amiss
-      systems:
-        type: object
-        description: Map[String, SubsystemStatus]
-
-  UpdateClusterRequest:
-    description: ''
-    properties:
-      machineConfig:
-        description: The machine configurations for the master and worker nodes
-        $ref: '#/definitions/UpdateMachineConfig'
-      autopause:
-        type: boolean
-        description: Whether autopause feature is enabled for this specific cluster. If unset, autopause will be enabled and a system default threshold will be used.
-      autopauseThreshold:
-        type: integer
-        description: The number of minutes of idle time to elapse before the cluster is autopaused. If autopause is set to false, this value is disregarded. A value of 0 is equivalent to autopause being turned off. If autopause is enabled and this is unset, a system default threshold will be used.
-
-  UpdateMachineConfig:
-    description: 'The configuration for a single Dataproc cluster'
-    properties:
-      numberOfWorkers:
-        type: integer
-        description: |
-          Optional, number of workers in the cluster. Can be 0 (default), 2 or more. Google Dataproc does not allow 1 worker.
-      numberOfPreemptibleWorkers:
-        type: integer
-        description: |
-          Optional, the number of preemptible workers. If unspecified, the default number is 0. Ignored if numberOfWorkers is 0.
-          For more information, see https://cloud.google.com/compute/docs/instances/preemptible
-      masterMachineType:
-        type: string
-        description: |
-          Optional, the machine type determines the number of CPUs and memory for the master node. For example "n1-standard-16"
-          or "n1-highmem-64". To decide which is right for you, see https://cloud.google.com/compute/docs/machine-types
-      masterDiskSize:
-        type: integer
-        description: |
-          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. Note: disk size cannot be
-          decreased in an update request, only increased.
 
 ##########################################################################################
 ## Subset of Welder API models

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -1,10 +1,7 @@
 # This file is a hand-crafted combination of Leo and its proxy APIs.
 #  - A subset of Welder (modified for cluster/path prefix): https://github.com/DataBiosphere/welder/blob/master/server/src/main/resources/api-docs.yaml
 #  - A subset of Jupyter (modified for cluster/path prefix): https://github.com/jupyter/notebook/blob/master/notebook/services/api/api.yaml
-#
-# TODO(calbach): Remove the following once the client-side codegen can support
-# OAS3 generation for the new Leo APIs.
-#  - Subset of Leo API used client-side: https://github.com/broadinstitute/leonardo/blob/develop/src/main/resources/swagger/api-docs.yaml
+#  - Subset of Leo API used client-side (downgraded to Swagger2): https://github.com/broadinstitute/leonardo/blob/develop/src/main/resources/swagger/api-docs.yaml
 
 swagger: '2.0'
 info:

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -23,10 +23,10 @@ produces:
 tags:
   - name: test
     description: Test API
-  - name: cluster
-    description: Clusters API
-  - name: notebooks
-    description: Notebooks API
+  - name: runtime
+    description: Runtimes API
+  - name: proxy
+    description: Notebook proxy API
   - name: jupyter
     description: Jupyter API
 
@@ -47,22 +47,21 @@ securityDefinitions:
       profile: profile authorization
 
 ##########################################################################################
-## PATHS
+## Subset of Leo APIs needed by the frontend. Just leave them here for ease of
+## access. If we want to consolidate these APIs, we can later decide to migrate
+## the Welder and Jupyter spec to OAS3 as well, and move typescript codegen.
 ##########################################################################################
 
-# TODO(calbach): migrate start/stop into new swagger3 spec; currently these are
-# needed by typescript.
-
 paths:
-  '/api/cluster/{googleProject}/{clusterName}/stop':
+
+  /api/google/v1/runtimes/{googleProject}/{name}/stop:
     post:
-      summary: Stops a Dataproc cluster
-      description: |
-        Stops the instances of a Dataproc cluster, but retains any data persisted on disk. The
-        cluster may be restarted with the /start endpoint.
-      operationId: stopCluster
+      summary: Stops a Dataproc cluster or Google Compute Engine instance
+      description: >
+        Stops the running compute, but retains any data persisted on disk. The runtime may be restarted with the /start endpoint.
+      operationId: stopRuntime
       tags:
-        - cluster
+        - runtimes
       parameters:
         - in: path
           name: googleProject
@@ -70,36 +69,40 @@ paths:
           required: true
           type: string
         - in: path
-          name: clusterName
-          description: clusterName
+          name: name
+          description: runtime name
           required: true
           type: string
       responses:
-        '202':
-          description: Cluster stop request accepted
-        '403':
-          description: User does not have permission to perform action on cluster
-        '404':
-          description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '409':
-          description: Cluster cannot be stopped
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
+        "202":
+          description: Runtime stop request accepted
+        "403":
+          description: User does not have permission to perform action on runtime
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "409":
+          description: Runtime cannot be stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "500":
           description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-
-  '/api/cluster/{googleProject}/{clusterName}/start':
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+  /api/google/v1/runtimes/{googleProject}/{name}/start:
     post:
-      summary: Starts a Dataproc cluster
-      description: |
-        Starts the instances of a stopped Dataproc cluster.
-      operationId: startCluster
+      summary: Starts a Dataproc cluster or Google Compute Engine instance
+      description: Starts the a stopped runtime
+      operationId: startRuntime
       tags:
-        - cluster
+        - runtimes
       parameters:
         - in: path
           name: googleProject
@@ -107,38 +110,48 @@ paths:
           required: true
           type: string
         - in: path
-          name: clusterName
-          description: clusterName
+          name: name
+          description: runtimeName
           required: true
           type: string
       responses:
-        '202':
-          description: Cluster start request accepted
-        '403':
-          description: User does not have permission to perform action on cluster
-        '404':
-          description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '409':
-          description: Cluster cannot be started
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
+        "202":
+          description: Runtime start request accepted
+        "403":
+          description: User does not have permission to perform action on runtime
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "409":
+          description: Runtime cannot be started
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "500":
           description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
 
-  '/notebooks/{googleProject}/{clusterName}/setCookie':
+  "/proxy/{googleProject}/{clusterName}/setCookie":
     get:
-      summary: (Deprecated) Sets a browser cookie needed to authorize connections to a Jupyter notebook
-      description: |
-        If using Google token-based authorization to a Jupyter notebook, the Leo proxy accepts a
+      summary: Sets a browser cookie needed to authorize connections to a Dataproc
+        cluster
+      description: >
+        If using Google token-based authorization to a cluster, the Leo proxy
+        accepts a
+
         Google token passed as a cookie value. This endpoint facilitates setting that cookie.
+
         It accepts a bearer token in an Authorization header and responds with a Set-Cookie header.
       operationId: setCookie
       tags:
-        - notebooks
+        - proxy
       parameters:
         - in: path
           name: googleProject
@@ -150,38 +163,49 @@ paths:
           required: true
           type: string
       responses:
-        '204':
+        "204":
           description: Successfully set a cookie
-        '401':
+        "401":
           description: Proxy connection unauthorized
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '404':
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "404":
           description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
+        "500":
           description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
 
-  '/notebooks/invalidateToken':
+  /proxy/invalidateToken:
     get:
-      summary: (Deprecated) Invalidates a token
-      description: |
-        If using Google token-based auth, call this endpoint when a user's Google token is invalidated
+      summary: Invalidates a token
+      description: >
+        If using Google token-based auth, call this endpoint when a user's
+        Google token is invalidated
+
         (e.g. when logging out of the application). This ensures that the token is also invalidated in Leo
-        and that the user's proxied notebook connections stop working.
+
+        and that the user's proxied connections stop working.
       operationId: invalidateToken
       tags:
-        - notebooks
+        - proxy
       responses:
-        '200':
+        "200":
           description: Successfully invalidated a token
-        '500':
+        "500":
           description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
+          content:
+            application/json:
+              schema:
+                $ref: "#/definitions/ErrorReport"
 
 ##########################################################################################
 ## Subset of the Welder API

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -77,22 +77,10 @@ paths:
           description: User does not have permission to perform action on runtime
         "404":
           description: Runtime not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "409":
           description: Runtime cannot be stopped
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "500":
           description: Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
   /api/google/v1/runtimes/{googleProject}/{name}/start:
     post:
       summary: Starts a Dataproc cluster or Google Compute Engine instance
@@ -118,22 +106,10 @@ paths:
           description: User does not have permission to perform action on runtime
         "404":
           description: Runtime not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "409":
           description: Runtime cannot be started
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "500":
           description: Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
 
   "/proxy/{googleProject}/{runtimeName}/setCookie":
     get:
@@ -164,22 +140,10 @@ paths:
           description: Successfully set a cookie
         "401":
           description: Proxy connection unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "404":
           description: Runtime not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
         "500":
           description: Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
 
   /proxy/invalidateToken:
     get:
@@ -199,10 +163,6 @@ paths:
           description: Successfully invalidated a token
         "500":
           description: Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/definitions/ErrorReport"
 
 ##########################################################################################
 ## Subset of the Welder API

--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -18,8 +18,6 @@ basePath: /
 produces:
   - application/json
 tags:
-  - name: notebooks
-    description: Notebooks Welder API
   - name: runtimes
     description: Runtimes API
   - name: proxy
@@ -185,7 +183,7 @@ paths:
       summary: ''
       operationId: welderLocalize
       tags:
-        - notebooks
+        - proxy
       parameters:
         - in: body
           description: ''
@@ -216,7 +214,7 @@ paths:
       summary: 'creates the specified storage link configuration for the runtime'
       operationId: welderCreateStorageLink
       tags:
-        - notebooks
+        - proxy
       parameters:
         - in: body
           description: ''

--- a/ui/src/app/pages/analysis/notebook-redirect.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.spec.tsx
@@ -6,12 +6,12 @@ import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, queryParamsStore, serverConfigStore, urlParamsStore, userProfileStore} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 import {RuntimeApi, RuntimeStatus, WorkspaceAccessLevel} from 'generated/fetch';
-import {ClusterApi as NotebooksClusterApi, JupyterApi, NotebooksApi} from 'notebooks-generated/fetch';
+import {RuntimesApi as LeoRuntimesApi, JupyterApi, NotebooksApi} from 'notebooks-generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {JupyterApiStub} from 'testing/stubs/jupyter-api-stub';
 import {NotebooksApiStub} from 'testing/stubs/notebooks-api-stub';
-import {NotebooksClusterApiStub} from 'testing/stubs/notebooks-cluster-api-stub';
+import {LeoRuntimesApiStub} from 'testing/stubs/leo-runtimes-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
 
@@ -52,7 +52,7 @@ describe('NotebookRedirect', () => {
     registerApiClient(RuntimeApi, runtimeStub);
     registerApiClientNotebooks(JupyterApi, new JupyterApiStub());
     registerApiClientNotebooks(NotebooksApi, new NotebooksApiStub());
-    registerApiClientNotebooks(NotebooksClusterApi, new NotebooksClusterApiStub());
+    registerApiClientNotebooks(LeoRuntimesApi, new LeoRuntimesApiStub());
 
     serverConfigStore.next({gsuiteDomain: 'x'});
     urlParamsStore.next({

--- a/ui/src/app/pages/analysis/notebook-redirect.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.spec.tsx
@@ -6,11 +6,11 @@ import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, queryParamsStore, serverConfigStore, urlParamsStore, userProfileStore} from 'app/utils/navigation';
 import {Kernels} from 'app/utils/notebook-kernels';
 import {RuntimeApi, RuntimeStatus, WorkspaceAccessLevel} from 'generated/fetch';
-import {RuntimesApi as LeoRuntimesApi, JupyterApi, NotebooksApi} from 'notebooks-generated/fetch';
+import {RuntimesApi as LeoRuntimesApi, JupyterApi, ProxyApi} from 'notebooks-generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {JupyterApiStub} from 'testing/stubs/jupyter-api-stub';
-import {NotebooksApiStub} from 'testing/stubs/notebooks-api-stub';
+import {ProxyApiStub} from 'testing/stubs/proxy-api-stub';
 import {LeoRuntimesApiStub} from 'testing/stubs/leo-runtimes-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces-api-stub';
@@ -51,7 +51,7 @@ describe('NotebookRedirect', () => {
 
     registerApiClient(RuntimeApi, runtimeStub);
     registerApiClientNotebooks(JupyterApi, new JupyterApiStub());
-    registerApiClientNotebooks(NotebooksApi, new NotebooksApiStub());
+    registerApiClientNotebooks(ProxyApi, new ProxyApiStub());
     registerApiClientNotebooks(LeoRuntimesApi, new LeoRuntimesApiStub());
 
     serverConfigStore.next({gsuiteDomain: 'x'});

--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -12,7 +12,7 @@ import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {Spinner} from 'app/components/spinners';
 import {NotebookIcon} from 'app/icons/notebook-icon';
 import {ReminderIcon} from 'app/icons/reminder';
-import {jupyterApi, notebooksApi} from 'app/services/notebooks-swagger-fetch-clients';
+import {jupyterApi, proxyApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
@@ -275,7 +275,7 @@ export const NotebookRedirect = fp.flow(withUserProfile(), withCurrentWorkspace(
     }
 
     private async initializeNotebookCookies(c: Runtime) {
-      return await this.runtimeRetry(() => notebooksApi().setCookie(c.googleProject, c.runtimeName, {
+      return await this.runtimeRetry(() => proxyApi().setCookie(c.googleProject, c.runtimeName, {
         withCredentials: true,
         crossDomain: true,
         credentials: 'include',

--- a/ui/src/app/services/notebooks-swagger-fetch-clients.ts
+++ b/ui/src/app/services/notebooks-swagger-fetch-clients.ts
@@ -8,11 +8,11 @@
 
 import {
   BaseAPI,
-  RuntimesApi,
   Configuration as FetchConfiguration,
   FetchAPI,
   JupyterApi,
-  ProxyApi
+  ProxyApi,
+  RuntimesApi
 } from 'notebooks-generated/fetch';
 
 let frozen = false;

--- a/ui/src/app/services/notebooks-swagger-fetch-clients.ts
+++ b/ui/src/app/services/notebooks-swagger-fetch-clients.ts
@@ -8,11 +8,11 @@
 
 import {
   BaseAPI,
-  ClusterApi,
+  RuntimesApi,
   Configuration as FetchConfiguration,
   FetchAPI,
   JupyterApi,
-  NotebooksApi
+  ProxyApi
 } from 'notebooks-generated/fetch';
 
 let frozen = false;
@@ -43,9 +43,9 @@ function bindCtor<T extends BaseAPI>(ctor: new() => T): () => T {
 }
 
 // To add a new service, add a new entry below. Note that these properties are
-// getters for the API clients, e.g.: clusterApi().listClusters();
-export const notebooksClusterApi = bindCtor(ClusterApi);
-export const notebooksApi = bindCtor(NotebooksApi);
+// getters for the API clients, e.g.: leoRuntimesApi().listRuntimes();
+export const leoRuntimesApi = bindCtor(RuntimesApi);
+export const proxyApi = bindCtor(ProxyApi);
 export const jupyterApi = bindCtor(JupyterApi);
 
 export function bindApiClients(conf: FetchConfiguration, f: FetchAPI) {

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {notebooksClusterApi, registerApiClient as registerApiClientNotebooks} from 'app/services/notebooks-swagger-fetch-clients';
+import {leoRuntimesApi, registerApiClient as registerApiClientNotebooks} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi, registerApiClient} from 'app/services/swagger-fetch-clients';
 import {LeoRuntimeInitializer, LeoRuntimeInitializerOptions} from 'app/utils/leo-runtime-initializer';
 import {Runtime} from 'generated/fetch';
@@ -8,14 +8,14 @@ import {RuntimeStatus} from 'generated/fetch';
 import {RuntimeApi} from 'generated/fetch/api';
 import SpyInstance = jest.SpyInstance;
 import expect = jest.Expect;
-import {ClusterApi as NotebooksClusterApi} from 'notebooks-generated/fetch';
+import {RuntimesApi as LeoRuntimesApi} from 'notebooks-generated/fetch';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
-import {NotebooksClusterApiStub} from 'testing/stubs/notebooks-cluster-api-stub';
+import {LeoRuntimesApiStub} from 'testing/stubs/leo-runtimes-api-stub';
 
 let mockGetRuntime: SpyInstance;
 let mockCreateRuntime: SpyInstance;
 let mockDeleteRuntime: SpyInstance;
-let mockStartCluster: SpyInstance;
+let mockStartRuntime: SpyInstance;
 
 const baseRuntime: Runtime = {
   runtimeName: 'aou-rw-3',
@@ -30,12 +30,12 @@ describe('RuntimeInitializer', () => {
     jest.useFakeTimers();
 
     registerApiClient(RuntimeApi, new RuntimeApiStub());
-    registerApiClientNotebooks(NotebooksClusterApi, new NotebooksClusterApiStub());
+    registerApiClientNotebooks(LeoRuntimesApi, new LeoRuntimesApiStub());
 
     mockGetRuntime = jest.spyOn(runtimeApi(), 'getRuntime');
     mockCreateRuntime = jest.spyOn(runtimeApi(), 'createRuntime');
     mockDeleteRuntime = jest.spyOn(runtimeApi(), 'deleteRuntime');
-    mockStartCluster = jest.spyOn(notebooksClusterApi(), 'startCluster');
+    mockStartRuntime = jest.spyOn(leoRuntimesApi(), 'startRuntime');
   });
 
   afterEach(() => {
@@ -111,7 +111,7 @@ describe('RuntimeInitializer', () => {
       {status: RuntimeStatus.Running}
     ]);
     const runtime = await runInitializerAndTimers();
-    expect(mockStartCluster).toHaveBeenCalled();
+    expect(mockStartRuntime).toHaveBeenCalled();
     expect(runtime.status).toEqual(RuntimeStatus.Running);
   });
 

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -1,4 +1,4 @@
-import {notebooksClusterApi} from 'app/services/notebooks-swagger-fetch-clients';
+import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import {isAbortError, reportError} from 'app/utils/errors';
 import {Runtime, RuntimeStatus} from 'generated/fetch';
@@ -183,8 +183,7 @@ export class LeoRuntimeInitializer {
       throw new ExceededActionCountError(
         `Reached max runtime resume count (${this.maxResumeCount})`, this.currentRuntime);
     }
-    // TODO(calbach): Convert this usage to the new OAS3 Leo API.
-    await notebooksClusterApi().startCluster(
+    await leoRuntimesApi().startRuntime(
       this.currentRuntime.googleProject, this.currentRuntime.runtimeName, {signal: this.abortSignal});
     this.resumeCount++;
   }

--- a/ui/src/testing/stubs/leo-runtimes-api-stub.ts
+++ b/ui/src/testing/stubs/leo-runtimes-api-stub.ts
@@ -1,7 +1,7 @@
-import {ClusterApi} from 'notebooks-generated/fetch';
+import {RuntimesApi} from 'notebooks-generated/fetch';
 
 
-export class NotebooksClusterApiStub extends ClusterApi {
+export class LeoRuntimesApiStub extends RuntimesApi {
 
   constructor() {
     super(undefined, undefined, (..._: any[]) => {
@@ -9,7 +9,7 @@ export class NotebooksClusterApiStub extends ClusterApi {
     });
   }
 
-  public startCluster(googleProject: string, clusterName: string,
+  public startRuntime(googleProject: string, runtimeName: string,
     extraHttpRequestParams?: any): Promise<Response> {
     return new Promise<Response>(resolve => {
       resolve(new Response());

--- a/ui/src/testing/stubs/proxy-api-stub.ts
+++ b/ui/src/testing/stubs/proxy-api-stub.ts
@@ -1,6 +1,6 @@
-import {NotebooksApi} from 'notebooks-generated/fetch';
+import {ProxyApi} from 'notebooks-generated/fetch';
 
-export class NotebooksApiStub extends NotebooksApi {
+export class ProxyApiStub extends ProxyApi {
 
   constructor() {
     super(undefined, undefined, (..._: any[]) => {
@@ -8,7 +8,7 @@ export class NotebooksApiStub extends NotebooksApi {
     });
   }
 
-  public setCookie(googleProject: string, clusterName: string, options?: any): Promise<Response> {
+  public setCookie(googleProject: string, runtimeName: string, options?: any): Promise<Response> {
     return new Promise<Response>(resolve => {
       resolve(new Response());
     });


### PR DESCRIPTION
(part 4 of ??)

Depends on #3934 

I considered migrating these to OAS3, but realized I'd need to generate a new set of codegen targets and corresponding boilerplate and also bring in the swagger3 codegen CLI. This didn't seem worth the effort, so instead I downgraded these 4 simple APIs to swagger2, which was a straightforward transformation.

- Upgrade cluster APIs to new Runtime variants
- Upgrade deprecated notebooks APIs --> newer "proxy" variants
- Relabeled Welder endpoints under `proxy` for consistency