### PR TITLE
[RW-5487][risk=no] generated new synth cdr and updated csv files

### DIFF
--- a/api/config/cdr_versions_test.json
+++ b/api/config/cdr_versions_test.json
@@ -33,7 +33,7 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_5"
+    "cdrDbName": "synth_r_2019q4_6"
   },
   {
     "cdrVersionId": 4,

--- a/api/db-cdr/changelog-data/db.changelog-1.xml
+++ b/api/db-cdr/changelog-data/db.changelog-1.xml
@@ -27,6 +27,8 @@
     <delete tableName="cb_person"/>
     <delete tableName="cb_data_filter"/>
     <delete tableName="ds_linking"/>
+    <delete tableName="cb_survey_attribute"/>
+    <delete tableName="cb_survey_version"/>
 
     <loadData tableName="domain_info" file="csv/domain_info.csv" encoding="UTF-8" quotchar='"'>
       <column name="concept_id" type="NUMERIC"/>
@@ -302,6 +304,23 @@
       <column name="omop_sql" type="STRING"/>
       <column name="join_value" type="STRING"/>
       <column name="domain" type="STRING"/>
+    </loadData>
+
+    <loadData tableName="cb_survey_attribute" file="csv/cb_survey_attribute.csv" encoding="UTF-8"
+      quotchar='"'>
+      <column name="id" type="NUMERIC"/>
+      <column name="question_concept_id" type="NUMERIC"/>
+      <column name="answer_concept_id" type="NUMERIC"/>
+      <column name="survey_id" type="NUMERIC"/>
+      <column name="item_count" type="NUMERIC"/>
+    </loadData>
+
+    <loadData tableName="cb_survey_version" file="csv/cb_survey_version.csv" encoding="UTF-8"
+      quotchar='"'>
+      <column name="survey_id" type="NUMERIC"/>
+      <column name="concept_id" type="NUMERIC"/>
+      <column name="version" type="STRING"/>
+      <column name="display_order" type="NUMERIC"/>
     </loadData>
 
   </changeSet>


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-5487

- Bumping to synth_r_2019q4_6 in test
- Adding cb_survey_attribute and cb_survey_version

Note: please run `./project.rb run-local-data-migrations` in order to see new cope survey trees locally.