### PR TITLE
[no ticket][risk=no] Puppeteer: workspace pages improvement

### DIFF
--- a/e2e/app/component/data-resource-card.ts
+++ b/e2e/app/component/data-resource-card.ts
@@ -2,20 +2,13 @@ import {ElementHandle, Page} from 'puppeteer';
 import * as fp from 'lodash/fp';
 import {waitWhileLoading} from 'utils/test-utils';
 import {getPropValue} from 'utils/element-utils';
+import {ResourceCard} from 'app/text-labels';
 import CardBase from './card-base';
 
 const DataResourceCardSelector = {
   cardRootXpath: '//*[@data-test-id="card"]',
   cardNameXpath: '@data-test-id="card-name"',
   cardTypeXpath: './/*[@data-test-id="card-type"]',
-}
-
-export enum CardType {
-  Cohort = 'Cohort',
-  ConceptSet = 'Concept Set',
-  Notebook = 'Notebook',
-  Dataset = 'Dataset',
-  CohortReview = 'Cohort Review',
 }
 
 /**
@@ -77,7 +70,7 @@ export default class DataResourceCard extends CardBase {
     super(page);
   }
 
-  async findCard(resourceName: string, cardType?: CardType): Promise<DataResourceCard | null> {
+  async findCard(resourceName: string, cardType?: ResourceCard): Promise<DataResourceCard | null> {
     const selector = `.//*[${DataResourceCardSelector.cardNameXpath} and normalize-space(text())="${resourceName}"]`;
     let elements: DataResourceCard[];
     if (cardType === undefined) {
@@ -114,7 +107,7 @@ export default class DataResourceCard extends CardBase {
     return element;
   }
 
-  async getResourceCard(cardType: CardType = CardType.Cohort): Promise<DataResourceCard[]> {
+  async getResourceCard(cardType: ResourceCard = ResourceCard.Cohort): Promise<DataResourceCard[]> {
     const matchArray: DataResourceCard[] = [];
     const allCards = await DataResourceCard.findAllCards(this.page);
     for (const card of allCards) {
@@ -143,7 +136,7 @@ export default class DataResourceCard extends CardBase {
    * @param {string} cardName
    * @param {CardType} cardType
    */
-  async cardExists(cardName: string, cardType: CardType):  Promise<boolean> {
+  async cardExists(cardName: string, cardType: ResourceCard):  Promise<boolean> {
     const cards = await this.getResourceCard(cardType);
     const names = await Promise.all(cards.map(item => item.getResourceName()));
     const filterdList = names.filter(name => name === cardName);

--- a/e2e/app/component/share-modal.ts
+++ b/e2e/app/component/share-modal.ts
@@ -25,6 +25,7 @@ export default class ShareModal extends Modal {
     await ownerOpt.click();
 
     await this.clickButton(LinkText.Save, {waitForClose: true});
+    console.log(`Shared workspace to user ${username} with role ${level}`);
   }
 
   async removeUser(username: string): Promise<void> {

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -1,7 +1,7 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {WorkspaceAccessLevel} from 'app/text-labels';
 import * as fp from 'lodash/fp';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {getPropValue} from 'utils/element-utils';
 import CardBase from './card-base';
 
@@ -125,7 +125,7 @@ export default class WorkspaceCard extends CardBase {
       elemt.click(),
     ]);
     if (waitForDataPage) {
-      const dataPage = new DataPage(this.page);
+      const dataPage = new WorkspaceDataPage(this.page);
       await dataPage.waitForLoad();
     }
     return name;

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -2,7 +2,7 @@ import {Frame, Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import {CardType} from 'app/component/data-resource-card';
+import {ResourceCard} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 import NotebookCell, {CellType} from './notebook-cell';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
@@ -187,7 +187,7 @@ export default class NotebookPage extends AuthenticatedPage {
    */
   async deleteNotebook(notebookName: string): Promise<void> {
     const analysisPage = await this.goAnalysisPage();
-    await analysisPage.deleteResource(notebookName, CardType.Notebook);
+    await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   }
 
   private async getIFrame(): Promise<Frame> {

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -2,6 +2,7 @@ import {Frame, Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
+import {CardType} from 'app/component/data-resource-card';
 import AuthenticatedPage from './authenticated-page';
 import NotebookCell, {CellType} from './notebook-cell';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
@@ -186,7 +187,7 @@ export default class NotebookPage extends AuthenticatedPage {
    */
   async deleteNotebook(notebookName: string): Promise<void> {
     const analysisPage = await this.goAnalysisPage();
-    await analysisPage.deleteNotebook(notebookName);
+    await analysisPage.deleteResource(notebookName, CardType.Notebook);
   }
 
   private async getIFrame(): Promise<Frame> {

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -2,7 +2,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
-import {TabLabelAlias, WorkspaceAccessLevel} from 'app/text-labels';
+import {TabLabel, WorkspaceAccessLevel} from 'app/text-labels';
 import {ElementType} from 'app/xpath-options';
 import {getPropValue} from 'utils/element-utils';
 import Button from 'app/element/button';
@@ -22,7 +22,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
       await Promise.all([
         waitForDocumentTitle(this.page, PageTitle),
         waitWhileLoading(this.page),
-        this.page.waitForXPath(buildXPath({name: TabLabelAlias.About, type: ElementType.Tab})),
+        this.page.waitForXPath(buildXPath({name: TabLabel.About, type: ElementType.Tab})),
       ]);
       return true;
     } catch (err) {
@@ -32,7 +32,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
   }
 
   async isOpen(): Promise<boolean> {
-    const selector = buildXPath({name: TabLabelAlias.About, type: ElementType.Tab});
+    const selector = buildXPath({name: TabLabel.About, type: ElementType.Tab});
     return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
   }
 

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -2,17 +2,16 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
-import {WorkspaceAccessLevel} from 'app/text-labels';
+import {TabLabelAlias, WorkspaceAccessLevel} from 'app/text-labels';
 import {ElementType} from 'app/xpath-options';
 import {getPropValue} from 'utils/element-utils';
-import AuthenticatedPage from './authenticated-page';
-import {TabLabelAlias} from './data-page';
 import Button from 'app/element/button';
 import ShareModal from 'app/component/share-modal';
+import WorkspaceBase from './workspace-base';
 
 export const PageTitle = 'View Workspace Details';
 
-export default class WorkspaceAboutPage extends AuthenticatedPage{
+export default class WorkspaceAboutPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -8,13 +8,13 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
-import AuthenticatedPage from './authenticated-page';
 import CopyModal from 'app/component/copy-modal';
 import NotebookPage from './notebook-page';
+import WorkspaceBase from './workspace-base';
 
 const PageTitle = 'View Notebooks';
 
-export default class WorkspaceAnalysisPage extends AuthenticatedPage {
+export default class WorkspaceAnalysisPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -33,24 +33,6 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     }
   }
 
-   /**
-    * Delete notebook thru Ellipsis menu located inside the Notebook resource card.
-    * @param {string} notebookName
-    */
-  async deleteNotebook(notebookName: string): Promise<string[]> {
-    const resourceCard = await DataResourceCard.findCard(this.page, notebookName);
-    await resourceCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalContentText = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteNotebook, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Notebook "${notebookName}"`);
-    await this.waitForLoad();
-    return modalContentText;
-  }
-
   /**
    * Create a new notebook.
    * - Click "Create a New Notebook" link in Analysis page.

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -1,9 +1,9 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import NewNotebookModal from 'app/component/new-notebook-modal';
 import Link from 'app/element/link';
 import Textbox from 'app/element/textbox';
-import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, ResourceCard} from 'app/text-labels';
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
@@ -110,7 +110,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
    */
   async duplicateNotebook(notebookName: string): Promise<string> {
     const resourceCard = new DataResourceCard(this.page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickEllipsisAction(EllipsisMenuAction.Duplicate, {waitForNav: false});
     await waitWhileLoading(this.page);
     return `Duplicate of ${notebookName}`; // name of clone notebook
@@ -125,7 +125,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   async copyNotebookToWorkspace(notebookName: string, destinationWorkspace: string, destinationNotebookName?: string): Promise<void> {
     // Open Copy modal.s
     const resourceCard = new DataResourceCard(this.page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickEllipsisAction(EllipsisMenuAction.CopyToAnotherWorkspace, {waitForNav: false});
     // Fill out modal fields.
     const copyModal = await new CopyModal(this.page);

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -1,11 +1,11 @@
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import Link from 'app/element/link';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
-import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 
 
@@ -33,7 +33,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Delete ConceptSet, Dataset or Cohort thru Ellipsis menu located inside the resource card.
    * @param {string} resourceName
    */
-  async deleteResource(resourceName: string, resourceType: CardType): Promise<string[]> {
+  async deleteResource(resourceName: string, resourceType: ResourceCard): Promise<string[]> {
     const resourceCard = new DataResourceCard(this.page);
     const card = await resourceCard.findCard(resourceName, resourceType);
     if (!card) {
@@ -48,16 +48,16 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
     let link;
     switch (resourceType) {
-    case CardType.Cohort:
+    case ResourceCard.Cohort:
       link = LinkText.DeleteCohort;
       break;
-    case CardType.ConceptSet:
+    case ResourceCard.ConceptSet:
       link = LinkText.DeleteConceptSet;
       break;
-    case CardType.Dataset:
+    case ResourceCard.Dataset:
       link = LinkText.DeleteDataset;
       break;
-    case CardType.Notebook:
+    case ResourceCard.Notebook:
       link = LinkText.DeleteNotebook;
       break;
     default:

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -1,0 +1,56 @@
+import {Page} from 'puppeteer';
+import {waitWhileLoading} from 'utils/test-utils';
+import DataResourceCard, {CardType} from '../component/data-resource-card';
+import Modal from '../component/modal';
+import Link from '../element/link';
+import {buildXPath} from 'app/xpath-builders';
+import {ElementType} from 'app/xpath-options';
+import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
+import AuthenticatedPage from './authenticated-page';
+
+
+export default abstract class WorkspaceBase extends AuthenticatedPage {
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Select DATA, ANALYSIS or ABOUT page tab.
+   * @param {TabLabelAlias} tabName
+   * @param opts
+   */
+  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    const { waitPageChange = true } = opts;
+    const selector = buildXPath({name: tabName, type: ElementType.Tab});
+    const tab = new Link(this.page, selector);
+    waitPageChange ? await tab.clickAndWait() : await tab.click();
+    await tab.dispose();
+    return waitWhileLoading(this.page);
+  }
+
+  /**
+   * Delete ConceptSet, Dataset or Cohort thru Ellipsis menu located inside the resource card.
+   * @param {string} resourceName
+   */
+  async deleteResource(resourceName: string, resourceType: CardType): Promise<string[]> {
+    const resourceCard = new DataResourceCard(this.page);
+    const card = await resourceCard.findCard(resourceName, resourceType);
+    if (!card) {
+      throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
+    }
+
+    const menu = card.getEllipsis();
+    await menu.clickAction(EllipsisMenuAction.Delete, {waitForNav: false});
+
+    const modal = new Modal(this.page);
+    const modalTextContent = await modal.getTextContent();
+    await modal.clickButton(LinkText.DeleteConceptSet, {waitForClose: true});
+    await waitWhileLoading(this.page);
+
+    console.log(`Deleted Concept Set "${resourceName}"`);
+    return modalTextContent;
+  }
+
+
+}

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -5,7 +5,7 @@ import Modal from 'app/component/modal';
 import Link from 'app/element/link';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
-import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 
 
@@ -17,10 +17,10 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
   /**
    * Select DATA, ANALYSIS or ABOUT page tab.
-   * @param {TabLabelAlias} tabName
+   * @param {TabLabel} tabName
    * @param opts
    */
-  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+  async openTab(tabName: TabLabel, opts: {waitPageChange?: boolean} = {}): Promise<void> {
     const { waitPageChange = true } = opts;
     const selector = buildXPath({name: tabName, type: ElementType.Tab});
     const tab = new Link(this.page, selector);

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -1,11 +1,11 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import {EllipsisMenuAction, Language, LinkText, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
@@ -80,7 +80,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    */
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
-    const datasetCard = await resourceCard.findCard(datasetName, CardType.Dataset);
+    const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
     await datasetCard.clickEllipsisAction(EllipsisMenuAction.exportToNotebook, {waitForNav: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
   }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -3,13 +3,9 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
-import Link from 'app/element/link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import AuthenticatedPage from 'app/page/authenticated-page';
-import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
-import {buildXPath} from 'app/xpath-builders';
-import {ElementType} from 'app/xpath-options';
+import {EllipsisMenuAction, Language, LinkText, TabLabelAlias} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
@@ -21,21 +17,11 @@ import ConceptsetSearchPage from './conceptset-search-page';
 import DatasetBuildPage from './dataset-build-page';
 import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
-
-export enum TabLabelAlias {
-  Data = 'Data',
-  Analysis = 'Analysis',
-  About = 'About',
-  Cohorts = 'Cohorts',
-  Datasets = 'Datasets',
-  CohortReviews = 'Cohort Reviews',
-  ConceptSets = 'Concept Sets',
-  ShowAll = 'Show All',
-}
+import WorkspaceBase from './workspace-base';
 
 const PageTitle = 'Data Page';
 
-export default class DataPage extends AuthenticatedPage {
+export default class WorkspaceDataPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);
@@ -65,24 +51,6 @@ export default class DataPage extends AuthenticatedPage {
   async selectWorkspaceAction(action: EllipsisMenuAction): Promise<void> {
     const ellipsisMenu = new EllipsisMenu(this.page, './/*[@data-test-id="workspace-menu-button"]');
     return ellipsisMenu.clickAction(action);
-  }
-
-  /**
-   * Select DATA, ANALYSIS or ABOUT page tab.
-   * @param {TabLabelAlias} tabName
-   * @param opts
-   */
-  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    const {waitPageChange = true} = opts;
-    const selector = buildXPath({name: tabName, type: ElementType.Tab});
-    const tab = new Link(this.page, selector);
-    if (waitPageChange) {
-      await tab.clickAndWait();
-    } else {
-      await tab.click();
-    }
-    await tab.dispose();
-    return waitWhileLoading(this.page);
   }
 
   async getAddDatasetButton(): Promise<ClrIconLink> {

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -5,7 +5,7 @@ import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import {EllipsisMenuAction, Language, LinkText, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, TabLabel} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
@@ -54,11 +54,11 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async getAddDatasetButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Datasets, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: TabLabel.Datasets, iconShape: 'plus-circle'});
   }
 
   async getAddCohortsButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Cohorts, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: TabLabel.Cohorts, iconShape: 'plus-circle'});
   }
 
   // Click Add Datasets button.
@@ -123,8 +123,8 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async findCohortCard(cohortName?: string): Promise<DataResourceCard> {
-    await this.openTab(TabLabelAlias.Data);
-    await this.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await this.openTab(TabLabel.Data);
+    await this.openTab(TabLabel.Cohorts, {waitPageChange: false});
     if (cohortName === undefined) {
       // if cohort name isn't specified, find any existing cohort.
       return DataResourceCard.findAnyCard(this.page);
@@ -184,7 +184,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    * @param {Language} lang The notebook language.
    */
   async createNotebook(notebookName: string, lang: Language = Language.Python): Promise<NotebookPage> {
-    await this.openTab(TabLabelAlias.Analysis);
+    await this.openTab(TabLabel.Analysis);
     const analysisPage = new WorkspaceAnalysisPage(this.page);
     return analysisPage.createNotebook(notebookName, lang);
   }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -86,42 +86,6 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   /**
-   * Delete cohort by look up its name using Ellipsis menu.
-   * @param {string} cohortName
-   */
-  async deleteCohort(cohortName: string): Promise<string[]> {
-    const cohortCard = await DataResourceCard.findCard(this.page, cohortName);
-    if (cohortCard == null) {
-      throw new Error(`Failed to find Cohort: "${cohortName}".`);
-    }
-    await cohortCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-    const modalContent = await (new CohortBuildPage(this.page)).deleteConfirmationDialog();
-    console.log(`Deleted Cohort "${cohortName}"`);
-    return modalContent;
-  }
-
-  /**
-   * Delete Dataset thru Ellipsis menu located inside the Dataset Resource card.
-   * @param {string} datasetName
-   */
-  async deleteDataset(datasetName: string): Promise<string[]> {
-    const datasetCard = await DataResourceCard.findCard(this.page, datasetName);
-    if (datasetCard == null) {
-      throw new Error(`Failed to find Dataset: "${datasetName}".`);
-    }
-    await datasetCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalContentText = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteDataset, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Dataset "${datasetName}"`);
-    await this.waitForLoad();
-    return modalContentText;
-  }
-
-  /**
    * Rename Dataset thru the Ellipsis menu located inside the Dataset Resource card.
    * @param {string} datasetName
    * @param {string} newDatasetName
@@ -142,26 +106,6 @@ export default class WorkspaceDataPage extends WorkspaceBase {
     await waitWhileLoading(this.page);
 
     console.log(`Renamed Dataset "${datasetName}" to "${newDatasetName}"`);
-  }
-
-  /**
-   * Delete ConceptSet thru Ellipsis menu located inside the Concept Set resource card.
-   * @param {string} conceptsetName
-   */
-  async deleteConceptSet(conceptsetName: string): Promise<string[]> {
-    const conceptSetCard = await DataResourceCard.findCard(this.page, conceptsetName);
-    if (conceptSetCard == null) {
-      throw new Error(`Failed to find Concept Set: "${conceptsetName}".`);
-    }
-    await conceptSetCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalTextContent = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteConceptSet, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Concept Set "${conceptsetName}"`);
-    return modalTextContent;
   }
 
   async renameCohort(cohortName: string, newCohortName: string): Promise<void> {

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -7,7 +7,7 @@ import {makeWorkspaceName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
 import {findWorkspace, waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
-import DataPage from './data-page';
+import WorkspaceDataPage from './workspace-data-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 
 const faker = require('faker/locale/en_US');
@@ -149,7 +149,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     const workspaceCard = await findWorkspace(this.page, {workspaceName, create: true});
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(this.page);
+    const dataPage = new WorkspaceDataPage(this.page);
     const notebookPage = await dataPage.createNotebook(notebookName, lang); // Python 3 is the default
 
     // Do not run any code. Simply returns to the Workspace Analysis tab.

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -81,3 +81,11 @@ export enum TabLabel {
    ConceptSets = 'Concept Sets',
    ShowAll = 'Show All',
 }
+
+export enum ResourceCard {
+   Cohort = 'Cohort',
+   ConceptSet = 'Concept Set',
+   Notebook = 'Notebook',
+   Dataset = 'Dataset',
+   CohortReview = 'Cohort Review',
+}

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -70,3 +70,14 @@ export enum Language {
    Python = 'Python',
    R = 'R',
 }
+
+export enum TabLabelAlias {
+   Data = 'Data',
+   Analysis = 'Analysis',
+   About = 'About',
+   Cohorts = 'Cohorts',
+   Datasets = 'Datasets',
+   CohortReviews = 'Cohort Reviews',
+   ConceptSets = 'Concept Sets',
+   ShowAll = 'Show All',
+}

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -71,7 +71,7 @@ export enum Language {
    R = 'R',
 }
 
-export enum TabLabelAlias {
+export enum TabLabel {
    Data = 'Data',
    Analysis = 'Analysis',
    About = 'About',

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -1,13 +1,13 @@
-import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
+import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
-import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
+import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import DataResourceCard from 'app/component/data-resource-card';
-import Button from 'app/element/button';
 
 
 describe('User can create new Cohorts', () => {
@@ -201,14 +201,14 @@ describe('User can create new Cohorts', () => {
     expect(newCardsCount).toBe(origCardsCount + 1);
 
     // Delete duplicated cohort.
-    let modalTextContent = await dataPage.deleteCohort(`Duplicate of ${cohortName}`);
+    let modalTextContent = await dataPage.deleteResource(`Duplicate of ${cohortName}`, CardType.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
 
     // Delete new cohort.
-    modalTextContent = await dataPage.deleteCohort(cohortName);
+    modalTextContent = await dataPage.deleteResource(cohortName, CardType.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
 
   });
 
 
-});
+})

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -1,9 +1,9 @@
 import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
-import {EllipsisMenuAction, LinkText} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -30,7 +30,7 @@ describe('User can create new Cohorts', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Click Add Cohorts button
     const addCohortsButton = await dataPage.getAddCohortsButton();
@@ -118,7 +118,7 @@ describe('User can create new Cohorts', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Save url
     const workspaceDataUrl = page.url();

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -1,11 +1,11 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -201,11 +201,11 @@ describe('User can create new Cohorts', () => {
     expect(newCardsCount).toBe(origCardsCount + 1);
 
     // Delete duplicated cohort.
-    let modalTextContent = await dataPage.deleteResource(`Duplicate of ${cohortName}`, CardType.Cohort);
+    let modalTextContent = await dataPage.deleteResource(`Duplicate of ${cohortName}`, ResourceCard.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
 
     // Delete new cohort.
-    modalTextContent = await dataPage.deleteResource(cohortName, CardType.Cohort);
+    modalTextContent = await dataPage.deleteResource(cohortName, ResourceCard.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
 
   });

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -5,7 +5,7 @@ import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -189,7 +189,7 @@ describe('User can create new Cohorts', () => {
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
-    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openTab(TabLabel.Data);
 
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,9 +1,9 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Link from 'app/element/link';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {TabLabel} from 'app/text-labels';
+import {ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
@@ -100,7 +100,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     expect(await DataResourceCard.findCard(page, newCohortName)).toBeTruthy();
 
     // Delete cohort.
-    const modalTextContent = await dataPage.deleteResource(newCohortName, CardType.Cohort);
+    const modalTextContent = await dataPage.deleteResource(newCohortName, ResourceCard.Cohort);
 
     // Verify Delete dialog content text
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,11 +1,12 @@
 import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
 import {makeRandomName} from 'utils/str-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
+import {TabLabelAlias} from '../../app/text-labels';
 
 
 describe('User can create, modify, rename and delete Cohort', () => {
@@ -31,7 +32,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     // Click Add Cohorts button in Data page.
     await dataPage.getAddCohortsButton().then((butn) => butn.clickAndWait());
 

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,12 +1,12 @@
+import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Link from 'app/element/link';
+import CohortActionsPage from 'app/page/cohort-actions-page';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {TabLabelAlias} from 'app/text-labels';
+import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
-import DataResourceCard from 'app/component/data-resource-card';
-import {makeRandomName} from 'utils/str-utils';
-import CohortActionsPage from 'app/page/cohort-actions-page';
-import {TabLabelAlias} from '../../app/text-labels';
 
 
 describe('User can create, modify, rename and delete Cohort', () => {
@@ -100,7 +100,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     expect(await DataResourceCard.findCard(page, newCohortName)).toBeTruthy();
 
     // Delete cohort.
-    const modalTextContent = await dataPage.deleteCohort(newCohortName);
+    const modalTextContent = await dataPage.deleteResource(newCohortName, CardType.Cohort);
 
     // Verify Delete dialog content text
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -3,7 +3,7 @@ import Link from 'app/element/link';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {TabLabelAlias} from 'app/text-labels';
+import {TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
@@ -89,8 +89,8 @@ describe('User can create, modify, rename and delete Cohort', () => {
     const cohortActionsPage = new CohortActionsPage(page);
     await cohortActionsPage.waitForLoad();
 
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Data);
+    await dataPage.openTab(TabLabel.Cohorts, {waitPageChange: false});
 
     // Rename cohort.
     const newCohortName = makeRandomName();

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -4,7 +4,7 @@ import CohortBuildPage from 'app/page/cohort-build-page';
 import CohortParticipantDetailPage from 'app/page/cohort-participant-detail-page';
 import CohortReviewModal from 'app/page/cohort-review-modal';
 import CohortReviewPage from 'app/page/cohort-review-page';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {waitForText} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
 
@@ -27,7 +27,7 @@ describe('Cohort review tests', () => {
 
     await findWorkspace(page).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const cohortCard = await dataPage.createCohort();
     const cohortName = await cohortCard.getResourceName();
     console.log(`Created Cohort: "${cohortName}"`);

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
-import {TabLabelAlias} from '../../app/text-labels';
+import {TabLabel} from '../../app/text-labels';
 
 describe('Cohorts UI tests', () => {
 
@@ -54,7 +54,7 @@ describe('Cohorts UI tests', () => {
     const exportButton = await cohortPage.getExportButton();
     expect(await exportButton.isDisabled()).toBe(true);
 
-    await dataPage.openTab(TabLabelAlias.About, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.About, {waitPageChange: false});
 
     // Don't save. Confirm Discard Changes
     const modalTextContent = await cohortPage.discardChangesConfirmationDialog();

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -1,9 +1,10 @@
 import {PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
+import {TabLabelAlias} from '../../app/text-labels';
 
 describe('Cohorts UI tests', () => {
 
@@ -22,7 +23,7 @@ describe('Cohorts UI tests', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     const addCohortsButton = await dataPage.getAddCohortsButton();
     await addCohortsButton.clickAndWait();

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,8 +1,8 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {TabLabel} from 'app/text-labels';
+import {ResourceCard, TabLabel} from 'app/text-labels';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -70,7 +70,7 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openTab(TabLabel.Data);
     await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
 
-    const modalTextContent = await dataPage.deleteResource(conceptName, CardType.ConceptSet);
+    const modalTextContent = await dataPage.deleteResource(conceptName, ResourceCard.ConceptSet);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
   });
 
@@ -153,18 +153,18 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Delete Dataset.
-    const textContent = await dataPage.deleteResource(datasetName, CardType.Dataset);
+    const textContent = await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
     await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
 
-    await dataPage.deleteResource(conceptName1, CardType.ConceptSet);
-    await dataPage.deleteResource(conceptName2, CardType.ConceptSet);
+    await dataPage.deleteResource(conceptName1, ResourceCard.ConceptSet);
+    await dataPage.deleteResource(conceptName2, ResourceCard.ConceptSet);
   });
 
 });

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -2,7 +2,7 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {TabLabelAlias} from 'app/text-labels';
+import {TabLabel} from 'app/text-labels';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -67,8 +67,8 @@ describe('Create Concept Sets from Domains', () => {
     console.log(`Created Concept Set "${conceptName}"`);
 
     // Delete Concept Set
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Data);
+    await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
 
     const modalTextContent = await dataPage.deleteResource(conceptName, CardType.ConceptSet);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
@@ -149,8 +149,8 @@ describe('Create Concept Sets from Domains', () => {
     const datasetName = await saveModal.saveDataset();
 
     // Verify Dataset created successful.
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Data);
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
@@ -161,7 +161,7 @@ describe('Create Concept Sets from Domains', () => {
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
 
     await dataPage.deleteResource(conceptName1, CardType.ConceptSet);
     await dataPage.deleteResource(conceptName2, CardType.ConceptSet);

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -2,9 +2,9 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {TabLabelAlias} from 'app/text-labels';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import {TabLabelAlias} from 'app/text-labels';
 
 describe('Create Concept Sets from Domains', () => {
 
@@ -70,7 +70,7 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openTab(TabLabelAlias.Data);
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
 
-    const modalTextContent = await dataPage.deleteConceptSet(conceptName);
+    const modalTextContent = await dataPage.deleteResource(conceptName, CardType.ConceptSet);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
   });
 
@@ -157,14 +157,14 @@ describe('Create Concept Sets from Domains', () => {
     expect(dataSetExists).toBe(true);
 
     // Delete Dataset.
-    const textContent = await dataPage.deleteDataset(datasetName);
+    const textContent = await dataPage.deleteResource(datasetName, CardType.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
 
-    await dataPage.deleteConceptSet(conceptName1);
-    await dataPage.deleteConceptSet(conceptName2);
+    await dataPage.deleteResource(conceptName1, CardType.ConceptSet);
+    await dataPage.deleteResource(conceptName2, CardType.ConceptSet);
   });
 
 });

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,9 +1,10 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
+import {TabLabelAlias} from 'app/text-labels';
 
 describe('Create Concept Sets from Domains', () => {
 
@@ -21,7 +22,7 @@ describe('Create Concept Sets from Domains', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     // Click Add Concept Sets button.
@@ -85,7 +86,7 @@ describe('Create Concept Sets from Domains', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     // Start: Create new Concept Set 1

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -1,11 +1,11 @@
 import {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceCard from 'app/component/workspace-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {LinkText, TabLabel} from 'app/text-labels';
+import {LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import Link from 'app/element/link';
@@ -89,7 +89,7 @@ describe('Editing and Copying Concept Sets', () => {
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
     await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
-    await dataPage.deleteResource(newName, CardType.ConceptSet);
+    await dataPage.deleteResource(newName, ResourceCard.ConceptSet);
   });
 
   /**
@@ -143,13 +143,13 @@ describe('Editing and Copying Concept Sets', () => {
     expect(url).toContain(copyToWorkspace.replace(/-/g, ''));
 
     const resourceCard = new DataResourceCard(page);
-    const exists = await resourceCard.cardExists(conceptSetCopyName, CardType.ConceptSet);
+    const exists = await resourceCard.cardExists(conceptSetCopyName, ResourceCard.ConceptSet);
     expect(exists).toBe(true);
 
     console.log(`Copied Concept Set: "${conceptName} from workspace: "${copyFromWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${copyToWorkspace}"`)
 
     // Delete Concept Sets
-    await dataPage.deleteResource(conceptSetCopyName, CardType.ConceptSet);
+    await dataPage.deleteResource(conceptSetCopyName, ResourceCard.ConceptSet);
   });
 
 

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -4,8 +4,8 @@ import WorkspaceCard from 'app/component/workspace-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import {LinkText} from 'app/text-labels';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {LinkText, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import Link from 'app/element/link';
@@ -27,7 +27,7 @@ describe('Editing and Copying Concept Sets', () => {
     // Create a workspace
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     let conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
 
     // Select first two rows.
@@ -109,7 +109,7 @@ describe('Editing and Copying Concept Sets', () => {
     await workspace2.clickWorkspaceName();
 
     // Look for one existing Concept Set in workspace2. If none exists, create a new Concept Set.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
 
     // Create new Concept Set

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -5,7 +5,7 @@ import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {LinkText, TabLabelAlias} from 'app/text-labels';
+import {LinkText, TabLabel} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import Link from 'app/element/link';
@@ -88,7 +88,7 @@ describe('Editing and Copying Concept Sets', () => {
     // Navigate to workspace Data page, then delete Concept Set
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
     await dataPage.deleteResource(newName, CardType.ConceptSet);
   });
 
@@ -110,7 +110,7 @@ describe('Editing and Copying Concept Sets', () => {
 
     // Look for one existing Concept Set in workspace2. If none exists, create a new Concept Set.
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.ConceptSets, {waitPageChange: false});
 
     // Create new Concept Set
     const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -89,7 +89,7 @@ describe('Editing and Copying Concept Sets', () => {
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
-    await dataPage.deleteConceptSet(newName);
+    await dataPage.deleteResource(newName, CardType.ConceptSet);
   });
 
   /**
@@ -149,7 +149,7 @@ describe('Editing and Copying Concept Sets', () => {
     console.log(`Copied Concept Set: "${conceptName} from workspace: "${copyFromWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${copyToWorkspace}"`)
 
     // Delete Concept Sets
-    await dataPage.deleteConceptSet(conceptSetCopyName);
+    await dataPage.deleteResource(conceptSetCopyName, CardType.ConceptSet);
   });
 
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,8 +1,8 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
-import {EllipsisMenuAction, LinkText} from 'app/text-labels';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -25,7 +25,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetPage = await dataPage.clickAddDatasetButton();
 
     await datasetPage.selectCohorts(['All Participants']);
@@ -70,7 +70,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Cohorts button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const addCohortsButton = await dataPage.getAddCohortsButton();
     await addCohortsButton.clickAndWait();
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,8 +1,8 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -35,7 +35,7 @@ describe('Create Dataset', () => {
 
     // Verify create successful
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Rename Dataset
@@ -45,14 +45,14 @@ describe('Create Dataset', () => {
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     // Verify rename successful
-    const newDatasetExists = await resourceCard.cardExists(newDatasetName, CardType.Dataset);
+    const newDatasetExists = await resourceCard.cardExists(newDatasetName, ResourceCard.Dataset);
     expect(newDatasetExists).toBe(true);
 
-    const oldDatasetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const oldDatasetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(oldDatasetExists).toBe(false);
 
     // Delete Dataset
-    const textContent = await dataPage.deleteResource(newDatasetName, CardType.Dataset);
+    const textContent = await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
   });
@@ -110,7 +110,7 @@ describe('Create Dataset', () => {
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Edit the dataset to include "All Participants".
@@ -126,7 +126,7 @@ describe('Create Dataset', () => {
     await dataPage.waitForLoad();
 
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
-    await dataPage.deleteResource(datasetName, CardType.Dataset);
+    await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
   });
 
 });

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, LinkText, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -42,7 +42,7 @@ describe('Create Dataset', () => {
     const newDatasetName = makeRandomName();
     await dataPage.renameDataset(datasetName, newDatasetName);
 
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     // Verify rename successful
     const newDatasetExists = await resourceCard.cardExists(newDatasetName, CardType.Dataset);
@@ -96,7 +96,7 @@ describe('Create Dataset', () => {
     await waitForText(page, 'Cohort Saved Successfully');
     console.log(`Created Cohort "${cohortName}"`);
 
-    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openTab(TabLabel.Data);
 
     // Click Add Datasets button.
     const datasetPage = await dataPage.clickAddDatasetButton();
@@ -107,7 +107,7 @@ describe('Create Dataset', () => {
     let datasetName = await saveModal.saveDataset({exportToNotebook: false});
 
     // Verify create successful.
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
@@ -125,7 +125,7 @@ describe('Create Dataset', () => {
     datasetName = await saveModal.saveDataset({exportToNotebook: false}, true);
     await dataPage.waitForLoad();
 
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
     await dataPage.deleteResource(datasetName, CardType.Dataset);
   });
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -52,7 +52,7 @@ describe('Create Dataset', () => {
     expect(oldDatasetExists).toBe(false);
 
     // Delete Dataset
-    const textContent = await dataPage.deleteDataset(newDatasetName);
+    const textContent = await dataPage.deleteResource(newDatasetName, CardType.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
   });
@@ -126,7 +126,7 @@ describe('Create Dataset', () => {
     await dataPage.waitForLoad();
 
     await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
-    await dataPage.deleteDataset(datasetName);
+    await dataPage.deleteResource(datasetName, CardType.Dataset);
   });
 
 });

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,10 +1,10 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -62,13 +62,13 @@ describe('Create Dataset', () => {
 
     // Verify new notebook exists.
     const resourceCard = new DataResourceCard(page);
-    const notebookExists = await resourceCard.cardExists(newNotebookName, CardType.Notebook);
+    const notebookExists = await resourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
     expect(notebookExists).toBe(true);
 
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
 
     // Delete notebook
-    await analysiPage.deleteResource(newNotebookName, CardType.Notebook);
+    await analysiPage.deleteResource(newNotebookName, ResourceCard.Notebook);
 
     // Resource cards count decrease by 1.
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
@@ -78,7 +78,7 @@ describe('Create Dataset', () => {
     await dataPage.openTab(TabLabel.Data);
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
-    await dataPage.deleteResource(newDatasetName, CardType.Dataset);
+    await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
   });
 
   /**
@@ -101,7 +101,7 @@ describe('Create Dataset', () => {
     await waitWhileLoading(page);
 
     const resourceCard = new DataResourceCard(page);
-    const datasetCard = await resourceCard.findCard(datasetName, CardType.Dataset);
+    const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
     await datasetCard.clickEllipsisAction(EllipsisMenuAction.exportToNotebook, {waitForNav: false});
 
     const exportModal = new ExportToNotebookModal(page);
@@ -112,12 +112,12 @@ describe('Create Dataset', () => {
 
     // Verify notebook created successfully.
     await dataPage.openTab(TabLabel.Analysis);
-    const cardExists = await resourceCard.cardExists(notebookName, CardType.Notebook);
+    const cardExists = await resourceCard.cardExists(notebookName, ResourceCard.Notebook);
     expect(cardExists).toBe(true);
 
     // Delete notebook.
     const analysisPage = new WorkspaceAnalysisPage(page);
-    await analysisPage.deleteResource(notebookName, CardType.Notebook);
+    await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   });
 
 });

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,10 +1,10 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction} from 'app/text-labels';
+import {EllipsisMenuAction, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -24,7 +24,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     await datasetBuildPage.selectCohorts(['All Participants']);
@@ -91,7 +91,7 @@ describe('Create Dataset', () => {
     await findWorkspace(page).then(card => card.clickWorkspaceName());
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     await datasetBuildPage.selectCohorts(['All Participants']);

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,9 +1,9 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
-import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {EllipsisMenuAction, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -68,7 +68,7 @@ describe('Create Dataset', () => {
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
 
     // Delete notebook
-    await analysiPage.deleteNotebook(newNotebookName);
+    await analysiPage.deleteResource(newNotebookName, CardType.Notebook);
 
     // Resource cards count decrease by 1.
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
@@ -78,7 +78,7 @@ describe('Create Dataset', () => {
     await dataPage.openTab(TabLabelAlias.Data);
     await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
 
-    await dataPage.deleteDataset(newDatasetName);
+    await dataPage.deleteResource(newDatasetName, CardType.Dataset);
   });
 
   /**
@@ -117,7 +117,7 @@ describe('Create Dataset', () => {
 
     // Delete notebook.
     const analysisPage = new WorkspaceAnalysisPage(page);
-    await analysisPage.deleteNotebook(notebookName);
+    await analysisPage.deleteResource(notebookName, CardType.Notebook);
   });
 
 });

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -4,7 +4,7 @@ import Link from 'app/element/link';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -75,8 +75,8 @@ describe('Create Dataset', () => {
     expect(newCardsCount).toBe(origCardsCount - 1);
 
     // Delete Dataset.
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Data);
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     await dataPage.deleteResource(newDatasetName, CardType.Dataset);
   });
@@ -111,7 +111,7 @@ describe('Create Dataset', () => {
     await exportModal.fillInModal(notebookName);
 
     // Verify notebook created successfully.
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openTab(TabLabel.Analysis);
     const cardExists = await resourceCard.cardExists(notebookName, CardType.Notebook);
     expect(cardExists).toBe(true);
 

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -5,7 +5,7 @@ import {Ethnicity} from 'app/page/cohort-criteria-modal';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Language, TabLabelAlias} from 'app/text-labels';
+import {Language, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -77,21 +77,21 @@ describe('Create Dataset', () => {
 
     // Delete test data sequence is: Delete Notebook, then Dataset, finally Cohort.
     // Delete Notebook
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openTab(TabLabel.Analysis);
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await analysisPage.waitForLoad();
     await analysisPage.deleteResource(newNotebookName, CardType.Notebook);
 
     // Delete Dataset
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Data);
+    await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
     const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, CardType.Dataset);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
-    await dataPage.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await dataPage.openTab(TabLabel.Cohorts, {waitPageChange: false});
 
     const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, CardType.Cohort);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,13 +1,13 @@
 import Link from 'app/element/link';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import {Ethnicity} from 'app/page/cohort-criteria-modal';
-import {Language} from 'app/text-labels';
+import {Language, TabLabelAlias} from 'app/text-labels';
 
 describe('Create Dataset', () => {
 
@@ -25,7 +25,7 @@ describe('Create Dataset', () => {
     const workspaceName = await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
     const cohortBuildPage = await datasetBuildPage.clickAddCohortsButton();
 

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,11 +1,10 @@
-import {CardType} from 'app/component/data-resource-card';
 import Link from 'app/element/link';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import {Ethnicity} from 'app/page/cohort-criteria-modal';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Language, TabLabel} from 'app/text-labels';
+import {Language, ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -81,19 +80,19 @@ describe('Create Dataset', () => {
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await analysisPage.waitForLoad();
-    await analysisPage.deleteResource(newNotebookName, CardType.Notebook);
+    await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
 
     // Delete Dataset
     await dataPage.openTab(TabLabel.Data);
     await dataPage.openTab(TabLabel.Datasets, {waitPageChange: false});
 
-    const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, CardType.Dataset);
+    const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
     await dataPage.openTab(TabLabel.Cohorts, {waitPageChange: false});
 
-    const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, CardType.Cohort);
+    const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, ResourceCard.Cohort);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
 
   });

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,13 +1,14 @@
+import {CardType} from 'app/component/data-resource-card';
 import Link from 'app/element/link';
+import CohortActionsPage from 'app/page/cohort-actions-page';
+import {Ethnicity} from 'app/page/cohort-criteria-modal';
+import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import NotebookPreviewPage from 'app/page/notebook-preview-page';
+import {Language, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import CohortActionsPage from 'app/page/cohort-actions-page';
-import {Ethnicity} from 'app/page/cohort-criteria-modal';
-import {Language, TabLabelAlias} from 'app/text-labels';
 
 describe('Create Dataset', () => {
 
@@ -80,19 +81,19 @@ describe('Create Dataset', () => {
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await analysisPage.waitForLoad();
-    await analysisPage.deleteNotebook(newNotebookName);
+    await analysisPage.deleteResource(newNotebookName, CardType.Notebook);
 
     // Delete Dataset
     await dataPage.openTab(TabLabelAlias.Data);
     await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
 
-    const datasetDeleteDialogText = await dataPage.deleteDataset(newDatasetName);
+    const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, CardType.Dataset);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
     await dataPage.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
 
-    const cohortDeleteDialogText = await dataPage.deleteCohort(newCohortName);
+    const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, CardType.Cohort);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
 
   });

--- a/e2e/tests/notebook/import-r-lib.spec.ts
+++ b/e2e/tests/notebook/import-r-lib.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import * as fs from 'fs';
 import {makeRandomName} from 'utils/str-utils';
@@ -20,7 +20,7 @@ describe('Jupyter notebook tests in R', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('import-r-lib');
     const notebook = await dataPage.createNotebook(notebookName, Language.R);
 

--- a/e2e/tests/notebook/notebook-owner-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-owner-actions.spec.ts
@@ -1,7 +1,7 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import NewNotebookModal from 'app/component/new-notebook-modal';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {LinkText} from 'app/text-labels';
+import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeWorkspaceName} from 'utils/str-utils';
 import {signIn} from 'utils/test-utils';
 
@@ -53,7 +53,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Page remain unchanged, still should be the Analysis page.
     expect(await workspaceAnalysisPage.isLoaded()).toBe(true);
 
-    await workspaceAnalysisPage.deleteResource(notebookName, CardType.Notebook);
+    await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   })
 
   test('Notebook can be duplicated by workspace owner', async () => {
@@ -62,8 +62,8 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     const workspaceAnalysisPage = await workspacesPage.createNotebook({workspaceName, notebookName});
     const duplNotebookName = await workspaceAnalysisPage.duplicateNotebook(notebookName);
     // Delete clone notebook.
-    await workspaceAnalysisPage.deleteResource(duplNotebookName, CardType.Notebook);
-    await workspaceAnalysisPage.deleteResource(notebookName, CardType.Notebook);
+    await workspaceAnalysisPage.deleteResource(duplNotebookName, ResourceCard.Notebook);
+    await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   })
 
   test('Notebook can be renamed by workspace owner', async () => {
@@ -76,13 +76,13 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     expect(modalTextContents).toContain(`Enter new name for ${notebookName}.ipynb`);
 
     const newNotebookCard = new DataResourceCard(page);
-    let cardExists = await newNotebookCard.cardExists(newName, CardType.Notebook);
+    let cardExists = await newNotebookCard.cardExists(newName, ResourceCard.Notebook);
     expect(cardExists).toBe(true);
 
-    cardExists = await newNotebookCard.cardExists(notebookName, CardType.Notebook);
+    cardExists = await newNotebookCard.cardExists(notebookName, ResourceCard.Notebook);
     expect(cardExists).toBe(false);
 
-    await workspaceAnalysisPage.deleteResource(newName, CardType.Notebook);
+    await workspaceAnalysisPage.deleteResource(newName, ResourceCard.Notebook);
   })
 
 

--- a/e2e/tests/notebook/notebook-owner-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-owner-actions.spec.ts
@@ -53,7 +53,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Page remain unchanged, still should be the Analysis page.
     expect(await workspaceAnalysisPage.isLoaded()).toBe(true);
 
-    await workspaceAnalysisPage.deleteNotebook(notebookName);
+    await workspaceAnalysisPage.deleteResource(notebookName, CardType.Notebook);
   })
 
   test('Notebook can be duplicated by workspace owner', async () => {
@@ -62,8 +62,8 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     const workspaceAnalysisPage = await workspacesPage.createNotebook({workspaceName, notebookName});
     const duplNotebookName = await workspaceAnalysisPage.duplicateNotebook(notebookName);
     // Delete clone notebook.
-    await workspaceAnalysisPage.deleteNotebook(duplNotebookName);
-    await workspaceAnalysisPage.deleteNotebook(notebookName);
+    await workspaceAnalysisPage.deleteResource(duplNotebookName, CardType.Notebook);
+    await workspaceAnalysisPage.deleteResource(notebookName, CardType.Notebook);
   })
 
   test('Notebook can be renamed by workspace owner', async () => {
@@ -82,7 +82,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     cardExists = await newNotebookCard.cardExists(notebookName, CardType.Notebook);
     expect(cardExists).toBe(false);
 
-    await workspaceAnalysisPage.deleteNotebook(newName);
+    await workspaceAnalysisPage.deleteResource(newName, CardType.Notebook);
   })
 
 

--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -15,7 +15,7 @@ describe('Jupyter notebook tests in Python language', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('py');
     const notebook = await dataPage.createNotebook(notebookName);
 

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
@@ -17,7 +17,7 @@ describe('Jupyter notebook tests in R language', () => {
     await workspaceCard.clickWorkspaceName();
 
     const notebookName = makeRandomName('r-notebook');
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebook = await dataPage.createNotebook(notebookName, Language.R);
 
     const kernelName = await notebook.getKernelName();

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {Language, TabLabelAlias} from 'app/text-labels';
+import {Language, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
@@ -21,7 +21,7 @@ describe('Jupyter Notebook tests in Python language', () => {
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openTab(TabLabel.Analysis);
 
     const notebookName = makeRandomName('py-notebook');
     const analysisPage = new WorkspaceAnalysisPage(page);

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,7 +1,7 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {Language, TabLabel} from 'app/text-labels';
+import {Language, ResourceCard, TabLabel} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
@@ -39,7 +39,7 @@ describe('Jupyter Notebook tests in Python language', () => {
 
     // Find and open saved notebook and verify notebook contents match.
     const resourceCard = new DataResourceCard(page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickResourceName();
 
     const notebookPreviewPage = new NotebookPreviewPage(page);

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {Language} from 'app/text-labels';
+import {Language, TabLabelAlias} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
@@ -20,7 +20,7 @@ describe('Jupyter Notebook tests in Python language', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.openTab(TabLabelAlias.Analysis);
 
     const notebookName = makeRandomName('py-notebook');

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -66,7 +66,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     await modal.clickButton(LinkText.StayHere, {waitForClose: true});
 
     // Delete notebook
-    const deleteModalTextContent = await analysisPage.deleteNotebook(copyFromNotebookName);
+    const deleteModalTextContent = await analysisPage.deleteResource(copyFromNotebookName, CardType.Notebook);
     expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${copyFromNotebookName}?`);
 
     // Perform actions in copied notebook.
@@ -94,7 +94,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Exit notebook. Returns to the Workspace Analysis tab.
     await copyNotebookPage.goAnalysisPage();
     // Delete notebook
-    const modalTextContent = await analysisPage.deleteNotebook(copiedNotebookName);
+    const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, CardType.Notebook);
     expect(modalTextContent).toContain('This will permanently delete the Notebook.');
   })
 

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -1,8 +1,8 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import {LinkText} from 'app/text-labels';
+import {LinkText, TabLabelAlias} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -34,7 +34,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
 
     // Create notebook in copy-from workspace.
     const copyFromNotebookName = makeRandomName('pytest');
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Get the billing project name from page url.
     const fromWorkspaceNamespace = extractNamespace(new URL(page.url()));

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -1,8 +1,8 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import {LinkText, TabLabel} from 'app/text-labels';
+import {LinkText, ResourceCard, TabLabel} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -66,7 +66,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     await modal.clickButton(LinkText.StayHere, {waitForClose: true});
 
     // Delete notebook
-    const deleteModalTextContent = await analysisPage.deleteResource(copyFromNotebookName, CardType.Notebook);
+    const deleteModalTextContent = await analysisPage.deleteResource(copyFromNotebookName, ResourceCard.Notebook);
     expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${copyFromNotebookName}?`);
 
     // Perform actions in copied notebook.
@@ -78,7 +78,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Verify copy-to notebook exists in destination Workspace
     await dataPage.openTab(TabLabel.Analysis);
     const dataResourceCard = new DataResourceCard(page);
-    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
+    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
     expect(notebookCard).toBeTruthy();
 
     // Open copied notebook and run code to verify billing project name.
@@ -94,7 +94,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Exit notebook. Returns to the Workspace Analysis tab.
     await copyNotebookPage.goAnalysisPage();
     // Delete notebook
-    const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, CardType.Notebook);
+    const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, ResourceCard.Notebook);
     expect(modalTextContent).toContain('This will permanently delete the Notebook.');
   })
 

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import {LinkText, TabLabelAlias} from 'app/text-labels';
+import {LinkText, TabLabel} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -76,7 +76,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     const toWorkspaceNamespace = extractNamespace(new URL(page.url()));
 
     // Verify copy-to notebook exists in destination Workspace
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openTab(TabLabel.Analysis);
     const dataResourceCard = new DataResourceCard(page);
     const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
     expect(notebookCard).toBeTruthy();

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -1,4 +1,4 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
@@ -7,7 +7,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel, TabLabel} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel, TabLabel, ResourceCard} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
@@ -78,7 +78,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);
-    const menu = await dataResourceCard.findCard(notebookName, CardType.Notebook).then(card => card.getEllipsis());
+    const menu = await dataResourceCard.findCard(notebookName, ResourceCard.Notebook).then(card => card.getEllipsis());
     await menu.clickEllipsis(); // open ellipsis menu.
     expect(await menu.isDisabled(EllipsisMenuAction.Rename)).toBe(true);
     expect(await menu.isDisabled(EllipsisMenuAction.Duplicate)).toBe(true);
@@ -110,7 +110,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
     expect(linkDisplayed).toBe(true);
 
     // Verify copied notebook exists in collaborator Workspace.
-    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
+    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
     expect(notebookCard).toBeTruthy();
 
     // Notebook actions Rename, Duplicate, Delete and Copy to another Workspace actions are avaliable to click.

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -7,7 +7,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel, TabLabel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
@@ -74,7 +74,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Verify notebook actions list.
     await workspaceCard.clickWorkspaceName();
-    await new WorkspaceDataPage(newPage).openTab(TabLabelAlias.Analysis);
+    await new WorkspaceDataPage(newPage).openTab(TabLabel.Analysis);
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -3,11 +3,11 @@ import Modal from 'app/component/modal';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
 import Link from 'app/element/link';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel, TabLabelAlias} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
@@ -35,7 +35,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
   test('Workspace reader copy notebook to another workspace', async () => {
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('pyAdd');
     let notebook = await dataPage.createNotebook(notebookName, Language.Python);
 
@@ -74,7 +74,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Verify notebook actions list.
     await workspaceCard.clickWorkspaceName();
-    await new DataPage(newPage).openTab(TabLabelAlias.Analysis);
+    await new WorkspaceDataPage(newPage).openTab(TabLabelAlias.Analysis);
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -1,7 +1,7 @@
 import WorkspacesPage from 'app/page/workspaces-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {EllipsisMenuAction} from 'app/text-labels';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 
 describe('Clone workspace', () => {
 
@@ -33,7 +33,7 @@ describe('Clone workspace', () => {
       await workspacesPage.clickCreateFinishButton(finishButton);
 
       // wait for Data page
-      const dataPage = new DataPage(page);
+      const dataPage = new WorkspaceDataPage(page);
       await dataPage.waitForLoad();
       // save Data page URL for comparison
       const workspaceDataUrl1 = page.url();
@@ -55,7 +55,7 @@ describe('Clone workspace', () => {
       const workspaceCard = await findWorkspace(page);
       await workspaceCard.clickWorkspaceName();
 
-      const dataPage = new DataPage(page);
+      const dataPage = new WorkspaceDataPage(page);
       await dataPage.selectWorkspaceAction(EllipsisMenuAction.Duplicate);
 
       const workspacesPage = new WorkspacesPage(page);

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -1,5 +1,5 @@
 import Link from 'app/element/link';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage, {FieldSelector} from 'app/page/workspaces-page';
 import {signIn, performActions} from 'utils/test-utils';
 import Button from 'app/element/button';
@@ -73,7 +73,7 @@ describe('Creating new workspaces', () => {
 
   // helper function to check visible workspace link on Data page
   async function verifyWorkspaceLinkOnDataPage(workspaceName: string) {
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
 
     const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,6 +1,6 @@
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {EllipsisMenuAction} from 'app/text-labels';
+import {EllipsisMenuAction, TabLabelAlias} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
 import {findWorkspace, performActions, signIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
@@ -37,7 +37,7 @@ describe('Editing workspace thru workspace card ellipsis menu', () => {
     await updateButton.waitUntilEnabled();
     await workspacesPage.clickCreateFinishButton(updateButton);
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
 
     // Check Workspace Information

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,6 +1,6 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {EllipsisMenuAction, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, TabLabel} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
 import {findWorkspace, performActions, signIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
@@ -43,7 +43,7 @@ describe('Editing workspace thru workspace card ellipsis menu', () => {
     // Check Workspace Information
 
     // Check CDR version
-    await dataPage.openTab(TabLabelAlias.About);
+    await dataPage.openTab(TabLabel.About);
     const aboutPage = new WorkspaceAboutPage(page);
     const cdrValue = await aboutPage.getCdrVersion();
     expect(cdrValue).toEqual(expect.stringContaining(selectedValue));

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -5,7 +5,7 @@ import Link from 'app/element/link';
 import HomePage from 'app/page/home-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel, TabLabelAlias} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel, TabLabel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
@@ -110,7 +110,7 @@ describe('Share workspace', () => {
 
       // Make sure the Search input-field in Share modal is disabled.
       await workspaceCard2.clickWorkspaceName();
-      await (new WorkspaceDataPage(newPage)).openTab(TabLabelAlias.About);
+      await (new WorkspaceDataPage(newPage)).openTab(TabLabel.About);
       const aboutPage = new WorkspaceAboutPage(newPage);
       await aboutPage.waitForLoad();
       const modal2 = await aboutPage.openShareModal();

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -5,10 +5,10 @@ import Link from 'app/element/link';
 import HomePage from 'app/page/home-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel, TabLabelAlias} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 
 describe('Share workspace', () => {
 
@@ -110,7 +110,7 @@ describe('Share workspace', () => {
 
       // Make sure the Search input-field in Share modal is disabled.
       await workspaceCard2.clickWorkspaceName();
-      await (new DataPage(newPage)).openTab(TabLabelAlias.About);
+      await (new WorkspaceDataPage(newPage)).openTab(TabLabelAlias.About);
       const aboutPage = new WorkspaceAboutPage(newPage);
       await aboutPage.waitForLoad();
       const modal2 = await aboutPage.openShareModal();


### PR DESCRIPTION
* Create `workspace-base.ts` abstract class for extend by `workspace-data-page.ts`, `workspace-analysis-page.ts` and `workspace-about-page.ts` classes. It contains common workspace-page functions.
* The common `deleteResource` function replaces `deleteCohort`, `deleteConceptSet`, `deleteNotebook` and `deleteDataset` functions to reduce code duplication.
* Rename `data-page.ts` to `workspace-data-page.ts` to have a consistent name convention like other `workspace-*.ts` page names. 
* Move `CardType` enum from `data-resource-card.ts` to `text-labels.ts` and rename to `ResourceCard`.
* Move `TabLabelAlias` enum from `workspace-data-page.ts` to `text-labels.ts` and rename to `TabLabel`.