### PR TITLE
[risk=no] Upgrade dependency-check-gradle to 6.0.1

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -49,7 +49,7 @@ buildscript {
     classpath 'net.ltgt.gradle:gradle-apt-plugin:0.21'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$project.ext.KOTLIN_VERSION"
     classpath "org.jetbrains.kotlin:kotlin-noarg:$project.ext.KOTLIN_VERSION"
-    classpath 'org.owasp:dependency-check-gradle:5.1.0'
+    classpath 'org.owasp:dependency-check-gradle:6.0.1'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:$project.ext.SPRING_BOOT_VERSION"
   }
 }


### PR DESCRIPTION
Fix for failing api-deps-check job in circle-ci