### PR TITLE
[risk=no][no ticket] simplify billing status

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -13,7 +13,6 @@ import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.model.BillingStatus;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -107,12 +107,4 @@ public class CommonMappers {
   public int etagToCdrVersion(String etag) {
     return Strings.isNullOrEmpty(etag) ? 1 : Etags.toVersion(etag);
   }
-
-  public BillingStatus checkBillingFeatureFlag(BillingStatus billingStatus) {
-    if (!workbenchConfigProvider.get().featureFlags.enableBillingLockout) {
-      return BillingStatus.ACTIVE;
-    } else {
-      return billingStatus;
-    }
-  }
 }


### PR DESCRIPTION
A method to adjust BillingStatus values based on a feature flag is [no longer necessary](https://precisionmedicineinitiative.atlassian.net/browse/RW-4688), as the flag is always true (and the method is just a simple pass-through). However, we were seeing some really sluggish performance in the new `RreportingMapper` that might be due to this method repeatedly checking the workbench config provider (still unproven).

Since it's no longer necessary, we might as well axe it now.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
