### PR TITLE
[RW-5363][risk=no]  Puppeteer test for notebook download

### DIFF
--- a/e2e/app/page/notebook-download-modal.ts
+++ b/e2e/app/page/notebook-download-modal.ts
@@ -1,0 +1,55 @@
+import {ElementHandle, Frame, Page} from 'puppeteer';
+import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
+
+enum Xpath {
+  modal = '//*[@role="dialog"]',
+  policyCheckbox = '//*[@id="confirm-policy"]',
+  downloadButton = '//*[@id="aou-download"]',
+}
+
+// Note: this does not extended the standard e2e Modal component because it
+// assumes the Jupyter UI is running in an iframe. It therefore needs to operate
+// on a frame, rather than on the global page.
+export default class NotebookDownloadModal {
+
+  constructor(private page: Page, private frame: Frame) {}
+
+  async waitUntilVisible(): Promise<ElementHandle> {
+    return await this.frame.waitForXPath(Xpath.modal, {visible: true});
+  }
+
+  async waitForLoad(): Promise<this> {
+    try {
+      await this.waitUntilVisible();
+    } catch (e) {
+      await savePageToFile(this.page);
+      await takeScreenshot(this.page);
+      const title = await this.page.title();
+      throw new Error(`"${title}" modal waitForLoad() encountered ${e}`);
+    }
+    return this;
+  }
+
+  async waitUntilClose(): Promise<void> {
+    await this.frame.waitForXPath(Xpath.modal, {hidden: true});
+  }
+
+  async clickPolicyCheckbox(): Promise<void> {
+    const checkbox = await this.getPolicyCheckbox();
+    await checkbox.focus();
+    await checkbox.hover();
+    await checkbox.click();
+    await this.frame.evaluate(e => {
+      (window as any).$(e).change();
+    }, checkbox);
+    await this.page.waitFor(500);
+  }
+
+  async getPolicyCheckbox(): Promise<ElementHandle> {
+    return this.frame.waitForXPath(Xpath.modal + Xpath.policyCheckbox, {visible: true});
+  }
+
+  async getDownloadButton(): Promise<ElementHandle> {
+    return this.frame.waitForXPath(Xpath.modal + Xpath.downloadButton, {visible: true});
+  }
+}

--- a/e2e/app/page/notebook-download-modal.ts
+++ b/e2e/app/page/notebook-download-modal.ts
@@ -36,12 +36,16 @@ export default class NotebookDownloadModal {
 
   async clickPolicyCheckbox(): Promise<void> {
     const checkbox = await this.getPolicyCheckbox();
+
+    // XXX: All of this fails to actually dynamically update the checkbox value in
+    // headless mode. Simply clicking the element works fine in debug mode.
     await checkbox.focus();
     await checkbox.hover();
     await checkbox.click();
-    await this.frame.evaluate(e => {
-      (window as any).$(e).change();
-    }, checkbox);
+    console.log(await this.frame.evaluate(e => {
+      console.log(e);
+      return (window as any).$(e).change();
+    }, checkbox));
     await this.page.waitFor(500);
   }
 

--- a/e2e/app/page/notebook-download-modal.ts
+++ b/e2e/app/page/notebook-download-modal.ts
@@ -36,21 +36,20 @@ export default class NotebookDownloadModal {
 
   async clickPolicyCheckbox(): Promise<void> {
     const checkbox = await this.getPolicyCheckbox();
-
-    // XXX: All of this fails to actually dynamically update the checkbox value in
-    // headless mode. Simply clicking the element works fine in debug mode.
-    await checkbox.focus();
-    await checkbox.hover();
     await checkbox.click();
-    console.log(await this.frame.evaluate(e => {
-      console.log(e);
-      return (window as any).$(e).change();
-    }, checkbox));
-    await this.page.waitFor(500);
   }
 
   async getPolicyCheckbox(): Promise<ElementHandle> {
     return this.frame.waitForXPath(Xpath.modal + Xpath.policyCheckbox, {visible: true});
+  }
+
+  async clickDownloadButton(): Promise<void> {
+    // Chrome headless is unable to click this button properly using standard
+    // ElementHandle.click(). Even a standard element click() doesn't do it,
+    // likely because the Jupyter UI heavily uses jQuery event handling.
+    await this.frame.evaluate(() => {
+      return (window as any).$('#aou-download').click();
+    });
   }
 
   async getDownloadButton(): Promise<ElementHandle> {

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -25,7 +25,7 @@ enum Xpath {
   fileMenuDropdown = '//a[text()="File"]',
   downloadMenuDropdown = '//a[text()="Download as"]',
   downloadIpynbButton = '//*[@id="download_ipynb"]/a',
-  downloadPdfButton = '//*[@id="download_pdf"]/a',
+  downloadMarkdownButton = '//*[@id="download_markdown"]/a',
 }
 
 export enum Mode {
@@ -105,8 +105,8 @@ export default class NotebookPage extends AuthenticatedPage {
     return this.downloadAs(Xpath.downloadIpynbButton)
   }
 
-  async downloadAsPdf(): Promise<NotebookDownloadModal> {
-    return this.downloadAs(Xpath.downloadPdfButton);
+  async downloadAsMarkdown(): Promise<NotebookDownloadModal> {
+    return this.downloadAs(Xpath.downloadMarkdownButton);
   }
 
   /**

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -6,17 +6,26 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import {ResourceCard} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 import NotebookCell, {CellType} from './notebook-cell';
+import NotebookDownloadModal from './notebook-download-modal';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 
 // CSS selectors
 enum CssSelector {
   body = 'body.notebook_app',
   notebookContainer = '#notebook-container',
+
   toolbarContainer = '#maintoolbar-container',
   runCellButton = 'button[data-jupyter-action="jupyter-notebook:run-cell-and-select-next"]',
   saveNotebookButton = 'button[data-jupyter-action="jupyter-notebook:save-notebook"]',
   kernelIcon = '#kernel_indicator_icon',
   kernelName = '.kernel_indicator_name',
+}
+
+enum Xpath {
+  fileMenuDropdown = '//a[text()="File"]',
+  downloadMenuDropdown = '//a[text()="Download as"]',
+  downloadIpynbButton = '//*[@id="download_ipynb"]/a',
+  downloadPdfButton = '//*[@id="download_pdf"]/a',
 }
 
 export enum Mode {
@@ -79,6 +88,25 @@ export default class NotebookPage extends AuthenticatedPage {
     const saveButton = await frame.waitForSelector(CssSelector.saveNotebookButton, {visible: true});
     await saveButton.click();
     await saveButton.dispose();
+  }
+
+  private async downloadAs(formatXpath: string): Promise<NotebookDownloadModal> {
+    const frame = await this.getIFrame();
+
+    await (await frame.waitForXPath(Xpath.fileMenuDropdown, {visible: true})).click();
+    await (await frame.waitForXPath(Xpath.downloadMenuDropdown, {visible: true})).hover();
+    await (await frame.waitForXPath(formatXpath, {visible: true})).click();
+
+    const modal = new NotebookDownloadModal(this.page, frame);
+    return await modal.waitForLoad();
+  }
+
+  async downloadAsIpynb(): Promise<NotebookDownloadModal> {
+    return this.downloadAs(Xpath.downloadIpynbButton)
+  }
+
+  async downloadAsPdf(): Promise<NotebookDownloadModal> {
+    return this.downloadAs(Xpath.downloadPdfButton);
   }
 
   /**

--- a/e2e/tests/notebook/notebook-download.spec.ts
+++ b/e2e/tests/notebook/notebook-download.spec.ts
@@ -18,6 +18,9 @@ describe('Jupyter notebook download test', () => {
     downloadBtn = await modal.getDownloadButton();
     const btnProps = await downloadBtn.getProperties();
     expect(btnProps['disabled']).toBeFalsy();
+    // XXX: In debug mode, test execution completely stops when a new tab is
+    // opened for this download. Test can be resumed by closing the tab or
+    // clicking back into the notebooks tab.
     await downloadBtn.click();
 
     // Ideally we'd verify that the file was downloaded. Unfortunately this

--- a/e2e/tests/notebook/notebook-download.spec.ts
+++ b/e2e/tests/notebook/notebook-download.spec.ts
@@ -2,6 +2,7 @@ import NotebookDownloadModal from 'app/page/notebook-download-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
+import {waitForFn} from 'utils/waits-utils';
 
 describe('Jupyter notebook download test', () => {
 
@@ -72,15 +73,16 @@ describe('Jupyter notebook download test', () => {
     await testDownloadModal(await notebook.downloadAsPdf());
 
     // Wait a bit to process new tab creation events.
-    await page.waitFor(500);
-
     // ipynb is special, and doesn't yield a recognizable URL for download.
     // As of 9/22/20 I was unable to find a clear mechanism for validating ipynb
     // download. All other formats, however, go through nbconvert - resulting
     // in a recognizable URL.
-    expect(newTabUrls.find(url => {
+    const sawPdf = await waitForFn(() => newTabUrls.find(url => {
       return url.includes('nbconvert/pdf') && url.includes(notebookName);
-    })).toBeTruthy();
+    }));
+    if (!sawPdf) {
+      fail(`did not see new tab for PDF download, got: ${newTabUrls}`);
+    }
   }, 20 * 60 * 1000);
 
 })

--- a/e2e/tests/notebook/notebook-download.spec.ts
+++ b/e2e/tests/notebook/notebook-download.spec.ts
@@ -1,0 +1,65 @@
+import NotebookDownloadModal from 'app/page/notebook-download-modal';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {makeRandomName} from 'utils/str-utils';
+import {findWorkspace, signIn} from 'utils/test-utils';
+
+describe('Jupyter notebook download test', () => {
+
+  beforeEach(async () => {
+    await signIn(page);
+  });
+
+  const testDownloadModal = async (modal: NotebookDownloadModal): Promise<void> => {
+    let downloadBtn = await modal.getDownloadButton();
+    expect(await downloadBtn.getProperty('disabled')).toBeTruthy();
+
+    await modal.clickPolicyCheckbox();
+
+    downloadBtn = await modal.getDownloadButton();
+    const btnProps = await downloadBtn.getProperties();
+    expect(btnProps['disabled']).toBeFalsy();
+    await downloadBtn.click();
+
+    // Ideally we'd verify that the file was downloaded. Unfortunately this
+    // seems to be non-trivial in Puppeteer: https://github.com/puppeteer/puppeteer/issues/299
+    await modal.waitUntilClose();
+  }
+
+  /**
+   * Test:
+   * - Find an existing workspace.
+   * - Create a new Notebook and add code.
+   * - Save notebook.
+   * - for ipynb, pdf:
+   *   - Download notebook.
+   *   - Verify policy warnings modal interactions.
+   */
+  test('download notebook with policy warnings', async () => {
+    // Event listener for taargetCreated events (new pages/popups)
+    // adds the new page to the global.pages variable so it can be accessed immediately in the test that created it
+    browser.on('targetcreated', async () => {
+        console.log('New Tab Created');
+        const pages = await browser.pages();
+      console.log('global.pages.length', pages.length);
+      console.log(pages.map(p => p.url()));
+    });
+
+    const workspaceCard = await findWorkspace(page);
+    await workspaceCard.clickWorkspaceName();
+
+    const dataPage = new WorkspaceDataPage(page);
+    const notebookName = makeRandomName('py');
+    const notebook = await dataPage.createNotebook(notebookName);
+
+    // Run some Python code so the notebook has content.
+    await notebook.runCodeCell(1, {code: 'print("download test!")'});
+
+    // Save and download.
+    await notebook.save();
+
+    await testDownloadModal(await notebook.downloadAsIpynb());
+    console.log(page.url());
+    await testDownloadModal(await notebook.downloadAsPdf());
+  }, 20 * 60 * 1000);
+
+})


### PR DESCRIPTION
See code comments for details. Finally got this working after a lot of trial and error. The biggest blockers:

1. Utilities all use Page, rather than Frame. This meant I couldn't use existing libraries for frame elements.
1. Some things rendered offscreen on headless - adding the viewport fixed this.
1. Some events were not firing in headless, a `page.evaluate(() => $(..).click())` ultimately solved this, since Jupyter relies on jQuery pretty heavily.
1. Download opens a new tab. In debug mode, this takes control of the browser - need to bring the main page to the foreground in order to continue..