### PR TITLE
[no ticket][risk=no] Puppeteer: e2e circleci jobs have independent test users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,8 @@ commands:
           command: |
             case << parameters.env_name >> in
               "staging") echo 'export USER_NAME=$PUPPETEER_USER_STAGING' >> $BASH_ENV ;;
-              "local" | "test") echo 'export USER_NAME=$PUPPETEER_USER_TEST' >> $BASH_ENV ;;
+              "test") echo 'export USER_NAME=$PUPPETEER_USER_TEST' >> $BASH_ENV ;;
+              "local") echo 'export USER_NAME=$PUPPETEER_USER_LOCAL' >> $BASH_ENV ;;
             esac
             echo 'export PASSWORD=$PUPPETEER_USER_PASSWORD' >> $BASH_ENV
             source $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,7 +616,7 @@ jobs:
       NODE_ENV: development
     resource_class: medium+
     working_directory: ~/workbench
-    parallelism: 1
+    parallelism: 2
     steps:
       - checkout_init_git
       - run:


### PR DESCRIPTION
Issue:
Thru observation, it seems when there are many circleci jobs running concurrently (triggered by PRs and merge to master branch), more concurrent login sessions are likely trigger Google captcha during login. This is all because one user email is used for all circleci jobs.

Proposed solution: 
`puppeteer-e2e-local-ui` job will run tests with a different `PUPPETEER_USER_LOCAL` user. And, increase its parallelism to 2 to reduce long test playback time.