### PR TITLE
[risk=no][RW-5542] Correct issue with minimizeChrome

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -67,13 +67,17 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    // This is allows the react-router conversion to utilize various route config properties
+
+    // ROUTER MIGRATION: This is allows the react-router conversion to utilize various route config properties
     // Once we are fully converted the help sidebar and modals will need to be reworked a bit to eliminate this Angular code
-    this.subscriptions.push(routeDataStore.subscribe(({helpContentKey, notebookHelpSidebarStyles, contentFullHeightOverride}) => {
-      this.helpContentKey = helpContentKey;
-      this.notebookStyles = notebookHelpSidebarStyles;
-      this.contentFullHeightOverride = contentFullHeightOverride;
-    }));
+    this.subscriptions.push(routeDataStore.subscribe(
+      ({minimizeChrome, helpContentKey, notebookHelpSidebarStyles, contentFullHeightOverride}) => {
+        this.helpContentKey = helpContentKey;
+        this.notebookStyles = notebookHelpSidebarStyles;
+        this.contentFullHeightOverride = contentFullHeightOverride;
+        this.displayNavBar = !minimizeChrome;
+      }
+    ));
 
     const sidebarState = localStorage.getItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE);
     if (!!sidebarState) {
@@ -94,8 +98,11 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
             this.setSidebarState(false);
           }
         }));
-    this.subscriptions.push(routeConfigDataStore.subscribe(({minimizeChrome}) => {
-      this.displayNavBar = !minimizeChrome;
+    this.subscriptions.push(routeConfigDataStore.subscribe((data) => {
+      // ROUTER MIGRATION: Prevent dueling route configs during react transition - only apply minimizeChrome if there is route data
+      if (!fp.isEqual(data, {})) {
+        this.displayNavBar = !data.minimizeChrome;
+      }
     }));
     this.subscriptions.push(urlParamsStore
       .map(({ns, wsid}) => ({ns, wsid}))


### PR DESCRIPTION
Description:
The `minimizeChrome` data flag was not getting used when added to the react router routes. Additionally, the `minimizeChrome` flag is implicitly used even when it is not defined in the route data config.  This can cause dueling route configs, where the pass through angular route provides no data and utilizes the minimizeChrome flag as an `undefined` value (turning the nav menu on) and the react route later uses it as `true` turning the menu off.

The menu is wider than the other content and was rendering when it should not have been - this is why the help bar did not align in some cases.

I manually test the various route navigations to ensure the menu is turned off when minimizeChrome is specified.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
