### PR TITLE
[risk=low][RW-5560][RW-5561] Cross-CDR UX for Copy Concept Set and Notebook to Workspace 

### DIFF
--- a/e2e/app/component/copy-modal.ts
+++ b/e2e/app/component/copy-modal.ts
@@ -19,12 +19,12 @@ export default class CopyModal extends Modal {
     return new Textbox(this.page, `${this.getXpath()}//*[contains(text(), "Name")]/ancestor::node()[1]/input[@type="text"]`);
   }
 
- /**
-  *
-  * @param {string} workspaceName Destination Workspace name.
-  * @param {string} newName New name.
-  */
-  async copyToAnotherWorkspace(workspaceName: string, newName?: string): Promise<void> {
+  /**
+   *
+   * @param {string} workspaceName Destination Workspace name.
+   * @param {string} newName New name.
+   */
+  async beginCopyToAnotherWorkspace(workspaceName: string, newName?: string): Promise<void> {
     // Click dropdown trigger.
     const destinationInput = await this.getDestinationTextbox();
     await destinationInput.click();
@@ -38,6 +38,15 @@ export default class CopyModal extends Modal {
       const nameInput = await this.getNameTextbox();
       await nameInput.type(newName);
     }
+  }
+
+ /**
+  *
+  * @param {string} workspaceName Destination Workspace name.
+  * @param {string} newName New name.
+  */
+  async copyToAnotherWorkspace(workspaceName: string, newName?: string): Promise<void> {
+    await this.beginCopyToAnotherWorkspace(workspaceName, newName);
 
     await this.clickButton(LinkText.Copy);
     await waitWhileLoading(this.page);

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -17,7 +17,6 @@ const faker = require('faker/locale/en_US');
 export const PageTitle = 'Create Workspace';
 
 export const LabelAlias = {
-  CDR_VERSION: 'Workspace Name',  // select CDR Version
   SELECT_BILLING: 'Select account',   // select billing account
   WORKSPACE_NAME: 'Workspace Name',  // Workspace name input textbox
   RESEARCH_PURPOSE: 'Research purpose',
@@ -77,7 +76,9 @@ export const FIELD = {
     textOption: {name: LabelAlias.WORKSPACE_NAME, ancestorLevel: 2, type: ElementType.Textbox}
   },
   cdrVersionSelect: {
-    textOption: {name: LabelAlias.CDR_VERSION, type: ElementType.Select}
+    // Note: The CDR Version dropdown does not have a label of its own.
+    // Use the nearby Workspace Name instead.
+    textOption: {name: LabelAlias.WORKSPACE_NAME, type: ElementType.Select}
   },
   billingAccountSelect: {
     textOption: {name: LabelAlias.SELECT_BILLING, type: ElementType.Select}
@@ -249,6 +250,10 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     return Select.findByName(this.page, FIELD.cdrVersionSelect.textOption);
   }
 
+  async getBillingAccountSelect(): Promise<Select> {
+    return Select.findByName(this.page, FIELD.billingAccountSelect.textOption);
+  }
+
   async getCreateWorkspaceButton(): Promise<Button> {
     return Button.findByName(this.page, FIELD.createWorkspaceButton.textOption);
   }
@@ -327,7 +332,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * @param {string} billingAccount
    */
   async selectBillingAccount(billingAccount: string = UseFreeCredits) {
-    const billingAccountSelect = await Select.findByName(this.page, FIELD.billingAccountSelect.textOption);
+    const billingAccountSelect = await this.getBillingAccountSelect();
     await billingAccountSelect.selectOption(billingAccount);
   }
 

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -9,6 +9,7 @@ import {waitForDocumentTitle, waitForText, waitWhileLoading} from 'utils/waits-u
 import ReactSelect from 'app/element/react-select';
 import WorkspaceDataPage from './workspace-data-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
+import {config} from 'resources/workbench-config';
 import {UseFreeCredits} from './workspace-base';
 
 const faker = require('faker/locale/en_US');
@@ -73,6 +74,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
    */
   async createWorkspace(
      workspaceName: string,
+     cdrVersionName: string = config.defaultCdrVersionName,
      billingAccount: string = UseFreeCredits,
      reviewRequest: boolean = false): Promise<string[]> {
 
@@ -83,8 +85,8 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     await (await editPage.getWorkspaceNameTextbox()).type(workspaceName);
     await (await editPage.getWorkspaceNameTextbox()).pressTab();
 
-    // select the default CDR Version
-    await editPage.selectCdrVersion();
+    // select the chosen CDR Version
+    await editPage.selectCdrVersion(cdrVersionName);
 
     // select Billing Account
     await editPage.selectBillingAccount(billingAccount);

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -23,6 +23,7 @@ const local = {
   userEmailDomain: '@fake-research-aou.org',
   collaboratorUsername: 'puppetmaster@fake-research-aou.org',
   defaultCdrVersionName: 'Synthetic Dataset v1',
+  altCdrVersionName: 'Synthetic Dataset v1 with Microarray',
 };
 
 // workbench test environment
@@ -32,6 +33,7 @@ const test = {
   userEmailDomain: '@fake-research-aou.org',
   collaboratorUsername: 'puppetmaster@fake-research-aou.org',
   defaultCdrVersionName: 'Synthetic Dataset v3',
+  altCdrVersionName: 'Synthetic Dataset v2',
 };
 
 // workbench staging environment
@@ -41,8 +43,8 @@ const staging = {
   userEmailDomain: '@staging.fake-research-aou.org',
   collaboratorUsername: 'puppetcitester4@staging.fake-research-aou.org',
   defaultCdrVersionName: 'Synthetic Dataset v3',
-}
-;
+  altCdrVersionName: 'Synthetic Dataset v2',
+};
 
 // workbench stable environment
 const stable = {
@@ -50,6 +52,7 @@ const stable = {
   apiBaseUrl: process.env.STABLE_API_URL,
   userEmailDomain: '@stable.fake-research-aou.org',
   defaultCdrVersionName: 'Synthetic Dataset v3',
+  altCdrVersionName: 'Synthetic Dataset v2',
 };
 
 

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -3,10 +3,57 @@ import Modal from 'app/component/modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {createWorkspace, findWorkspace, signIn} from 'utils/test-utils';
+import {config} from 'resources/workbench-config';
 
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
 jest.setTimeout(20 * 60 * 1000);
+
+async function copyNotebook(srcCdrVersionName: string, destCdrVersionName: string) {
+  const destWorkspace = await createWorkspace(page, destCdrVersionName).then(card => card.getWorkspaceName());
+
+  await createWorkspace(page, srcCdrVersionName).then(card => card.clickWorkspaceName());
+
+  // Create notebook in copy-from workspace.
+  const sourceNotebookName = makeRandomName('pytest');
+  const dataPage = new WorkspaceDataPage(page);
+
+  const sourceWorkspacePage = await dataPage.createNotebook(sourceNotebookName);
+
+  // Exit notebook and returns to the Workspace Analysis tab.
+  const analysisPage = await sourceWorkspacePage.goAnalysisPage();
+
+  // Copy to destination Workspace and give notebook a new name.
+  const copiedNotebookName = makeRandomName('copy-of');
+  await analysisPage.copyNotebookToWorkspace(sourceNotebookName, destWorkspace, copiedNotebookName);
+
+  // Verify Copy Success modal.
+  const modal = new Modal(page);
+  await modal.waitForButton(LinkText.GoToCopiedNotebook);
+  const textContent = await modal.getTextContent();
+  const successMsg = `Successfully copied ${sourceNotebookName}  to ${destWorkspace} . Do you want to view the copied Notebook?`;
+  expect(textContent).toContain(successMsg);
+  // Dismiss modal.
+  await modal.clickButton(LinkText.StayHere, {waitForClose: true});
+
+  // Delete notebook
+  const deleteModalTextContent = await analysisPage.deleteResource(sourceNotebookName, ResourceCard.Notebook);
+  expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${sourceNotebookName}?`);
+
+  // Perform actions in copied notebook.
+  // Open destination Workspace
+  await findWorkspace(page, {workspaceName: destWorkspace}).then(card => card.clickWorkspaceName());
+
+  // Verify copy-to notebook exists in destination Workspace
+  await dataPage.openAnalysisPage();
+  const dataResourceCard = new DataResourceCard(page);
+  const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
+  expect(notebookCard).toBeTruthy();
+
+  // Delete notebook
+  const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, ResourceCard.Notebook);
+  expect(modalTextContent).toContain('This will permanently delete the Notebook.');
+}
 
 describe('Workspace owner Jupyter notebook action tests', () => {
 
@@ -24,52 +71,8 @@ describe('Workspace owner Jupyter notebook action tests', () => {
    * - Open copied notebook and run code to print WORKSPACE_NAMESPACE. It should match destination Workspace namespace.
    * - Delete notebooks.
    */
-  test('Copy notebook to another Workspace', async () => {
-    // Create destination workspace
-    const toWorkspace = await findWorkspace(page, {create: true}).then(card => card.getWorkspaceName());
-
-    // Create copy-from workspace
-    await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
-
-    // Create notebook in copy-from workspace.
-    const copyFromNotebookName = makeRandomName('pytest');
-    const dataPage = new WorkspaceDataPage(page);
-
-    const copyFromNotebookPage = await dataPage.createNotebook(copyFromNotebookName);
-
-    // Exit notebook and returns to the Workspace Analysis tab.
-    const analysisPage = await copyFromNotebookPage.goAnalysisPage();
-
-    // Copy to destination Workspace and give notebook a new name.
-    const copiedNotebookName = makeRandomName('copy-of');
-    await analysisPage.copyNotebookToWorkspace(copyFromNotebookName, toWorkspace, copiedNotebookName);
-
-    // Verify Copy Success modal.
-    const modal = new Modal(page);
-    await modal.waitForButton(LinkText.GoToCopiedNotebook);
-    const textContent = await modal.getTextContent();
-    const successMsg = `Successfully copied ${copyFromNotebookName}  to ${toWorkspace} . Do you want to view the copied Notebook?`;
-    expect(textContent).toContain(successMsg);
-    // Dismiss modal.
-    await modal.clickButton(LinkText.StayHere, {waitForClose: true});
-
-    // Delete notebook
-    const deleteModalTextContent = await analysisPage.deleteResource(copyFromNotebookName, ResourceCard.Notebook);
-    expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${copyFromNotebookName}?`);
-
-    // Perform actions in copied notebook.
-    // Open destination Workspace
-    await findWorkspace(page, {workspaceName: toWorkspace}).then(card => card.clickWorkspaceName());
-
-    // Verify copy-to notebook exists in destination Workspace
-    await dataPage.openAnalysisPage();
-    const dataResourceCard = new DataResourceCard(page);
-    const notebookCard = await dataResourceCard.findCard(copiedNotebookName, ResourceCard.Notebook);
-    expect(notebookCard).toBeTruthy();
-
-    // Delete notebook
-    const modalTextContent = await analysisPage.deleteResource(copiedNotebookName, ResourceCard.Notebook);
-    expect(modalTextContent).toContain('This will permanently delete the Notebook.');
+  test('Copy notebook to another Workspace when CDR versions match', async () => {
+    await copyNotebook(config.defaultCdrVersionName, config.defaultCdrVersionName);
   })
 
 });

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -9,7 +9,17 @@ import {config} from 'resources/workbench-config';
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
 jest.setTimeout(20 * 60 * 1000);
 
-async function copyNotebook(srcCdrVersionName: string, destCdrVersionName: string) {
+/**
+ * Test:
+ * - Create new Workspace as the copy-to destination Workspace.
+ * - Create new Workspace as copy-from Workspace and create new notebook in this Workspace.
+ * - Run code to print WORKSPACE_NAMESPACE. It should match Workspace namespace from Workspace URL.
+ * - Copy notebook to destination Workspace and give copied notebook a new name.
+ * - Verify copied notebook is in destination Workspace.
+ * - Open copied notebook and run code to print WORKSPACE_NAMESPACE. It should match destination Workspace namespace.
+ * - Delete notebooks.
+ */
+async function copyNotebookTest(srcCdrVersionName: string, destCdrVersionName: string) {
   const destWorkspace = await createWorkspace(page, destCdrVersionName).then(card => card.getWorkspaceName());
 
   await createWorkspace(page, srcCdrVersionName).then(card => card.clickWorkspaceName());
@@ -61,18 +71,11 @@ describe('Workspace owner Jupyter notebook action tests', () => {
     await signIn(page);
   });
 
-  /**
-   * Test:
-   * - Create new Workspace as the copy-to destination Workspace.
-   * - Create new Workspace as copy-from Workspace and create new notebook in this Workspace.
-   * - Run code to print WORKSPACE_NAMESPACE. It should match Workspace namespace from Workspace URL.
-   * - Copy notebook to destination Workspace and give copied notebook a new name.
-   * - Verify copied notebook is in destination Workspace.
-   * - Open copied notebook and run code to print WORKSPACE_NAMESPACE. It should match destination Workspace namespace.
-   * - Delete notebooks.
-   */
   test('Copy notebook to another Workspace when CDR versions match', async () => {
-    await copyNotebook(config.defaultCdrVersionName, config.defaultCdrVersionName);
+    await copyNotebookTest(config.defaultCdrVersionName, config.defaultCdrVersionName);
   })
 
+  test('Copy notebook to another Workspace when CDR versions differ', async () => {
+    await copyNotebookTest(config.defaultCdrVersionName, config.altCdrVersionName);
+  })
 });

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -14,6 +14,7 @@ import {WorkspaceAccessLevel} from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import {makeWorkspaceName} from './str-utils';
+import {config} from 'resources/workbench-config';
 
 export async function signIn(page: Page, userId?: string, passwd?: string): Promise<void> {
   const loginPage = new GoogleLoginPage(page);
@@ -176,6 +177,20 @@ export async function performAction(
     throw new Error(`${identifier} is not recognized.`);
   }
 
+}
+
+export async function createWorkspace(page: Page, cdrVersionName: string = config.defaultCdrVersionName): Promise<WorkspaceCard> {
+  const workspacesPage = new WorkspacesPage(page);
+  await workspacesPage.load();
+
+  const name = makeWorkspaceName();
+
+  await workspacesPage.createWorkspace(name, cdrVersionName);
+  console.log(`Created workspace "${name}" with CDR Version "${cdrVersionName}"`);
+  await workspacesPage.load();
+
+  const workspaceCard = new WorkspaceCard(page);
+  return workspaceCard.findCard(name);
 }
 
 /**

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -1,17 +1,18 @@
-import {mount} from 'enzyme';
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 import Select from 'react-select';
 
 import {TextInput} from 'app/components/inputs';
-import {registerApiClient, workspacesApi} from 'app/services/swagger-fetch-clients';
-import {WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
-import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
-
+import {conceptSetsApi, registerApiClient, workspacesApi} from 'app/services/swagger-fetch-clients';
+import {ConceptSetsApi, ResourceType, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import {dropNotebookFileSuffix} from 'app/pages/analysis/util';
-import {CopyModalComponent, CopyModalProps, CopyModalState} from './copy-modal';
-import {ResourceType} from 'generated/fetch';
+
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
+import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
+
+import {CopyModalComponent, CopyModalProps, CopyModalState} from './copy-modal';
 
 describe('CopyModal', () => {
   let props: CopyModalProps;
@@ -45,37 +46,60 @@ describe('CopyModal', () => {
       name: 'The Nose',
       id: 'the nose',
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-    }
+    },
+    {
+      namespace: 'Something Different',
+      name: 'Sesame Street',
+      id: 'sesame-street',
+      cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
+    },
   ];
+
+  const altCdrWorkspace = workspaces[4];
+
   const fromWorkspaceNamespace = workspaces[0].namespace;
   const fromWorkspaceFirecloudName = workspaces[0].id;
+  const fromCdrVersionId = workspaces[0].cdrVersionId;
   const fromResourceName = 'notebook';
+  const notebookSaveFunction = (copyRequest) => {
+    return workspacesApi().copyNotebook(
+        fromWorkspaceNamespace,
+        fromWorkspaceFirecloudName,
+        dropNotebookFileSuffix(fromResourceName),
+        copyRequest
+    );
+  }
+
+  type AnyWrapper = (ShallowWrapper|ReactWrapper);
+
+  function getConceptSetCdrMismatchError(wrapper: AnyWrapper): AnyWrapper {
+    return wrapper.find('[data-test-id="concept-set-cdr-mismatch-error"]');
+  }
+
+  function getNotebookCdrMismatchWarning(wrapper: AnyWrapper): AnyWrapper {
+    return wrapper.find('[data-test-id="notebook-cdr-mismatch-warning"]');
+  }
 
   beforeEach(() => {
-    const apiStub = new WorkspacesApiStub(workspaces);
-    registerApiClient(WorkspacesApi, apiStub);
+    const wsApiStub = new WorkspacesApiStub(workspaces);
+    registerApiClient(WorkspacesApi, wsApiStub);
+
     props = {
       cdrVersionListResponse: cdrVersionListResponse,
       fromWorkspaceNamespace: fromWorkspaceNamespace,
       fromWorkspaceFirecloudName: fromWorkspaceFirecloudName,
       fromResourceName: fromResourceName,
-      fromCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+      fromCdrVersionId: fromCdrVersionId,
       resourceType: ResourceType.NOTEBOOK,
       onClose: () => {},
       onCopy: () => {},
-      saveFunction: (copyRequest) => {
-        return workspacesApi().copyNotebook(
-          fromWorkspaceNamespace,
-          fromWorkspaceFirecloudName,
-          dropNotebookFileSuffix(fromResourceName),
-          copyRequest
-        );
-      }
+      saveFunction: notebookSaveFunction,
     };
-    apiStub.workspaceAccess.set(workspaces[0].id, WorkspaceAccessLevel.OWNER);
-    apiStub.workspaceAccess.set(workspaces[1].id, WorkspaceAccessLevel.READER);
-    apiStub.workspaceAccess.set(workspaces[2].id, WorkspaceAccessLevel.WRITER);
-    apiStub.workspaceAccess.set(workspaces[3].id, WorkspaceAccessLevel.NOACCESS);
+    wsApiStub.workspaceAccess.set(workspaces[0].id, WorkspaceAccessLevel.OWNER);
+    wsApiStub.workspaceAccess.set(workspaces[1].id, WorkspaceAccessLevel.READER);
+    wsApiStub.workspaceAccess.set(workspaces[2].id, WorkspaceAccessLevel.WRITER);
+    wsApiStub.workspaceAccess.set(workspaces[3].id, WorkspaceAccessLevel.NOACCESS);
+    wsApiStub.workspaceAccess.set(workspaces[4].id, WorkspaceAccessLevel.WRITER);
   });
 
   it('should render', async() => {
@@ -93,7 +117,25 @@ describe('CopyModal', () => {
 
     const options = wrapper.find(Select).find({type: 'option'}).map(e => e.text());
 
-    expect(options).toEqual([workspaces[0].name, workspaces[2].name]);
+    expect(options).toEqual([workspaces[0].name, workspaces[2].name, workspaces[4].name]);
+  });
+
+  it('should list workspaces with the same CDR version first', async() => {
+    // choose a workspace with an alternative CDR version instead of the default
+    props.fromWorkspaceNamespace = altCdrWorkspace.namespace;
+    props.fromWorkspaceFirecloudName = altCdrWorkspace.id;
+    props.fromCdrVersionId = altCdrWorkspace.cdrVersionId;
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const select = wrapper.find(Select);
+    select.instance().setState({menuIsOpen: true});
+    wrapper.update();
+
+    const options = wrapper.find(Select).find({type: 'option'}).map(e => e.text());
+
+    expect(options).toEqual([altCdrWorkspace.name, workspaces[0].name, workspaces[2].name]);
   });
 
   it('should call correct copyNotebook() call after selecting an option and entering a name', async() => {
@@ -130,12 +172,146 @@ describe('CopyModal', () => {
     );
   });
 
-  it('should disable copy button if option is not selected', async() => {
+  it('should call correct copyNotebook() call when a mismatched CDR is selected', async() => {
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // Open Select options. Simulating a click doesn't work for some reason
+    const select = wrapper.find(Select);
+    select.instance().setState({menuIsOpen: true});
+    wrapper.update();
+
+    // Select an option
+    wrapper.find(Select).find({type: 'option'})
+        .findWhere(e => e.text() === altCdrWorkspace.name)
+        .first()
+        .simulate('click');
+
+    expect(getNotebookCdrMismatchWarning(wrapper).getDOMNode().textContent).toBe(
+        'The selected destination workspace uses a different dataset version ' +
+        `(${CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION}) than the current workspace ` +
+        `(${CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION}). ` +
+        'Edits may be required to ensure your analysis is functional and accurate.');
+
+    // Type out new name
+    wrapper.find(TextInput).simulate('change', {target: {value: 'Freeblast'}});
+
+    const spy = jest.spyOn(workspacesApi(), 'copyNotebook');
+    // Click copy button
+    wrapper.find('[data-test-id="copy-button"]').first().simulate('click');
+
+    expect(spy).toHaveBeenCalledWith(
+        props.fromWorkspaceNamespace,
+        props.fromWorkspaceFirecloudName,
+        props.fromResourceName,
+        {
+          toWorkspaceName: altCdrWorkspace.id,
+          toWorkspaceNamespace: altCdrWorkspace.namespace,
+          newName: 'Freeblast'
+        }
+    );
+  });
+
+  it('should disable copy notebook button if option is not selected', async() => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
     const spy = jest.spyOn(workspacesApi(), 'copyNotebook');
 
+    // Click copy button
+    const copyButton = wrapper.find('[data-test-id="copy-button"]').first();
+    copyButton.simulate('click');
+
+    expect(copyButton.prop('disabled')).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call correct copyConceptSet() call after selecting an option with a matching CDR and entering a name', async() => {
+    const csApiStub = new ConceptSetsApiStub();
+    registerApiClient(ConceptSetsApi, csApiStub);
+
+    props.resourceType = ResourceType.CONCEPTSET;
+    props.fromResourceName = csApiStub.conceptSets[0].name;
+    props.saveFunction = (copyRequest) => {
+      return conceptSetsApi().copyConceptSet(
+          fromWorkspaceNamespace,
+          fromWorkspaceFirecloudName,
+          props.fromResourceName,
+          copyRequest
+      );
+    }
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // Open Select options. Simulating a click doesn't work for some reason
+    const select = wrapper.find(Select);
+    select.instance().setState({menuIsOpen: true});
+    wrapper.update();
+
+    // Select an option
+    wrapper.find(Select).find({type: 'option'})
+        .findWhere(e => e.text() === workspaces[2].name)
+        .first()
+        .simulate('click');
+
+    // Type out new name
+    wrapper.find(TextInput).simulate('change', {target: {value: 'Some Concepts'}});
+
+    const spy = jest.spyOn(conceptSetsApi(), 'copyConceptSet');
+    // Click copy button
+    wrapper.find('[data-test-id="copy-button"]').first().simulate('click');
+
+    expect(spy).toHaveBeenCalledWith(
+        props.fromWorkspaceNamespace,
+        props.fromWorkspaceFirecloudName,
+        props.fromResourceName,
+        {
+          toWorkspaceName: workspaces[2].id,
+          toWorkspaceNamespace: workspaces[2].namespace,
+          newName: 'Some Concepts'
+        }
+    );
+  });
+
+  it('should disable concept set copy button when a mismatched CDR is selected', async() => {
+    const csApiStub = new ConceptSetsApiStub();
+    registerApiClient(ConceptSetsApi, csApiStub);
+
+    props.resourceType = ResourceType.CONCEPTSET;
+    props.fromResourceName = csApiStub.conceptSets[0].name;
+    props.saveFunction = (copyRequest) => {
+      return conceptSetsApi().copyConceptSet(
+          fromWorkspaceNamespace,
+          fromWorkspaceFirecloudName,
+          props.fromResourceName,
+          copyRequest
+      );
+    }
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // Open Select options. Simulating a click doesn't work for some reason
+    const select = wrapper.find(Select);
+    select.instance().setState({menuIsOpen: true});
+    wrapper.update();
+
+    // Select an option
+    wrapper.find(Select).find({type: 'option'})
+        .findWhere(e => e.text() === altCdrWorkspace.name)
+        .first()
+        .simulate('click');
+
+    expect(getConceptSetCdrMismatchError(wrapper).getDOMNode().textContent).toBe(
+        'Can’t copy to that workspace. It uses a different dataset version ' +
+        `(${CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION}) than the current workspace ` +
+        `(${CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION}).`);
+
+    // Type out new name
+    wrapper.find(TextInput).simulate('change', {target: {value: 'Some Concepts'}});
+
+    const spy = jest.spyOn(conceptSetsApi(), 'copyConceptSet');
     // Click copy button
     const copyButton = wrapper.find('[data-test-id="copy-button"]').first();
     copyButton.simulate('click');

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -301,10 +301,11 @@ class CopyModalComponent extends React.Component<Props, State> {
       return;
     }
 
-    fp.cond([
-      [rt => rt === ResourceType.NOTEBOOK, () => this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId)],
-      [rt => rt === ResourceType.CONCEPTSET, () => this.setConceptSetCdrMismatchError(destination, fromCdrVersionId)],
-    ])(resourceType);
+    if (resourceType === ResourceType.NOTEBOOK) {
+      this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId);
+    } else if (resourceType === ResourceType.CONCEPTSET) {
+      this.setConceptSetCdrMismatchError(destination, fromCdrVersionId);
+    }
   }
 
   renderFormBody() {

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -77,6 +77,11 @@ const styles = reactStyles({
     lineHeight: '24px',
     marginTop: '1rem',
   },
+  conceptSetsRestriction: {
+    color: colors.primary,
+    fontFamily: 'Montserrat',
+    fontSize: '14px',
+  },
 });
 
 const ConceptSetCdrMismatch = (props: {text: string}) =>
@@ -84,6 +89,10 @@ const ConceptSetCdrMismatch = (props: {text: string}) =>
 
 const NotebookCdrMismatch = (props: {text: string}) =>
     <div data-test-id='notebook-cdr-mismatch-warning' style={styles.notebookCdrMismatch}>{props.text}</div>;
+
+const ConceptSetRestrictionText = () => <div style={styles.conceptSetsRestriction}>
+  Concept sets can only be copied to workspaces using the same CDR version.
+</div>;
 
 class CopyModalComponent extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -197,11 +206,13 @@ class CopyModalComponent extends React.Component<Props, State> {
   }
 
   render() {
+    const {resourceType} = this.props;
     const {loading, requestState} = this.state;
 
     return (
       <Modal onRequestClose={this.props.onClose}>
-        <ModalTitle>Copy to Workspace</ModalTitle>
+        <ModalTitle style={{marginBottom: '0.5rem'}}>Copy to Workspace</ModalTitle>
+        {resourceType === ResourceType.CONCEPTSET && <ConceptSetRestrictionText/>}
         {loading ?
           <ModalBody style={{ textAlign: 'center' }}><Spinner /></ModalBody> :
           <ModalBody>

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -301,11 +301,10 @@ class CopyModalComponent extends React.Component<Props, State> {
       return;
     }
 
-    if (resourceType === ResourceType.NOTEBOOK) {
-      this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId);
-    } else if (resourceType === ResourceType.CONCEPTSET) {
-      this.setConceptSetCdrMismatchError(destination, fromCdrVersionId);
-    }
+    fp.cond([
+      [rt => rt === ResourceType.NOTEBOOK, () => this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId)],
+      [rt => rt === ResourceType.CONCEPTSET, () => this.setConceptSetCdrMismatchError(destination, fromCdrVersionId)],
+    ])(resourceType);
   }
 
   renderFormBody() {

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -14,6 +14,8 @@ import {reactStyles, withCdrVersions} from 'app/utils';
 import { navigate } from 'app/utils/navigation';
 import {toDisplay} from 'app/utils/resourceActions';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
+import {ClrIcon} from "./icons";
+import {FlexRow} from "./flex";
 
 enum RequestState { UNSENT, COPY_ERROR, SUCCESS }
 
@@ -82,13 +84,26 @@ const styles = reactStyles({
     fontFamily: 'Montserrat',
     fontSize: '14px',
   },
+  warningIcon: {
+    color: colors.warning,
+    height: '20px',
+    width: '20px',
+    align: 'top',
+  },
 });
 
 const ConceptSetCdrMismatch = (props: {text: string}) =>
     <div data-test-id='concept-set-cdr-mismatch-error' style={styles.conceptSetCdrMismatch}>{props.text}</div>;
 
 const NotebookCdrMismatch = (props: {text: string}) =>
-    <div data-test-id='notebook-cdr-mismatch-warning' style={styles.notebookCdrMismatch}>{props.text}</div>;
+    <div data-test-id='notebook-cdr-mismatch-warning' style={styles.notebookCdrMismatch}>
+      <FlexRow>
+        <div style={{paddingRight: '0.5rem'}}>
+          <ClrIcon shape='warning-standard' class='is-solid' style={styles.warningIcon}/>
+        </div>
+        {props.text}
+      </FlexRow>
+    </div>;
 
 const ConceptSetRestrictionText = () => <div style={styles.conceptSetsRestriction}>
   Concept sets can only be copied to workspaces using the same CDR version.

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -14,8 +14,8 @@ import {reactStyles, withCdrVersions} from 'app/utils';
 import { navigate } from 'app/utils/navigation';
 import {toDisplay} from 'app/utils/resourceActions';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
-import {ClrIcon} from "./icons";
-import {FlexRow} from "./flex";
+import {FlexRow} from './flex';
+import {ClrIcon} from './icons';
 
 enum RequestState { UNSENT, COPY_ERROR, SUCCESS }
 

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -79,9 +79,11 @@ const styles = reactStyles({
   },
 });
 
-const ConceptSetCdrMismatch = (props: {text: string}) => <div style={styles.conceptSetCdrMismatch}>{props.text}</div>;
+const ConceptSetCdrMismatch = (props: {text: string}) =>
+    <div data-test-id='concept-set-cdr-mismatch-error' style={styles.conceptSetCdrMismatch}>{props.text}</div>;
 
-const NotebookCdrMismatch = (props: {text: string}) => <div style={styles.notebookCdrMismatch}>{props.text}</div>;
+const NotebookCdrMismatch = (props: {text: string}) =>
+    <div data-test-id='notebook-cdr-mismatch-warning' style={styles.notebookCdrMismatch}>{props.text}</div>;
 
 class CopyModalComponent extends React.Component<Props, State> {
   constructor(props: Props) {

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -3,6 +3,8 @@ import {ArchivalStatus, CdrVersion, CdrVersionListResponse, CdrVersionsApi, Data
 export class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION = 'Fake CDR Version';
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
+  static ALT_WORKSPACE_CDR_VERSION = 'Alternative CDR Version';
+  static ALT_WORKSPACE_CDR_VERSION_ID = 'altCdrVersion';
 }
 
 export const cdrVersionListResponse = {
@@ -14,7 +16,14 @@ export const cdrVersionListResponse = {
       dataAccessLevel: DataAccessLevel.Registered,
       archivalStatus: ArchivalStatus.LIVE,
       creationTime: 0
-    }
+    },
+    {
+      name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
+      cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
+      dataAccessLevel: DataAccessLevel.Registered,
+      archivalStatus: ArchivalStatus.LIVE,
+      creationTime: 0
+    },
   ]
 };
 

--- a/ui/src/testing/stubs/concept-sets-api-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-api-stub.ts
@@ -1,5 +1,5 @@
 
-import {UpdateConceptSetRequest} from 'generated';
+import {CopyRequest, UpdateConceptSetRequest} from 'generated';
 import {
   ConceptSet,
   ConceptSetListResponse,
@@ -165,5 +165,15 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
       resolve(target);
     });
   }
+
+  copyConceptSet(fromWorkspaceNamespace: string,
+    fromWorkspaceId: string,
+    fromNotebookName: String,
+    copyRequest: CopyRequest): Promise<any> {
+    return new Promise<any>(resolve => {
+      resolve({});
+    });
+  }
+
 
 }


### PR DESCRIPTION
Description:

RW-5560 Prevent Copy Concept to Workspace with a different CDR, with error message
![copy_concept_set](https://user-images.githubusercontent.com/2701406/94298590-679dd280-ff34-11ea-8835-7be9419e9d0e.gif)


RW-5561 Warn when copying Notebook to Workspace with a different CDR (but allow it)
![copy_notebook](https://user-images.githubusercontent.com/2701406/94298593-68366900-ff34-11ea-8eb1-a87b2f72b1b6.gif)


TODO: styling to better match mocks
~TODO: unit tests~
TODO: e2e tests

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
