### PR TITLE
[no ticket][risk=no] Puppeteer: Login reusing page cookies

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -17,43 +17,7 @@ beforeEach(async () => {
   // See https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaultnavigationtimeouttimeout
   page.setDefaultNavigationTimeout(navTimeOut);
   page.setDefaultTimeout(timeOut);
-});
 
-/**
- * At the end of each test completion, do:
- * - Disable network interception.
- * - Delete broswer cookies.
- * - Reset global page and browser variables.
- */
-afterEach(async () => {
-  await page.deleteCookie(...await page.cookies());
-  await jestPuppeteer.resetPage();
-  await jestPuppeteer.resetBrowser();
-});
-
-/**
- * Enable network interception in new page and block unwanted requests.
- */
-beforeAll(async () => {
-  await page.setRequestInterception(true);
-  page.on('request', (request) => {
-    const requestUrl = url.parse(request.url(), true);
-    const host = requestUrl.hostname;
-    // to improve page load performance, block network requests unrelated to application.
-    try {
-      if (host === 'www.google-analytics.com'
-           || host === 'accounts.youtube.com'
-           || host === 'static.zdassets.com'
-           || host === 'play.google.com'
-           || request.url().endsWith('content-security-index-report')) {
-        request.abort();
-      } else {
-        request.continue();
-      }
-    } catch (err) {
-      console.error(err);
-    }
-  });
   if (isDebugMode) {
     // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
     page.on('requestfailed', request => {
@@ -65,8 +29,4 @@ beforeAll(async () => {
     // Emitted when a script has uncaught exception
     page.on('pageerror', error => console.error(`❌ ${error}`));
   }
-});
-
-afterAll(async () => {
-  await page.setRequestInterception(false);
 });

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -34,7 +34,7 @@ describe('Home page ui tests', () => {
 
       // check workspace name has characters
       const cardName = await card.getWorkspaceName();
-      expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
+      await expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
 
       // check Workspace Action menu for listed actions
       const ellipsis = card.getEllipsis();

--- a/e2e/utils/user-login-cookies.ts
+++ b/e2e/utils/user-login-cookies.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs'
+import {Cookie} from 'puppeteer';
+
+function getCookieFileName(userId: string): string {
+  const id = userId.split('@')[0];
+  return `./${id}_cookies.json`;
+}
+
+export const saveCookiesToFile = (cookies: Cookie[], userId: string): void => {
+  const cookiesFile = getCookieFileName(userId);
+  fs.writeFileSync(cookiesFile, JSON.stringify(cookies, null, 2));
+}
+
+export const readCookiesFromFile = (userId: string): Cookie[] | null => {
+  const cookiesFile = getCookieFileName(userId);
+  const fileExists = fs.existsSync(cookiesFile);
+  if (fileExists) {
+    const cookies = fs.readFileSync(cookiesFile).toString();
+    return JSON.parse(cookies);
+  }
+  return null;
+}


### PR DESCRIPTION
Within same test file (suite), page cookies could be used to log in to the Workbench app. Doing so reduces total number of logins and slightly decreases test playback total time.
Cookies data is saved to `./${userName}_cookies.json` file after first successful login.
Cookies are not sharable among different test files (suites). Cookies are unique to browser instances.