### PR TITLE
[no ticket][risk=no] Puppeteer: refactor workspace pages

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -1,7 +1,7 @@
 import {ElementHandle, Page} from 'puppeteer';
 import {WorkspaceAccessLevel} from 'app/text-labels';
 import * as fp from 'lodash/fp';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {getPropValue} from 'utils/element-utils';
 import CardBase from './card-base';
 
@@ -125,7 +125,7 @@ export default class WorkspaceCard extends CardBase {
       elemt.click(),
     ]);
     if (waitForDataPage) {
-      const dataPage = new DataPage(this.page);
+      const dataPage = new WorkspaceDataPage(this.page);
       await dataPage.waitForLoad();
     }
     return name;

--- a/e2e/app/element/checkbox.ts
+++ b/e2e/app/element/checkbox.ts
@@ -1,6 +1,7 @@
 import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {ElementType, XPathOptions} from 'app/xpath-options';
+import {waitForFn} from '../../utils/waits-utils';
 import BaseElement from './base-element';
 import {buildXPath} from 'app/xpath-builders';
 
@@ -25,16 +26,26 @@ export default class Checkbox extends BaseElement {
   }
 
   /**
-   * Click on checkbox element for checked
+   * Click (check) checkbox element.
    */
-  async check(): Promise<void> {
-    const is = await this.isChecked();
-    if (!is) {
-      await this.focus();
-      await this.clickWithEval();
-      await this.page.waitFor(500);
+  async check(maxAttempts: number = 2): Promise<void> {
+    const checked = await this.isChecked();
+    if (!checked) {
+      const intervalMillis = 2000;
+      const result = await waitForFn(
+         async () => {
+           await this.focus();
+           await this.clickWithEval();
+           await this.page.waitFor(500);
+           await this.isChecked();
+         },
+         intervalMillis,
+         intervalMillis * maxAttempts );
+
+      if (!result) {
+        throw new Error(`Checkbox ('${this.getXpath()}') check failed.`)
+      }
     }
-    // check and retry ??
   }
 
   /**

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -1,12 +1,9 @@
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import {buildXPath} from 'app/xpath-builders';
 import {WorkspaceAccessLevel} from 'app/text-labels';
-import {ElementType} from 'app/xpath-options';
 import {getPropValue} from 'utils/element-utils';
 import WorkspaceBase from './workspace-base';
-import {TabLabelAlias} from './workspace-data-page';
 import Button from 'app/element/button';
 import ShareModal from 'app/component/share-modal';
 
@@ -23,7 +20,6 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
       await Promise.all([
         waitForDocumentTitle(this.page, PageTitle),
         waitWhileLoading(this.page),
-        this.page.waitForXPath(buildXPath({name: TabLabelAlias.About, type: ElementType.Tab})),
       ]);
       return true;
     } catch (err) {

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -1,18 +1,18 @@
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
-import {waitForAttributeEquality, waitForDocumentTitle} from 'utils/waits-utils';
+import {waitForDocumentTitle} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
 import {WorkspaceAccessLevel} from 'app/text-labels';
 import {ElementType} from 'app/xpath-options';
 import {getPropValue} from 'utils/element-utils';
-import AuthenticatedPage from './authenticated-page';
-import {TabLabelAlias} from './data-page';
+import WorkspaceBase from './workspace-base';
+import {TabLabelAlias} from './workspace-data-page';
 import Button from 'app/element/button';
 import ShareModal from 'app/component/share-modal';
 
 export const PageTitle = 'View Workspace Details';
 
-export default class WorkspaceAboutPage extends AuthenticatedPage{
+export default class WorkspaceAboutPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);
@@ -30,11 +30,6 @@ export default class WorkspaceAboutPage extends AuthenticatedPage{
       console.log(`WorkspaceAboutPage isLoaded() encountered ${err}`);
       return false;
     }
-  }
-
-  async isOpen(): Promise<boolean> {
-    const selector = buildXPath({name: TabLabelAlias.About, type: ElementType.Tab});
-    return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
   }
 
   async findUserInCollaboratorList(username: string): Promise<WorkspaceAccessLevel> {

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -8,13 +8,13 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
-import AuthenticatedPage from './authenticated-page';
 import CopyModal from 'app/component/copy-modal';
 import NotebookPage from './notebook-page';
+import WorkspaceBase from './workspace-base';
 
 const PageTitle = 'View Notebooks';
 
-export default class WorkspaceAnalysisPage extends AuthenticatedPage {
+export default class WorkspaceAnalysisPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -1,0 +1,39 @@
+import {Page} from 'puppeteer';
+import {waitWhileLoading} from 'utils/test-utils';
+import {waitForAttributeEquality} from 'utils/waits-utils';
+import Link from 'app/element/link';
+import {buildXPath} from 'app/xpath-builders';
+import {ElementType} from 'app/xpath-options';
+import AuthenticatedPage from './authenticated-page';
+import {TabLabelAlias} from './workspace-data-page';
+
+export default abstract class WorkspaceBase extends AuthenticatedPage {
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+   /**
+    * Select DATA, ANALYSIS or ABOUT page tab.
+    * @param {TabLabel} tabName
+    * @param opts
+    */
+  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    const { waitPageChange = true } = opts;
+    const selector = buildXPath({name: tabName, type: ElementType.Tab});
+    const tab = new Link(this.page, selector);
+    waitPageChange ? await tab.clickAndWait() : await tab.click();
+    await tab.dispose();
+    return waitWhileLoading(this.page);
+  }
+
+  /**
+   * Is tab currently open or selected?
+   */
+  async isOpen(tabName: TabLabelAlias): Promise<boolean> {
+    const selector = buildXPath({name: tabName, type: ElementType.Tab});
+    return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
+  }
+
+
+}

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -1,11 +1,21 @@
-import {Page} from 'puppeteer';
-import {waitWhileLoading} from 'utils/test-utils';
-import {waitForAttributeEquality} from 'utils/waits-utils';
 import Link from 'app/element/link';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
+import {Page} from 'puppeteer';
+import {waitWhileLoading} from 'utils/test-utils';
+import {waitForAttributeEquality} from 'utils/waits-utils';
 import AuthenticatedPage from './authenticated-page';
-import {TabLabelAlias} from './workspace-data-page';
+
+export enum TabLabelAlias {
+  Data = 'Data',
+  Analysis = 'Analysis',
+  About = 'About',
+  Cohorts = 'Cohorts',
+  Datasets = 'Datasets',
+  CohortReviews = 'Cohort Reviews',
+  ConceptSets = 'Concept Sets',
+  ShowAll = 'Show All',
+}
 
 export default abstract class WorkspaceBase extends AuthenticatedPage {
 
@@ -13,14 +23,62 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     super(page);
   }
 
-   /**
-    * Select DATA, ANALYSIS or ABOUT page tab.
-    * @param {TabLabel} tabName
-    * @param opts
-    */
-  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+  /**
+   * Click Data tab to open Data page.
+   * @param opts
+   */
+  async openDataPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.Data, opts);
+  }
+
+  /**
+   * Click Analysis tab to open Analysis page.
+   * @param opts
+   */
+  async openAnalysisPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.Analysis, opts);
+  }
+
+  /**
+   * Click About tab to open About page.
+   * @param opts
+   */
+  async openAboutPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.About, opts);
+  }
+
+  /**
+   * Click Datasets subtab in Data page.
+   * @param opts
+   */
+  async openDatasetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.Datasets, opts);
+  }
+
+  /**
+   * Click Cohorts subtab in Data page.
+   * @param opts
+   */
+  async openCohortsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.Cohorts, opts);
+  }
+
+  /**
+   * Click Concept Sets subtab in Data page.
+   * @param opts
+   */
+  async openConceptSetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
+    return this.openTab(TabLabelAlias.ConceptSets, opts);
+  }
+
+  /**
+   * Click page tab.
+   * @param {string} pageTabName Page tab name
+   * @param opts
+   */
+  async openTab(pageTabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
     const { waitPageChange = true } = opts;
-    const selector = buildXPath({name: tabName, type: ElementType.Tab});
+    const selector = buildXPath({name: pageTabName, type: ElementType.Tab});
     const tab = new Link(this.page, selector);
     waitPageChange ? await tab.clickAndWait() : await tab.click();
     await tab.dispose();
@@ -29,9 +87,10 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
   /**
    * Is tab currently open or selected?
+   * @param {TabLabelAlias} pageTabName Tab name.
    */
-  async isOpen(tabName: TabLabelAlias): Promise<boolean> {
-    const selector = buildXPath({name: tabName, type: ElementType.Tab});
+  async isOpen(pageTabName: TabLabelAlias): Promise<boolean> {
+    const selector = buildXPath({name: pageTabName, type: ElementType.Tab});
     return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
   }
 

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -6,7 +6,7 @@ import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality} from 'utils/waits-utils';
 import AuthenticatedPage from './authenticated-page';
 
-export enum TabLabelAlias {
+export enum TabLabels {
   Data = 'Data',
   Analysis = 'Analysis',
   About = 'About',
@@ -28,7 +28,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openDataPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.Data, opts);
+    return this.openTab(TabLabels.Data, opts);
   }
 
   /**
@@ -36,7 +36,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openAnalysisPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.Analysis, opts);
+    return this.openTab(TabLabels.Analysis, opts);
   }
 
   /**
@@ -44,7 +44,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openAboutPage(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.About, opts);
+    return this.openTab(TabLabels.About, opts);
   }
 
   /**
@@ -52,7 +52,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openDatasetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.Datasets, opts);
+    return this.openTab(TabLabels.Datasets, opts);
   }
 
   /**
@@ -60,7 +60,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openCohortsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.Cohorts, opts);
+    return this.openTab(TabLabels.Cohorts, opts);
   }
 
   /**
@@ -68,7 +68,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param opts
    */
   async openConceptSetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabelAlias.ConceptSets, opts);
+    return this.openTab(TabLabels.ConceptSets, opts);
   }
 
   /**
@@ -76,7 +76,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param {string} pageTabName Page tab name
    * @param opts
    */
-  async openTab(pageTabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
+  async openTab(pageTabName: TabLabels, opts: {waitPageChange?: boolean} = {}): Promise<void> {
     const { waitPageChange = true } = opts;
     const selector = buildXPath({name: pageTabName, type: ElementType.Tab});
     const tab = new Link(this.page, selector);
@@ -87,9 +87,9 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
   /**
    * Is tab currently open or selected?
-   * @param {TabLabelAlias} pageTabName Tab name.
+   * @param {TabLabels} pageTabName Tab name.
    */
-  async isOpen(pageTabName: TabLabelAlias): Promise<boolean> {
+  async isOpen(pageTabName: TabLabels): Promise<boolean> {
     const selector = buildXPath({name: pageTabName, type: ElementType.Tab});
     return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
   }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -19,17 +19,6 @@ import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 import WorkspaceBase from './workspace-base';
 
-export enum TabLabelAlias {
-  Data = 'Data',
-  Analysis = 'Analysis',
-  About = 'About',
-  Cohorts = 'Cohorts',
-  Datasets = 'Datasets',
-  CohortReviews = 'Cohort Reviews',
-  ConceptSets = 'Concept Sets',
-  ShowAll = 'Show All',
-}
-
 const PageTitle = 'Data Page';
 
 export default class WorkspaceDataPage extends WorkspaceBase {
@@ -65,11 +54,11 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async getAddDatasetButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Datasets, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: 'Datasets', iconShape: 'plus-circle'});
   }
 
   async getAddCohortsButton(): Promise<ClrIconLink> {
-    return ClrIconLink.findByName(this.page, {name: TabLabelAlias.Cohorts, iconShape: 'plus-circle'});
+    return ClrIconLink.findByName(this.page, {name: 'Cohorts', iconShape: 'plus-circle'});
   }
 
   // Click Add Datasets button.
@@ -190,8 +179,8 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async findCohortCard(cohortName?: string): Promise<DataResourceCard> {
-    await this.openTab(TabLabelAlias.Data);
-    await this.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await this.openDataPage();
+    await this.openCohortsSubtab({waitPageChange: false});
     if (cohortName === undefined) {
       // if cohort name isn't specified, find any existing cohort.
       return DataResourceCard.findAnyCard(this.page);
@@ -251,7 +240,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    * @param {Language} lang The notebook language.
    */
   async createNotebook(notebookName: string, lang: Language = Language.Python): Promise<NotebookPage> {
-    await this.openTab(TabLabelAlias.Analysis);
+    await this.openAnalysisPage();
     const analysisPage = new WorkspaceAnalysisPage(this.page);
     return analysisPage.createNotebook(notebookName, lang);
   }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -3,13 +3,9 @@ import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
-import Link from 'app/element/link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import AuthenticatedPage from 'app/page/authenticated-page';
 import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
-import {buildXPath} from 'app/xpath-builders';
-import {ElementType} from 'app/xpath-options';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
@@ -21,6 +17,7 @@ import ConceptsetSearchPage from './conceptset-search-page';
 import DatasetBuildPage from './dataset-build-page';
 import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
+import WorkspaceBase from './workspace-base';
 
 export enum TabLabelAlias {
   Data = 'Data',
@@ -35,7 +32,7 @@ export enum TabLabelAlias {
 
 const PageTitle = 'Data Page';
 
-export default class DataPage extends AuthenticatedPage {
+export default class WorkspaceDataPage extends WorkspaceBase {
 
   constructor(page: Page) {
     super(page);
@@ -65,24 +62,6 @@ export default class DataPage extends AuthenticatedPage {
   async selectWorkspaceAction(action: EllipsisMenuAction): Promise<void> {
     const ellipsisMenu = new EllipsisMenu(this.page, './/*[@data-test-id="workspace-menu-button"]');
     return ellipsisMenu.clickAction(action);
-  }
-
-  /**
-   * Select DATA, ANALYSIS or ABOUT page tab.
-   * @param {TabLabelAlias} tabName
-   * @param opts
-   */
-  async openTab(tabName: TabLabelAlias, opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    const {waitPageChange = true} = opts;
-    const selector = buildXPath({name: tabName, type: ElementType.Tab});
-    const tab = new Link(this.page, selector);
-    if (waitPageChange) {
-      await tab.clickAndWait();
-    } else {
-      await tab.click();
-    }
-    await tab.dispose();
-    return waitWhileLoading(this.page);
   }
 
   async getAddDatasetButton(): Promise<ClrIconLink> {

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -7,7 +7,7 @@ import {makeWorkspaceName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
 import {findWorkspace, waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
-import DataPage from './data-page';
+import WorkspaceDataPage from './workspace-data-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 
 const faker = require('faker/locale/en_US');
@@ -149,7 +149,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     const workspaceCard = await findWorkspace(this.page, {workspaceName, create: true});
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(this.page);
+    const dataPage = new WorkspaceDataPage(this.page);
     const notebookPage = await dataPage.createNotebook(notebookName, lang); // Python 3 is the default
 
     // Do not run any code. Simply returns to the Workspace Analysis tab.

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -3,7 +3,7 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -189,7 +189,7 @@ describe('User can create new Cohorts', () => {
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
-    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openDataPage();
 
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -3,7 +3,7 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -30,7 +30,7 @@ describe('User can create new Cohorts', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Click Add Cohorts button
     const addCohortsButton = await dataPage.getAddCohortsButton();
@@ -118,7 +118,7 @@ describe('User can create new Cohorts', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Save url
     const workspaceDataUrl = page.url();

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,6 +1,6 @@
 import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -88,8 +88,8 @@ describe('User can create, modify, rename and delete Cohort', () => {
     const cohortActionsPage = new CohortActionsPage(page);
     await cohortActionsPage.waitForLoad();
 
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await dataPage.openDataPage();
+    await dataPage.openCohortsSubtab({waitPageChange: false});
 
     // Rename cohort.
     const newCohortName = makeRandomName();

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,6 +1,6 @@
 import Link from 'app/element/link';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 import DataResourceCard from 'app/component/data-resource-card';
@@ -31,7 +31,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     // Click Add Cohorts button in Data page.
     await dataPage.getAddCohortsButton().then((butn) => butn.clickAndWait());
 

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -4,7 +4,7 @@ import CohortBuildPage from 'app/page/cohort-build-page';
 import CohortParticipantDetailPage from 'app/page/cohort-participant-detail-page';
 import CohortReviewModal from 'app/page/cohort-review-modal';
 import CohortReviewPage from 'app/page/cohort-review-page';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {waitForText} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
 
@@ -27,7 +27,7 @@ describe('Cohort review tests', () => {
 
     await findWorkspace(page).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const cohortCard = await dataPage.createCohort();
     const cohortName = await cohortCard.getResourceName();
     console.log(`Created Cohort: "${cohortName}"`);

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -1,9 +1,9 @@
-import {PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import {PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
+import WorkspaceAboutPage from 'app/page/workspace-about-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import WorkspaceAboutPage from 'app/page/workspace-about-page';
 
 describe('Cohorts UI tests', () => {
 
@@ -22,7 +22,7 @@ describe('Cohorts UI tests', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     const addCohortsButton = await dataPage.getAddCohortsButton();
     await addCohortsButton.clickAndWait();
@@ -65,7 +65,7 @@ describe('Cohorts UI tests', () => {
     // Check ABOUT tab is open
     const aboutPage = new WorkspaceAboutPage(page);
     await aboutPage.waitForLoad();
-    const isOpen = await aboutPage.isOpen();
+    const isOpen = await aboutPage.isOpen(TabLabelAlias.About);
     expect(isOpen).toBe(true);
   });
 

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -1,9 +1,10 @@
 import CohortBuildPage from 'app/page/cohort-build-page';
 import {PhysicalMeasurementsCriteria} from 'app/page/cohort-criteria-modal';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
+import {TabLabelAlias} from 'app/page/workspace-base';
 
 describe('Cohorts UI tests', () => {
 
@@ -53,7 +54,7 @@ describe('Cohorts UI tests', () => {
     const exportButton = await cohortPage.getExportButton();
     expect(await exportButton.isDisabled()).toBe(true);
 
-    await dataPage.openTab(TabLabelAlias.About, {waitPageChange: false});
+    await dataPage.openAboutPage({waitPageChange: false});
 
     // Don't save. Confirm Discard Changes
     const modalTextContent = await cohortPage.discardChangesConfirmationDialog();

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import {TabLabelAlias} from 'app/page/workspace-base';
+import {TabLabels} from 'app/page/workspace-base';
 
 describe('Cohorts UI tests', () => {
 
@@ -66,7 +66,7 @@ describe('Cohorts UI tests', () => {
     // Check ABOUT tab is open
     const aboutPage = new WorkspaceAboutPage(page);
     await aboutPage.waitForLoad();
-    const isOpen = await aboutPage.isOpen(TabLabelAlias.About);
+    const isOpen = await aboutPage.isOpen(TabLabels.About);
     expect(isOpen).toBe(true);
   });
 

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,7 +1,7 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -66,8 +66,8 @@ describe('Create Concept Sets from Domains', () => {
     console.log(`Created Concept Set "${conceptName}"`);
 
     // Delete Concept Set
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openDataPage();
+    await dataPage.openConceptSetsSubtab({waitPageChange: false});
 
     const modalTextContent = await dataPage.deleteConceptSet(conceptName);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
@@ -148,8 +148,8 @@ describe('Create Concept Sets from Domains', () => {
     const datasetName = await saveModal.saveDataset();
 
     // Verify Dataset created successful.
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDataPage();
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
@@ -160,7 +160,7 @@ describe('Create Concept Sets from Domains', () => {
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openConceptSetsSubtab({waitPageChange: false});
 
     await dataPage.deleteConceptSet(conceptName1);
     await dataPage.deleteConceptSet(conceptName2);

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,7 +1,7 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 
@@ -21,7 +21,7 @@ describe('Create Concept Sets from Domains', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     // Click Add Concept Sets button.
@@ -85,7 +85,7 @@ describe('Create Concept Sets from Domains', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     // Start: Create new Concept Set 1

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceCard from 'app/component/workspace-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
@@ -88,7 +88,7 @@ describe('Editing and Copying Concept Sets', () => {
     // Navigate to workspace Data page, then delete Concept Set
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openConceptSetsSubtab({waitPageChange: false});
     await dataPage.deleteConceptSet(newName);
   });
 
@@ -110,7 +110,7 @@ describe('Editing and Copying Concept Sets', () => {
 
     // Look for one existing Concept Set in workspace2. If none exists, create a new Concept Set.
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
+    await dataPage.openConceptSetsSubtab({waitPageChange: false});
 
     // Create new Concept Set
     const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceCard from 'app/component/workspace-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {LinkText} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
@@ -27,7 +27,7 @@ describe('Editing and Copying Concept Sets', () => {
     // Create a workspace
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     let conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
 
     // Select first two rows.
@@ -109,7 +109,7 @@ describe('Editing and Copying Concept Sets', () => {
     await workspace2.clickWorkspaceName();
 
     // Look for one existing Concept Set in workspace2. If none exists, create a new Concept Set.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.openTab(TabLabelAlias.ConceptSets, {waitPageChange: false});
 
     // Create new Concept Set

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -42,7 +42,7 @@ describe('Create Dataset', () => {
     const newDatasetName = makeRandomName();
     await dataPage.renameDataset(datasetName, newDatasetName);
 
-    await dataPage.openDataPage({waitPageChange: false});
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     // Verify rename successful
     const newDatasetExists = await resourceCard.cardExists(newDatasetName, CardType.Dataset);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -42,7 +42,7 @@ describe('Create Dataset', () => {
     const newDatasetName = makeRandomName();
     await dataPage.renameDataset(datasetName, newDatasetName);
 
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDataPage({waitPageChange: false});
 
     // Verify rename successful
     const newDatasetExists = await resourceCard.cardExists(newDatasetName, CardType.Dataset);
@@ -96,7 +96,7 @@ describe('Create Dataset', () => {
     await waitForText(page, 'Cohort Saved Successfully');
     console.log(`Created Cohort "${cohortName}"`);
 
-    await dataPage.openTab(TabLabelAlias.Data);
+    await dataPage.openDataPage();
 
     // Click Add Datasets button.
     const datasetPage = await dataPage.clickAddDatasetButton();
@@ -107,7 +107,7 @@ describe('Create Dataset', () => {
     let datasetName = await saveModal.saveDataset({exportToNotebook: false});
 
     // Verify create successful.
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
@@ -125,7 +125,7 @@ describe('Create Dataset', () => {
     datasetName = await saveModal.saveDataset({exportToNotebook: false}, true);
     await dataPage.waitForLoad();
 
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
     await dataPage.deleteDataset(datasetName);
   });
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import {EllipsisMenuAction, LinkText} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -25,7 +25,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetPage = await dataPage.clickAddDatasetButton();
 
     await datasetPage.selectCohorts(['All Participants']);
@@ -70,7 +70,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Cohorts button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const addCohortsButton = await dataPage.getAddCohortsButton();
     await addCohortsButton.clickAndWait();
 

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import {EllipsisMenuAction} from 'app/text-labels';
@@ -24,7 +24,7 @@ describe('Create Dataset', () => {
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     await datasetBuildPage.selectCohorts(['All Participants']);
@@ -91,7 +91,7 @@ describe('Create Dataset', () => {
     await findWorkspace(page).then(card => card.clickWorkspaceName());
 
     // Click Add Datasets button.
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     await datasetBuildPage.selectCohorts(['All Participants']);

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,7 +1,7 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import {EllipsisMenuAction} from 'app/text-labels';
@@ -75,8 +75,8 @@ describe('Create Dataset', () => {
     expect(newCardsCount).toBe(origCardsCount - 1);
 
     // Delete Dataset.
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDataPage();
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     await dataPage.deleteDataset(newDatasetName);
   });
@@ -111,7 +111,7 @@ describe('Create Dataset', () => {
     await exportModal.fillInModal(notebookName);
 
     // Verify notebook created successfully.
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openAnalysisPage();
     const cardExists = await resourceCard.cardExists(notebookName, CardType.Notebook);
     expect(cardExists).toBe(true);
 

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,6 +1,6 @@
 import Link from 'app/element/link';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -76,21 +76,21 @@ describe('Create Dataset', () => {
 
     // Delete test data sequence is: Delete Notebook, then Dataset, finally Cohort.
     // Delete Notebook
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openAnalysisPage();
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await analysisPage.waitForLoad();
     await analysisPage.deleteNotebook(newNotebookName);
 
     // Delete Dataset
-    await dataPage.openTab(TabLabelAlias.Data);
-    await dataPage.openTab(TabLabelAlias.Datasets, {waitPageChange: false});
+    await dataPage.openDataPage();
+    await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     const datasetDeleteDialogText = await dataPage.deleteDataset(newDatasetName);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
-    await dataPage.openTab(TabLabelAlias.Cohorts, {waitPageChange: false});
+    await dataPage.openCohortsSubtab({waitPageChange: false});
 
     const cohortDeleteDialogText = await dataPage.deleteCohort(newCohortName);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -1,6 +1,6 @@
 import Link from 'app/element/link';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
@@ -25,7 +25,7 @@ describe('Create Dataset', () => {
     const workspaceName = await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
     const cohortBuildPage = await datasetBuildPage.clickAddCohortsButton();
 

--- a/e2e/tests/notebook/import-r-lib.spec.ts
+++ b/e2e/tests/notebook/import-r-lib.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import * as fs from 'fs';
 import {makeRandomName} from 'utils/str-utils';
@@ -20,7 +20,7 @@ describe('Jupyter notebook tests in R', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('import-r-lib');
     const notebook = await dataPage.createNotebook(notebookName, Language.R);
 

--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -15,7 +15,7 @@ describe('Jupyter notebook tests in Python language', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('py');
     const notebook = await dataPage.createNotebook(notebookName);
 

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -1,4 +1,4 @@
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
@@ -17,7 +17,7 @@ describe('Jupyter notebook tests in R language', () => {
     await workspaceCard.clickWorkspaceName();
 
     const notebookName = makeRandomName('r-notebook');
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebook = await dataPage.createNotebook(notebookName, Language.R);
 
     const kernelName = await notebook.getKernelName();

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,5 +1,5 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
@@ -21,7 +21,7 @@ describe('Jupyter Notebook tests in Python language', () => {
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openAnalysisPage();
 
     const notebookName = makeRandomName('py-notebook');
     const analysisPage = new WorkspaceAnalysisPage(page);

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,5 +1,5 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
@@ -20,7 +20,7 @@ describe('Jupyter Notebook tests in Python language', () => {
     const workspaceCard = await findWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.openTab(TabLabelAlias.Analysis);
 
     const notebookName = makeRandomName('py-notebook');

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -1,6 +1,6 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {LinkText} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
@@ -76,7 +76,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     const toWorkspaceNamespace = extractNamespace(new URL(page.url()));
 
     // Verify copy-to notebook exists in destination Workspace
-    await dataPage.openTab(TabLabelAlias.Analysis);
+    await dataPage.openAnalysisPage();
     const dataResourceCard = new DataResourceCard(page);
     const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
     expect(notebookCard).toBeTruthy();

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -1,6 +1,6 @@
 import DataResourceCard, {CardType} from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {LinkText} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
@@ -34,7 +34,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
 
     // Create notebook in copy-from workspace.
     const copyFromNotebookName = makeRandomName('pytest');
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
 
     // Get the billing project name from page url.
     const fromWorkspaceNamespace = extractNamespace(new URL(page.url()));

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -3,7 +3,7 @@ import Modal from 'app/component/modal';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
 import Link from 'app/element/link';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
@@ -74,7 +74,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Verify notebook actions list.
     await workspaceCard.clickWorkspaceName();
-    await new WorkspaceDataPage(newPage).openTab(TabLabelAlias.Analysis);
+    await new WorkspaceDataPage(newPage).openAnalysisPage();
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -3,7 +3,7 @@ import Modal from 'app/component/modal';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
 import Link from 'app/element/link';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
@@ -35,7 +35,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
   test('Workspace reader copy notebook to another workspace', async () => {
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('pyAdd');
     let notebook = await dataPage.createNotebook(notebookName, Language.Python);
 
@@ -74,7 +74,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Verify notebook actions list.
     await workspaceCard.clickWorkspaceName();
-    await new DataPage(newPage).openTab(TabLabelAlias.Analysis);
+    await new WorkspaceDataPage(newPage).openTab(TabLabelAlias.Analysis);
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -1,7 +1,7 @@
 import WorkspacesPage from 'app/page/workspaces-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {EllipsisMenuAction} from 'app/text-labels';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 
 describe('Clone workspace', () => {
 
@@ -33,7 +33,7 @@ describe('Clone workspace', () => {
       await workspacesPage.clickCreateFinishButton(finishButton);
 
       // wait for Data page
-      const dataPage = new DataPage(page);
+      const dataPage = new WorkspaceDataPage(page);
       await dataPage.waitForLoad();
       // save Data page URL for comparison
       const workspaceDataUrl1 = page.url();
@@ -55,7 +55,7 @@ describe('Clone workspace', () => {
       const workspaceCard = await findWorkspace(page);
       await workspaceCard.clickWorkspaceName();
 
-      const dataPage = new DataPage(page);
+      const dataPage = new WorkspaceDataPage(page);
       await dataPage.selectWorkspaceAction(EllipsisMenuAction.Duplicate);
 
       const workspacesPage = new WorkspacesPage(page);

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -12,7 +12,7 @@ describe('Creating new workspaces', () => {
     await signIn(page);
   });
 
-  test('Create workspace - NO request for review', async () => {
+  test.skip('Create workspace - NO request for review', async () => {
     const newWorkspaceName = makeWorkspaceName();
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -12,7 +12,7 @@ describe('Creating new workspaces', () => {
     await signIn(page);
   });
 
-  test.skip('Create workspace - NO request for review', async () => {
+  test('Create workspace - NO request for review', async () => {
     const newWorkspaceName = makeWorkspaceName();
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -1,5 +1,5 @@
 import Link from 'app/element/link';
-import DataPage from 'app/page/data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage, {FieldSelector} from 'app/page/workspaces-page';
 import {signIn, performActions} from 'utils/test-utils';
 import Button from 'app/element/button';
@@ -73,7 +73,7 @@ describe('Creating new workspaces', () => {
 
   // helper function to check visible workspace link on Data page
   async function verifyWorkspaceLinkOnDataPage(workspaceName: string) {
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
 
     const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,4 +1,4 @@
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {EllipsisMenuAction} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
@@ -37,7 +37,7 @@ describe('Editing workspace thru workspace card ellipsis menu', () => {
     await updateButton.waitUntilEnabled();
     await workspacesPage.clickCreateFinishButton(updateButton);
 
-    const dataPage = new DataPage(page);
+    const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
 
     // Check Workspace Information

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,4 +1,4 @@
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {EllipsisMenuAction} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
@@ -43,7 +43,7 @@ describe('Editing workspace thru workspace card ellipsis menu', () => {
     // Check Workspace Information
 
     // Check CDR version
-    await dataPage.openTab(TabLabelAlias.About);
+    await dataPage.openAboutPage();
     const aboutPage = new WorkspaceAboutPage(page);
     const cdrValue = await aboutPage.getCdrVersion();
     expect(cdrValue).toEqual(expect.stringContaining(selectedValue));

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -8,7 +8,7 @@ import WorkspacesPage from 'app/page/workspaces-page';
 import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
-import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 
 describe('Share workspace', () => {
 
@@ -110,7 +110,7 @@ describe('Share workspace', () => {
 
       // Make sure the Search input-field in Share modal is disabled.
       await workspaceCard2.clickWorkspaceName();
-      await (new WorkspaceDataPage(newPage)).openTab(TabLabelAlias.About);
+      await (new WorkspaceDataPage(newPage)).openAboutPage();
       const aboutPage = new WorkspaceAboutPage(newPage);
       await aboutPage.waitForLoad();
       const modal2 = await aboutPage.openShareModal();

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -8,7 +8,7 @@ import WorkspacesPage from 'app/page/workspaces-page';
 import {EllipsisMenuAction, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
-import DataPage, {TabLabelAlias} from 'app/page/data-page';
+import WorkspaceDataPage, {TabLabelAlias} from 'app/page/workspace-data-page';
 
 describe('Share workspace', () => {
 
@@ -110,7 +110,7 @@ describe('Share workspace', () => {
 
       // Make sure the Search input-field in Share modal is disabled.
       await workspaceCard2.clickWorkspaceName();
-      await (new DataPage(newPage)).openTab(TabLabelAlias.About);
+      await (new WorkspaceDataPage(newPage)).openTab(TabLabelAlias.About);
       const aboutPage = new WorkspaceAboutPage(newPage);
       await aboutPage.waitForLoad();
       const modal2 = await aboutPage.openShareModal();


### PR DESCRIPTION
* Create new `workspace-base.ts` abstract class for extend by `workspace-data-page.ts`, `workspace-analysis-page.ts` and `workspace-about-page.ts` classes. It contains common workspace-page functions.

* Rename `data-page.ts` to `workspace-data-page.ts` to have a consistent name convention like other `workspace-*.ts` page names. 
