### PR TITLE
[RW-5466][risk=no] Add versions to COPE survey attributes

### DIFF
--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -314,30 +314,6 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
           estCount: attr.itemCount,
           valueAsConceptId: attr.surveyId
         }));
-        if (!form.cat.length) {
-          // Mock survey versions for testing COPE attributes layout
-          // TODO remove before merging
-          form.cat = [
-            {
-              checked: false,
-              conceptName: 'May 2020',
-              estCount: 4622,
-              valueAsConceptId: 100,
-            },
-            {
-              checked: false,
-              conceptName: 'June 2020',
-              estCount: 2080,
-              valueAsConceptId: 101,
-            },
-            {
-              checked: false,
-              conceptName: 'July 2020',
-              estCount: 1621,
-              valueAsConceptId: 102
-            }
-          ];
-        }
         if (numericalAttributes) {
           numericalAttributes.items.forEach(attr => {
             if (!form.num.length) {

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -200,6 +200,7 @@ interface State {
   count: number;
   countError: boolean;
   form: AttributeForm;
+  isCOPESurvey: boolean;
   loading: boolean;
   options: any;
 }
@@ -212,6 +213,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         count: null,
         countError: false,
         form: {exists: false, num: [], cat: []},
+        isCOPESurvey: false,
         loading: true,
         options: [
           {label: 'Equals', value: Operator.EQUAL},
@@ -294,7 +296,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
             [attr.conceptName]: parseInt(attr.estCount, 10)
           }));
         }
-        this.setState({count: this.nodeCount, form, loading: false});
+        this.setState({count: this.nodeCount, form, isCOPESurvey: true, loading: false});
       } else {
         this.getAttributes();
       }
@@ -598,7 +600,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
 
     render() {
       const {close, node: {domainId, name, parentId, subtype}} = this.props;
-      const {calculating, count, countError, form, loading, options} = this.state;
+      const {calculating, count, countError, form, isCOPESurvey, loading, options} = this.state;
       const {formErrors, formValid} = this.validateForm();
       const disableAdd = calculating || !formValid;
       const disableCalculate = disableAdd || form.exists || form.num.every(attr => attr.operator === 'ANY');
@@ -618,9 +620,9 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
               {err}
             </div>)}
           </div>}
-          {this.isMeasurement && <div>
+          {(this.isMeasurement || isCOPESurvey) && <div>
             <div style={styles.label}>{this.displayName}</div>
-            <CheckBox onChange={(v) => this.toggleCheckbox(v)}/> Any value (lab exists)
+            <CheckBox onChange={(v) => this.toggleCheckbox(v)}/> Any value {this.isMeasurement && <span>(lab exists)</span>}
             {!form.exists && form.num.length > 0 && <div style={styles.orCircle}>OR</div>}
           </div>}
           {!form.exists && <div style={{minHeight: '10rem'}}>

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -336,7 +336,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         this.setState({count: null, form, isCOPESurvey: true, loading: false});
       } else {
         options.unshift({label: optionUtil.ANY.display, value: AttrName[AttrName.ANY]});
-        this.setState({options}, () => this.getAttributes());
+        this.setState({isCOPESurvey: false, options}, () => this.getAttributes());
       }
     }
 

--- a/ui/src/app/cohort-search/search-state.service.ts
+++ b/ui/src/app/cohort-search/search-state.service.ts
@@ -5,6 +5,7 @@ export const initSearchRequest = {includes: [], excludes: [], dataFilters: []} a
 export const searchRequestStore = new BehaviorSubject<any>(initSearchRequest);
 export const idsInUse = new BehaviorSubject<any>(new Set());
 export const ppiQuestions = new BehaviorSubject<any>({});
+export const ppiSurveys = new BehaviorSubject<any>({});
 export const encountersStore = new BehaviorSubject<any>(undefined);
 export const criteriaMenuOptionsStore = new BehaviorSubject<any>({});
 export const ageCountStore = new BehaviorSubject<any>({});

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -153,7 +153,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   loadChildren() {
-    const {node: {count, domainId, id, isStandard, name, type}} = this.props;
+    const {node: {conceptId, count, domainId, id, isStandard, name, type}} = this.props;
     this.setState({loading: true});
     const {cdrVersionId} = (currentWorkspaceStore.getValue());
     const criteriaType = domainId === DomainType.DRUG.toString() ? CriteriaType.ATC.toString() : type;
@@ -170,7 +170,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           if (resp.items.length > 0 && domainId === DomainType.SURVEY.toString() && !resp.items[0].group) {
             // save questions in the store so we can display them along with answers if selected
             const questions = ppiQuestions.getValue();
-            questions[id] = {count, name};
+            questions[id] = {conceptId, count, name};
             ppiQuestions.next(questions);
           }
         }
@@ -279,7 +279,8 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     }
   }
 
-  setAttributes(node: NodeProp) {
+  setAttributes(event: Event, node: NodeProp) {
+    event.stopPropagation();
     if (serverConfigStore.getValue().enableCohortBuilderV2) {
       delete node.children;
       attributesSelectionStore.next(node);
@@ -327,7 +328,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
             {hasAttributes
               ? <ClrIcon style={{color: colors.accent}}
                   shape='slider' dir='right' size='20'
-                  onClick={() => this.setAttributes(node)}/>
+                  onClick={(e) => this.setAttributes(e, node)}/>
               : selected
                 ? <ClrIcon style={{...styles.selectIcon, ...styles.selected}}
                     shape='check-circle' size='20'/>

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -319,7 +319,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
             ? <Spinner size={16}/>
             : <ClrIcon style={{color: colors.disabled}}
               shape={'angle ' + (expanded ? 'down' : 'right')}
-              size='16' onClick={() => this.toggleExpanded()}/>}
+              size='16'/>}
         </button>}
         <div style={hover ? {...styles.treeNodeContent, background: colors.light} : styles.treeNodeContent}
           onMouseEnter={() => this.setState({hover: true})}

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -14,7 +14,7 @@ import {attributesSelectionStore, currentCohortCriteriaStore, currentWorkspaceSt
 import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 
 const COPE_SURVEY_ID = 1333342;
-const COPE_SURVEY_GROUP_NAME = 'COVID-19 Participant Experience (COPE) Survey';
+export const COPE_SURVEY_GROUP_NAME = 'COVID-19 Participant Experience (COPE) Survey';
 const styles = reactStyles({
   code: {
     color: colors.dark,

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {SearchBar} from 'app/cohort-search/search-bar/search-bar.component';
+import {ppiSurveys} from 'app/cohort-search/search-state.service';
 import {TreeNode} from 'app/cohort-search/tree-node/tree-node.component';
 import {ClrIcon} from 'app/components/icons';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -125,6 +126,13 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
         this.setState({children});
       } else {
         this.setState({children: resp.items});
+        if (domainId === DomainType.SURVEY.toString()) {
+          const rootSurveys = ppiSurveys.getValue();
+          if (!rootSurveys[cdrVersionId]) {
+            rootSurveys[cdrVersionId] = resp.items;
+            ppiSurveys.next(rootSurveys);
+          }
+        }
       }
     })
     .catch(error => {


### PR DESCRIPTION
Implement UI for categorical (versions) and numerical attributes for COPE survey nodes.

COPE attributes form with categorical and numerical attributes
![Screen Shot 2020-09-23 at 11 05 24 PM](https://user-images.githubusercontent.com/40036095/94099960-df171900-fdf1-11ea-8f7f-13dce55e7601.png)

COPE attributes form with 'Any version' and 'Any value' selected
![Screen Shot 2020-09-23 at 11 06 02 PM](https://user-images.githubusercontent.com/40036095/94100014-fd7d1480-fdf1-11ea-9550-a20ede7797f4.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
