### PR TITLE
[RW-5402][risk=no] Read-only sidebar runtime panel

### DIFF
--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -189,7 +189,7 @@ export const Button = ({type = 'primary', style = {}, disabled = false, ...props
   />;
 };
 
-export const MenuItem = ({icon, tooltip = '', disabled = false, children, ...props}) => {
+export const MenuItem = ({icon = null, tooltip = '', disabled = false, children, style = {}, ...props}) => {
   return <TooltipTrigger side='left' content={tooltip}>
     <Clickable
       // data-test-id is the text within the MenuItem, with whitespace removed
@@ -201,12 +201,13 @@ export const MenuItem = ({icon, tooltip = '', disabled = false, children, ...pro
         fontSize: 12, minWidth: 125, height: 32,
         color: disabled ? colorWithWhiteness(colors.dark, disabledAlpha) : 'black',
         padding: '0 12px',
-        cursor: disabled ? 'not-allowed' : 'pointer'
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        ...style
       }}
       hover={!disabled ? {backgroundColor: colorWithWhiteness(colors.accent, 0.92)} : undefined}
       {...props}
     >
-      <ClrIcon shape={icon} style={{marginRight: 8}} size={15}/>
+      {icon && <ClrIcon shape={icon} style={{marginRight: 8}} size={15}/>}
       {children}
     </Clickable>
   </TooltipTrigger>;

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -57,7 +57,7 @@ describe('HelpSidebar', () => {
     props = {helpContentKey: 'notebookStorage', sidebarOpen: true};
     const wrapper = component();
     expect(wrapper.find('[data-test-id="section-title-0"]').text()).toBe(sidebarContent.notebookStorage[0].title);
-    expect(wrapper.find('[data-test-id="help-sidebar-icon-help"]').get(0).props.icon.iconName).toBe('folder-open');
+    expect(wrapper.find('[data-test-id="help-sidebar-icon-notebooksHelp"]').get(0).props.icon.iconName).toBe('folder-open');
   });
 
   it('should update marginRight style when sidebarOpen prop changes', () => {
@@ -85,6 +85,7 @@ describe('HelpSidebar', () => {
     wrapper.find({'data-test-id': 'Share-menu-item'}).first().simulate('click');
     expect(shareSpy).toHaveBeenCalled();
   });
+
   it('should hide workspace icon if on critera search page', async() => {
     const wrapper = component();
     currentCohortCriteriaStore.next([]);
@@ -92,20 +93,23 @@ describe('HelpSidebar', () => {
     expect(wrapper.find({'data-test-id': 'workspace-menu-button'}).length).toBe(0);
     expect(wrapper.find({'data-test-id': 'criteria-count'}).length).toBe(1);
   });
+
   it('should update count if criteria is added', async() => {
     const wrapper = component();
     currentCohortCriteriaStore.next([criteria1, criteria2]);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find({'data-test-id': 'criteria-count'}).first().props().children).toBe(2);
   });
-  it('should not display cluster control icon for read-only workspaces', () => {
+
+  it('should not display runtime control icon for read-only workspaces', () => {
     props = {workspace: {accessLevel: WorkspaceAccessLevel.READER}}
     const wrapper = component();
-    expect(wrapper.find({'data-test-id': 'help-sidebar-icon-thunderstorm'}).length).toBe(0);
+    expect(wrapper.find({'data-test-id': 'help-sidebar-icon-runtime'}).length).toBe(0);
   });
-  it('should display cluster control icon for writable workspaces', () => {
+
+  it('should display runtime control icon for writable workspaces', () => {
     props = {workspace: {accessLevel: WorkspaceAccessLevel.WRITER}}
     const wrapper = component();
-    expect(wrapper.find({'data-test-id': 'help-sidebar-icon-thunderstorm'}).length).toBe(1);
+    expect(wrapper.find({'data-test-id': 'help-sidebar-icon-runtime'}).length).toBe(1);
   });
 });

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -266,7 +266,7 @@ const iconConfigs = {
 
 const helpIconName = (helpContentKey: string) => {
   return helpContentKey === NOTEBOOK_HELP_CONTENT ? 'notebooksHelp' : 'help';
-}
+};
 
 const icons = (
   helpContentKey: string,

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -16,6 +16,7 @@ import {SelectionList} from 'app/cohort-search/selection-list/selection-list.com
 import {FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
+import {RuntimePanel} from 'app/pages/analysis/runtime-panel';
 import {SidebarContent} from 'app/pages/data/cohort-review/sidebar-content.component';
 import {participantStore} from 'app/services/review-state.service';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
@@ -44,7 +45,7 @@ import canWrite = WorkspacePermissionsUtil.canWrite;
 
 const proIcons = {
   arrowLeft: '/assets/icons/arrow-left-regular.svg',
-  thunderstorm: '/assets/icons/thunderstorm-solid.svg',
+  runtime: '/assets/icons/thunderstorm-solid.svg',
   times: '/assets/icons/times-light.svg'
 };
 const sidebarContent = require('assets/json/help-sidebar.json');
@@ -206,63 +207,82 @@ const iconStyles = {
 
 export const NOTEBOOK_HELP_CONTENT = 'notebookStorage';
 
-// TODO uncomment 'thunderstorm' icon when runtime configuration function is ready
-// helpContentKey is the json key for the block of help content that is being displayed on this
-// sidebar. If the block of help content is about notebook storage, we want to display a different
-// icon on the sidebar and different tooltip, etc.
+const iconConfigs = {
+  'criteria': {
+    disabled: false,
+    faIcon: faInbox,
+    label: 'Selected Criteria',
+    page: 'criteria',
+    style: {fontSize: '21px'},
+    tooltip: 'Selected Criteria',
+    contentPadding: '0.5rem 0.5rem 0',
+    contentWidthRem: '20',
+    hideSidebarFooter: true
+  },
+  'help': {
+    disabled: false,
+    faIcon: faInfoCircle,
+    label: 'Help Icon',
+    page: null,
+    style: {fontSize: '21px'},
+    tooltip: 'Help Tips',
+  },
+  'notebooksHelp': {
+    disabled: false,
+    faIcon: faFolderOpen,
+    label: 'Storage Icon',
+    page: null,
+    style: {fontSize: '21px'},
+    tooltip: 'Workspace Storage',
+  },
+  'dataDictionary': {
+    disabled: false,
+    faIcon: faBook,
+    label: 'Data Dictionary Icon',
+    page: null,
+    style: {color: colors.white, fontSize: '20px', marginTop: '5px'},
+    tooltip: 'Data Dictionary',
+  },
+  'annotations': {
+    disabled: false,
+    faIcon: faEdit,
+    label: 'Annotations Icon',
+    page: 'reviewParticipantDetail',
+    style: {fontSize: '20px', marginLeft: '3px'},
+    tooltip: 'Annotations',
+  },
+  'runtime': {
+    disabled: false,
+    faIcon: null,
+    label: 'Cloud Icon',
+    page: null,
+    style: {height: '22px', width: '22px', marginTop: '0.25rem'},
+    tooltip: 'Compute Configuration',
+    contentPadding: '1.25rem',
+    contentWidthRem: '30',
+    hideSidebarFooter: true
+  }
+};
+
+const helpIconName = (helpContentKey: string) => {
+  return helpContentKey === NOTEBOOK_HELP_CONTENT ? 'notebooksHelp' : 'help';
+}
+
 const icons = (
   helpContentKey: string,
   enableCustomRuntimes: boolean,
   workspaceAccessLevel: WorkspaceAccessLevel
 ) => {
-  const iconsList = [
-    {
-      id: 'criteria',
-      disabled: false,
-      faIcon: faInbox,
-      label: 'Selected Criteria',
-      page: 'criteria',
-      style: {fontSize: '21px'},
-      tooltip: 'Selected Criteria'
-    },
-    {
-      id: 'help',
-      disabled: false,
-      faIcon: helpContentKey === NOTEBOOK_HELP_CONTENT ? faFolderOpen : faInfoCircle,
-      label: helpContentKey === NOTEBOOK_HELP_CONTENT ? 'Storage Icon' : 'Help Icon',
-      page: null,
-      style: {fontSize: '21px'},
-      tooltip: helpContentKey === NOTEBOOK_HELP_CONTENT ? 'Workspace Storage' : 'Help Tips',
-    }, {
-      id: 'dataDictionary',
-      disabled: false,
-      faIcon: faBook,
-      label: 'Data Dictionary Icon',
-      page: null,
-      style: {color: colors.white, fontSize: '20px', marginTop: '5px'},
-      tooltip: 'Data Dictionary',
-    }, {
-      id: 'annotations',
-      disabled: false,
-      faIcon: faEdit,
-      label: 'Annotations Icon',
-      page: 'reviewParticipantDetail',
-      style: {fontSize: '20px', marginLeft: '3px'},
-      tooltip: 'Annotations',
-    }];
+  const keys = [
+    'criteria',
+    helpIconName(helpContentKey),
+    'dataDictionary',
+    'annotations'
+  ];
   if (enableCustomRuntimes && canWrite(workspaceAccessLevel)) {
-    return [...iconsList, {
-      id: 'thunderstorm',
-      disabled: false,
-      faIcon: null,
-      label: 'Cloud Icon',
-      page: null,
-      style: {height: '22px', width: '22px', marginTop: '0.25rem'},
-      tooltip: 'Compute Configuration',
-    }];
-  } else {
-    return iconsList;
+    keys.push('runtime');
   }
+  return keys.map(k => ({...iconConfigs[k], id: k}));
 };
 
 const analyticsLabels = {
@@ -302,7 +322,8 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
     constructor(props: Props) {
       super(props);
       this.state = {
-        activeIcon: props.sidebarOpen ? 'help' : undefined,
+        // TODO(RW-5607): Remember which icon was active.
+        activeIcon: props.sidebarOpen ? helpIconName(props.helpContentKey) : undefined,
         filteredContent: undefined,
         participant: undefined,
         searchTerm: '',
@@ -524,7 +545,10 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
     }
 
     get sidebarWidth() {
-      return this.state.activeIcon === 'criteria' ? '20' : '14';
+      if (this.state.activeIcon && iconConfigs[this.state.activeIcon].contentWidthRem) {
+        return iconConfigs[this.state.activeIcon].contentWidthRem;
+      }
+      return '14';
     }
 
     render() {
@@ -536,7 +560,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
         display: activeIcon === tab ? 'block' : 'none',
         height: 'calc(100% - 1rem)',
         overflow: 'auto',
-        padding: '0.5rem 0.5rem ' + (tab === 'criteria' ? '0' : '5.5rem'),
+        padding: iconConfigs[tab].contentPadding || '0.5rem 0.5rem 5.5rem'
       });
       return <div id='help-sidebar'>
         <div style={notebookStyles ? {...styles.iconContainer, ...styles.notebookOverrides} : {...styles.iconContainer}}>
@@ -576,7 +600,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
                      alt='Close'/>
               </Clickable>
             </FlexRow>}
-            <div style={contentStyle('help')}>
+            <div style={contentStyle(helpIconName(helpContentKey))}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>{helpContentKey === NOTEBOOK_HELP_CONTENT ? 'Workspace storage' : 'Help Tips'}</h3>
               {helpContentKey !== NOTEBOOK_HELP_CONTENT &&
                 <div style={styles.textSearch}>
@@ -606,6 +630,9 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
                 : <div style={{marginTop: '0.5rem'}}><em>No results found</em></div>
               }
             </div>
+            <div style={contentStyle('runtime')}>
+              {<RuntimePanel />}
+            </div>
             <div style={contentStyle('annotations')}>
               {participant && <SidebarContent />}
             </div>
@@ -614,7 +641,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
                 {!!currentCohortSearchContextStore.getValue() && <SelectionList back={() => setSidebarState(false)} selections={[]}/>}
               </div>
             </div>
-            {activeIcon !== 'criteria' && <div style={styles.footer}>
+            {(iconConfigs[activeIcon] || {}).hideSidebarFooter || <div style={styles.footer}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
               <p style={styles.contentItem}>
                 Visit our <StyledAnchorTag href={supportUrls.helpCenter}

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -1,0 +1,65 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {Spinner} from 'app/components/spinners';
+import {RuntimePanel, Props} from 'app/pages/analysis/runtime-panel';
+import {workspaceStubs} from 'testing/stubs/workspaces-api-stub';
+import {runtimeApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
+import {RuntimeApi} from 'generated/fetch/api';
+import {WorkspaceAccessLevel} from 'generated/fetch';
+
+
+describe('RuntimePanel', () => {
+  let props: Props;
+  let runtimeApiStub: RuntimeApiStub;
+
+  const component = () => {
+    return mount(<RuntimePanel {...props}/>);
+  };
+
+  beforeEach(() => {
+    props = {
+      workspace: {...workspaceStubs[0], accessLevel: WorkspaceAccessLevel.WRITER}
+    };
+    runtimeApiStub = new RuntimeApiStub();
+    registerApiClient(RuntimeApi, runtimeApiStub);
+  });
+
+  it('should show loading spinner while loading', async() => {
+    const wrapper = component();
+
+    // Check before ticking - stub returns the runtime asynchronously.
+    expect(!wrapper.exists({'data-test-id': 'runtime-panel'}))
+    expect(wrapper.exists(Spinner));
+
+    // Now getRuntime returns.
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.exists({'data-test-id': 'runtime-panel'}));
+    expect(!wrapper.exists(Spinner));
+  });
+
+  it('should render runtime details', async() => {
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    const imageDropdown = wrapper.find({'data-test-id': 'runtime-image-dropdown'}).find('label').first();
+    expect(imageDropdown.exists()).toBeTruthy();
+
+    expect(imageDropdown.text()).toContain(runtimeApiStub.runtime.toolDockerImage);
+  });
+
+  it('should restrict memory options by cpu', async() => {
+    runtimeApiStub.runtime.dataprocConfig.masterMachineType = 'n1-standard-8';
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const memoryOptions = wrapper.find('#runtime-ram .p-dropdown-item');
+    expect(memoryOptions.exists()).toBeTruthy();
+
+    // See app/utils/machines.ts, these are the valid memory options for an 8
+    // CPU machine in GCE.
+    expect(memoryOptions.map(m => m.text())).toEqual(['7.8', '30', '52']);
+  });
+});

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {Spinner} from 'app/components/spinners';
 import {RuntimePanel, Props} from 'app/pages/analysis/runtime-panel';
 import {workspaceStubs} from 'testing/stubs/workspaces-api-stub';
-import {runtimeApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {RuntimeApi} from 'generated/fetch/api';
@@ -60,6 +60,6 @@ describe('RuntimePanel', () => {
 
     // See app/utils/machines.ts, these are the valid memory options for an 8
     // CPU machine in GCE.
-    expect(memoryOptions.map(m => m.text())).toEqual(['7.8', '30', '52']);
+    expect(memoryOptions.map(m => m.text())).toEqual(['7.2', '30', '52']);
   });
 });

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -1,0 +1,207 @@
+import {Button, Clickable, MenuItem} from 'app/components/buttons';
+import {FlexColumn, FlexRow} from 'app/components/flex';
+import {ClrIcon} from 'app/components/icons';
+import {PopupTrigger} from 'app/components/popups';
+import {Spinner} from 'app/components/spinners';
+import {runtimeApi} from 'app/services/swagger-fetch-clients';
+import colors, {addOpacity} from 'app/styles/colors';
+import {reactStyles, withCurrentWorkspace} from 'app/utils';
+import {machineTypes} from 'app/utils/machines';
+import {WorkspaceData} from 'app/utils/workspace-data';
+import {Dropdown} from 'primereact/dropdown';
+import {InputNumber} from 'primereact/inputnumber';
+
+import {Runtime} from 'generated/fetch';
+
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+
+
+const styles = reactStyles({
+  sectionHeader: {
+    color: colors.primary,
+    fontSize: '16px',
+    fontWeight: 700,
+    lineHeight: '1rem',
+    marginBottom: '12px',
+    marginTop: '12px'
+  },
+  controlSection: {
+    backgroundColor: String(addOpacity(colors.white, .75)),
+    borderRadius: '3px',
+    padding: '.75rem',
+    marginTop: '.75rem'
+  },
+  presetMenuItem: {
+    color: colors.primary,
+    fontSize: '14px'
+  }
+});
+
+const defaultMachineType = machineTypes.find(({name}) => name === 'n1-standard-4');
+
+export interface Props {
+  workspace: WorkspaceData;
+}
+
+interface State {
+  // Whether the initial runtime load is still in progress.
+  loading: boolean;
+  // Whether there was an error in loading the runtime data.
+  error: boolean;
+  // The runtime. null if none exists, or if there was an error in loading the
+  // runtime.
+  runtime: Runtime|null;
+}
+
+export const RuntimePanel = withCurrentWorkspace(
+  class extends React.Component<Props, State> {
+    private aborter = new AbortController();
+
+    constructor(props: Props) {
+      super(props);
+      this.state = {
+        loading: true,
+        error: false,
+        runtime: null
+      };
+    }
+
+    async componentDidMount() {
+      // TODO(RW-5420): Centralize a runtimeStore.
+      let runtime = null;
+      let error = false;
+      try {
+        runtime = await runtimeApi().getRuntime(this.props.workspace.namespace, {signal: this.aborter.signal});
+      } catch (e) {
+        // 404 is expected if the runtime doesn't exist, represent this as a null
+        // runtime rather than an error mode.
+        if (e.status !== 404) {
+          error = true;
+        }
+      }
+      this.setState({
+        runtime,
+        error,
+        loading: false
+      });
+    }
+
+    render() {
+      const {loading, error, runtime} = this.state;
+      if (loading) {
+        return <Spinner style={{width: '100%', marginTop: '5rem'}}/>;
+      } else if (error) {
+        return <div>Error loading compute configuration</div>;
+      } else if (!runtime) {
+        // TODO(RW-5591): Create runtime page goes here.
+        return <div>No runtime exists yet</div>;
+      }
+
+      const isDataproc = !!runtime.dataprocConfig;
+
+      let masterMachineName;
+      let masterDiskSize;
+      if (isDataproc) {
+        masterMachineName = runtime.dataprocConfig.masterMachineType;
+        masterDiskSize = runtime.dataprocConfig.masterDiskSize;
+      } else {
+        masterMachineName = runtime.gceConfig.machineType;
+        masterDiskSize = runtime.gceConfig.bootDiskSize;
+      }
+      const machineType = machineTypes.find(({name}) => name === masterMachineName) || defaultMachineType;
+
+      return <div data-test-id='runtime-panel'>
+        <h3 style={styles.sectionHeader}>Cloud analysis environment</h3>
+        <div>
+          Your analysis environment consists of an application and compute resources.
+          Your cloud environment is unique to this workspace and not shared with other users.
+        </div>
+        {/* TODO(RW-5419): Cost estimates go here. */}
+        <div style={styles.controlSection}>
+          {/* Recommended runtime: pick from default templates or change the image. */}
+          <FlexRow style={{justifyContent: 'space-between', marginTop: '.5rem', marginBottom: '1rem'}}>
+            <h3 style={{...styles.sectionHeader, margin: '0'}}>Custom cloud environment</h3>
+            <PopupTrigger side='bottom'
+                          closeOnClick
+                          content={
+                            <React.Fragment>
+                              <MenuItem style={styles.presetMenuItem}>General purpose analysis</MenuItem>
+                              <MenuItem style={styles.presetMenuItem}>Genomics analysis</MenuItem>
+                            </React.Fragment>
+                          }>
+              <Clickable data-test-id='runtime-presets-menu'
+                         disabled={true}>
+                Recommended environments <ClrIcon shape='caret down'/>
+              </Clickable>
+            </PopupTrigger>
+          </FlexRow>
+          <h3 style={styles.sectionHeader}>Application configuration</h3>
+          {/* TODO(RW-5413): Populate the image list with server driven options. */}
+          <Dropdown style={{width: '100%'}}
+                    data-test-id='runtime-image-dropdown'
+                    disabled={true}
+                    options={[runtime.toolDockerImage]}
+                    value={runtime.toolDockerImage}/>
+          {/* Runtime customization: change detailed machine configuration options. */}
+          <h3 style={styles.sectionHeader}>Cloud compute profile</h3>
+          <FlexRow style={{justifyContent: 'space-between'}}>
+            <div>
+              <label htmlFor='runtime-cpu'
+                     style={{marginRight: '.25rem'}}>CPUs</label>
+              <Dropdown id='runtime-cpu'
+                        disabled={true}
+                        options={fp.flow(
+                          /* Show all CPU options. */
+                          fp.map('cpu'),
+                          fp.union([machineType.cpu]),
+                          fp.sortBy(fp.identity)
+                        )(machineTypes)}
+                        value={machineType.cpu}/>
+            </div>
+            <div>
+              <label htmlFor='runtime-ram'
+                     style={{marginRight: '.25rem'}}>RAM (GB)</label>
+              <Dropdown id='runtime-ram'
+                        disabled={true}
+                        options={fp.flow(
+                          /* Show valid memory options as constrained by the currently selected CPU. */
+                          fp.filter(({cpu}) => cpu === machineType.cpu),
+                          fp.map('memory'),
+                          fp.union([machineType.memory]),
+                          fp.sortBy(fp.identity)
+                        )(machineTypes)}
+                        value={machineType.memory}/>
+            </div>
+            <div>
+              <label htmlFor='runtime-disk'
+                     style={{marginRight: '.25rem'}}>Disk (GB)</label>
+              <InputNumber id='runtime-disk'
+                           disabled={true}
+                           showButtons
+                           decrementButtonClassName='p-button-secondary'
+                           incrementButtonClassName='p-button-secondary'
+                           value={masterDiskSize}
+                           inputStyle={{padding: '.75rem .5rem', width: '2rem'}}
+                           min={50 /* Runtime API has a minimum 50GB requirement. */}/>
+            </div>
+          </FlexRow>
+          <FlexColumn style={{marginTop: '1rem'}}>
+            <label htmlFor='runtime-compute'>Compute type</label>
+            <Dropdown id='runtime-compute'
+                      style={{width: '10rem'}}
+                      disabled={true}
+                      options={['Dataproc cluster', 'Standard VM']}
+                      value={isDataproc ? 'Dataproc cluster' : 'Standard VM'}/>
+          </FlexColumn>
+        </div>
+        <FlexRow style={{justifyContent: 'flex-end', marginTop: '.75rem'}}>
+          <Button disabled={true}>Create</Button>
+        </FlexRow>
+      </div>;
+    }
+
+    componentWillUnmount() {
+      this.aborter.abort();
+    }
+  });

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -54,7 +54,7 @@ interface State {
   runtime: Runtime|null;
 }
 
-export const RuntimePanel = withCurrentWorkspace(
+export const RuntimePanel = withCurrentWorkspace()(
   class extends React.Component<Props, State> {
     private aborter = new AbortController();
 

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -1,0 +1,37 @@
+import * as fp from 'lodash/fp';
+
+// Copied from https://github.com/DataBiosphere/terra-ui/blob/219b063b07d56499ccc38013fd88f4f0b88f8cd6/src/data/machines.js
+
+const machineBases = [
+  { name: 'n1-standard-1', cpu: 1, memory: 3.75, price: 0.0475, preemptiblePrice: 0.0100 },
+  { name: 'n1-standard-2', cpu: 2, memory: 7.50, price: 0.0950, preemptiblePrice: 0.0200 },
+  { name: 'n1-standard-4', cpu: 4, memory: 15, price: 0.1900, preemptiblePrice: 0.0400 },
+  { name: 'n1-standard-8', cpu: 8, memory: 30, price: 0.3800, preemptiblePrice: 0.0800 },
+  { name: 'n1-standard-16', cpu: 16, memory: 60, price: 0.7600, preemptiblePrice: 0.1600 },
+  { name: 'n1-standard-32', cpu: 32, memory: 120, price: 1.5200, preemptiblePrice: 0.3200 },
+  { name: 'n1-standard-64', cpu: 64, memory: 240, price: 3.0400, preemptiblePrice: 0.6400 },
+  { name: 'n1-standard-96', cpu: 96, memory: 360, price: 4.5600, preemptiblePrice: 0.9600 },
+  { name: 'n1-highmem-2', cpu: 2, memory: 13, price: 0.1184, preemptiblePrice: 0.0250 },
+  { name: 'n1-highmem-4', cpu: 4, memory: 26, price: 0.2368, preemptiblePrice: 0.0500 },
+  { name: 'n1-highmem-8', cpu: 8, memory: 52, price: 0.4736, preemptiblePrice: 0.1000 },
+  { name: 'n1-highmem-16', cpu: 16, memory: 104, price: 0.9472, preemptiblePrice: 0.2000 },
+  { name: 'n1-highmem-32', cpu: 32, memory: 208, price: 1.8944, preemptiblePrice: 0.4000 },
+  { name: 'n1-highmem-64', cpu: 64, memory: 416, price: 3.7888, preemptiblePrice: 0.8000 },
+  { name: 'n1-highmem-96', cpu: 96, memory: 624, price: 5.6832, preemptiblePrice: 1.2000 },
+  { name: 'n1-highcpu-2', cpu: 2, memory: 1.8, price: 0.0709, preemptiblePrice: 0.0150 },
+  { name: 'n1-highcpu-4', cpu: 4, memory: 3.6, price: 0.1418, preemptiblePrice: 0.0300 },
+  { name: 'n1-highcpu-8', cpu: 8, memory: 7.2, price: 0.2836, preemptiblePrice: 0.0600 },
+  { name: 'n1-highcpu-16', cpu: 16, memory: 14.4, price: 0.5672, preemptiblePrice: 0.1200 },
+  { name: 'n1-highcpu-32', cpu: 32, memory: 28.8, price: 1.1344, preemptiblePrice: 0.2400 },
+  { name: 'n1-highcpu-64', cpu: 64, memory: 57.6, price: 2.2688, preemptiblePrice: 0.4800 },
+  { name: 'n1-highcpu-96', cpu: 96, memory: 86.4, price: 3.402, preemptiblePrice: 0.7200 }
+];
+
+export const machineTypes = fp.map(({ price, preemptiblePrice, ...details }) => ({
+  price: price + 0.004,
+  preemptiblePrice: preemptiblePrice + 0.002,
+  ...details
+}), machineBases); // adding prices for ephemeral IP's, per https://cloud.google.com/compute/network-pricing#ipaddress
+
+export const diskPrice = 0.04 / 730; // per GB hour, from https://cloud.google.com/compute/pricing
+export const dataprocCpuPrice = 0.01; // dataproc costs $0.01 per cpu per hour

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -27,11 +27,15 @@ const machineBases = [
   { name: 'n1-highcpu-96', cpu: 96, memory: 86.4, price: 3.402, preemptiblePrice: 0.7200 }
 ];
 
-export const machineTypes = fp.map(({ price, preemptiblePrice, ...details }) => ({
+export const allMachineTypes = fp.map(({ price, preemptiblePrice, ...details }) => ({
   price: price + 0.004,
   preemptiblePrice: preemptiblePrice + 0.002,
   ...details
 }), machineBases); // adding prices for ephemeral IP's, per https://cloud.google.com/compute/network-pricing#ipaddress
+
+// There are issues launching Leo runtimes with <4GB ram.
+// See https://broadworkbench.atlassian.net/browse/SATURN-1337
+export const validLeonardoMachineTypes = allMachineTypes.filter(({memory}) => memory >= 4);
 
 export const diskPrice = 0.04 / 730; // per GB hour, from https://cloud.google.com/compute/pricing
 export const dataprocCpuPrice = 0.01; // dataproc costs $0.01 per cpu per hour

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -16,7 +16,12 @@ export class RuntimeApiStub extends RuntimeApi {
       googleProject: 'Namespace',
       status: RuntimeStatus.Running,
       createdDate: '08/08/2018',
-      toolDockerImage: 'docker'
+      toolDockerImage: 'broadinstitute/terra-jupyter-aou:1.0.999',
+      dataprocConfig: {
+        masterMachineType: 'n1-standard-4',
+        masterDiskSize: 80,
+        numberOfWorkers: 0
+      }
     };
   }
 


### PR DESCRIPTION
Changes:
- Add basic runtime panel, rendered only for an active runtime
- Add loading spinner when the runtime is initially requested
- Add lookup table of GCE machine types
- Allow alternate size/configuration for the help sidebar panels; generalizes some logic which was hardcoded in for the criteria tab
- Implement basic machine type option filtering

![image](https://user-images.githubusercontent.com/822298/93401603-646d5d00-f837-11ea-9097-b2240e0025e4.png)

Notes:
- I took some liberties with the mocks around the recommended runtime dropdown since we don't have a component that behaves in the way described here.
- I also took some liberty with the disk numeric input since we don't have a component for this