### PR TITLE
[risk=medium][RW-5481] Link Admin Notebook Preview pages from Workspace Admin page

### DIFF
--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -6,12 +6,14 @@ import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {Error as ErrorDiv} from 'app/components/inputs';
+import {Error as ErrorDiv, TextArea} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
+import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {runtimeApi, workspaceAdminApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, UrlParamsProps, withUrlParams} from 'app/utils';
+import {navigate} from 'app/utils/navigation';
 import {
   getSelectedPopulations,
   getSelectedPrimaryPurposeItems
@@ -24,7 +26,7 @@ import {
 } from 'generated/fetch';
 import {Column} from 'primereact/column';
 import {DataTable} from 'primereact/datatable';
-import {ReactFragment} from 'react';
+import {ReactFragment, useEffect, useState} from 'react';
 
 const styles = reactStyles({
   infoRow: {
@@ -53,6 +55,14 @@ const styles = reactStyles({
     maxWidth: '1000px',
     marginTop: '1rem',
   },
+  textArea: {
+    maxWidth: '1000px',
+    height: '3rem',
+  },
+  button: {
+    marginLeft: '20px',
+    height: '1rem',
+  },
 });
 
 const PurpleLabel = ({style = {}, children}) => {
@@ -77,14 +87,27 @@ const formatMB = (fileSize: number): string => {
   }
 };
 
-const FileDetailsTable = (props: {data: Array<FileDetail>, bucket: string}) => {
-  const {data, bucket} = props;
+const NOTEBOOKS_DIRECTORY = 'notebooks';
+const NOTEBOOKS_SUFFIX = '.ipynb';
+
+interface FileDetailsProps {
+  workspaceNamespace: string;
+  data: Array<FileDetail>;
+  bucket: string;
+}
+
+const FileDetailsTable = (props: FileDetailsProps) => {
+  const {workspaceNamespace, data, bucket} = props;
 
   interface TableEntry {
-    name: string;
-    size: string;
     location: string;
+    rawName: string;
+    nameCell: ReactFragment;
+    size: string;
   }
+
+  const [tableData, setTableData] = useState<Array<TableEntry>>();
+  const [accessReason, setAccessReason] = useState('');
 
   const parseLocation = (file: FileDetail): string => {
     const prefixLength = bucket.length;
@@ -95,35 +118,73 @@ const FileDetailsTable = (props: {data: Array<FileDetail>, bucket: string}) => {
     return file.path.substring(start, end);
   };
 
-  const formattedData: Array<TableEntry> = data.map(file => {
-    return {
-      name: file.name,
-      size: formatMB(file.sizeInBytes),
-      location: parseLocation(file)
+  const nameCell = (file: FileDetail): React.ReactFragment => {
+    const filename = file.name.trim();
+    const navigateToPreview = () => {
+      navigate(['admin', 'workspaces', workspaceNamespace, filename],
+          { queryParams: { accessReason: accessReason } });
     };
-  });
 
-  const sortedData = formattedData.sort((a, b) => {
-    const locCmp = a.location.localeCompare(b.location);
-    if (locCmp === 0) {
-      return a.name.localeCompare(b.name);
+    // remove first check after RW-5626
+    if (NOTEBOOKS_DIRECTORY === parseLocation(file) && filename.endsWith(NOTEBOOKS_SUFFIX)) {
+      return <FlexRow>
+        <span>{filename}</span>
+        <TooltipTrigger content='Please enter an access reason below' disabled={accessReason && accessReason.trim()}>
+          <Button style={styles.button} disabled={!accessReason || !accessReason.trim()} onClick={navigateToPreview}>Preview</Button>
+        </TooltipTrigger>
+      </FlexRow>;
     } else {
-      return locCmp;
+      return <span>{filename}</span>;
     }
-  });
+  };
 
-  return <DataTable
-      data-test-id='object-details-table'
-      value={sortedData}
-      style={styles.fileDetailsTable}
-      scrollable={true}
-      paginator={true}
-      paginatorTemplate='CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown'
-      currentPageReportTemplate='Showing {first} to {last} of {totalRecords} entries'>
-    <Column field='location' header='Location'/>
-    <Column field='name' header='Filename'/>
-    <Column field='size' header='File size (MB)' style={{textAlign: 'right'}}/>
-  </DataTable>;
+  const formatMB = (fileSize: number): string => {
+    const mb = fileSize / 1000000.0;
+    if (mb < 1.0) {
+      return '<1';
+    } else {
+      return mb.toFixed(2);
+    }
+  };
+
+  const setupTable = () => {
+    setTableData(data
+        .map(file => {
+          return {
+            location: parseLocation(file),
+            rawName: file.name,
+            nameCell: nameCell(file),
+            size: formatMB(file.sizeInBytes),
+          }; })
+        .sort((a, b) => {
+          const locCmp = a.location.localeCompare(b.location);
+          if (locCmp === 0) {
+            return a.rawName.localeCompare(b.rawName);
+          } else {
+            return locCmp;
+          }}));
+  };
+
+  useEffect(() => {
+    setupTable();
+  }, [accessReason]);
+
+  return <FlexColumn>
+    <DataTable
+        data-test-id='object-details-table'
+        value={tableData}
+        style={styles.fileDetailsTable}
+        scrollable={true}
+        paginator={true}
+        paginatorTemplate='CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown'
+        currentPageReportTemplate='Showing {first} to {last} of {totalRecords} entries'>
+      <Column field='location' header='Location'/>
+      <Column field='nameCell' header='Filename'/>
+      <Column field='size' header='File size (MB)' style={{textAlign: 'right'}}/>
+    </DataTable>
+    <PurpleLabel>To preview notebooks, enter Access Reason (for auditing purposes)</PurpleLabel>
+    <TextArea style={styles.textArea} value={accessReason} onChange={setAccessReason}/>
+  </FlexColumn>;
 };
 
 interface State {
@@ -320,7 +381,10 @@ class AdminWorkspaceImpl extends React.Component<UrlParamsProps, State> {
               {formatMB(resources.cloudStorage.storageBytesUsed)}
             </WorkspaceInfoField>
           </div>
-          {files && <FileDetailsTable data={files} bucket={resources.cloudStorage.storageBucketPath}/>}
+          {files && <FileDetailsTable
+              workspaceNamespace={workspace.namespace}
+              data={files}
+              bucket={resources.cloudStorage.storageBucketPath}/>}
           <h3>Research Purpose</h3>
           <div className='research-purpose' style={{marginTop: '1rem'}}>
             <WorkspaceInfoField labelText='Primary purpose of project'>

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -161,12 +161,9 @@ const FileDetailsTable = (props: FileDetailsProps) => {
           size: formatMB(file.sizeInBytes),
         }; })
       .sort((a, b) => {
-        const locCmp = a.location.localeCompare(b.location);
-        if (locCmp === 0) {
-          return a.rawName.localeCompare(b.rawName);
-        } else {
-          return locCmp;
-        }}));
+        const locationComparison = a.location.localeCompare(b.location);
+        return locationComparison === 0 ? a.rawName.localeCompare(b.rawName) : locationComparison;
+        }));
   };
 
   useEffect(() => {

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -139,11 +139,12 @@ const NameCell = (props: NameCellProps) => {
   const isNotebook = () => (NOTEBOOKS_DIRECTORY === parseLocation(file, bucket)) && filename.endsWith(NOTEBOOKS_SUFFIX);
   const isTooLargeNotebook = () => isNotebook() && (file.sizeInBytes > MAX_NOTEBOOK_READ_SIZE_BYTES);
 
+  const dummyValue = undefined;
   return fp.cond([
     [isTooLargeNotebook, fileTooLarge],
     [isNotebook, fileWithPreviewButton],
     [fp.stubTrue, filenameSpan]
-  ]);
+  ])(dummyValue);
 };
 
 interface FileDetailsProps {

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -159,7 +159,7 @@ const FileDetailsTable = (props: FileDetailsProps) => {
   interface TableEntry {
     location: string;
     rawName: string;
-    nameCell: any;
+    nameCell: JSX.Element;
     size: string;
   }
 

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -55,11 +55,11 @@ const styles = reactStyles({
     maxWidth: '1000px',
     marginTop: '1rem',
   },
-  textArea: {
+  accessReasonText: {
     maxWidth: '1000px',
     height: '3rem',
   },
-  button: {
+  previewButton: {
     marginLeft: '20px',
     height: '1rem',
   },
@@ -143,14 +143,14 @@ const FileDetailsTable = (props: FileDetailsProps) => {
           {filenameText}
           <TooltipTrigger
             content={`Files larger than ${formatMB(MAX_NOTEBOOK_READ_SIZE_BYTES)} MB are too large to preview`}
-          ><Button style={styles.button} disabled={true}>Preview</Button>
+          ><Button style={styles.previewButton} disabled={true}>Preview</Button>
           </TooltipTrigger>
         </FlexRow>;
       } else {
         return <FlexRow>
           {filenameText}
           <TooltipTrigger content='Please enter an access reason below' disabled={accessReason && accessReason.trim()}>
-            <Button style={styles.button} disabled={!accessReason || !accessReason.trim()}
+            <Button style={styles.previewButton} disabled={!accessReason || !accessReason.trim()}
                     onClick={navigateToPreview}>Preview</Button>
           </TooltipTrigger>
         </FlexRow>;
@@ -196,7 +196,7 @@ const FileDetailsTable = (props: FileDetailsProps) => {
       <Column field='size' header='File size (MB)' style={{textAlign: 'right'}}/>
     </DataTable>
     <PurpleLabel>To preview notebooks, enter Access Reason (for auditing purposes)</PurpleLabel>
-    <TextArea style={styles.textArea} value={accessReason} onChange={setAccessReason}/>
+    <TextArea style={styles.accessReasonText} value={accessReason} onChange={setAccessReason}/>
   </FlexColumn>;
 };
 

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -87,6 +87,15 @@ const formatMB = (fileSize: number): string => {
   }
 };
 
+const parseLocation = (file: FileDetail, bucket: string): string => {
+  const prefixLength = bucket.length;
+  const start = prefixLength + 1;  // slash after bucket name
+  const suffixPos = file.path.lastIndexOf(file.name);
+  const end = suffixPos - 1;  // slash before filename
+
+  return file.path.substring(start, end);
+};
+
 const NOTEBOOKS_DIRECTORY = 'notebooks';
 const NOTEBOOKS_SUFFIX = '.ipynb';
 const MAX_NOTEBOOK_READ_SIZE_BYTES = 5 * 1000 * 1000; // see NotebooksServiceImpl
@@ -110,15 +119,6 @@ const FileDetailsTable = (props: FileDetailsProps) => {
   const [tableData, setTableData] = useState<Array<TableEntry>>();
   const [accessReason, setAccessReason] = useState('');
 
-  const parseLocation = (file: FileDetail): string => {
-    const prefixLength = bucket.length;
-    const start = prefixLength + 1;  // slash after bucket name
-    const suffixPos = file.path.lastIndexOf(file.name);
-    const end = suffixPos - 1;  // slash before filename
-
-    return file.path.substring(start, end);
-  };
-
   const nameCell = (file: FileDetail): React.ReactFragment => {
     const filename = file.name.trim();
     const filenameText = <span>{filename}</span>;
@@ -128,7 +128,7 @@ const FileDetailsTable = (props: FileDetailsProps) => {
     };
 
     // remove first check after RW-5626
-    if (NOTEBOOKS_DIRECTORY === parseLocation(file) && filename.endsWith(NOTEBOOKS_SUFFIX)) {
+    if (NOTEBOOKS_DIRECTORY === parseLocation(file, bucket) && filename.endsWith(NOTEBOOKS_SUFFIX)) {
       if (file.sizeInBytes > MAX_NOTEBOOK_READ_SIZE_BYTES) {
         return <FlexRow>
           {filenameText}
@@ -155,7 +155,7 @@ const FileDetailsTable = (props: FileDetailsProps) => {
     setTableData(data
       .map(file => {
         return {
-          location: parseLocation(file),
+          location: parseLocation(file, bucket),
           rawName: file.name,
           nameCell: nameCell(file),
           size: formatMB(file.sizeInBytes),

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -138,7 +138,7 @@ const FileDetailsTable = (props: FileDetailsProps) => {
 
     // remove first check after RW-5626
     if (NOTEBOOKS_DIRECTORY === parseLocation(file) && filename.endsWith(NOTEBOOKS_SUFFIX)) {
-      if (file.rawSize > MAX_NOTEBOOK_READ_SIZE_BYTES) {
+      if (file.sizeInBytes > MAX_NOTEBOOK_READ_SIZE_BYTES) {
         return <FlexRow>
           {filenameText}
           <TooltipTrigger

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -139,12 +139,15 @@ const NameCell = (props: NameCellProps) => {
   const isNotebook = () => (NOTEBOOKS_DIRECTORY === parseLocation(file, bucket)) && filename.endsWith(NOTEBOOKS_SUFFIX);
   const isTooLargeNotebook = () => isNotebook() && (file.sizeInBytes > MAX_NOTEBOOK_READ_SIZE_BYTES);
 
-  const dummyValue = undefined;
+  // if (tooLarge()) fileTooLarge();
+  // else if (isNotebook()) fileWithPreviewButton();
+  // else filenameSpan();
+  const requiredDummyParameter = undefined;
   return fp.cond([
     [isTooLargeNotebook, fileTooLarge],
     [isNotebook, fileWithPreviewButton],
     [fp.stubTrue, filenameSpan]
-  ])(dummyValue);
+  ])(requiredDummyParameter);
 };
 
 interface FileDetailsProps {

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -119,15 +119,6 @@ const FileDetailsTable = (props: FileDetailsProps) => {
     return file.path.substring(start, end);
   };
 
-  const formatMB = (fileSize: number): string => {
-    const mb = fileSize / 1000000.0;
-    if (mb < 1.0) {
-      return '<1';
-    } else {
-      return mb.toFixed(2);
-    }
-  };
-
   const nameCell = (file: FileDetail): React.ReactFragment => {
     const filename = file.name.trim();
     const filenameText = <span>{filename}</span>;
@@ -162,20 +153,20 @@ const FileDetailsTable = (props: FileDetailsProps) => {
 
   const setupTable = () => {
     setTableData(data
-        .map(file => {
-          return {
-            location: parseLocation(file),
-            rawName: file.name,
-            nameCell: nameCell(file),
-            size: formatMB(file.sizeInBytes),
-          }; })
-        .sort((a, b) => {
-          const locCmp = a.location.localeCompare(b.location);
-          if (locCmp === 0) {
-            return a.rawName.localeCompare(b.rawName);
-          } else {
-            return locCmp;
-          }}));
+      .map(file => {
+        return {
+          location: parseLocation(file),
+          rawName: file.name,
+          nameCell: nameCell(file),
+          size: formatMB(file.sizeInBytes),
+        }; })
+      .sort((a, b) => {
+        const locCmp = a.location.localeCompare(b.location);
+        if (locCmp === 0) {
+          return a.rawName.localeCompare(b.rawName);
+        } else {
+          return locCmp;
+        }}));
   };
 
   useEffect(() => {

--- a/ui/src/app/pages/admin/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-workspace.tsx
@@ -110,34 +110,40 @@ interface NameCellProps {
 const NameCell = (props: NameCellProps) => {
   const {file, bucket, workspaceNamespace, accessReason} = props;
   const filename = file.name.trim();
-  const filenameText = <span>{filename}</span>;
+
+  const filenameSpan = <span>{filename}</span>;
+
+  const fileTooLarge = <FlexRow>
+    {filenameSpan}
+    <TooltipTrigger
+        content={`Files larger than ${formatMB(MAX_NOTEBOOK_READ_SIZE_BYTES)} MB are too large to preview`}
+    ><Button style={styles.previewButton} disabled={true}>Preview</Button>
+    </TooltipTrigger>
+  </FlexRow>;
 
   const navigateToPreview = () => {
     navigate(['admin', 'workspaces', workspaceNamespace, filename],
         { queryParams: { accessReason: accessReason } });
   };
 
+  const fileWithPreviewButton = <FlexRow>
+    {filenameSpan}
+    <TooltipTrigger content='Please enter an access reason below' disabled={accessReason && accessReason.trim()}>
+      <Button style={styles.previewButton}
+              disabled={!accessReason || !accessReason.trim()}
+              onClick={navigateToPreview}>Preview</Button>
+    </TooltipTrigger>
+  </FlexRow>;
+
   // remove first check after RW-5626
   if (NOTEBOOKS_DIRECTORY === parseLocation(file, bucket) && filename.endsWith(NOTEBOOKS_SUFFIX)) {
     if (file.sizeInBytes > MAX_NOTEBOOK_READ_SIZE_BYTES) {
-      return <FlexRow>
-        {filenameText}
-        <TooltipTrigger
-          content={`Files larger than ${formatMB(MAX_NOTEBOOK_READ_SIZE_BYTES)} MB are too large to preview`}
-        ><Button style={styles.previewButton} disabled={true}>Preview</Button>
-        </TooltipTrigger>
-      </FlexRow>;
+      return fileTooLarge;
     } else {
-      return <FlexRow>
-        {filenameText}
-        <TooltipTrigger content='Please enter an access reason below' disabled={accessReason && accessReason.trim()}>
-          <Button style={styles.previewButton} disabled={!accessReason || !accessReason.trim()}
-                  onClick={navigateToPreview}>Preview</Button>
-        </TooltipTrigger>
-      </FlexRow>;
+      return fileWithPreviewButton;
     }
   } else {
-    return filenameText;
+    return filenameSpan;
   }
 };
 


### PR DESCRIPTION
Description:

~This is a **Stacked PR** branching off #4028~

Add [Preview] buttons to notebook files in the Workspace Admin page file listing.  Enable only if the admin provides an access reason and the file size is below the maximum (5MB).

Does not add buttons for notebook files outside of the standard location.  (TODO RW-5626)

![Notebook Preview buttons](https://user-images.githubusercontent.com/2701406/93919764-24492700-fcdc-11ea-9d23-f6f6d93f940a.gif)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
