### PR TITLE
[RW-5405][risk=no] Rename cluster assets

### DIFF
--- a/api/snippets-menu/README.md
+++ b/api/snippets-menu/README.md
@@ -1,11 +1,11 @@
 # Snippets Menu
 
-AoU Clusters enable the [Snippets Menu extension](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/snippets_menu/readme.html)
+AoU Runtimes enable the [Snippets Menu extension](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/snippets_menu/readme.html)
 with custom AoU-specific code snippets. The snippets live in
-https://github.com/all-of-us/workbench-snippets. AoU configures Leo clusters as
+https://github.com/all-of-us/workbench-snippets. AoU configures Leo runtimes as
 follows to enable this:
 
-1. Enable the snippets_menu/main extension in ../src/main/webapp/static/initialize_notebook_cluster.sh
+1. Enable the snippets_menu/main extension in ../src/main/webapp/static/initialize_notebook_runtime.sh
 1. Deploy a Jupyter UI extension to configure the menu with AoU-specific snippets
 
 ## Updating Snippets
@@ -24,7 +24,7 @@ Prerequisite: Must have `jq` installed (for pretty printing).
     ./import_json_from_snippets_repo.sh <path to workbench-snippets repo>
     ```
 1. Commit changes and go through normal pull request process.
-1. Wait for a release; note that changes are only visible for clusters started
+1. Wait for a release; note that changes are only visible for runtimes started
     after the release.
 
 ## Snippets Extension Implementation

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -100,8 +100,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         .labels(ImmutableMap.of(RUNTIME_LABEL_AOU, "true", RUNTIME_LABEL_CREATED_BY, userEmail))
         .defaultClientId(config.server.oauthClientId)
         // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
-        .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_cluster.sh")
-        .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_cluster.sh")
+        .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_runtime.sh")
+        .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_runtime.sh")
         .userJupyterExtensionConfig(
             new LeonardoUserJupyterExtensionConfig()
                 .nbExtensions(nbExtensions)

--- a/api/src/main/webapp/static/README.md
+++ b/api/src/main/webapp/static/README.md
@@ -1,9 +1,9 @@
 # Static Files in AppEngine
-We host a number of public static files in GAE for cluster creation. Generated files will be copied here at build time and gitnored (e.g. snippets menu), if any.
+We host a number of public static files in GAE for runtime creation. Generated files will be copied here at build time and gitnored (e.g. snippets menu), if any.
 
-# initialize_notebook_cluster.sh
+# initialize_notebook_runtime.sh
 
-This is the script run on the Leonardo Jupyter server at cluster initialization
+This is the script run on the Leonardo Jupyter server at runtime initialization
 time, i.e. the [jupyterUserScriptUri](
 https://github.com/DataBiosphere/leonardo/blob/cfdbff2448b9cff73ad658ba028d1feafab01b81/src/main/resources/swagger/api-docs.yaml#L509).
 
@@ -31,17 +31,14 @@ To manually test updates to any notebook server assets (initialization script, U
 
 - Run a **local** API server with this config update and point a local UI to it
 - Open your local Workbench UI, go to the workspace 'About' tab, and click 'Reset notebook server'.
-- Wait for the notebook cluster to be created.
+- Wait for the notebook runtime to be created.
 - Revert changes to `config_local.json` before sending a PR
 
 ## Debugging Script Issues
 
-- Find your existing notebook cluster if any, by authorizing as your
-  fake-research-aou.org user [here](
-  https://leonardo.dsde-dev.broadinstitute.org/#!/cluster/listClusters).
-- Call `listClusters` and take the returned `stagingBucket` value.
-- `gcloud auth login USER@fake-research-aou.org`
-- `gsutil ls gs://STAGING_BUCKET`
+- Run `./project.rb list-runtimes --project all-of-us-workbench-test` to find your runtime name
+- Run `./project.rb describe <runtime-name>` to print debug information about
+  the runtime. This will include command lines for listing out associated log files
 - Dig through the directories until you find the initialization script output
   log, as of 4/3/19 the file was named `dataproc-initialization-script-0_output`
 
@@ -56,9 +53,9 @@ This can be used to quickly test command lines or reproduce bugs.
 # Local Jupyter extension testing
 
 Tweak the above instructions for testing the user script to push a modified
-extension and modify the cluster controller to use it.
+extension and modify the runtime controller to use it.
 
-Alternatively, on a live version of a Leo cluster, use Chrome local overrides to
+Alternatively, on a live version of a Leo runtime, use Chrome local overrides to
 plug in your locally modified Javascript.
 
 - Follow these instructions to setup local overrides: https://developers.google.com/web/updates/2018/01/devtools#overrides

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Log all commands, logs are written to the Leo staging directory during startup
+# and can be found via the Leo API's GetRuntimeResponse.asyncRuntimeFields.stagingBucket.
+set -x
+
+# Initializes a Jupyter notebook runtime. This file is hosted from the Workbench
+# API server and its path is passed in as jupyterUserScriptUri during notebook
+# runtime creation.
+
+# As of initial Workbench launch, we will not be offering or have a need for
+# Spark on notebooks runtimes. Disable the kernels to avoid presenting spurious
+# kernel options to researchers. See https://github.com/DataBiosphere/leonardo/issues/321.
+jupyter kernelspec uninstall -f pyspark2
+jupyter kernelspec uninstall -f pyspark3
+
+# Enable any built-in extensions. Snippets menu is used for AoU-specific code
+# snippet insertion, see README.md for more details.
+jupyter nbextension enable snippets_menu/main
+
+# Section represents the jupyter page to which the extension will be applied to
+jupyter nbextension enable aou-upload-policy-extension/main --section=tree
+

--- a/api/src/main/webapp/static/start_notebook_runtime.sh
+++ b/api/src/main/webapp/static/start_notebook_runtime.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Log all commands, logs are written to the Leo staging directory during startup
+# and can be found via the Leo API's GetRuntimeResponse.asyncRuntimeFields.stagingBucket.
+set -x
+
+# Runs before every Jupyter notebook runtime startup, including both creation
+# and resumes. This file is served as a static asset from the Workbench API
+# server and its path is passed in as jupyterStartUserScriptUri during notebook
+# runtime creation. This runs after initialize_notebook_runtime.sh on creation.
+
+pushd /usr/local/share/wondershaper
+wondershaper -a "eth0" -u 16384 # kilobits; 16Mib/s (2MiB/s)
+
+popd


### PR DESCRIPTION
Renaming cluster -> runtime (part 6 of 8).

- Functional no-op
- Updated corresponding docs as well
- The two "new" shell scripts are just renamed copies of existing scripts, with wording changes in comments only
  - The old assets need to stay there until the old clusters phase out, i.e. 2w after this goes live