### PR TITLE
[RW-5577][risk=no] Bumping cdr versions

### DIFF
--- a/api/config/cdr_versions_preprod.json
+++ b/api/config/cdr_versions_preprod.json
@@ -9,7 +9,7 @@
     "creationTime": "2019-10-21 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 224143,
-    "cdrDbName": "r_2020q3_1"
+    "cdrDbName": "r_2019q4_7"
   },
   {
     "cdrVersionId": 2,
@@ -32,6 +32,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_5"
+    "cdrDbName": "synth_r_2019q4_6"
   }
 ]

--- a/api/config/cdr_versions_prod.json
+++ b/api/config/cdr_versions_prod.json
@@ -57,6 +57,6 @@
     "creationTime": "2019-10-04 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 224143,
-    "cdrDbName": "r_2019q4_6"
+    "cdrDbName": "r_2019q4_7"
   }
 ]

--- a/api/config/cdr_versions_stable.json
+++ b/api/config/cdr_versions_stable.json
@@ -59,6 +59,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_5"
+    "cdrDbName": "synth_r_2019q4_6"
   }
 ]

--- a/api/config/cdr_versions_staging.json
+++ b/api/config/cdr_versions_staging.json
@@ -59,6 +59,6 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_5"
+    "cdrDbName": "synth_r_2019q4_6"
   }
 ]


### PR DESCRIPTION
Bumping cdr versions
**Staging** - synth_r_2019q4_5 -> synth_r_2019q4_6
**Stable**   - synth_r_2019q4_5 -> synth_r_2019q4_6
**Preprod** - r_2020q3_1  -> r_2019q4_7 and synth_r_2019q4_5 -> synth_r_2019q4_6
**Prod**      - r_2019q4_6 -> r_2019q4_7