### PR TITLE
[RW-5445][risk=no]UI: Add "versions" indicator for COPE in survey hierarchy

### DIFF
--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
-import {CohortBuilderApi} from 'generated/fetch';
+import {CohortBuilderApi, DomainType} from 'generated/fetch';
 import defaultServerConfig from 'testing/default-server-config';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
@@ -19,6 +19,23 @@ const treeNodeStub = {
   hasAttributes: true,
   id: 316305,
   name: 'Height Detail',
+  parentId: 0,
+  predefinedAttributes: null,
+  selectable: true,
+  subtype: 'HEIGHT',
+  type: 'PM'
+} as NodeProp;
+
+const surveyCOPETreeNodeStub = {
+  children: [],
+  code: '',
+  conceptId: 328232,
+  count: 0,
+  domainId: DomainType.SURVEY.toString(),
+  group: true,
+  hasAttributes: false,
+  id: 328232,
+  name: 'COVID-19 Related Symptoms',
   parentId: 0,
   predefinedAttributes: null,
   selectable: true,
@@ -47,5 +64,17 @@ describe('TreeNode', () => {
                                       selectedIds={[]}
                                       setAttributes={() => {}}/>);
     expect(wrapper).toBeTruthy();
+  });
+  it('should display Versiond if SURVEY is COPE', () => {
+    const wrapper = mount(<TreeNode autocompleteSelection={undefined}
+                                    groupSelections={[]}
+                                    node={surveyCOPETreeNodeStub}
+                                    scrollToMatch={() => {}}
+                                    searchTerms={''}
+                                    select={() => {}}
+                                    selectedIds={[]}
+                                    setAttributes={() => {}}/>);
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.find('[data-test-id="displayName"]').text()).toContain('COVID-19 Related Symptoms -  Versioned');
   });
 });

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -35,11 +35,11 @@ const surveyCOPETreeNodeStub = {
   group: true,
   hasAttributes: false,
   id: 328232,
-  name: 'COVID-19 Related Symptoms',
+  name: 'COVID-19 Participant Experience (COPE) Survey',
   parentId: 0,
   predefinedAttributes: null,
   selectable: true,
-  subtype: 'HEIGHT',
+  subtype: 'SURVEY',
   type: 'PM'
 } as NodeProp;
 describe('TreeNode', () => {
@@ -75,6 +75,6 @@ describe('TreeNode', () => {
                                     selectedIds={[]}
                                     setAttributes={() => {}}/>);
     expect(wrapper).toBeTruthy();
-    expect(wrapper.find('[data-test-id="displayName"]').text()).toContain('COVID-19 Related Symptoms -  Versioned');
+    expect(wrapper.find('[data-test-id="displayName"]').text()).toContain('COVID-19 Participant Experience (COPE) Survey -  Versioned');
   });
 });

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -29,7 +29,7 @@ const treeNodeStub = {
 const surveyCOPETreeNodeStub = {
   children: [],
   code: '',
-  conceptId: 328232,
+  conceptId: 1333342,
   count: 0,
   domainId: DomainType.SURVEY.toString(),
   group: true,
@@ -65,7 +65,7 @@ describe('TreeNode', () => {
                                       setAttributes={() => {}}/>);
     expect(wrapper).toBeTruthy();
   });
-  it('should display Versiond if SURVEY is COPE', () => {
+  it('should display Versioned if SURVEY is COPE', () => {
     const wrapper = mount(<TreeNode autocompleteSelection={undefined}
                                     groupSelections={[]}
                                     node={surveyCOPETreeNodeStub}

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -13,7 +13,8 @@ import {triggerEvent} from 'app/utils/analytics';
 import {attributesSelectionStore, currentCohortCriteriaStore, currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
 import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 
-const COPE_SURVEY_ID = 328232;
+const COPE_SURVEY_ID = 1333342;
+const COPE_SURVEY_GROUP_NAME = 'COVID-19 Participant Experience (COPE) Survey';
 const styles = reactStyles({
   code: {
     color: colors.dark,
@@ -288,8 +289,9 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   get isCOPESurvey() {
-    const {node: {domainId, hasAttributes, id}} = this.props;
-    return !hasAttributes && id === COPE_SURVEY_ID && domainId === DomainType.SURVEY.toString() ;
+    const {node: {conceptId, name, subtype}} = this.props;
+    return subtype === CriteriaSubType.SURVEY.toString() && conceptId === COPE_SURVEY_ID &&
+       name === COPE_SURVEY_GROUP_NAME;
   }
 
   render() {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -13,7 +13,6 @@ import {triggerEvent} from 'app/utils/analytics';
 import {attributesSelectionStore, currentCohortCriteriaStore, currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
 import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 
-// COPE Survey ID will not change
 const COPE_SURVEY_ID = 328232;
 const styles = reactStyles({
   code: {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -13,6 +13,8 @@ import {triggerEvent} from 'app/utils/analytics';
 import {attributesSelectionStore, currentCohortCriteriaStore, currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
 import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 
+// COPE Survey ID will not change
+const COPE_SURVEY_ID = 328232;
 const styles = reactStyles({
   code: {
     color: colors.dark,
@@ -286,6 +288,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     }
   }
 
+  get isCOPESurvey() {
+    const {node: {domainId, hasAttributes, id}} = this.props;
+    return !hasAttributes && id === COPE_SURVEY_ID && domainId === DomainType.SURVEY.toString() ;
+  }
+
   render() {
     const {autocompleteSelection, groupSelections, node,
       node: {code, count, domainId, id, group, hasAttributes, name, parentId, selectable}, scrollToMatch, searchTerms, select, selectedIds,
@@ -331,7 +338,9 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           {(!!code && code !== name) && <div style={styles.code}>{code}</div>}
           <TooltipTrigger content={<div>{displayName}</div>} disabled={!this.state.truncated}>
             <div style={styles.name} ref={(e) => this.name = e}>
-              <span style={searchMatch ? styles.searchMatch : {}}>{displayName}</span>
+              <span data-test-id='displayName' style={searchMatch ? styles.searchMatch : {}}>{displayName}
+              {this.isCOPESurvey && <span style={{paddingRight: '0.1rem'}}> - <i> Versioned</i> </span>}
+              </span>
             </div>
           </TooltipTrigger>
           {this.showCount && <div style={{whiteSpace: 'nowrap'}}>


### PR DESCRIPTION

<img width="587" alt="Screen Shot 2020-09-10 at 1 11 05 AM" src="https://user-images.githubusercontent.com/34481816/92684541-b1b37100-f303-11ea-9c00-da5018ffbe79.png">

<img width="610" alt="Screen Shot 2020-09-10 at 1 20 05 AM" src="https://user-images.githubusercontent.com/34481816/92684583-c5f76e00-f303-11ea-9c55-311311230f15.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
