### PR TITLE
[RW-5474][risk=no] Modify RandomizeVCF to take in a list of sample names

### DIFF
--- a/api/genomics/src/test/java/org/pmiops/workbench/genomics/RandomizeVcfTest.java
+++ b/api/genomics/src/test/java/org/pmiops/workbench/genomics/RandomizeVcfTest.java
@@ -3,10 +3,11 @@ package org.pmiops.workbench.genomics;
 import static com.google.common.truth.Truth.assertThat;
 
 import htsjdk.variant.variantcontext.Allele;
-import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import org.junit.Test;
@@ -16,7 +17,9 @@ public class RandomizeVcfTest {
       new VCFFileReader(new File("src/test/resources/NA12878_204126160130_R01C01.toy.vcf.gz"));
   private static final Random random = new Random(0);
   private static final VariantContext variantContext = reader.iterator().next();
-  private static final RandomizeVcf randomizeVcf = new RandomizeVcf(2, random);
+
+  private static final List<String> sampleNames = Arrays.asList("sn1", "sn2");
+  private static final RandomizeVcf randomizeVcf = new RandomizeVcf(sampleNames, random);
 
   @Test
   public void testRandomizeVariant() {
@@ -26,6 +29,9 @@ public class RandomizeVcfTest {
     // ...is that allele from the bank of possible alleles at that position?
     // ignoring ref/var
     assertThat(randomizedVariant.getGenotypes().size()).isEqualTo(2);
+    assertThat(randomizedVariant.getGenotypes().getSampleNames())
+        .isEqualTo(new HashSet<>(sampleNames));
+
     randomizedVariant.getGenotypes().stream()
         .flatMap(genotype -> genotype.getAlleles().stream())
         .forEach(
@@ -34,13 +40,6 @@ public class RandomizeVcfTest {
                         variantContext.getAlleles().stream()
                             .anyMatch(vcAllele -> vcAllele.basesMatch(allele)))
                     .isTrue());
-  }
-
-  @Test
-  public void testRandomizeGenotypes() {
-    Genotype genotype = variantContext.getGenotype(0);
-    Genotype randomizedGenotype = randomizeVcf.randomizeGenotype(variantContext, genotype, 0);
-    assertThat(randomizedGenotype.getSampleName()).isNotEqualTo(genotype.getSampleName());
   }
 
   @Test

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2629,9 +2629,9 @@ def randomize_vcf(cmd_name, *args)
           "by running tabix -p vcf [vcf path]"
   )
   op.add_option(
-      "--number-of-copies [n]",
-      -> (opts, n) {opts.n = n},
-      "How many random vcfs to generate."
+      "--sample-names-file [sn]",
+      -> (opts, sn) {opts.sn = sn},
+      "File containing newline separated sample names"
   )
   op.add_option(
       "--output-path [out]",
@@ -2641,7 +2641,7 @@ def randomize_vcf(cmd_name, *args)
   op.parse.validate
 
   basename = File.basename(op.opts.vcf, ".vcf.gz")
-  app_args = "-PappArgs=['-V#{op.opts.vcf}','-O#{op.opts.out}','-N#{op.opts.n}']"
+  app_args = "-PappArgs=['-V#{op.opts.vcf}','-O#{op.opts.out}','--sample-names', '#{op.opts.sn}']"
   Common.new.run_inline %W{./gradlew -p genomics randomizeVcf} + [app_args]
 end
 


### PR DESCRIPTION
Example invocation: `./project.rb randomize-vcf --vcf ~/broad/variantstore/NA12878_204126160130_R01C01.vcf --sample-names-file ~/broad/workbench/api/sample_names.txt --output-path /mnt/genomics/randomized.vcf`
Created from Mob session

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
