### PR TITLE
[RW-5388][risk=low][P1] cannot export Dataset to notebook using the snowman menu

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -319,7 +319,8 @@ public class DataSetController implements DataSetApiDelegate {
       }
     }
     Map<String, QueryJobConfiguration> queriesByDomain =
-        dataSetService.domainToBigQueryConfig(dataSetExportRequest.getDataSetRequest(), dbWorkspace.getWorkspaceId());
+        dataSetService.domainToBigQueryConfig(
+            dataSetExportRequest.getDataSetRequest(), dbWorkspace.getWorkspaceId());
 
     String qualifier = generateRandomEightCharacterQualifier();
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.DataDictionaryEntry;
 import org.pmiops.workbench.model.DataSet;
+import org.pmiops.workbench.model.DataSetGenerateCodeRequest;
 import org.pmiops.workbench.model.DataSetPreviewRequest;
 import org.pmiops.workbench.model.DataSetRequest;
 import org.pmiops.workbench.model.KernelTypeEnum;
@@ -27,7 +28,7 @@ public interface DataSetService {
 
   QueryJobConfiguration previewBigQueryJobConfig(DataSetPreviewRequest dataSetPreviewRequest);
 
-  Map<String, QueryJobConfiguration> domainToBigQueryConfig(DataSetRequest dataSet);
+  Map<String, QueryJobConfiguration> domainToBigQueryConfig(DataSetGenerateCodeRequest dataSet, long workspaceId);
 
   List<String> generateCodeCells(
       KernelTypeEnum kernelTypeEnum,

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
@@ -28,7 +28,8 @@ public interface DataSetService {
 
   QueryJobConfiguration previewBigQueryJobConfig(DataSetPreviewRequest dataSetPreviewRequest);
 
-  Map<String, QueryJobConfiguration> domainToBigQueryConfig(DataSetGenerateCodeRequest dataSet, long workspaceId);
+  Map<String, QueryJobConfiguration> domainToBigQueryConfig(
+      DataSetGenerateCodeRequest dataSet, long workspaceId);
 
   List<String> generateCodeCells(
       KernelTypeEnum kernelTypeEnum,

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -336,8 +336,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   public Map<String, QueryJobConfiguration> domainToBigQueryConfig(
       DataSetGenerateCodeRequest dataSetRequest, long workspaceId) {
     DbDataset dbDataset =
-        dataSetDao.findByNameAndWorkspaceId(
-            dataSetRequest.getName(), workspaceId);
+        dataSetDao.findByNameAndWorkspaceId(dataSetRequest.getName(), workspaceId);
     final boolean includesAllParticipants =
         getBuiltinBooleanFromNullable(dbDataset.getIncludesAllParticipants());
     final ImmutableList<DbCohort> cohortsSelected =

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
@@ -14,6 +14,8 @@ public interface DataSetDao extends CrudRepository<DbDataset, Long> {
 
   List<DbDataset> findDataSetsByConceptSetIds(long conceptId);
 
+  DbDataset findByNameAndWorkspaceId(String name, long workspaceId);
+
   List<DbDataset> findByWorkspaceId(long workspaceId);
 
   default Map<Boolean, Long> getInvalidToCountMap() {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2191,7 +2191,7 @@ paths:
         name: dataSet
         required: true
         schema:
-          "$ref": "#/definitions/DataSetRequest"
+          "$ref": "#/definitions/DataSetGenerateCodeRequest"
       responses:
         200:
           description: 'A SQL query for each domain in the Data Set'
@@ -4610,6 +4610,16 @@ definitions:
         description: 'All the selected domain/value pairs in the data set'
         items:
           "$ref": "#/definitions/DomainValuePair"
+  DataSetGenerateCodeRequest:
+      type: object
+      description: Data Set Object with just DataSet Name and description
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        description:
+          type: string
   PrePackagedConceptSetEnum:
     type: string
     enum:
@@ -4625,7 +4635,7 @@ definitions:
     - newNotebook
     properties:
       dataSetRequest:
-        "$ref": "#/definitions/DataSetRequest"
+        "$ref": "#/definitions/DataSetGenerateCodeRequest"
       notebookName:
         type: string
       newNotebook:

--- a/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set-modal.tsx
@@ -14,7 +14,7 @@ import {encodeURIComponentStrict, navigateByUrl} from 'app/utils/navigation';
 
 import {appendNotebookFileSuffix} from 'app/pages/analysis/util';
 import {AnalyticsTracker} from 'app/utils/analytics';
-import {DataSet, DataSetRequest, FileDetail, KernelTypeEnum} from 'generated/fetch';
+import {DataSet, DataSetGenerateCodeRequest, FileDetail, KernelTypeEnum} from 'generated/fetch';
 
 interface Props {
   closeFunction: Function;
@@ -87,13 +87,8 @@ class ExportDataSetModal extends React.Component<
     const {dataSet} = this.props;
     return {
       name: dataSet.name,
-      includesAllParticipants: dataSet.includesAllParticipants,
       description: dataSet.description,
-      conceptSetIds: dataSet.conceptSets.map(cs => cs.id),
-      cohortIds: dataSet.cohorts.map(c => c.id),
-      domainValuePairs: dataSet.domainValuePairs,
-      prePackagedConceptSet: dataSet.prePackagedConceptSet
-    } as DataSetRequest;
+    } as DataSetGenerateCodeRequest;
   }
 
   async generateQuery() {


### PR DESCRIPTION
Since workspace get resource call return DataSet object with a clientLight version, it does not have concept/cohort Id information. Because of this the export call was throwing null pointer exception.

As part of this PR instead of sending empty arrays for concept and cohort i created a new object for DatasetRequest that contains just the name and descirption

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
