### PR TITLE
[RW-5413][risk=no] Plumb legal runtime images list through ConfigController

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
+    "runtimeImages": {
+      "gce": ["test-gce-docker-image"],
+      "dataproc": ["test-dataproc-docker-image"]
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "",
-    "shibbolethUiBaseUrl": ""
+    "shibbolethUiBaseUrl": "",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -15,7 +15,11 @@
     "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.0.6",
     "welderDockerImage": "broadinstitute/welder-server:7ae1a62",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
-    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev"
+    "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
+    "runtimeImages": {
+      "gce": [],
+      "dataproc": []
+    }
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -50,13 +50,18 @@ public class ConfigController implements ConfigApiDelegate {
             .enableCustomRuntimes(config.featureFlags.enableCustomRuntimes)
             .runtimeImages(
                 Stream.concat(
-                    config.firecloud.runtimeImages.dataproc.stream().map(imageName -> new RuntimeImage()
-                        .cloudService(CloudServiceEnum.DATAPROC.toString())
-                        .name(imageName)),
-                    config.firecloud.runtimeImages.gce.stream().map(imageName -> new RuntimeImage()
-                        .cloudService(CloudServiceEnum.GCE.toString())
-                        .name(imageName))
-                ).collect(Collectors.toList()))
-    );
+                        config.firecloud.runtimeImages.dataproc.stream()
+                            .map(
+                                imageName ->
+                                    new RuntimeImage()
+                                        .cloudService(CloudServiceEnum.DATAPROC.toString())
+                                        .name(imageName)),
+                        config.firecloud.runtimeImages.gce.stream()
+                            .map(
+                                imageName ->
+                                    new RuntimeImage()
+                                        .cloudService(CloudServiceEnum.GCE.toString())
+                                        .name(imageName)))
+                    .collect(Collectors.toList())));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -1,8 +1,12 @@
 package org.pmiops.workbench.api;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.model.ConfigResponse;
+import org.pmiops.workbench.model.RuntimeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +47,16 @@ public class ConfigController implements ConfigApiDelegate {
             .enableConceptSetSearchV2(config.featureFlags.enableConceptSetSearchV2)
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
             .enableCOPESurvey(config.featureFlags.enableCOPESurvey)
-            .enableCustomRuntimes(config.featureFlags.enableCustomRuntimes));
+            .enableCustomRuntimes(config.featureFlags.enableCustomRuntimes)
+            .runtimeImages(
+                Stream.concat(
+                    config.firecloud.runtimeImages.dataproc.stream().map(imageName -> new RuntimeImage()
+                        .cloudService(CloudServiceEnum.DATAPROC.toString())
+                        .name(imageName)),
+                    config.firecloud.runtimeImages.gce.stream().map(imageName -> new RuntimeImage()
+                        .cloudService(CloudServiceEnum.GCE.toString())
+                        .name(imageName))
+                ).collect(Collectors.toList()))
+    );
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.config;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A class representing the main workbench configuration; parsed from JSON stored in the database.
@@ -128,6 +129,13 @@ public class WorkbenchConfig {
     // This is the base URL that a browser client should be redirected to in order to complete
     // an authentication round trip with eRA Commons.
     public String shibbolethUiBaseUrl;
+
+    public RuntimeImages runtimeImages;
+  }
+
+  public static class RuntimeImages {
+    public ArrayList<String> gce;
+    public ArrayList<String> dataproc;
   }
 
   public static class AuthConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.config;
 
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A class representing the main workbench configuration; parsed from JSON stored in the database.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3937,6 +3937,18 @@ definitions:
         type: boolean
         default: false
         description: Whether user should be able to customize notebook runtime settings.
+      runtimeImages:
+        type: array
+        items:
+          "$ref": "#/definitions/RuntimeImage"
+
+  RuntimeImage:
+    type: object
+    properties:
+      cloudService:
+        type: string
+      name:
+        type: string
 
   FeaturedWorkspacesConfigResponse:
     type: object


### PR DESCRIPTION
Description:
Example of JSON response
```
  "runtimeImages": [
    {
      "cloudService": "DATAPROC",
      "name": "test-dataproc-docker-image"
    },
    {
      "cloudService": "GCE",
      "name": "test-gce-docker-image"
    }
  ]
```

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
