### PR TITLE
[RW-5404][risk=low] GetRuntime: support user override runtime semantics

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -45,7 +45,6 @@ import org.pmiops.workbench.model.RuntimeStatus;
 import org.pmiops.workbench.model.UpdateClusterConfigRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
-import org.pmiops.workbench.notebooks.LeonardoNotebooksClientImpl;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -203,12 +202,17 @@ public class RuntimeController implements RuntimeApiDelegate {
               .get();
 
       final String OVERRIDE_LABEL =
-          LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
               RuntimeConfigurationType.USEROVERRIDE);
       Map<String, String> runtimeLabels = (Map<String, String>) mostRecentRuntime.getLabels();
       if (runtimeLabels != null
           && OVERRIDE_LABEL.equals(
-              runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG))) {
+              runtimeLabels.get(LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG))) {
+        Runtime runtime = leonardoMapper.toApiRuntime(mostRecentRuntime);
+        if (!runtime.getStatus().equals(RuntimeStatus.DELETED)) {
+          log.warning("Runtimes returned from ListRuntimes should be DELETED but found " + runtime.getStatus());
+        }
+
         return ResponseEntity.ok(
             leonardoMapper.toApiRuntime(mostRecentRuntime).status(RuntimeStatus.DELETED));
       } else {

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -186,20 +186,31 @@ public class RuntimeController implements RuntimeApiDelegate {
         throw e;
       }
 
-      List<LeonardoListRuntimeResponse> runtimes = leonardoNotebooksClient.listRuntimesByProject(workspaceNamespace);
+      List<LeonardoListRuntimeResponse> runtimes =
+          leonardoNotebooksClient.listRuntimesByProject(workspaceNamespace);
       if (runtimes.isEmpty()) {
         throw e;
       }
 
-      LeonardoListRuntimeResponse mostRecentRuntime = runtimes.stream()
-          .sorted((a,b) -> b.getAuditInfo().getCreatedDate().compareTo(a.getAuditInfo().getCreatedDate()))
-          .findFirst()
-          .get();
+      LeonardoListRuntimeResponse mostRecentRuntime =
+          runtimes.stream()
+              .sorted(
+                  (a, b) ->
+                      b.getAuditInfo()
+                          .getCreatedDate()
+                          .compareTo(a.getAuditInfo().getCreatedDate()))
+              .findFirst()
+              .get();
 
-      final String OVERRIDE_LABEL = LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(RuntimeConfigurationType.USEROVERRIDE);
+      final String OVERRIDE_LABEL =
+          LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+              RuntimeConfigurationType.USEROVERRIDE);
       Map<String, String> runtimeLabels = (Map<String, String>) mostRecentRuntime.getLabels();
-      if (runtimeLabels != null && OVERRIDE_LABEL.equals(runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG))) {
-        return ResponseEntity.ok(leonardoMapper.toApiRuntime(mostRecentRuntime).status(RuntimeStatus.DELETED));
+      if (runtimeLabels != null
+          && OVERRIDE_LABEL.equals(
+              runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG))) {
+        return ResponseEntity.ok(
+            leonardoMapper.toApiRuntime(mostRecentRuntime).status(RuntimeStatus.DELETED));
       } else {
         throw e;
       }

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -206,11 +206,12 @@ public class RuntimeController implements RuntimeApiDelegate {
               RuntimeConfigurationType.USEROVERRIDE);
       Map<String, String> runtimeLabels = (Map<String, String>) mostRecentRuntime.getLabels();
       if (runtimeLabels != null
-          && OVERRIDE_LABEL.equals(
-              runtimeLabels.get(LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG))) {
+          && OVERRIDE_LABEL.equals(runtimeLabels.get(LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG))) {
         Runtime runtime = leonardoMapper.toApiRuntime(mostRecentRuntime);
         if (!runtime.getStatus().equals(RuntimeStatus.DELETED)) {
-          log.warning("Runtimes returned from ListRuntimes should be DELETED but found " + runtime.getStatus());
+          log.warning(
+              "Runtimes returned from ListRuntimes should be DELETED but found "
+                  + runtime.getStatus());
         }
 
         return ResponseEntity.ok(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,7 +16,8 @@ public interface LeonardoNotebooksClient {
   /** lists all notebook runtimes as the appengine SA, to be used only for admin operations */
   List<LeonardoListRuntimeResponse> listRuntimesByProjectAsService(String googleProject);
 
-  List<LeonardoListRuntimeResponse> listRuntimesByProject(String googleProject);
+  List<LeonardoListRuntimeResponse> listRuntimesByProject(
+      String googleProject, boolean includeDeleted);
 
   /**
    * Creates a notebooks runtime owned by the current authenticated user.

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClient.java
@@ -16,6 +16,8 @@ public interface LeonardoNotebooksClient {
   /** lists all notebook runtimes as the appengine SA, to be used only for admin operations */
   List<LeonardoListRuntimeResponse> listRuntimesByProjectAsService(String googleProject);
 
+  List<LeonardoListRuntimeResponse> listRuntimesByProject(String googleProject);
+
   /**
    * Creates a notebooks runtime owned by the current authenticated user.
    *

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -190,10 +190,11 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
-  public List<LeonardoListRuntimeResponse> listRuntimesByProject(String googleProject) {
+  public List<LeonardoListRuntimeResponse> listRuntimesByProject(
+      String googleProject, boolean includeDeleted) {
     RuntimesApi runtimesApi = runtimesApiProvider.get();
     return leonardoRetryHandler.run(
-        (context) -> runtimesApi.listRuntimesByProject(googleProject, null, true));
+        (context) -> runtimesApi.listRuntimesByProject(googleProject, null, includeDeleted));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.notebooks;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.ImmutableBiMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +26,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig.CloudServiceEnum;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
 import org.pmiops.workbench.model.Runtime;
-import org.pmiops.workbench.model.RuntimeConfigurationType;
 import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
@@ -42,16 +39,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
-  private static final String RUNTIME_LABEL_AOU = "all-of-us";
-  public static final String RUNTIME_LABEL_AOU_CONFIG = "all-of-us-config";
-  private static final String RUNTIME_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
-  public static final BiMap<RuntimeConfigurationType, String>
-      RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
-          ImmutableBiMap.of(
-              RuntimeConfigurationType.USEROVERRIDE, "user-override",
-              RuntimeConfigurationType.DEFAULTGCE, "default-gce",
-              RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
@@ -114,13 +102,13 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         "aou-upload-policy-extension", assetsBaseUrl + "/aou-upload-policy-extension.js");
 
     Map<String, String> runtimeLabels = new HashMap<>();
-    runtimeLabels.put(RUNTIME_LABEL_AOU, "true");
-    runtimeLabels.put(RUNTIME_LABEL_CREATED_BY, userEmail);
+    runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_AOU, "true");
+    runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_CREATED_BY, userEmail);
 
     if (runtime.getConfigurationType() != null) {
       runtimeLabels.put(
-          RUNTIME_LABEL_AOU_CONFIG,
-          RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(runtime.getConfigurationType()));
+          LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
+          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(runtime.getConfigurationType()));
     }
 
     LeonardoCreateRuntimeRequest request =

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.notebooks;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,12 +43,12 @@ import org.springframework.stereotype.Service;
 public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private static final String RUNTIME_LABEL_AOU = "all-of-us";
-  private static final String RUNTIME_LABEL_AOU_CONFIG = "all-of-us-config";
+  public static final String RUNTIME_LABEL_AOU_CONFIG = "all-of-us-config";
   private static final String RUNTIME_LABEL_CREATED_BY = "created-by";
   private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
-  public static final Map<RuntimeConfigurationType, String>
+  public static final BiMap<RuntimeConfigurationType, String>
       RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
-          ImmutableMap.of(
+          ImmutableBiMap.of(
               RuntimeConfigurationType.USEROVERRIDE, "user-override",
               RuntimeConfigurationType.DEFAULTGCE, "default-gce",
               RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
@@ -203,7 +204,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   public List<LeonardoListRuntimeResponse> listRuntimesByProject(String googleProject) {
     RuntimesApi runtimesApi = runtimesApiProvider.get();
     return leonardoRetryHandler.run(
-        (context) -> runtimesApi.listRuntimesByProject(googleProject, null, false));
+        (context) -> runtimesApi.listRuntimesByProject(googleProject, null, true));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -200,6 +200,13 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   }
 
   @Override
+  public List<LeonardoListRuntimeResponse> listRuntimesByProject(String googleProject) {
+    RuntimesApi runtimesApi = runtimesApiProvider.get();
+    return leonardoRetryHandler.run(
+        (context) -> runtimesApi.listRuntimesByProject(googleProject, null, false));
+  }
+
+  @Override
   public void deleteRuntime(String googleProject, String runtimeName) {
     RuntimesApi runtimesApi = runtimesApiProvider.get();
     leonardoRetryHandler.run(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -108,7 +108,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     if (runtime.getConfigurationType() != null) {
       runtimeLabels.put(
           LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
-          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(runtime.getConfigurationType()));
+          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+              runtime.getConfigurationType()));
     }
 
     LeonardoCreateRuntimeRequest request =

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -30,12 +30,11 @@ public interface LeonardoMapper {
   String RUNTIME_LABEL_AOU = "all-of-us";
   String RUNTIME_LABEL_AOU_CONFIG = "all-of-us-config";
   String RUNTIME_LABEL_CREATED_BY = "created-by";
-  BiMap<RuntimeConfigurationType, String>
-      RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
-          ImmutableBiMap.of(
-              RuntimeConfigurationType.USEROVERRIDE, "user-override",
-              RuntimeConfigurationType.DEFAULTGCE, "default-gce",
-              RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
+  BiMap<RuntimeConfigurationType, String> RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
+      ImmutableBiMap.of(
+          RuntimeConfigurationType.USEROVERRIDE, "user-override",
+          RuntimeConfigurationType.DEFAULTGCE, "default-gce",
+          RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
 
   DataprocConfig toDataprocConfig(LeonardoMachineConfig leonardoMachineConfig);
 
@@ -96,8 +95,7 @@ public interface LeonardoMapper {
   }
 
   default void mapLabels(Runtime runtime, Map<String, String> runtimeLabels) {
-    if (runtimeLabels == null
-        || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
+    if (runtimeLabels == null || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
       runtime.setConfigurationType(RuntimeConfigurationType.DEFAULTDATAPROC);
     } else {
       runtime.setConfigurationType(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.utils.mappers;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.gson.Gson;
 import java.util.List;
 import java.util.Map;
@@ -21,10 +23,19 @@ import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
 import org.pmiops.workbench.model.RuntimeStatus;
-import org.pmiops.workbench.notebooks.LeonardoNotebooksClientImpl;
 
 @Mapper(config = MapStructConfig.class)
 public interface LeonardoMapper {
+
+  String RUNTIME_LABEL_AOU = "all-of-us";
+  String RUNTIME_LABEL_AOU_CONFIG = "all-of-us-config";
+  String RUNTIME_LABEL_CREATED_BY = "created-by";
+  BiMap<RuntimeConfigurationType, String>
+      RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
+          ImmutableBiMap.of(
+              RuntimeConfigurationType.USEROVERRIDE, "user-override",
+              RuntimeConfigurationType.DEFAULTGCE, "default-gce",
+              RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
 
   DataprocConfig toDataprocConfig(LeonardoMachineConfig leonardoMachineConfig);
 
@@ -86,13 +97,13 @@ public interface LeonardoMapper {
 
   default void mapLabels(Runtime runtime, Map<String, String> runtimeLabels) {
     if (runtimeLabels == null
-        || runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG) == null) {
+        || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
       runtime.setConfigurationType(RuntimeConfigurationType.DEFAULTDATAPROC);
     } else {
       runtime.setConfigurationType(
-          LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP
+          RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP
               .inverse()
-              .get(runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG)));
+              .get(runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG)));
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -78,17 +78,21 @@ public interface LeonardoMapper {
   }
 
   @AfterMapping
-  default void listRuntimeAfterMapper(@MappingTarget Runtime runtime, LeonardoListRuntimeResponse leonardoListRuntimeResponse) {
+  default void listRuntimeAfterMapper(
+      @MappingTarget Runtime runtime, LeonardoListRuntimeResponse leonardoListRuntimeResponse) {
     mapLabels(runtime, (Map<String, String>) leonardoListRuntimeResponse.getLabels());
     mapRuntimeConfig(runtime, leonardoListRuntimeResponse.getRuntimeConfig());
   }
 
   default void mapLabels(Runtime runtime, Map<String, String> runtimeLabels) {
-    if (runtimeLabels == null || runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG) == null) {
+    if (runtimeLabels == null
+        || runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG) == null) {
       runtime.setConfigurationType(RuntimeConfigurationType.DEFAULTDATAPROC);
     } else {
       runtime.setConfigurationType(
-          LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.inverse().get(runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG)));
+          LeonardoNotebooksClientImpl.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP
+              .inverse()
+              .get(runtimeLabels.get(LeonardoNotebooksClientImpl.RUNTIME_LABEL_AOU_CONFIG)));
     }
   }
 
@@ -99,22 +103,15 @@ public interface LeonardoMapper {
 
     Gson gson = new Gson();
     LeonardoRuntimeConfig runtimeConfig =
-        gson.fromJson(
-            gson.toJson(runtimeConfigObj),
-            LeonardoRuntimeConfig.class);
+        gson.fromJson(gson.toJson(runtimeConfigObj), LeonardoRuntimeConfig.class);
 
     if (CloudServiceEnum.DATAPROC.equals(runtimeConfig.getCloudService())) {
       runtime.dataprocConfig(
           toDataprocConfig(
-              gson.fromJson(
-                  gson.toJson(runtimeConfigObj),
-                  LeonardoMachineConfig.class)));
+              gson.fromJson(gson.toJson(runtimeConfigObj), LeonardoMachineConfig.class)));
     } else if (CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService())) {
       runtime.gceConfig(
-          toGceConfig(
-              gson.fromJson(
-                  gson.toJson(runtimeConfigObj),
-                  LeonardoGceConfig.class)));
+          toGceConfig(gson.fromJson(gson.toJson(runtimeConfigObj), LeonardoGceConfig.class)));
     } else {
       throw new IllegalArgumentException(
           "Invalid LeonardoGetRuntimeResponse.RuntimeConfig.cloudService : "

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -96,6 +96,8 @@ public interface LeonardoMapper {
 
   default void mapLabels(Runtime runtime, Map<String, String> runtimeLabels) {
     if (runtimeLabels == null || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
+      // If there's no label, fall back onto the old behavior where every Runtime was created with a
+      // default Dataproc config
       runtime.setConfigurationType(RuntimeConfigurationType.DEFAULTDATAPROC);
     } else {
       runtime.setConfigurationType(

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -255,11 +255,7 @@ public class RuntimeControllerTest {
 
     String createdDate = Date.fromYearMonthDay(1988, 12, 26).toString();
 
-    dataprocConfig =
-        new DataprocConfig()
-            .numberOfWorkers(0)
-            .masterMachineType("n1-standard-4")
-            .masterDiskSize(50);
+    Runtime tmpRuntime = new Runtime();
 
     dataprocConfigObj = new LinkedTreeMap<>();
     dataprocConfigObj.put("cloudService", "DATAPROC");
@@ -267,13 +263,17 @@ public class RuntimeControllerTest {
     dataprocConfigObj.put("masterMachineType", "n1-standard-4");
     dataprocConfigObj.put("masterDiskSize", 50.0);
 
-    gceConfig = new GceConfig().bootDiskSize(10).diskSize(100).machineType("n1-standard-2");
+    leonardoMapper.mapRuntimeConfig(tmpRuntime, dataprocConfigObj);
+    dataprocConfig = tmpRuntime.getDataprocConfig();
 
     gceConfigObj = new LinkedTreeMap<>();
     gceConfigObj.put("cloudService", "GCE");
     gceConfigObj.put("bootDiskSize", 10.0);
     gceConfigObj.put("diskSize", 100.0);
     gceConfigObj.put("machineType", "n1-standard-2");
+
+    leonardoMapper.mapRuntimeConfig(tmpRuntime, gceConfigObj);
+    gceConfig = tmpRuntime.getGceConfig();
 
     testLeoRuntime =
         new LeonardoGetRuntimeResponse()

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import java.time.Clock;
 import java.time.Instant;
@@ -224,6 +224,12 @@ public class RuntimeControllerTest {
   private Runtime testRuntime;
   private DbWorkspace testWorkspace;
 
+  private DataprocConfig dataprocConfig;
+  private LinkedTreeMap<String, Object> dataprocConfigObj;
+
+  private GceConfig gceConfig;
+  private LinkedTreeMap<String, Object> gceConfigObj;
+
   @Before
   public void setUp() {
     config = WorkbenchConfig.createEmptyConfig();
@@ -232,6 +238,7 @@ public class RuntimeControllerTest {
     config.firecloud.notebookRuntimeDefaultMachineType = "n1-standard-4";
     config.firecloud.notebookRuntimeDefaultDiskSizeGb = 50;
     config.access.enableComplianceTraining = true;
+    config.featureFlags.enableCustomRuntimes = true;
 
     user = new DbUser();
     user.setUsername(LOGGED_IN_USER_EMAIL);
@@ -248,17 +255,28 @@ public class RuntimeControllerTest {
 
     String createdDate = Date.fromYearMonthDay(1988, 12, 26).toString();
 
-    DataprocConfig dataprocConfig =
+    dataprocConfig =
         new DataprocConfig()
             .numberOfWorkers(0)
             .masterMachineType("n1-standard-4")
             .masterDiskSize(50);
 
-    LinkedTreeMap<String, Object> dataProcConfigObj = new LinkedTreeMap<>();
-    dataProcConfigObj.put("cloudService", "DATAPROC");
-    dataProcConfigObj.put("numberOfWorkers", 0);
-    dataProcConfigObj.put("masterMachineType", "n1-standard-4");
-    dataProcConfigObj.put("masterDiskSize", 50.0);
+    dataprocConfigObj = new LinkedTreeMap<>();
+    dataprocConfigObj.put("cloudService", "DATAPROC");
+    dataprocConfigObj.put("numberOfWorkers", 0);
+    dataprocConfigObj.put("masterMachineType", "n1-standard-4");
+    dataprocConfigObj.put("masterDiskSize", 50.0);
+
+    gceConfig = new GceConfig()
+        .bootDiskSize(10)
+        .diskSize(100)
+        .machineType("n1-standard-2");
+
+    gceConfigObj = new LinkedTreeMap<>();
+    gceConfigObj.put("cloudService", "GCE");
+    gceConfigObj.put("bootDiskSize", 10.0);
+    gceConfigObj.put("diskSize", 100.0);
+    gceConfigObj.put("machineType", "n1-standard-2");
 
     testLeoRuntime =
         new LeonardoGetRuntimeResponse()
@@ -267,7 +285,7 @@ public class RuntimeControllerTest {
             .status(LeonardoRuntimeStatus.DELETING)
             .runtimeImages(Collections.singletonList(RUNTIME_IMAGE))
             .autopauseThreshold(AUTOPAUSE_THRESHOLD)
-            .runtimeConfig(dataProcConfigObj)
+            .runtimeConfig(dataprocConfigObj)
             .auditInfo(new LeonardoAuditInfo().createdDate(createdDate));
     testLeoListRuntimeResponse =
         new LeonardoListRuntimeResponse()
@@ -277,6 +295,7 @@ public class RuntimeControllerTest {
     testRuntime =
         new Runtime()
             .runtimeName(getRuntimeName())
+            .configurationType(RuntimeConfigurationType.DEFAULTDATAPROC)
             .googleProject(BILLING_PROJECT_ID)
             .status(RuntimeStatus.DELETING)
             .toolDockerImage(TOOL_DOCKER_IMAGE)
@@ -376,8 +395,7 @@ public class RuntimeControllerTest {
 
   @Test
   public void testGetRuntime_defaultLabel_dataproc() throws ApiException {
-    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default"));
-    testLeoRuntime.setRuntimeConfig(ImmutableMap.of("cloudService", "DATAPROC"));
+    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default-dataproc"));
 
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime);
@@ -388,8 +406,7 @@ public class RuntimeControllerTest {
 
   @Test
   public void testGetRuntime_defaultLabel_gce() throws ApiException {
-    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default"));
-    testLeoRuntime.setRuntimeConfig(ImmutableMap.of("cloudService", "GCE"));
+    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default-gce"));
 
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime);
@@ -420,7 +437,88 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_noGetRuntime_hasListRuntimesWithMostRecentOverride() throws ApiException {
+  public void testGetRuntime_fromListRuntimes() throws ApiException {
+    String timestamp = "2020-09-13T19:19:57.347Z";
+
+    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+        .thenThrow(new ApiException(404, "Not found"));
+    when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
+        .thenReturn(ImmutableList.of(
+            new LeonardoListRuntimeResponse()
+                .googleProject("google-project")
+                .runtimeName("expected-runtime")
+                .status(LeonardoRuntimeStatus.CREATING)
+                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
+        ));
+
+    Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
+
+    assertThat(runtime.getRuntimeName()).isEqualTo("expected-runtime");
+    assertThat(runtime.getGoogleProject()).isEqualTo("google-project");
+    assertThat(runtime.getStatus()).isEqualTo(RuntimeStatus.DELETED);
+    assertThat(runtime.getConfigurationType()).isEqualTo(RuntimeConfigurationType.USEROVERRIDE);
+    assertThat(runtime.getCreatedDate()).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void testGetRuntime_fromListRuntimes_gceConfig() throws ApiException {
+    String timestamp = "2020-09-13T19:19:57.347Z";
+
+    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+        .thenThrow(new ApiException(404, "Not found"));
+    when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
+        .thenReturn(ImmutableList.of(
+            new LeonardoListRuntimeResponse()
+                .runtimeConfig(gceConfigObj)
+                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
+        ));
+
+    Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
+
+    assertThat(runtime.getGceConfig()).isEqualTo(gceConfig);
+    assertThat(runtime.getDataprocConfig()).isNull();
+  }
+
+  @Test
+  public void testGetRuntime_fromListRuntimes_dataprocConfig() throws ApiException {
+    String timestamp = "2020-09-13T19:19:57.347Z";
+
+    LinkedTreeMap<String, Object> dataProcConfigObj = new LinkedTreeMap<>();
+    dataProcConfigObj.put("cloudService", "DATAPROC");
+    dataProcConfigObj.put("masterDiskSize", 50.0);
+    dataProcConfigObj.put("masterMachineType", "n1-standard-4");
+    dataProcConfigObj.put("numberOfPreemptibleWorkers", 4);
+    dataProcConfigObj.put("numberOfWorkerLocalSSDs", 8);
+    dataProcConfigObj.put("numberOfWorkers", 3);
+    dataProcConfigObj.put("workerDiskSize", 30);
+    dataProcConfigObj.put("workerMachineType", "n1-standard-2");
+
+    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+        .thenThrow(new ApiException(404, "Not found"));
+    when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
+        .thenReturn(ImmutableList.of(
+            new LeonardoListRuntimeResponse()
+                .runtimeConfig(dataProcConfigObj)
+                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
+        ));
+
+    Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
+
+    assertThat(runtime.getDataprocConfig().getMasterDiskSize()).isEqualTo(50);
+    assertThat(runtime.getDataprocConfig().getMasterMachineType()).isEqualTo("n1-standard-4");
+    assertThat(runtime.getDataprocConfig().getNumberOfPreemptibleWorkers()).isEqualTo(4);
+    assertThat(runtime.getDataprocConfig().getNumberOfWorkerLocalSSDs()).isEqualTo(8);
+    assertThat(runtime.getDataprocConfig().getNumberOfWorkers()).isEqualTo(3);
+    assertThat(runtime.getDataprocConfig().getWorkerDiskSize()).isEqualTo(30);
+    assertThat(runtime.getDataprocConfig().getWorkerMachineType()).isEqualTo("n1-standard-2");
+    assertThat(runtime.getGceConfig()).isNull();
+  }
+
+  @Test
+  public void testGetRuntime_fromListRuntimes_checkMostRecent() throws ApiException {
     String olderTimestamp = "2020-09-13T19:19:57.347Z";
     String newerTimestamp = "2020-09-14T19:19:57.347Z";
 
@@ -429,7 +527,7 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
         .thenReturn(ImmutableList.of(
             new LeonardoListRuntimeResponse()
-                .runtimeName("override-runtime")
+                .runtimeName("expected-runtime")
                 .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp))
                 .labels(ImmutableMap.of("all-of-us-config", "user-override")),
             new LeonardoListRuntimeResponse()
@@ -442,7 +540,7 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_noGetRuntime_hasListRuntimesWithOldOverride() throws ApiException {
+  public void testGetRuntime_fromListRuntime_mostRecentIsDefaultLabel() throws ApiException {
     String olderTimestamp = "2020-09-13T19:19:57.347Z";
     String newerTimestamp = "2020-09-14T19:19:57.347Z";
 
@@ -464,7 +562,7 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_noGetRuntime_hasListRuntimesWithNoOverride() throws ApiException {
+  public void testGetRuntime_fromListRuntime_mostRecentHasNoLabel() throws ApiException {
     String olderTimestamp = "2020-09-13T19:19:57.347Z";
     String newerTimestamp = "2020-09-14T19:19:57.347Z";
 
@@ -486,15 +584,6 @@ public class RuntimeControllerTest {
 
   @Test
   public void testGetRuntime_gceConfig() throws ApiException {
-    GceConfig gceConfig =
-        new GceConfig().bootDiskSize(10).diskSize(100).machineType("n1-standard-2");
-
-    LinkedTreeMap<String, Object> gceConfigObj = new LinkedTreeMap<>();
-    gceConfigObj.put("bootDiskSize", 10.0);
-    gceConfigObj.put("diskSize", 100.0);
-    gceConfigObj.put("machineType", "n1-standard-2");
-    gceConfigObj.put("cloudService", "GCE");
-
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime.runtimeConfig(gceConfigObj));
 
@@ -720,6 +809,8 @@ public class RuntimeControllerTest {
 
   @Test
   public void testCreateRuntime_nullRuntime() throws ApiException {
+    config.featureFlags.enableCustomRuntimes = false;
+
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
@@ -730,6 +821,8 @@ public class RuntimeControllerTest {
 
   @Test
   public void testCreateRuntime_emptyRuntime() throws ApiException {
+    config.featureFlags.enableCustomRuntimes = false;
+
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
@@ -746,7 +839,7 @@ public class RuntimeControllerTest {
 
     runtimeController.createRuntime(
         BILLING_PROJECT_ID,
-        new Runtime().configurationType(RuntimeConfigurationType.DEFAULTDATAPROC));
+        new Runtime().configurationType(RuntimeConfigurationType.DEFAULTDATAPROC).dataprocConfig(testRuntime.getDataprocConfig()));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());
@@ -763,7 +856,7 @@ public class RuntimeControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
 
     runtimeController.createRuntime(
-        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.DEFAULTGCE));
+        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.DEFAULTGCE).dataprocConfig(dataprocConfig));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());
@@ -780,7 +873,7 @@ public class RuntimeControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
 
     runtimeController.createRuntime(
-        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.USEROVERRIDE));
+        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.USEROVERRIDE).dataprocConfig(dataprocConfig));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -267,10 +267,7 @@ public class RuntimeControllerTest {
     dataprocConfigObj.put("masterMachineType", "n1-standard-4");
     dataprocConfigObj.put("masterDiskSize", 50.0);
 
-    gceConfig = new GceConfig()
-        .bootDiskSize(10)
-        .diskSize(100)
-        .machineType("n1-standard-2");
+    gceConfig = new GceConfig().bootDiskSize(10).diskSize(100).machineType("n1-standard-2");
 
     gceConfigObj = new LinkedTreeMap<>();
     gceConfigObj.put("cloudService", "GCE");
@@ -443,14 +440,14 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .googleProject("google-project")
-                .runtimeName("expected-runtime")
-                .status(LeonardoRuntimeStatus.CREATING)
-                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .googleProject("google-project")
+                    .runtimeName("expected-runtime")
+                    .status(LeonardoRuntimeStatus.CREATING)
+                    .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "user-override"))));
 
     Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
 
@@ -468,12 +465,12 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .runtimeConfig(gceConfigObj)
-                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .runtimeConfig(gceConfigObj)
+                    .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "user-override"))));
 
     Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
 
@@ -498,12 +495,12 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .runtimeConfig(dataProcConfigObj)
-                .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "user-override"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .runtimeConfig(dataProcConfigObj)
+                    .auditInfo(new LeonardoAuditInfo().createdDate(timestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "user-override"))));
 
     Runtime runtime = runtimeController.getRuntime(BILLING_PROJECT_ID).getBody();
 
@@ -525,18 +522,19 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .runtimeName("expected-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "user-override")),
-            new LeonardoListRuntimeResponse()
-                .runtimeName("default-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "default"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("expected-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "user-override")),
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("default-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "default"))));
 
-    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody().getRuntimeName()).isEqualTo("expected-runtime");
+    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody().getRuntimeName())
+        .isEqualTo("expected-runtime");
   }
 
   @Test
@@ -547,16 +545,16 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .runtimeName("override-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "user-override")),
-            new LeonardoListRuntimeResponse()
-                .runtimeName("default-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "default"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("override-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "user-override")),
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("default-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "default"))));
 
     assertThrows(NotFoundException.class, () -> runtimeController.getRuntime(BILLING_PROJECT_ID));
   }
@@ -569,15 +567,15 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new ApiException(404, "Not found"));
     when(userRuntimesApi.listRuntimesByProject(BILLING_PROJECT_ID, null, true))
-        .thenReturn(ImmutableList.of(
-            new LeonardoListRuntimeResponse()
-                .runtimeName("override-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp)),
-            new LeonardoListRuntimeResponse()
-                .runtimeName("default-runtime")
-                .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
-                .labels(ImmutableMap.of("all-of-us-config", "default"))
-        ));
+        .thenReturn(
+            ImmutableList.of(
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("override-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(newerTimestamp)),
+                new LeonardoListRuntimeResponse()
+                    .runtimeName("default-runtime")
+                    .auditInfo(new LeonardoAuditInfo().createdDate(olderTimestamp))
+                    .labels(ImmutableMap.of("all-of-us-config", "default"))));
 
     assertThrows(NotFoundException.class, () -> runtimeController.getRuntime(BILLING_PROJECT_ID));
   }
@@ -839,7 +837,9 @@ public class RuntimeControllerTest {
 
     runtimeController.createRuntime(
         BILLING_PROJECT_ID,
-        new Runtime().configurationType(RuntimeConfigurationType.DEFAULTDATAPROC).dataprocConfig(testRuntime.getDataprocConfig()));
+        new Runtime()
+            .configurationType(RuntimeConfigurationType.DEFAULTDATAPROC)
+            .dataprocConfig(testRuntime.getDataprocConfig()));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());
@@ -856,7 +856,10 @@ public class RuntimeControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
 
     runtimeController.createRuntime(
-        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.DEFAULTGCE).dataprocConfig(dataprocConfig));
+        BILLING_PROJECT_ID,
+        new Runtime()
+            .configurationType(RuntimeConfigurationType.DEFAULTGCE)
+            .dataprocConfig(dataprocConfig));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());
@@ -873,7 +876,10 @@ public class RuntimeControllerTest {
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
 
     runtimeController.createRuntime(
-        BILLING_PROJECT_ID, new Runtime().configurationType(RuntimeConfigurationType.USEROVERRIDE).dataprocConfig(dataprocConfig));
+        BILLING_PROJECT_ID,
+        new Runtime()
+            .configurationType(RuntimeConfigurationType.USEROVERRIDE)
+            .dataprocConfig(dataprocConfig));
     verify(userRuntimesApi)
         .createRuntime(
             eq(BILLING_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());


### PR DESCRIPTION
Description:

Implements the logic where we will check the user's latest deleted runtime if we cannot find an active one through getRuntime.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
