### PR TITLE
[no ticket][risk=no] Puppeteer: workspace-base deleteResource function

### DIFF
--- a/e2e/app/component/data-resource-card.ts
+++ b/e2e/app/component/data-resource-card.ts
@@ -2,20 +2,13 @@ import {ElementHandle, Page} from 'puppeteer';
 import * as fp from 'lodash/fp';
 import {waitWhileLoading} from 'utils/test-utils';
 import {getPropValue} from 'utils/element-utils';
+import {ResourceCard} from 'app/text-labels';
 import CardBase from './card-base';
 
 const DataResourceCardSelector = {
   cardRootXpath: '//*[@data-test-id="card"]',
   cardNameXpath: '@data-test-id="card-name"',
   cardTypeXpath: './/*[@data-test-id="card-type"]',
-}
-
-export enum CardType {
-  Cohort = 'Cohort',
-  ConceptSet = 'Concept Set',
-  Notebook = 'Notebook',
-  Dataset = 'Dataset',
-  CohortReview = 'Cohort Review',
 }
 
 /**
@@ -77,7 +70,7 @@ export default class DataResourceCard extends CardBase {
     super(page);
   }
 
-  async findCard(resourceName: string, cardType?: CardType): Promise<DataResourceCard | null> {
+  async findCard(resourceName: string, cardType?: ResourceCard): Promise<DataResourceCard | null> {
     const selector = `.//*[${DataResourceCardSelector.cardNameXpath} and normalize-space(text())="${resourceName}"]`;
     let elements: DataResourceCard[];
     if (cardType === undefined) {
@@ -114,7 +107,7 @@ export default class DataResourceCard extends CardBase {
     return element;
   }
 
-  async getResourceCard(cardType: CardType = CardType.Cohort): Promise<DataResourceCard[]> {
+  async getResourceCard(cardType: ResourceCard = ResourceCard.Cohort): Promise<DataResourceCard[]> {
     const matchArray: DataResourceCard[] = [];
     const allCards = await DataResourceCard.findAllCards(this.page);
     for (const card of allCards) {
@@ -143,7 +136,7 @@ export default class DataResourceCard extends CardBase {
    * @param {string} cardName
    * @param {CardType} cardType
    */
-  async cardExists(cardName: string, cardType: CardType):  Promise<boolean> {
+  async cardExists(cardName: string, cardType: ResourceCard):  Promise<boolean> {
     const cards = await this.getResourceCard(cardType);
     const names = await Promise.all(cards.map(item => item.getResourceName()));
     const filterdList = names.filter(name => name === cardName);

--- a/e2e/app/component/share-modal.ts
+++ b/e2e/app/component/share-modal.ts
@@ -25,6 +25,7 @@ export default class ShareModal extends Modal {
     await ownerOpt.click();
 
     await this.clickButton(LinkText.Save, {waitForClose: true});
+    console.log(`Shared workspace to user ${username} with role ${level}`);
   }
 
   async removeUser(username: string): Promise<void> {

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -3,7 +3,7 @@ import {Frame, Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
-import {ResourceCard} from '../text-labels';
+import {ResourceCard} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 import NotebookCell, {CellType} from './notebook-cell';
 import WorkspaceAnalysisPage from './workspace-analysis-page';

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -1,11 +1,12 @@
+import * as fs from 'fs';
 import {Frame, Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
+import {ResourceCard} from '../text-labels';
 import AuthenticatedPage from './authenticated-page';
 import NotebookCell, {CellType} from './notebook-cell';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
-import * as fs from 'fs';
 
 // CSS selectors
 enum CssSelector {
@@ -186,7 +187,7 @@ export default class NotebookPage extends AuthenticatedPage {
    */
   async deleteNotebook(notebookName: string): Promise<void> {
     const analysisPage = await this.goAnalysisPage();
-    await analysisPage.deleteNotebook(notebookName);
+    await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   }
 
   private async getIFrame(): Promise<Frame> {

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -1,9 +1,9 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import NewNotebookModal from 'app/component/new-notebook-modal';
 import Link from 'app/element/link';
 import Textbox from 'app/element/textbox';
-import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, ResourceCard} from 'app/text-labels';
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
@@ -31,24 +31,6 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
       console.log(`WorkspaceAnalysisPage isLoaded() encountered ${err}`);
       return false;
     }
-  }
-
-   /**
-    * Delete notebook thru Ellipsis menu located inside the Notebook resource card.
-    * @param {string} notebookName
-    */
-  async deleteNotebook(notebookName: string): Promise<string[]> {
-    const resourceCard = await DataResourceCard.findCard(this.page, notebookName);
-    await resourceCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalContentText = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteNotebook, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Notebook "${notebookName}"`);
-    await this.waitForLoad();
-    return modalContentText;
   }
 
   /**
@@ -128,7 +110,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
    */
   async duplicateNotebook(notebookName: string): Promise<string> {
     const resourceCard = new DataResourceCard(this.page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickEllipsisAction(EllipsisMenuAction.Duplicate, {waitForNav: false});
     await waitWhileLoading(this.page);
     return `Duplicate of ${notebookName}`; // name of clone notebook
@@ -143,7 +125,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   async copyNotebookToWorkspace(notebookName: string, destinationWorkspace: string, destinationNotebookName?: string): Promise<void> {
     // Open Copy modal.s
     const resourceCard = new DataResourceCard(this.page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickEllipsisAction(EllipsisMenuAction.CopyToAnotherWorkspace, {waitForNav: false});
     // Fill out modal fields.
     const copyModal = await new CopyModal(this.page);

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -117,20 +117,20 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
     let link;
     switch (resourceType) {
-    case ResourceCard.Cohort:
-      link = LinkText.DeleteCohort;
-      break;
-    case ResourceCard.ConceptSet:
-      link = LinkText.DeleteConceptSet;
-      break;
-    case ResourceCard.Dataset:
-      link = LinkText.DeleteDataset;
-      break;
-    case ResourceCard.Notebook:
-      link = LinkText.DeleteNotebook;
-      break;
-    default:
-      throw new Error(`Case ${resourceType} handling is not defined.`);
+      case ResourceCard.Cohort:
+        link = LinkText.DeleteCohort;
+        break;
+      case ResourceCard.ConceptSet:
+        link = LinkText.DeleteConceptSet;
+        break;
+      case ResourceCard.Dataset:
+        link = LinkText.DeleteDataset;
+        break;
+      case ResourceCard.Notebook:
+        link = LinkText.DeleteNotebook;
+        break;
+      default:
+        throw new Error(`Case ${resourceType} handling is not defined.`);
     }
 
     await modal.clickButton(link, {waitForClose: true});

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -4,6 +4,9 @@ import {ElementType} from 'app/xpath-options';
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality} from 'utils/waits-utils';
+import DataResourceCard from '../component/data-resource-card';
+import Modal from '../component/modal';
+import {EllipsisMenuAction, LinkText, ResourceCard} from '../text-labels';
 import AuthenticatedPage from './authenticated-page';
 
 export enum TabLabels {
@@ -94,5 +97,48 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     return waitForAttributeEquality(this.page, {xpath: selector}, 'aria-selected', 'true');
   }
 
+  /**
+   * Delete ConceptSet, Dataset or Cohort thru Ellipsis menu located inside the resource card.
+   * @param {string} resourceName
+   * @param {ResourceCard} resourceType
+   */
+  async deleteResource(resourceName: string, resourceType: ResourceCard): Promise<string[]> {
+    const resourceCard = new DataResourceCard(this.page);
+    const card = await resourceCard.findCard(resourceName, resourceType);
+    if (!card) {
+      throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
+    }
+
+    await card.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
+
+    const modal = new Modal(this.page);
+    await modal.waitForLoad();
+    const modalTextContent = await modal.getTextContent();
+
+    let link;
+    switch (resourceType) {
+    case ResourceCard.Cohort:
+      link = LinkText.DeleteCohort;
+      break;
+    case ResourceCard.ConceptSet:
+      link = LinkText.DeleteConceptSet;
+      break;
+    case ResourceCard.Dataset:
+      link = LinkText.DeleteDataset;
+      break;
+    case ResourceCard.Notebook:
+      link = LinkText.DeleteNotebook;
+      break;
+    default:
+      throw new Error(`Case ${resourceType} handling is not defined.`);
+    }
+
+    await modal.clickButton(link, {waitForClose: true});
+    await waitWhileLoading(this.page);
+
+    console.log(`Deleted ${resourceType} card "${resourceName}"`);
+    await this.waitForLoad();
+    return modalTextContent;
+  }
 
 }

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -4,9 +4,9 @@ import {ElementType} from 'app/xpath-options';
 import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality} from 'utils/waits-utils';
-import DataResourceCard from '../component/data-resource-card';
-import Modal from '../component/modal';
-import {EllipsisMenuAction, LinkText, ResourceCard} from '../text-labels';
+import DataResourceCard from 'app/component/data-resource-card';
+import Modal from 'app/component/modal';
+import {EllipsisMenuAction, LinkText, ResourceCard} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 
 export enum TabLabels {
@@ -98,7 +98,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
   }
 
   /**
-   * Delete ConceptSet, Dataset or Cohort thru Ellipsis menu located inside the resource card.
+   * Delete Notebook, Concept Set, Dataset or Cohort thru Ellipsis menu located inside the data resource card.
    * @param {string} resourceName
    * @param {ResourceCard} resourceType
    */

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -1,11 +1,11 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import EllipsisMenu from 'app/component/ellipsis-menu';
 import Modal from 'app/component/modal';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import {EllipsisMenuAction, Language, LinkText} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, ResourceCard} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitWhileLoading} from 'utils/test-utils';
@@ -80,45 +80,9 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    */
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
-    const datasetCard = await resourceCard.findCard(datasetName, CardType.Dataset);
+    const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
     await datasetCard.clickEllipsisAction(EllipsisMenuAction.exportToNotebook, {waitForNav: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
-  }
-
-  /**
-   * Delete cohort by look up its name using Ellipsis menu.
-   * @param {string} cohortName
-   */
-  async deleteCohort(cohortName: string): Promise<string[]> {
-    const cohortCard = await DataResourceCard.findCard(this.page, cohortName);
-    if (cohortCard == null) {
-      throw new Error(`Failed to find Cohort: "${cohortName}".`);
-    }
-    await cohortCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-    const modalContent = await (new CohortBuildPage(this.page)).deleteConfirmationDialog();
-    console.log(`Deleted Cohort "${cohortName}"`);
-    return modalContent;
-  }
-
-  /**
-   * Delete Dataset thru Ellipsis menu located inside the Dataset Resource card.
-   * @param {string} datasetName
-   */
-  async deleteDataset(datasetName: string): Promise<string[]> {
-    const datasetCard = await DataResourceCard.findCard(this.page, datasetName);
-    if (datasetCard == null) {
-      throw new Error(`Failed to find Dataset: "${datasetName}".`);
-    }
-    await datasetCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalContentText = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteDataset, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Dataset "${datasetName}"`);
-    await this.waitForLoad();
-    return modalContentText;
   }
 
   /**
@@ -142,26 +106,6 @@ export default class WorkspaceDataPage extends WorkspaceBase {
     await waitWhileLoading(this.page);
 
     console.log(`Renamed Dataset "${datasetName}" to "${newDatasetName}"`);
-  }
-
-  /**
-   * Delete ConceptSet thru Ellipsis menu located inside the Concept Set resource card.
-   * @param {string} conceptsetName
-   */
-  async deleteConceptSet(conceptsetName: string): Promise<string[]> {
-    const conceptSetCard = await DataResourceCard.findCard(this.page, conceptsetName);
-    if (conceptSetCard == null) {
-      throw new Error(`Failed to find Concept Set: "${conceptsetName}".`);
-    }
-    await conceptSetCard.clickEllipsisAction(EllipsisMenuAction.Delete, {waitForNav: false});
-
-    const modal = new Modal(this.page);
-    const modalTextContent = await modal.getTextContent();
-    await modal.clickButton(LinkText.DeleteConceptSet, {waitForClose: true});
-    await waitWhileLoading(this.page);
-
-    console.log(`Deleted Concept Set "${conceptsetName}"`);
-    return modalTextContent;
   }
 
   async renameCohort(cohortName: string, newCohortName: string): Promise<void> {

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -74,3 +74,11 @@ export enum Language {
    Python = 'Python',
    R = 'R',
 }
+
+export enum ResourceCard {
+   Cohort = 'Cohort',
+   ConceptSet = 'Concept Set',
+   Notebook = 'Notebook',
+   Dataset = 'Dataset',
+   CohortReview = 'Cohort Review',
+}

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -1,14 +1,14 @@
 import HelpSidebar from 'app/component/help-sidebar';
 import {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/cohort-search-page';
+import DataResourceCard from 'app/component/data-resource-card';
+import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
-import {EllipsisMenuAction, LinkText} from 'app/text-labels';
+import {EllipsisMenuAction, LinkText, ResourceCard} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
-import DataResourceCard from 'app/component/data-resource-card';
-import Button from 'app/element/button';
 
 
 describe('User can create new Cohorts', () => {
@@ -203,11 +203,11 @@ describe('User can create new Cohorts', () => {
     expect(newCardsCount).toBe(origCardsCount + 1);
 
     // Delete duplicated cohort.
-    let modalTextContent = await dataPage.deleteCohort(`Duplicate of ${cohortName}`);
+    let modalTextContent = await dataPage.deleteResource(`Duplicate of ${cohortName}`, ResourceCard.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
 
     // Delete new cohort.
-    modalTextContent = await dataPage.deleteCohort(cohortName);
+    modalTextContent = await dataPage.deleteResource(cohortName, ResourceCard.Cohort);
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
 
   });

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -1,11 +1,12 @@
+import DataResourceCard from 'app/component/data-resource-card';
 import Link from 'app/element/link';
+import CohortActionsPage from 'app/page/cohort-actions-page';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
-import DataResourceCard from 'app/component/data-resource-card';
-import {makeRandomName} from 'utils/str-utils';
-import CohortActionsPage from 'app/page/cohort-actions-page';
+import {ResourceCard} from 'app/text-labels';
 
 
 describe('User can create, modify, rename and delete Cohort', () => {
@@ -99,7 +100,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     expect(await DataResourceCard.findCard(page, newCohortName)).toBeTruthy();
 
     // Delete cohort.
-    const modalTextContent = await dataPage.deleteCohort(newCohortName);
+    const modalTextContent = await dataPage.deleteResource(newCohortName, ResourceCard.Cohort);
 
     // Verify Delete dialog content text
     expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,9 +1,10 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
+import {ResourceCard} from 'app/text-labels';
 
 describe('Create Concept Sets from Domains', () => {
 
@@ -69,7 +70,7 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openDataPage();
     await dataPage.openConceptSetsSubtab({waitPageChange: false});
 
-    const modalTextContent = await dataPage.deleteConceptSet(conceptName);
+    const modalTextContent = await dataPage.deleteResource(conceptName, ResourceCard.ConceptSet);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
   });
 
@@ -152,18 +153,18 @@ describe('Create Concept Sets from Domains', () => {
     await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Delete Dataset.
-    const textContent = await dataPage.deleteDataset(datasetName);
+    const textContent = await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
     await dataPage.openConceptSetsSubtab({waitPageChange: false});
 
-    await dataPage.deleteConceptSet(conceptName1);
-    await dataPage.deleteConceptSet(conceptName2);
+    await dataPage.deleteResource(conceptName1, ResourceCard.ConceptSet);
+    await dataPage.deleteResource(conceptName2, ResourceCard.ConceptSet);
   });
 
 });

--- a/e2e/tests/conceptsets/conceptset-edit.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit.spec.ts
@@ -1,14 +1,14 @@
 import {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceCard from 'app/component/workspace-card';
+import Link from 'app/element/link';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
 import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {LinkText} from 'app/text-labels';
+import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
-import Link from 'app/element/link';
 
 
 describe('Editing and Copying Concept Sets', () => {
@@ -89,7 +89,7 @@ describe('Editing and Copying Concept Sets', () => {
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
     await dataPage.openConceptSetsSubtab({waitPageChange: false});
-    await dataPage.deleteConceptSet(newName);
+    await dataPage.deleteResource(newName, ResourceCard.ConceptSet);
   });
 
   /**
@@ -143,13 +143,13 @@ describe('Editing and Copying Concept Sets', () => {
     expect(url).toContain(copyToWorkspace.replace(/-/g, ''));
 
     const resourceCard = new DataResourceCard(page);
-    const exists = await resourceCard.cardExists(conceptSetCopyName, CardType.ConceptSet);
+    const exists = await resourceCard.cardExists(conceptSetCopyName, ResourceCard.ConceptSet);
     expect(exists).toBe(true);
 
     console.log(`Copied Concept Set: "${conceptName} from workspace: "${copyFromWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${copyToWorkspace}"`)
 
     // Delete Concept Sets
-    await dataPage.deleteConceptSet(conceptSetCopyName);
+    await dataPage.deleteResource(conceptSetCopyName, ResourceCard.ConceptSet);
   });
 
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -1,8 +1,8 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {EllipsisMenuAction} from 'app/text-labels';
+import {EllipsisMenuAction, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -35,7 +35,7 @@ describe('Create Dataset', () => {
 
     // Verify create successful
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Rename Dataset
@@ -45,14 +45,14 @@ describe('Create Dataset', () => {
     await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     // Verify rename successful
-    const newDatasetExists = await resourceCard.cardExists(newDatasetName, CardType.Dataset);
+    const newDatasetExists = await resourceCard.cardExists(newDatasetName, ResourceCard.Dataset);
     expect(newDatasetExists).toBe(true);
 
-    const oldDatasetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const oldDatasetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(oldDatasetExists).toBe(false);
 
     // Delete Dataset
-    const textContent = await dataPage.deleteDataset(newDatasetName);
+    const textContent = await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
   });
@@ -110,7 +110,7 @@ describe('Create Dataset', () => {
     await dataPage.openDatasetsSubtab({waitPageChange: false});
 
     const resourceCard = new DataResourceCard(page);
-    const dataSetExists = await resourceCard.cardExists(datasetName, CardType.Dataset);
+    const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(dataSetExists).toBe(true);
 
     // Edit the dataset to include "All Participants".
@@ -126,7 +126,7 @@ describe('Create Dataset', () => {
     await dataPage.waitForLoad();
 
     await dataPage.openDatasetsSubtab({waitPageChange: false});
-    await dataPage.deleteDataset(datasetName);
+    await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
   });
 
 });

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -1,10 +1,10 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import Link from 'app/element/link';
-import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction} from 'app/text-labels';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {EllipsisMenuAction, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -62,13 +62,13 @@ describe('Create Dataset', () => {
 
     // Verify new notebook exists.
     const resourceCard = new DataResourceCard(page);
-    const notebookExists = await resourceCard.cardExists(newNotebookName, CardType.Notebook);
+    const notebookExists = await resourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
     expect(notebookExists).toBe(true);
 
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
 
     // Delete notebook
-    await analysiPage.deleteNotebook(newNotebookName);
+    await analysiPage.deleteResource(newNotebookName, ResourceCard.Notebook);
 
     // Resource cards count decrease by 1.
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
@@ -78,7 +78,7 @@ describe('Create Dataset', () => {
     await dataPage.openDataPage();
     await dataPage.openDatasetsSubtab({waitPageChange: false});
 
-    await dataPage.deleteDataset(newDatasetName);
+    await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
   });
 
   /**
@@ -101,7 +101,7 @@ describe('Create Dataset', () => {
     await waitWhileLoading(page);
 
     const resourceCard = new DataResourceCard(page);
-    const datasetCard = await resourceCard.findCard(datasetName, CardType.Dataset);
+    const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
     await datasetCard.clickEllipsisAction(EllipsisMenuAction.exportToNotebook, {waitForNav: false});
 
     const exportModal = new ExportToNotebookModal(page);
@@ -112,12 +112,12 @@ describe('Create Dataset', () => {
 
     // Verify notebook created successfully.
     await dataPage.openAnalysisPage();
-    const cardExists = await resourceCard.cardExists(notebookName, CardType.Notebook);
+    const cardExists = await resourceCard.cardExists(notebookName, ResourceCard.Notebook);
     expect(cardExists).toBe(true);
 
     // Delete notebook.
     const analysisPage = new WorkspaceAnalysisPage(page);
-    await analysisPage.deleteNotebook(notebookName);
+    await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   });
 
 });

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -7,7 +7,7 @@ import {findWorkspace, signIn, waitWhileLoading} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import {Ethnicity} from 'app/page/cohort-search-page';
-import {Language} from 'app/text-labels';
+import {Language, ResourceCard} from 'app/text-labels';
 
 describe('Create Dataset', () => {
 
@@ -82,19 +82,19 @@ describe('Create Dataset', () => {
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await analysisPage.waitForLoad();
-    await analysisPage.deleteNotebook(newNotebookName);
+    await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
 
     // Delete Dataset
     await dataPage.openDataPage();
     await dataPage.openDatasetsSubtab({waitPageChange: false});
 
-    const datasetDeleteDialogText = await dataPage.deleteDataset(newDatasetName);
+    const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
     await dataPage.openCohortsSubtab({waitPageChange: false});
 
-    const cohortDeleteDialogText = await dataPage.deleteCohort(newCohortName);
+    const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, ResourceCard.Cohort);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
 
   });

--- a/e2e/tests/notebook/notebook-owner-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-owner-actions.spec.ts
@@ -1,7 +1,7 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import NewNotebookModal from 'app/component/new-notebook-modal';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {LinkText} from 'app/text-labels';
+import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeWorkspaceName} from 'utils/str-utils';
 import {signIn} from 'utils/test-utils';
 
@@ -53,7 +53,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Page remain unchanged, still should be the Analysis page.
     expect(await workspaceAnalysisPage.isLoaded()).toBe(true);
 
-    await workspaceAnalysisPage.deleteNotebook(notebookName);
+    await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   })
 
   test('Notebook can be duplicated by workspace owner', async () => {
@@ -62,8 +62,8 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     const workspaceAnalysisPage = await workspacesPage.createNotebook({workspaceName, notebookName});
     const duplNotebookName = await workspaceAnalysisPage.duplicateNotebook(notebookName);
     // Delete clone notebook.
-    await workspaceAnalysisPage.deleteNotebook(duplNotebookName);
-    await workspaceAnalysisPage.deleteNotebook(notebookName);
+    await workspaceAnalysisPage.deleteResource(duplNotebookName, ResourceCard.Notebook);
+    await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
   })
 
   test('Notebook can be renamed by workspace owner', async () => {
@@ -76,13 +76,13 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     expect(modalTextContents).toContain(`Enter new name for ${notebookName}.ipynb`);
 
     const newNotebookCard = new DataResourceCard(page);
-    let cardExists = await newNotebookCard.cardExists(newName, CardType.Notebook);
+    let cardExists = await newNotebookCard.cardExists(newName, ResourceCard.Notebook);
     expect(cardExists).toBe(true);
 
-    cardExists = await newNotebookCard.cardExists(notebookName, CardType.Notebook);
+    cardExists = await newNotebookCard.cardExists(notebookName, ResourceCard.Notebook);
     expect(cardExists).toBe(false);
 
-    await workspaceAnalysisPage.deleteNotebook(newName);
+    await workspaceAnalysisPage.deleteResource(newName, ResourceCard.Notebook);
   })
 
 

--- a/e2e/tests/notebook/notebook-save.spec.ts
+++ b/e2e/tests/notebook/notebook-save.spec.ts
@@ -1,7 +1,7 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {Language} from 'app/text-labels';
+import {Language, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
@@ -39,7 +39,7 @@ describe('Jupyter Notebook tests in Python language', () => {
 
     // Find and open saved notebook and verify notebook contents match.
     const resourceCard = new DataResourceCard(page);
-    const notebookCard = await resourceCard.findCard(notebookName, CardType.Notebook);
+    const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
     await notebookCard.clickResourceName();
 
     const notebookPreviewPage = new NotebookPreviewPage(page);

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -1,8 +1,8 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
-import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import {LinkText} from 'app/text-labels';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {LinkText, ResourceCard} from 'app/text-labels';
 import {extractNamespace, makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
@@ -66,7 +66,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     await modal.clickButton(LinkText.StayHere, {waitForClose: true});
 
     // Delete notebook
-    const deleteModalTextContent = await analysisPage.deleteNotebook(copyFromNotebookName);
+    const deleteModalTextContent = await analysisPage.deleteResource(copyFromNotebookName, ResourceCard.Notebook);
     expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${copyFromNotebookName}?`);
 
     // Perform actions in copied notebook.
@@ -78,7 +78,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Verify copy-to notebook exists in destination Workspace
     await dataPage.openAnalysisPage();
     const dataResourceCard = new DataResourceCard(page);
-    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
+    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
     expect(notebookCard).toBeTruthy();
 
     // Open copied notebook and run code to verify billing project name.
@@ -94,7 +94,7 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     // Exit notebook. Returns to the Workspace Analysis tab.
     await copyNotebookPage.goAnalysisPage();
     // Delete notebook
-    const modalTextContent = await analysisPage.deleteNotebook(copiedNotebookName);
+    const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, ResourceCard.Notebook);
     expect(modalTextContent).toContain('This will permanently delete the Notebook.');
   })
 

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -1,4 +1,4 @@
-import DataResourceCard, {CardType} from 'app/component/data-resource-card';
+import DataResourceCard from 'app/component/data-resource-card';
 import Modal from 'app/component/modal';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
@@ -7,7 +7,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import {EllipsisMenuAction, Language, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
+import {EllipsisMenuAction, Language, LinkText, ResourceCard, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn, signInAs, waitWhileLoading} from 'utils/test-utils';
@@ -78,7 +78,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Notebook actions Rename, Duplicate and Delete actions are disabled.
     const dataResourceCard = new DataResourceCard(newPage);
-    const menu = await dataResourceCard.findCard(notebookName, CardType.Notebook).then(card => card.getEllipsis());
+    const menu = await dataResourceCard.findCard(notebookName, ResourceCard.Notebook).then(card => card.getEllipsis());
     await menu.clickEllipsis(); // open ellipsis menu.
     expect(await menu.isDisabled(EllipsisMenuAction.Rename)).toBe(true);
     expect(await menu.isDisabled(EllipsisMenuAction.Duplicate)).toBe(true);
@@ -110,7 +110,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
     expect(linkDisplayed).toBe(true);
 
     // Verify copied notebook exists in collaborator Workspace.
-    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, CardType.Notebook);
+    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
     expect(notebookCard).toBeTruthy();
 
     // Notebook actions Rename, Duplicate, Delete and Copy to another Workspace actions are avaliable to click.

--- a/e2e/tslint.json
+++ b/e2e/tslint.json
@@ -35,10 +35,6 @@
       "single",
       "jsx-double"
     ],
-    "ter-indent": [
-      true,
-      2
-    ],
     "max-classes-per-file": true,
     "max-line-length": [
       true,


### PR DESCRIPTION
* Create common `deleteResource()` function in `workspace-base.ts` abstract class to replace `deleteCohort`, `deleteConceptSet`, `deleteNotebook` and `deleteDataset` functions to reduce code duplication.
* Move `CardType` enum from `data-resource-card.ts` to `text-labels.ts` and rename to `ResourceCard`.
