### PR TITLE
[RW-5363][risk=low] Add checkbox with custom Jupyter modal

### DIFF
--- a/api/src/main/webapp/static/aou-download-policy-extension.js
+++ b/api/src/main/webapp/static/aou-download-policy-extension.js
@@ -1,17 +1,73 @@
 // Workbench "Download policy" extension, to show the policy before letting user download the notebook
 
 define([
+    'jquery',
+    'base/js/dialog',
     'base/js/namespace'
-], (Jupyter) => {
+], ($, dialogLib, Jupyter) => {
+  const policyUrl = 'https://www.researchallofus.org/data-use-policies';
+
   const load = () => {
-    // This will open a dialog box when the user clicks any one of the Download As option.
-    // File will be downloaded only if the user clicks OK else it will just close the dialog box and do nothing.
-    $('#download_menu li a').click(function(e) {
+    $('#download_menu li a').click((e) => {
       e.preventDefault();
-      return confirm("Data Download Reminder" + "\n\n" +
-        "You are prohibited from taking screenshots or attempting in any way to remove participant-level data from the workbench. " +
-        "You are also prohibited from publishing or otherwise distributing any data or aggregate statistics corresponding to fewer than 20 participants unless expressly permitted by our data use policies. " +
-        "For more information, please see our Data Use Policies by visiting https://www.researchallofus.org/data-use-policies/.");
+
+      // Mirrors logic from here; the element id encodes the target format:
+      // https://github.com/jupyter/notebook/blob/8a4cbd0ad91371392b90672afea58560d37c847e/notebook/static/notebook/js/menubar.js#L197
+      const targetFmt = e.target.parentElement.getAttribute('id').substring(9);
+
+      // We reference the dialog element in the body callbacks, so declare here
+      // for the below closures.
+      let dialog;
+
+      // The following dialog code is modeled off of the Jupyter UI codebase. This is used over a
+      // standard alert dialog in order to support the required checkbox and links. In particular,
+      // the notebook rename modal was used for reference:
+      // https://github.com/jupyter/notebook/blob/8a4cbd0ad91371392b90672afea58560d37c847e/notebook/static/notebook/js/savewidget.js#L74-L132
+      const dialogBody = $('<div/>')
+          .append(
+              $(`<p>Our <a href="${policyUrl}" target="_blank">Data Use Policies</a> `+
+                'prohibit you from removing participant-level data from the workbench. You ' +
+                'are also prohibited from publishing or otherwise distributing any data or ' +
+                'aggregate statistics corresponding to fewer than 20 participants unless ' +
+                'expressly permitted by our data use policies.</p>'))
+          .append($("<br/>"))
+          .append(
+              $('<input/>')
+                .attr('type','checkbox')
+                .attr('id','confirm-policy')
+                .css('display', 'inline')
+                .change((e) => {
+                  dialog.find('#aou-download').prop('disabled', !e.target.checked);
+                }))
+          .append(
+            $('<label>I understand the data use policies and certify that this download will be ' +
+              `used in accordance with <a href="${policyUrl}" target="_blank"><i>All of Us</i> Data Use ` +
+              'Policies</a>.</label>')
+              .attr('for','confirm-policy')
+              .css('display', 'inline')
+              .css('margin-left', '5px'));
+      dialog = dialogLib.modal({
+        title: 'Data Download',
+        body: dialogBody,
+        default_button: "Cancel",
+        buttons : {
+          "Cancel": {
+            class: "btn-primary",
+          },
+          "Download": {
+            id: 'aou-download',
+            click: () => {
+              // See https://github.com/jupyter/notebook/blob/8a4cbd0ad91371392b90672afea58560d37c847e/notebook/static/notebook/js/menubar.js#L197
+              Jupyter.menubar._nbconvert(targetFmt, true);
+              dialog.modal('hide');
+            }
+          }
+        },
+        open : () => {
+          dialog.find('#aou-download').prop('disabled', true);
+        }
+      });
+      return false;
     });
   };
 


### PR DESCRIPTION
See code comments for details. Note pictured in the screencap: the download triggers in a new tab, the same as it does today.

![output](https://user-images.githubusercontent.com/822298/93654518-c1e9e100-f9d2-11ea-95bf-eeec2d210270.gif)

Follow-ups:
- This integration depends on implementation details of the Jupyter UI, which could change over time. Will add puppeteer coverage after this goes in.