### PR TITLE
[no ticket][risk=no] fixing display issue of gender, race, eth and sex at birth in review

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -623,8 +623,8 @@ public class CohortReviewController implements CohortReviewApiDelegate {
               ? CriteriaType.SEX.toString()
               : sortColumn;
       List<String> demoList =
-          cohortBuilderService.findSortedConceptIdsByDomainIdAndTypeAndParentIdNotIn(
-              DomainType.PERSON.toString(), 0L, criteriaSortColumn, sortName);
+          cohortBuilderService.findSortedConceptIdsByDomainIdAndType(
+              DomainType.PERSON.toString(), criteriaSortColumn, sortName);
       if (!demoList.isEmpty()) {
         pageRequest.setSortColumn(
             "FIELD("

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -242,15 +242,12 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select * from cb_criteria where domain_id = 'PERSON' and type in ('GENDER', 'RACE', 'ETHNICITY', 'SEX') and parent_id != 0 order by name asc",
+          "select * from cb_criteria where domain_id = 'PERSON' and type in ('GENDER', 'RACE', 'ETHNICITY', 'SEX') order by name asc",
       nativeQuery = true)
   List<DbCriteria> findAllDemographics();
 
-  List<DbCriteria> findByDomainIdAndTypeAndParentIdNotIn(
-      @Param("domainId") String domainId,
-      @Param("type") String type,
-      @Param("parentId") Long parentId,
-      Sort sort);
+  List<DbCriteria> findByDomainIdAndType(
+      @Param("domainId") String domainId, @Param("type") String type, Sort sort);
 
   @Query(
       value =

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -60,8 +60,8 @@ public interface CohortBuilderService {
    */
   Map<Long, String> findAllDemographicsMap();
 
-  List<String> findSortedConceptIdsByDomainIdAndTypeAndParentIdNotIn(
-      String domainId, Long parentId, String sortColumn, String sortName);
+  List<String> findSortedConceptIdsByDomainIdAndType(
+      String domainId, String sortColumn, String sortName);
 
   List<SurveyModule> findSurveyModules(String term);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -369,15 +369,14 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
-  public List<String> findSortedConceptIdsByDomainIdAndTypeAndParentIdNotIn(
-      String domainId, Long parentId, String sortColumn, String sortName) {
+  public List<String> findSortedConceptIdsByDomainIdAndType(
+      String domainId, String sortColumn, String sortName) {
     Sort sort =
         sortName.equalsIgnoreCase(Sort.Direction.ASC.toString())
             ? new Sort(Sort.Direction.ASC, "name")
             : new Sort(Sort.Direction.DESC, "name");
     List<DbCriteria> criteriaList =
-        cbCriteriaDao.findByDomainIdAndTypeAndParentIdNotIn(
-            DomainType.PERSON.toString(), sortColumn, 0L, sort);
+        cbCriteriaDao.findByDomainIdAndType(DomainType.PERSON.toString(), sortColumn, sort);
     List<String> demoList =
         criteriaList.stream()
             .map(

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -38,7 +38,6 @@ public class CBCriteriaDaoTest {
   private DbCriteria icd9Criteria;
   private DbCriteria icd10Criteria;
   private DbCriteria measurementCriteria;
-  private DbCriteria raceParent;
   private DbCriteria raceAsian;
   private DbCriteria raceWhite;
   private DbCriteria gender;
@@ -129,15 +128,6 @@ public class CBCriteriaDaoTest {
                 .addCode("LP123")
                 .addSynonyms("001[MEASUREMENT_rank1]")
                 .build());
-    raceParent =
-        cbCriteriaDao.save(
-            DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
-                .addType(CriteriaType.RACE.toString())
-                .addName("Race")
-                .addStandard(true)
-                .addParentId(0)
-                .build());
     raceAsian =
         cbCriteriaDao.save(
             DbCriteria.builder()
@@ -145,7 +135,6 @@ public class CBCriteriaDaoTest {
                 .addType(CriteriaType.RACE.toString())
                 .addName("Asian")
                 .addStandard(true)
-                .addParentId(raceParent.getId())
                 .build());
     raceWhite =
         cbCriteriaDao.save(
@@ -154,7 +143,6 @@ public class CBCriteriaDaoTest {
                 .addType(CriteriaType.RACE.toString())
                 .addName("White")
                 .addStandard(true)
-                .addParentId(raceParent.getId())
                 .build());
     gender =
         cbCriteriaDao.save(
@@ -286,7 +274,7 @@ public class CBCriteriaDaoTest {
     final List<DbCriteria> demoList =
         cbCriteriaDao.findCriteriaByDomainAndTypeOrderByIdAsc(
             DomainType.PERSON.toString(), CriteriaType.RACE.toString());
-    assertThat(demoList).containsExactly(raceParent, raceAsian, raceWhite);
+    assertThat(demoList).containsExactly(raceAsian, raceWhite);
   }
 
   @Test
@@ -350,18 +338,18 @@ public class CBCriteriaDaoTest {
   }
 
   @Test
-  public void findByDomainIdAndTypeAndParentIdNotIn() {
+  public void findByDomainIdAndType() {
     Sort sort = new Sort(Direction.ASC, "name");
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findByDomainIdAndType(
-            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
+            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), sort);
     assertThat(criteriaList).containsExactly(raceAsian, raceWhite).inOrder();
 
     // reverse
     sort = new Sort(Direction.DESC, "name");
     criteriaList =
         cbCriteriaDao.findByDomainIdAndType(
-            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
+            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), sort);
     assertThat(criteriaList).containsExactly(raceWhite, raceAsian).inOrder();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -353,14 +353,14 @@ public class CBCriteriaDaoTest {
   public void findByDomainIdAndTypeAndParentIdNotIn() {
     Sort sort = new Sort(Direction.ASC, "name");
     List<DbCriteria> criteriaList =
-        cbCriteriaDao.findByDomainIdAndTypeAndParentIdNotIn(
+        cbCriteriaDao.findByDomainIdAndType(
             DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
     assertThat(criteriaList).containsExactly(raceAsian, raceWhite).inOrder();
 
     // reverse
     sort = new Sort(Direction.DESC, "name");
     criteriaList =
-        cbCriteriaDao.findByDomainIdAndTypeAndParentIdNotIn(
+        cbCriteriaDao.findByDomainIdAndType(
             DomainType.PERSON.toString(), FilterColumns.RACE.toString(), 0L, sort);
     assertThat(criteriaList).containsExactly(raceWhite, raceAsian).inOrder();
   }


### PR DESCRIPTION
Removing parent rows from cb_criteria for gender, race, eth and sex at birth has caused some queries to return empty results.