### PR TITLE
[risk=low] Fix auth domain error message

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -149,10 +149,10 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
       // the user it was created for.
       userName = fireCloudService.getMe().getUserInfo().getUserEmail();
       if (!userName.endsWith(gsuiteDomainSuffix)) {
-        log.log(
-            Level.INFO,
-            "User {0} isn't in domain {1}, can't access the workbench",
-            new Object[] {userName, gsuiteDomainSuffix});
+        log.info(
+            String.format(
+                "User %s isn't in domain %s, can't access the workbench",
+                userName, gsuiteDomainSuffix));
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         return false;
       }


### PR DESCRIPTION
Description:

Format pattern was incorrect - it removed apostrophes and didn't substitute all values.

Before: `INFO: User joel.broad.dev@gmail.com isnt in domain {1}, cant access the workbench`
After `INFO: User joel.broad.dev@gmail.com isn't in domain @fake-research-aou.org, can't access the workbench`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test:local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
