### PR TITLE
[RW-4847][risk=low] Migrate last Leo endpoint: CreateCluster -> CreateRuntime

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -20,10 +20,11 @@ import org.pmiops.workbench.leonardo.ApiException;
 import org.pmiops.workbench.leonardo.LeonardoRetryHandler;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.api.ServiceInfoApi;
-import org.pmiops.workbench.leonardo.model.LeonardoClusterRequest;
+import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
+import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig.CloudServiceEnum;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
 import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.pmiops.workbench.notebooks.model.LocalizationEntry;
@@ -76,10 +77,10 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     this.workspaceService = workspaceService;
   }
 
-  private LeonardoClusterRequest buildCreateClusterRequest(
+  private LeonardoCreateRuntimeRequest buildCreateRuntimeRequest(
       String userEmail,
       @Nullable ClusterConfig clusterOverride,
-      Map<String, String> customClusterEnvironmentVariables) {
+      Map<String, String> customEnvironmentVariables) {
     // TODO(RW-5406): Remove cluster override.
     if (clusterOverride == null) {
       clusterOverride = new ClusterConfig();
@@ -96,25 +97,21 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     nbExtensions.put(
         "aou-upload-policy-extension", assetsBaseUrl + "/aou-upload-policy-extension.js");
 
-    return new LeonardoClusterRequest()
+    return new LeonardoCreateRuntimeRequest()
         .labels(ImmutableMap.of(RUNTIME_LABEL_AOU, "true", RUNTIME_LABEL_CREATED_BY, userEmail))
         .defaultClientId(config.server.oauthClientId)
         // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
         .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_cluster.sh")
         .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_cluster.sh")
         .userJupyterExtensionConfig(
-            new LeonardoUserJupyterExtensionConfig()
-                .nbExtensions(nbExtensions)
-                .serverExtensions(ImmutableMap.of("jupyterlab", "jupyterlab"))
-                .combinedExtensions(ImmutableMap.<String, String>of())
-                .labExtensions(ImmutableMap.<String, String>of()))
+            new LeonardoUserJupyterExtensionConfig().nbExtensions(nbExtensions))
         // Matches Terra UI's scopes, see RW-3531 for rationale.
         .addScopesItem("https://www.googleapis.com/auth/cloud-platform")
         .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
         .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
-        .enableWelder(true)
-        .machineConfig(
+        .runtimeConfig(
             new LeonardoMachineConfig()
+                .cloudService(CloudServiceEnum.DATAPROC)
                 .masterDiskSize(
                     Optional.ofNullable(clusterOverride.masterDiskSize)
                         .orElse(config.firecloud.notebookRuntimeDefaultDiskSizeGb))
@@ -123,7 +120,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                         .orElse(config.firecloud.notebookRuntimeDefaultMachineType)))
         .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
         .welderDockerImage(workbenchConfigProvider.get().firecloud.welderDockerImage)
-        .customClusterEnvironmentVariables(customClusterEnvironmentVariables);
+        .customEnvironmentVariables(customEnvironmentVariables);
   }
 
   @Override
@@ -145,12 +142,11 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
     leonardoRetryHandler.run(
         (context) -> {
-          // TODO(RW-4847): Switch to createRuntime once IA-2167 is fixed/deployed.
-          runtimesApi.createClusterV2(
-              buildCreateClusterRequest(
-                  user.getUsername(), user.getClusterConfigDefault(), customEnvironmentVariables),
+          runtimesApi.createRuntime(
               googleProject,
-              runtimeName);
+              runtimeName,
+              buildCreateRuntimeRequest(
+                  user.getUsername(), user.getClusterConfigDefault(), customEnvironmentVariables));
           return null;
         });
   }

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -853,8 +853,7 @@ paths:
         * Default labels clusterName, googleProject, serviceAccount, and notebookExtension cannot be overridden.
       operationId: createClusterV2
       tags:
-        # TODO(RW-4847): Revert this to the cluster tag, or just remove cluster tagged endpoints.
-        - runtimes
+        - cluster
       parameters:
         - in: path
           name: googleProject


### PR DESCRIPTION
(part 5 of 8)

This change was temporarily held back from https://github.com/all-of-us/workbench/pull/3926, since we discovered the above issue with the CreateRuntime endpoint.

Verified locally via a new runtime creation:
![image](https://user-images.githubusercontent.com/822298/92782297-b30f8880-f359-11ea-99a6-dd43fa7d1185.png)
