### PR TITLE
[RW-5462][risk=no] Endpoint for COPE survey versions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -34,7 +34,9 @@ import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.SurveyVersionListResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,10 +47,10 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   private static final String BAD_REQUEST_MESSAGE =
       "Bad Request: Please provide a valid %s. %s is not valid.";
 
-  private CdrVersionService cdrVersionService;
-  private ElasticSearchService elasticSearchService;
-  private Provider<WorkbenchConfig> configProvider;
-  private CohortBuilderService cohortBuilderService;
+  private final CdrVersionService cdrVersionService;
+  private final ElasticSearchService elasticSearchService;
+  private final Provider<WorkbenchConfig> configProvider;
+  private final CohortBuilderService cohortBuilderService;
 
   @Autowired
   CohortBuilderController(
@@ -209,6 +211,19 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     return ResponseEntity.ok(cohortBuilderService.findParticipantDemographics());
   }
 
+  @Override
+  public ResponseEntity<SurveyVersionListResponse> findSurveyVersionByQuestionConceptId(
+      Long cdrVersionId, Long surveyConceptId, Long questionConceptId) {
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<SurveyVersionListResponse>
+      findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+          Long cdrVersionId, Long surveyConceptId, Long questionConceptId, Long answerConceptId) {
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
   /**
    * This method helps determine what request can only be approximated by elasticsearch and must
    * fallback to the BQ implementation.
@@ -221,7 +236,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
             .flatMap(sg -> sg.getItems().stream())
             .flatMap(sgi -> sgi.getSearchParameters().stream())
             .collect(Collectors.toList());
-    return allGroups.stream().anyMatch(sg -> sg.getTemporal())
+    return allGroups.stream().anyMatch(SearchGroup::getTemporal)
         || allParams.stream().anyMatch(sp -> CriteriaSubType.BP.toString().equals(sp.getSubtype()));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
 import org.pmiops.workbench.model.SurveyVersionListResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -214,14 +213,24 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   @Override
   public ResponseEntity<SurveyVersionListResponse> findSurveyVersionByQuestionConceptId(
       Long cdrVersionId, Long surveyConceptId, Long questionConceptId) {
-    return new ResponseEntity<>(HttpStatus.OK);
+    cdrVersionService.setCdrVersion(cdrVersionId);
+    return ResponseEntity.ok(
+        new SurveyVersionListResponse()
+            .items(
+                cohortBuilderService.findSurveyVersionByQuestionConceptId(
+                    surveyConceptId, questionConceptId)));
   }
 
   @Override
   public ResponseEntity<SurveyVersionListResponse>
       findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
           Long cdrVersionId, Long surveyConceptId, Long questionConceptId, Long answerConceptId) {
-    return new ResponseEntity<>(HttpStatus.OK);
+    cdrVersionService.setCdrVersion(cdrVersionId);
+    return ResponseEntity.ok(
+        new SurveyVersionListResponse()
+            .items(
+                cohortBuilderService.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+                    surveyConceptId, questionConceptId, answerConceptId)));
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -253,14 +253,32 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select distinct csv.survey_id, csv.version, csa.item_count, csv.display_order "
+          "select surveyId, version, itemCount from( "
+              + "select csv.survey_id as surveyId, csv.version as version, sum(csa.item_count) as itemCount, csv.display_order "
               + "from cb_survey_version csv "
               + "join cb_survey_attribute csa on csv.survey_id = csa.survey_id "
               + "where csv.concept_id = :surveyConceptId "
               + "and csa.question_concept_id = :questionConceptId "
-              + "order by csv.display_order",
+              + "group by csv.survey_id, csv.version, csv.display_order "
+              + "order by csv.display_order) innerSql",
       nativeQuery = true)
   List<DbSurveyVersion> findSurveyVersionByQuestionConceptId(
       @Param("surveyConceptId") Long surveyConceptId,
       @Param("questionConceptId") Long questionConceptId);
+
+  @Query(
+      value =
+          "select surveyId, version, itemCount from( "
+              + "select distinct csv.survey_id as surveyId, csv.version as version, csa.item_count as itemCount, csv.display_order "
+              + "from cb_survey_version csv "
+              + "join cb_survey_attribute csa on csv.survey_id = csa.survey_id "
+              + "where csv.concept_id = :surveyConceptId "
+              + "and csa.question_concept_id = :questionConceptId "
+              + "and csa.answer_concept_id = :answerConceptId "
+              + "order by csv.display_order) innerSql",
+      nativeQuery = true)
+  List<DbSurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+      @Param("surveyConceptId") Long surveyConceptId,
+      @Param("questionConceptId") Long questionConceptId,
+      @Param("answerConceptId") Long answerConceptId);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaLookup;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
+import org.pmiops.workbench.cdr.model.DbSurveyVersion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -249,4 +250,17 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select distinct domain_id as domain, type, is_standard as standard from cb_criteria order by domain, type, is_standard",
       nativeQuery = true)
   List<DbMenuOption> findMenuOptions();
+
+  @Query(
+      value =
+          "select distinct csv.survey_id, csv.version, csa.item_count, csv.display_order "
+              + "from cb_survey_version csv "
+              + "join cb_survey_attribute csa on csv.survey_id = csa.survey_id "
+              + "where csv.concept_id = :surveyConceptId "
+              + "and csa.question_concept_id = :questionConceptId "
+              + "order by csv.display_order",
+      nativeQuery = true)
+  List<DbSurveyVersion> findSurveyVersionByQuestionConceptId(
+      @Param("surveyConceptId") Long surveyConceptId,
+      @Param("questionConceptId") Long questionConceptId);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/model/DbSurveyVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/model/DbSurveyVersion.java
@@ -1,0 +1,9 @@
+package org.pmiops.workbench.cdr.model;
+
+public interface DbSurveyVersion {
+  public long getSurveyId();
+
+  public String getVersion();
+
+  public long getItemCount();
+}

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -13,6 +13,7 @@ import org.pmiops.workbench.model.DemoChartInfo;
 import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.SurveyVersion;
 
 public interface CohortBuilderService {
 
@@ -53,4 +54,10 @@ public interface CohortBuilderService {
 
   List<String> findSortedConceptIdsByDomainIdAndTypeAndParentIdNotIn(
       String domainId, Long parentId, String sortColumn, String sortName);
+
+  List<SurveyVersion> findSurveyVersionByQuestionConceptId(
+      Long surveyConceptId, Long questionConceptId);
+
+  List<SurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+      Long surveyConceptId, Long questionConceptId, Long answerConceptId);
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -341,8 +341,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public List<SurveyVersion> findSurveyVersionByQuestionConceptId(
       Long surveyConceptId, Long questionConceptId) {
-    return cbCriteriaDao
-        .findSurveyVersionByQuestionConceptId(surveyConceptId, questionConceptId)
+    return cbCriteriaDao.findSurveyVersionByQuestionConceptId(surveyConceptId, questionConceptId)
         .stream()
         .map(cohortBuilderMapper::dbModelToClient)
         .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -46,6 +46,7 @@ import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchRequest;
 import org.pmiops.workbench.model.StandardFlag;
+import org.pmiops.workbench.model.SurveyVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -335,6 +336,27 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
             .map(c -> c.getConceptId().toString())
             .collect(Collectors.toList());
     return demoList;
+  }
+
+  @Override
+  public List<SurveyVersion> findSurveyVersionByQuestionConceptId(
+      Long surveyConceptId, Long questionConceptId) {
+    return cbCriteriaDao
+        .findSurveyVersionByQuestionConceptId(surveyConceptId, questionConceptId)
+        .stream()
+        .map(cohortBuilderMapper::dbModelToClient)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+      Long surveyConceptId, Long questionConceptId, Long answerConceptId) {
+    return cbCriteriaDao
+        .findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
+            surveyConceptId, questionConceptId, answerConceptId)
+        .stream()
+        .map(cohortBuilderMapper::dbModelToClient)
+        .collect(Collectors.toList());
   }
 
   private String modifyTermMatch(String term) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
@@ -6,10 +6,12 @@ import org.pmiops.workbench.cdr.model.DbAgeTypeCount;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbDataFilter;
+import org.pmiops.workbench.cdr.model.DbSurveyVersion;
 import org.pmiops.workbench.model.AgeTypeCount;
 import org.pmiops.workbench.model.Criteria;
 import org.pmiops.workbench.model.CriteriaAttribute;
 import org.pmiops.workbench.model.DataFilter;
+import org.pmiops.workbench.model.SurveyVersion;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
@@ -31,4 +33,6 @@ public interface CohortBuilderMapper {
   CriteriaAttribute dbModelToClient(DbCriteriaAttribute source);
 
   DataFilter dbModelToClient(DbDataFilter source);
+
+  SurveyVersion dbModelToClient(DbSurveyVersion source);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3331,6 +3331,64 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaAttributeListResponse"
+  "/v1/cohortbuilder/{cdrVersionId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}":
+    parameters:
+    - "$ref": "#/parameters/cdrVersionId"
+    get:
+      tags:
+      - cohortBuilder
+      description: Returns SurveyVersion with counts
+      operationId: findSurveyVersionByQuestionConceptId
+      parameters:
+      - in: path
+        name: surveyConceptId
+        type: integer
+        format: int64
+        required: true
+        description: surveyConceptId of the survey
+      - in: path
+        name: questionConceptId
+        type: integer
+        format: int64
+        required: true
+        description: questionConceptId of the question
+      responses:
+        200:
+          description: A collection of SurveyVersion
+          schema:
+            "$ref": "#/definitions/SurveyVersionListResponse"
+  "/v1/cohortbuilder/{cdrVersionId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}/{answerConceptId}":
+    parameters:
+    - "$ref": "#/parameters/cdrVersionId"
+    get:
+      tags:
+      - cohortBuilder
+      description: Returns SurveyVersion with counts
+      operationId: findSurveyVersionByQuestionConceptIdAndAnswerConceptId
+      parameters:
+      - in: path
+        name: surveyConceptId
+        type: integer
+        format: int64
+        required: true
+        description: surveyConceptId of the survey
+      - in: path
+        name: questionConceptId
+        type: integer
+        format: int64
+        required: true
+        description: questionConceptId of the question
+      - in: path
+        name: answerConceptId
+        type: integer
+        format: int64
+        required: true
+        description: answerConceptId of the answer
+      responses:
+        200:
+          description: A collection of SurveyVersion
+          schema:
+            "$ref": "#/definitions/SurveyVersionListResponse"
   "/v1/cohortbuilder/{cdrVersionId}/age/counts":
     parameters:
     - "$ref": "#/parameters/cdrVersionId"
@@ -7048,6 +7106,33 @@ definitions:
       estCount:
         description: possible count
         type: string
+  SurveyVersionListResponse:
+    type: object
+    required:
+    - items
+    properties:
+      items:
+        type: array
+        items:
+          "$ref": "#/definitions/SurveyVersion"
+  SurveyVersion:
+    type: object
+    required:
+    - surveyId
+    - version
+    - itemCount
+    properties:
+      surveyId:
+        description: id of the cope survey
+        type: integer
+        format: int64
+      version:
+        description: name of the verion
+        type: string
+      itemCount:
+        description: name of concept
+        type: integer
+        format: int64
   SearchRequest:
     description: 'The SearchRequest describes the state of the Cohort Builder at any
       given moment. It contains two keys, `include` and `exclude`, each of which specifies

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -38,6 +38,7 @@ import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.SurveyVersionListResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -627,6 +628,45 @@ public class CohortBuilderControllerTest {
         demos.getEthnicityList().get(0));
     assertEquals(
         new ConceptIdName().conceptId(4L).conceptName("Male"), demos.getSexAtBirthList().get(0));
+  }
+
+  @Test
+  public void findSurveyVersionByQuestionConceptId() {
+    jdbcTemplate.execute(
+        "create table cb_survey_version(survey_id integer, concept_id integer, version varchar(50), display_order integer)");
+    jdbcTemplate.execute(
+        "create table cb_survey_attribute(id integer, question_concept_id integer, answer_concept_id integer, survey_id integer, item_count integer)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (100, 1333342, 'May 2020', 1)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (101, 1333342, 'June 2020', 2)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (102, 1333342, 'July 2020', 3)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (1, 715713, 0, 100, 291)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (2, 715713, 0, 101, 148)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (3, 715713, 0, 102, 150)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (4, 715713, 903096, 100, 154)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (5, 715713, 903096, 101, 82)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (6, 715713, 903096, 102, 31)");
+    SurveyVersionListResponse response =
+        controller.findSurveyVersionByQuestionConceptId(1L, 1333342L, 715713L).getBody();
+    assertEquals(response.getItems().get(0).getSurveyId(), new Long("100"));
+    assertEquals(response.getItems().get(0).getVersion(), "May 2020");
+    assertEquals(response.getItems().get(0).getItemCount(), new Long("445"));
+    assertEquals(response.getItems().get(1).getSurveyId(), new Long("101"));
+    assertEquals(response.getItems().get(1).getVersion(), "June 2020");
+    assertEquals(response.getItems().get(1).getItemCount(), new Long("230"));
+    assertEquals(response.getItems().get(2).getSurveyId(), new Long("102"));
+    assertEquals(response.getItems().get(2).getVersion(), "July 2020");
+    assertEquals(response.getItems().get(2).getItemCount(), new Long("181"));
+    jdbcTemplate.execute("drop table cb_survey_version");
+    jdbcTemplate.execute("drop table cb_survey_attribute");
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
+import org.pmiops.workbench.cdr.model.DbSurveyVersion;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DomainType;
@@ -378,7 +379,71 @@ public class CBCriteriaDaoTest {
         "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (101, 1333342, 'June 2020', 2)");
     jdbcTemplate.execute(
         "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (102, 1333342, 'July 2020', 3)");
-    assertThat(cbCriteriaDao.findConceptId2ByConceptId1(12345L)).containsExactly(1);
-    jdbcTemplate.execute("drop table cb_criteria_relationship");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (1, 715713, 0, 100, 291)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (2, 715713, 0, 101, 148)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (3, 715713, 0, 102, 150)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (4, 715713, 903096, 100, 154)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (5, 715713, 903096, 101, 82)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (6, 715713, 903096, 102, 31)");
+    List<DbSurveyVersion> dbSurveyVersions =
+        cbCriteriaDao.findSurveyVersionByQuestionConceptId(1333342L, 715713L);
+    assertThat(dbSurveyVersions).hasSize(3);
+    assertThat(dbSurveyVersions.get(0).getSurveyId()).isEqualTo(100);
+    assertThat(dbSurveyVersions.get(0).getVersion()).isEqualTo("May 2020");
+    assertThat(dbSurveyVersions.get(0).getItemCount()).isEqualTo(445);
+    assertThat(dbSurveyVersions.get(1).getSurveyId()).isEqualTo(101);
+    assertThat(dbSurveyVersions.get(1).getVersion()).isEqualTo("June 2020");
+    assertThat(dbSurveyVersions.get(1).getItemCount()).isEqualTo(230);
+    assertThat(dbSurveyVersions.get(2).getSurveyId()).isEqualTo(102);
+    assertThat(dbSurveyVersions.get(2).getVersion()).isEqualTo("July 2020");
+    assertThat(dbSurveyVersions.get(2).getItemCount()).isEqualTo(181);
+    jdbcTemplate.execute("drop table cb_survey_version");
+    jdbcTemplate.execute("drop table cb_survey_attribute");
+  }
+
+  @Test
+  public void findSurveyVersionByQuestionConceptIdAndAnswerConceptId() {
+    jdbcTemplate.execute(
+        "create table cb_survey_version(survey_id integer, concept_id integer, version varchar(50), display_order integer)");
+    jdbcTemplate.execute(
+        "create table cb_survey_attribute(id integer, question_concept_id integer, answer_concept_id integer, survey_id integer, item_count integer)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (100, 1333342, 'May 2020', 1)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (101, 1333342, 'June 2020', 2)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (102, 1333342, 'July 2020', 3)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (1, 715713, 0, 100, 291)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (2, 715713, 0, 101, 148)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (3, 715713, 0, 102, 150)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (4, 715713, 903096, 100, 154)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (5, 715713, 903096, 101, 82)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_id, item_count) values (6, 715713, 903096, 102, 31)");
+    List<DbSurveyVersion> dbSurveyVersions =
+        cbCriteriaDao.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(1333342L, 715713L, 0L);
+    assertThat(dbSurveyVersions).hasSize(3);
+    assertThat(dbSurveyVersions.get(0).getSurveyId()).isEqualTo(100);
+    assertThat(dbSurveyVersions.get(0).getVersion()).isEqualTo("May 2020");
+    assertThat(dbSurveyVersions.get(0).getItemCount()).isEqualTo(291);
+    assertThat(dbSurveyVersions.get(1).getSurveyId()).isEqualTo(101);
+    assertThat(dbSurveyVersions.get(1).getVersion()).isEqualTo("June 2020");
+    assertThat(dbSurveyVersions.get(1).getItemCount()).isEqualTo(148);
+    assertThat(dbSurveyVersions.get(2).getSurveyId()).isEqualTo(102);
+    assertThat(dbSurveyVersions.get(2).getVersion()).isEqualTo("July 2020");
+    assertThat(dbSurveyVersions.get(2).getItemCount()).isEqualTo(150);
+    jdbcTemplate.execute("drop table cb_survey_version");
+    jdbcTemplate.execute("drop table cb_survey_attribute");
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -365,4 +365,20 @@ public class CBCriteriaDaoTest {
     assertThat(option9.getType()).isEqualTo("PPI");
     assertThat(option9.getStandard()).isFalse();
   }
+
+  @Test
+  public void findSurveyVersionByQuestionConceptId() {
+    jdbcTemplate.execute(
+        "create table cb_survey_version(survey_id integer, concept_id integer, version varchar(50), display_order integer)");
+    jdbcTemplate.execute(
+        "create table cb_survey_attribute(id integer, question_concept_id integer, answer_concept_id integer, survey_id integer, item_count integer)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (100, 1333342, 'May 2020', 1)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (101, 1333342, 'June 2020', 2)");
+    jdbcTemplate.execute(
+        "insert into cb_survey_version(survey_id, concept_id, version, display_order) values (102, 1333342, 'July 2020', 3)");
+    assertThat(cbCriteriaDao.findConceptId2ByConceptId1(12345L)).containsExactly(1);
+    jdbcTemplate.execute("drop table cb_criteria_relationship");
+  }
 }

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
@@ -8,6 +8,7 @@ import org.pmiops.workbench.cdr.model.DbAgeTypeCount;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbDataFilter;
+import org.pmiops.workbench.cdr.model.DbSurveyVersion;
 import org.pmiops.workbench.model.AgeTypeCount;
 import org.pmiops.workbench.model.Criteria;
 import org.pmiops.workbench.model.CriteriaAttribute;
@@ -15,6 +16,7 @@ import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DataFilter;
 import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.SurveyVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
@@ -122,6 +124,16 @@ public class CohortBuilderMapperTest {
         .isEqualTo(expectedAgeTypeCount);
   }
 
+  @Test
+  public void dbModelToClientSurveyVersion() {
+    SurveyVersion expectedSurveyVersion =
+        new SurveyVersion().surveyId(100L).version("May 2020").itemCount(2344L);
+    assertThat(
+            cohortBuilderMapper.dbModelToClient(
+                new CohortBuilderMapperTest.DbSurveyVersionImpl(100L, "May 2020", 2344L)))
+        .isEqualTo(expectedSurveyVersion);
+  }
+
   class DbAgeTypeCountImpl implements DbAgeTypeCount {
     private String ageType;
     private int age;
@@ -146,6 +158,33 @@ public class CohortBuilderMapperTest {
     @Override
     public long getCount() {
       return count;
+    }
+  }
+
+  class DbSurveyVersionImpl implements DbSurveyVersion {
+    private long surveyId;
+    private String version;
+    private long itemCount;
+
+    public DbSurveyVersionImpl(long surveyId, String version, long itemCount) {
+      this.surveyId = surveyId;
+      this.version = version;
+      this.itemCount = itemCount;
+    }
+
+    @Override
+    public long getSurveyId() {
+      return surveyId;
+    }
+
+    @Override
+    public String getVersion() {
+      return version;
+    }
+
+    @Override
+    public long getItemCount() {
+      return itemCount;
     }
   }
 }


### PR DESCRIPTION
This PR is adding 2 new endpoints for the COPE survey versions. There are 2 ways to call for survey versions. With question concept id or question concept id and answer concept id.

1. `findSurveyVersionByQuestionConceptId(cdrVersionId, surveyConceptId, questionConceptId)`
2. `findSurveyVersionByQuestionConceptIdAndAnswerConceptId(cdrVersionId, surveyConceptId, questionConceptId, answerConceptId)`