### PR TITLE
[RW-5624] [risk=no] Add length limits to user creation address fields

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -217,30 +217,56 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
         presence: {
           allowEmpty: false,
           message: '^Street address cannot be blank'
+        },
+        length: {
+          maximum: 95,
+          message: '^Street address must be 95 characters or fewer'
+        }
+      },
+      'address.streetAddress2': {
+        length: {
+          maximum: 95,
+          message: '^Street address 2 must be 95 characters or fewer'
         }
       },
       'address.city': {
         presence: {
           allowEmpty: false,
           message: '^City cannot be blank'
+        },
+        length: {
+          maximum: 95,
+          message: '^City must be 95 characters or fewer'
         }
       },
       'address.state': {
         presence: {
           allowEmpty: false,
           message: '^State cannot be blank'
+        },
+        length: {
+          maximum: 95,
+          message: '^State must be 95 characters or fewer'
         }
       },
       'address.zipCode': {
         presence: {
           allowEmpty: false,
           message: '^Zip code cannot be blank'
+        },
+        length: {
+          maximum: 10,
+          message: '^Zip code must be 10 characters or fewer'
         }
       },
       'address.country': {
         presence: {
           allowEmpty: false,
           message: '^Country cannot be blank'
+        },
+        length: {
+          maximum: 95,
+          message: '^Country must be 95 characters or fewer'
         }
       }
     };


### PR DESCRIPTION
Straightforward addition of client-side validation to reduce the chance of server-side errors.

Tested locally:

<img width="411" alt="Screen Shot 2020-09-22 at 8 41 16 AM" src="https://user-images.githubusercontent.com/51842/93886745-cdc7f280-fcb3-11ea-9d1e-abbbe7060451.png">
