### PR TITLE
[RW-5543][risk=no] Disable "edit" on the workspace card menu for writers

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -89,14 +89,14 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
                   }>
           Duplicate
         </MenuItem>
-        <TooltipTrigger content={<div>Requires Write Permission</div>}
-                        disabled={WorkspacePermissionsUtil.canWrite(accessLevel)}>
+        <TooltipTrigger content={<div>Requires Owner Permission</div>}
+                        disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='pencil'
                     onClick={() => {
                       AnalyticsTracker.Workspaces.OpenEditPage('Card');
                       navigate([wsPathPrefix, 'edit']); }
                     }
-                    disabled={!WorkspacePermissionsUtil.canWrite(accessLevel)}>
+                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
             Edit
           </MenuItem>
         </TooltipTrigger>


### PR DESCRIPTION
Only owners have this permission: https://github.com/all-of-us/workbench/blob/76478bf5553a92968629c42639bf24e044ee9589/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java#L348

I'm out on Tuesday, so feel free to merge this for me so it makes the release cut.