### PR TITLE
[RW-5625] [risk=no] Delete orphaned G Suite users if UserRow creation fails

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -290,6 +290,7 @@ public class ProfileController implements ProfileApiDelegate {
                 "Orphaned G Suite account %s could not be deleted. "
                     + "Manual intervention may be required",
                 gSuiteUsername));
+        log.log(Level.SEVERE, e2.getMessage(), e2);
         // Throw the original error rather than the G Suite error.
         throw e;
       }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -243,43 +243,58 @@ public class ProfileController implements ProfileApiDelegate {
     profileService.cleanProfile(profile);
     profileService.validateNewProfile(profile);
 
+    String gSuiteUsername =
+        profile.getUsername()
+            + "@"
+            + workbenchConfigProvider.get().googleDirectoryService.gSuiteDomain;
+
     com.google.api.services.directory.model.User googleUser =
         directoryService.createUser(
             profile.getGivenName(),
             profile.getFamilyName(),
-            profile.getUsername()
-                + "@"
-                + workbenchConfigProvider.get().googleDirectoryService.gSuiteDomain,
+            gSuiteUsername,
             profile.getContactEmail());
 
-    // Create a user that has no data access or FC user associated.
-    // We create this account before they sign in so we can keep track of which users we have
-    // created Google accounts for. This can be used subsequently to delete orphaned accounts.
-
-    // We store this information in our own database so that:
-    // 1) we can support bring-your-own account in future (when we won't be using directory service)
-    // 2) we can easily generate lists of researchers for the storefront, without joining to Google
-
-    // It's possible for the profile information to become out of sync with the user's Google
-    // profile, since it can be edited in our UI as well as the Google UI,  and we're fine with
-    // that; the expectation is their profile in AofU will be managed in AofU, not in Google.
-
-    DbUser user =
-        userService.createUser(
-            profile.getGivenName(),
-            profile.getFamilyName(),
-            googleUser.getPrimaryEmail(),
-            profile.getContactEmail(),
-            profile.getCurrentPosition(),
-            profile.getOrganization(),
-            profile.getAreaOfResearch(),
-            profile.getProfessionalUrl(),
-            profile.getDegrees(),
-            FROM_CLIENT_ADDRESS.apply(profile.getAddress()),
-            demographicSurveyMapper.demographicSurveyToDbDemographicSurvey(
-                profile.getDemographicSurvey()),
-            verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
-                profile.getVerifiedInstitutionalAffiliation(), institutionService));
+    DbUser user;
+    try {
+      user =
+          userService.createUser(
+              profile.getGivenName(),
+              profile.getFamilyName(),
+              googleUser.getPrimaryEmail(),
+              profile.getContactEmail(),
+              profile.getCurrentPosition(),
+              profile.getOrganization(),
+              profile.getAreaOfResearch(),
+              profile.getProfessionalUrl(),
+              profile.getDegrees(),
+              FROM_CLIENT_ADDRESS.apply(profile.getAddress()),
+              demographicSurveyMapper.demographicSurveyToDbDemographicSurvey(
+                  profile.getDemographicSurvey()),
+              verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
+                  profile.getVerifiedInstitutionalAffiliation(), institutionService));
+    } catch (Exception e) {
+      // If the creation of a User row in the RW database fails, we want to attempt to remove the
+      // G Suite account to avoid having an orphaned account with no record in our database.
+      log.severe(
+          String.format(
+              "An error occurred when creating DbUser for %s. Attempting to delete "
+                  + "orphaned G Suite account",
+              gSuiteUsername));
+      try {
+        directoryService.deleteUser(gSuiteUsername);
+        log.severe("Orphaned G Suite account has been deleted.");
+      } catch (Exception e2) {
+        log.severe(
+            String.format(
+                "Orphaned G Suite account %s could not be deleted. "
+                    + "Manual intervention may be required",
+                gSuiteUsername));
+        // Throw the original error rather than the G Suite error.
+        throw e;
+      }
+      throw e;
+    }
 
     if (request.getTermsOfServiceVersion() != null) {
       userService.submitTermsOfService(user, request.getTermsOfServiceVersion());

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbAddress.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbAddress.java
@@ -52,7 +52,12 @@ public class DbAddress {
     this.streetAddress2 = streetAddress2;
   }
 
-  @Column(name = "zip_code")
+  // Most @Column annotations in our codebase don't have a length specification. This is included
+  // on the zip_code field to allow test cases (where an in-memory H2 database is used instead of
+  // MySQL) to trigger an exception when a user attempts to save a DbUser row with too-large field
+  // payloads. See ProfileControllerTest for the test case, and the Liquibase changelogs for the
+  // SQL definition of this field.
+  @Column(name = "zip_code", length = 10)
   public String getZipCode() {
     return zipCode;
   }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -31,7 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -46,6 +45,7 @@ import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserDataUseAgreement;
@@ -181,6 +181,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     ProfileController.class,
     ProfileMapperImpl.class,
     ProfileService.class,
+    UserServiceImpl.class,
     UserServiceTestConfiguration.class,
     VerifiedInstitutionalAffiliationMapperImpl.class,
   })
@@ -215,7 +216,6 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Override
   public void setUp() throws IOException {
     super.setUp();
-    MockitoAnnotations.initMocks(this);
 
     config.googleDirectoryService.gSuiteDomain = GSUITE_DOMAIN;
 


### PR DESCRIPTION
See ticket for context – this was a small bug encountered as the result of a user report.

I *think* rolling back the G Suite user creation automatically in this case is the way to go. Happy to have a deeper discussion if anyone feels strongly otherwise.