### PR TITLE
[no ticket] [risk=no] Fix the audit timestamp string format

### DIFF
--- a/ui/src/app/components/admin/audit-card-list-view.tsx
+++ b/ui/src/app/components/admin/audit-card-list-view.tsx
@@ -183,7 +183,7 @@ const AuditActionCard = (props: { action: AuditAction }) => {
   // Something in the codegen is wonky here. the actionTime field is typed as a Date,
   // but turns out to be a number for some reason here. In other contexts it appears
   // to format itself happily though.
-  const timeString = moment(new Date(action.actionTime)).format('YYYY-MM-DD hh:mm:ss');
+  const timeString = moment(new Date(action.actionTime)).format('YYYY-MM-DD HH:mm:ss');
   const actionTypes = fp.flow(
     fp.map(fp.get('header.actionType')),
     fp.sortedUniq,


### PR DESCRIPTION
I think my PR #3875 broke the timestamp formatting, as I'm now seeing an 'invalid date' string on the audit page.

I double-checked the moment.js docs, and it's entirely plausible that this needs to be uppercase 'HH' to work correctly for 24-h format.

But then again, the "invalid date" string doesn't really suggest that the format was incorrect. Maybe there's something else going on here.
