### PR TITLE
[risk=low] Group workspaces in copy-to by CDR version

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -139,6 +139,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
+  @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "cohort", source = "dbCohort")
   // All workspaceResources have one object and all others are null.
@@ -154,6 +155,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
+  @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "cohortReview", source = "cohortReview")
   // All workspaceResources have one object and all others are null.
@@ -169,6 +171,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
+  @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "conceptSet", source = "conceptSet")
   // All workspaceResources have one object and all others are null.
@@ -184,6 +187,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
+  @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "dataSet", source = "dbDataset", qualifiedByName = "dbModelToClientLight")
   // All workspaceResources have one object and all others are null.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5732,6 +5732,8 @@ definitions:
         type: string
       workspaceBillingStatus:
         "$ref": "#/definitions/BillingStatus"
+      cdrVersionId:
+        type: string
       permission:
         type: string
       cohort:

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -9,57 +9,64 @@ import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 
 import {dropNotebookFileSuffix} from 'app/pages/analysis/util';
-import {CopyModal, CopyModalProps, CopyModalState} from './copy-modal';
+import {CopyModalComponent, CopyModalProps, CopyModalState} from './copy-modal';
 import {ResourceType} from 'generated/fetch';
+import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 
 describe('CopyModal', () => {
   let props: CopyModalProps;
 
   const component = () => {
-    return mount<CopyModal, CopyModalProps, CopyModalState>
-    (<CopyModal {...props}/>);
+    return mount<CopyModalComponent, CopyModalProps, CopyModalState>
+    (<CopyModalComponent {...props}/>);
   };
 
   const workspaces = [
     {
       namespace: 'El Capitan',
       name: 'Freerider',
-      id: 'freerider'
+      id: 'freerider',
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     },
     {
       namespace: 'El Capitan',
       name: 'Dawn Wall',
-      id: 'dawn wall'
+      id: 'dawn wall',
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     },
     {
       namespace: 'El Capitan',
       name: 'Zodiac',
-      id: 'zodiac'
+      id: 'zodiac',
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     },
     {
       namespace: 'El Capitan',
       name: 'The Nose',
-      id: 'the nose'
+      id: 'the nose',
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     }
   ];
-  const fromWorkspaceNamespace = 'namespace';
-  const fromWorkspaceName = 'name';
+  const fromWorkspaceNamespace = workspaces[0].namespace;
+  const fromWorkspaceFCName = workspaces[0].id;
   const fromResourceName = 'notebook';
 
   beforeEach(() => {
     const apiStub = new WorkspacesApiStub(workspaces);
     registerApiClient(WorkspacesApi, apiStub);
     props = {
+      cdrVersionListResponse: cdrVersionListResponse,
       fromWorkspaceNamespace: fromWorkspaceNamespace,
-      fromWorkspaceName: fromWorkspaceName,
+      fromWorkspaceFCName: fromWorkspaceFCName,
       fromResourceName: fromResourceName,
+      fromCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       resourceType: ResourceType.NOTEBOOK,
       onClose: () => {},
       onCopy: () => {},
       saveFunction: (copyRequest) => {
         return workspacesApi().copyNotebook(
           fromWorkspaceNamespace,
-          fromWorkspaceName,
+          fromWorkspaceFCName,
           dropNotebookFileSuffix(fromResourceName),
           copyRequest
         );
@@ -113,7 +120,7 @@ describe('CopyModal', () => {
 
     expect(spy).toHaveBeenCalledWith(
       props.fromWorkspaceNamespace,
-      props.fromWorkspaceName,
+      props.fromWorkspaceFCName,
       props.fromResourceName,
       {
         toWorkspaceName: workspaces[2].id,

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -48,7 +48,7 @@ describe('CopyModal', () => {
     }
   ];
   const fromWorkspaceNamespace = workspaces[0].namespace;
-  const fromWorkspaceFCName = workspaces[0].id;
+  const fromWorkspaceFirecloudName = workspaces[0].id;
   const fromResourceName = 'notebook';
 
   beforeEach(() => {
@@ -57,7 +57,7 @@ describe('CopyModal', () => {
     props = {
       cdrVersionListResponse: cdrVersionListResponse,
       fromWorkspaceNamespace: fromWorkspaceNamespace,
-      fromWorkspaceFCName: fromWorkspaceFCName,
+      fromWorkspaceFirecloudName: fromWorkspaceFirecloudName,
       fromResourceName: fromResourceName,
       fromCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       resourceType: ResourceType.NOTEBOOK,
@@ -66,7 +66,7 @@ describe('CopyModal', () => {
       saveFunction: (copyRequest) => {
         return workspacesApi().copyNotebook(
           fromWorkspaceNamespace,
-          fromWorkspaceFCName,
+          fromWorkspaceFirecloudName,
           dropNotebookFileSuffix(fromResourceName),
           copyRequest
         );
@@ -120,7 +120,7 @@ describe('CopyModal', () => {
 
     expect(spy).toHaveBeenCalledWith(
       props.fromWorkspaceNamespace,
-      props.fromWorkspaceFCName,
+      props.fromWorkspaceFirecloudName,
       props.fromResourceName,
       {
         toWorkspaceName: workspaces[2].id,

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -80,6 +80,7 @@ class CopyModalComponent extends React.Component<Props, State> {
       } else if (cdrv1 !== fromCdrVersionId && cdrv2 === fromCdrVersionId) {
         return 1;
       } else {
+        // TODO: a meaningful ordering, possibly as part of RW-5563
         return cdrv1.localeCompare(cdrv2);
       }
     };

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -70,7 +70,8 @@ class CopyModalComponent extends React.Component<Props, State> {
 
   cdrName(cdrVersionId: string): string {
     const {cdrVersionListResponse} = this.props;
-    return cdrVersionListResponse.items.find(version => version.cdrVersionId === cdrVersionId).name;
+    const version = cdrVersionListResponse.items.find(version => version.cdrVersionId === cdrVersionId);
+    return version ? version.name : "[CDR version not found]";
   }
 
   groupWorkspacesByCdrVersion(workspaces: Workspace[]): Array<WorkspaceOptions> {

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -70,8 +70,8 @@ class CopyModalComponent extends React.Component<Props, State> {
 
   cdrName(cdrVersionId: string): string {
     const {cdrVersionListResponse} = this.props;
-    const version = cdrVersionListResponse.items.find(version => version.cdrVersionId === cdrVersionId);
-    return version ? version.name : "[CDR version not found]";
+    const version = cdrVersionListResponse.items.find(v => v.cdrVersionId === cdrVersionId);
+    return version ? version.name : '[CDR version not found]';
   }
 
   groupWorkspacesByCdrVersion(workspaces: Workspace[]): Array<WorkspaceOptions> {

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -1,18 +1,20 @@
+import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import { Button } from 'app/components/buttons';
 import { styles as headerStyles } from 'app/components/headers';
 import { Select, TextInput, ValidationError } from 'app/components/inputs';
 import { Modal, ModalBody, ModalFooter, ModalTitle } from 'app/components/modals';
-import {ConceptSet, FileDetail, ResourceType, Workspace} from 'generated/fetch';
+import {CdrVersionListResponse, ConceptSet, FileDetail, ResourceType, Workspace} from 'generated/fetch';
 
 import { Spinner } from 'app/components/spinners';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
+import {reactStyles, withCdrVersions} from 'app/utils';
 import { navigate } from 'app/utils/navigation';
 import {toDisplay} from 'app/utils/resourceActions';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
 
-enum RequestState { UNSENT, ERROR, SUCCESS }
+enum RequestState { UNSENT, COPY_ERROR, SUCCESS }
 
 const ResourceTypeHomeTabs = new Map()
   .set(ResourceType.NOTEBOOK, 'notebooks')
@@ -21,9 +23,11 @@ const ResourceTypeHomeTabs = new Map()
   .set(ResourceType.DATASET, 'data');
 
 export interface Props {
+  cdrVersionListResponse: CdrVersionListResponse;
   fromWorkspaceNamespace: string;
-  fromWorkspaceName: string;
+  fromWorkspaceFCName: string;
   fromResourceName: string;
+  fromCdrVersionId: string;
   onClose: Function;
   onCopy: Function;
   resourceType: ResourceType;
@@ -31,42 +35,91 @@ export interface Props {
 }
 
 interface State {
-  writeableWorkspaces: Array<Workspace>;
+  workspaceOptions: Array<Object>;
   destination: Workspace;
   newName: string;
   requestState: RequestState;
-  errorMsg: string;
+  copyErrorMsg: string;
   loading: boolean;
 }
 
-const boldStyle = {
-  fontWeight: 600
-};
+const styles = reactStyles({
+  bold: {
+    fontWeight: 600
+  },
+});
 
-class CopyModal extends React.Component<Props, State> {
+class CopyModalComponent extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
     this.state = {
-      writeableWorkspaces: [],
+      workspaceOptions: [],
       newName: props.fromResourceName,
       destination: null,
       requestState: RequestState.UNSENT,
-      errorMsg: '',
-      loading: true
+      copyErrorMsg: '',
+      loading: true,
     };
+  }
+
+  cdrName(cdrVersionId: string): string {
+    const {cdrVersionListResponse} = this.props;
+    return cdrVersionListResponse.items.find(version => version.cdrVersionId === cdrVersionId).name;
+  }
+
+  groupWorkspacesByCdrVersion(workspaces: Workspace[]): Array<Object> {
+    const {fromCdrVersionId} = this.props;
+    const workspacesByCdr = fp.groupBy(w => w.cdrVersionId, workspaces);
+    const cdrVersions = Array.from(new Set(workspaces.map(w => w.cdrVersionId)));
+
+    // list the "from" CDR version first.
+    const fromCdrVersionFirst = (cdrv1: string, cdrv2: string) => {
+      if (cdrv1 === fromCdrVersionId && cdrv2 !== fromCdrVersionId) {
+        return -1;
+      } else if (cdrv1 !== fromCdrVersionId && cdrv2 === fromCdrVersionId) {
+        return 1;
+      } else {
+        return cdrv1.localeCompare(cdrv2);
+      }
+    };
+
+    return cdrVersions.sort(fromCdrVersionFirst).map(versionId => ({
+      label: this.cdrName(versionId),
+      options: workspacesByCdr[versionId].map(workspace => ({
+        'value': workspace,
+        'label': workspace.name,
+      })),
+    }));
   }
 
   componentDidMount() {
     workspacesApi().getWorkspaces()
       .then((response) => {
-        this.setState({
-          writeableWorkspaces: response.items
+        const writeableWorkspaces = response.items
             .filter(item => new WorkspacePermissions(item).canWrite)
-            .map(workspaceResponse => workspaceResponse.workspace),
+            .map(workspaceResponse => workspaceResponse.workspace);
+
+        this.setState({
+          workspaceOptions: this.groupWorkspacesByCdrVersion(writeableWorkspaces),
           loading: false
         });
       });
+  }
+
+  setCopyError(errorMsg: string) {
+    this.setState({
+      copyErrorMsg: errorMsg,
+      requestState: RequestState.COPY_ERROR,
+      loading: false
+    });
+  }
+
+  clearCopyError() {
+    this.setState({
+      copyErrorMsg: '',
+      requestState: RequestState.UNSENT,
+    });
   }
 
   save() {
@@ -89,11 +142,7 @@ class CopyModal extends React.Component<Props, State> {
             `original workspace.` :
           'An error occurred while copying. Please try again.';
 
-      this.setState({
-        errorMsg: errorMsg,
-        requestState: RequestState.ERROR,
-        loading: false
-      });
+      this.setCopyError(errorMsg);
     });
   }
 
@@ -109,15 +158,16 @@ class CopyModal extends React.Component<Props, State> {
   }
 
   render() {
+    const {loading, requestState} = this.state;
+
     return (
       <Modal onRequestClose={this.props.onClose}>
         <ModalTitle>Copy to Workspace</ModalTitle>
-        { this.state.loading ?
+        {loading ?
           <ModalBody style={{ textAlign: 'center' }}><Spinner /></ModalBody> :
           <ModalBody>
-            {(this.state.requestState === RequestState.UNSENT ||
-            this.state.requestState === RequestState.ERROR) && this.renderFormBody()}
-            {this.state.requestState === RequestState.SUCCESS && this.renderSuccessBody()}
+            {(requestState === RequestState.UNSENT || requestState === RequestState.COPY_ERROR) && this.renderFormBody()}
+            {requestState === RequestState.SUCCESS && this.renderSuccessBody()}
           </ModalBody>
         }
         <ModalFooter>
@@ -132,7 +182,7 @@ class CopyModal extends React.Component<Props, State> {
 
   getCloseButtonText() {
     if (this.state.requestState === RequestState.UNSENT ||
-      this.state.requestState === RequestState.ERROR) {
+      this.state.requestState === RequestState.COPY_ERROR) {
       return 'Close';
     } else if (this.state.requestState === RequestState.SUCCESS) {
       return 'Stay Here';
@@ -142,7 +192,7 @@ class CopyModal extends React.Component<Props, State> {
   renderActionButton() {
     const resourceType = toDisplay(this.props.resourceType);
     if (this.state.requestState === RequestState.UNSENT ||
-      this.state.requestState === RequestState.ERROR) {
+      this.state.requestState === RequestState.COPY_ERROR) {
       return (
         <Button style={{ marginLeft: '0.5rem' }}
                 disabled={this.state.destination === null || this.state.loading}
@@ -161,25 +211,29 @@ class CopyModal extends React.Component<Props, State> {
     }
   }
 
+  setDestination(destination: Workspace) {
+    this.clearCopyError();
+    this.setState({destination: destination});
+  }
+
   renderFormBody() {
+    const {destination, workspaceOptions, requestState, copyErrorMsg, newName} = this.state;
     return (
       <div>
         <div style={headerStyles.formLabel}>Destination *</div>
         <Select
-          value={this.state.destination}
-          options={this.state.writeableWorkspaces.map(workspace => ({
-            'value': workspace,
-            'label': workspace.name
-          }))}
-          onChange={(value) => { this.setState({ destination: value }); }} />
+          value={destination}
+          options={workspaceOptions}
+          onChange={(destWorkspace) => this.setDestination(destWorkspace)}
+        />
         <div style={headerStyles.formLabel}>Name *</div>
         <TextInput
           autoFocus
-          value={this.state.newName}
+          value={newName}
           onChange={v => this.setState({ newName: v })}
         />
-        {this.state.requestState === RequestState.ERROR &&
-        <ValidationError> {this.state.errorMsg} </ValidationError>}
+        {requestState === RequestState.COPY_ERROR &&
+        <ValidationError> {copyErrorMsg} </ValidationError>}
       </div>
     );
   }
@@ -188,15 +242,18 @@ class CopyModal extends React.Component<Props, State> {
     const {fromResourceName, resourceType} = this.props;
     return (
       <div> Successfully copied
-        <b style={boldStyle}> {fromResourceName} </b> to
-        <b style={boldStyle}> {this.state.destination.name} </b>.
+        <b style={styles.bold}> {fromResourceName} </b> to
+        <b style={styles.bold}> {this.state.destination.name} </b>.
         Do you want to view the copied {toDisplay(resourceType)}?</div>
     );
   }
 }
 
+const CopyModal = fp.flow(withCdrVersions())(CopyModalComponent);
+
 export {
   CopyModal,
+  CopyModalComponent,
   Props as CopyModalProps,
   State as CopyModalState,
 };

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -34,8 +34,13 @@ export interface Props {
   saveFunction: (CopyRequest) => Promise<FileDetail | ConceptSet>;
 }
 
+interface WorkspaceOptions {
+  label: string;
+  options: Array<{label: string, value: Workspace}>;
+}
+
 interface State {
-  workspaceOptions: Array<Object>;
+  workspaceOptions: Array<WorkspaceOptions>;
   destination: Workspace;
   newName: string;
   requestState: RequestState;
@@ -68,7 +73,7 @@ class CopyModalComponent extends React.Component<Props, State> {
     return cdrVersionListResponse.items.find(version => version.cdrVersionId === cdrVersionId).name;
   }
 
-  groupWorkspacesByCdrVersion(workspaces: Workspace[]): Array<Object> {
+  groupWorkspacesByCdrVersion(workspaces: Workspace[]): Array<WorkspaceOptions> {
     const {fromCdrVersionId} = this.props;
     const workspacesByCdr = fp.groupBy(w => w.cdrVersionId, workspaces);
     const cdrVersions = Array.from(new Set(workspaces.map(w => w.cdrVersionId)));

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -25,7 +25,7 @@ const ResourceTypeHomeTabs = new Map()
 export interface Props {
   cdrVersionListResponse: CdrVersionListResponse;
   fromWorkspaceNamespace: string;
-  fromWorkspaceFCName: string;
+  fromWorkspaceFirecloudName: string;
   fromResourceName: string;
   fromCdrVersionId: string;
   onClose: Function;

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -377,8 +377,9 @@ export class ResourceCard extends React.Component<Props, State> {
                           closeFunction={() => this.closeConfirmDelete()}/>}
       {this.state.copyingConceptSet && <CopyModal
         fromWorkspaceNamespace={this.props.resourceCard.workspaceNamespace}
-        fromWorkspaceName={this.props.resourceCard.workspaceFirecloudName}
+        fromWorkspaceFCName={this.props.resourceCard.workspaceFirecloudName}
         fromResourceName={this.props.resourceCard.conceptSet.name}
+        fromCdrVersionId={this.props.resourceCard.cdrVersionId}
         resourceType={this.resourceType}
         onClose={() => this.setState({copyingConceptSet: false})}
         onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -377,7 +377,7 @@ export class ResourceCard extends React.Component<Props, State> {
                           closeFunction={() => this.closeConfirmDelete()}/>}
       {this.state.copyingConceptSet && <CopyModal
         fromWorkspaceNamespace={this.props.resourceCard.workspaceNamespace}
-        fromWorkspaceFCName={this.props.resourceCard.workspaceFirecloudName}
+        fromWorkspaceFirecloudName={this.props.resourceCard.workspaceFirecloudName}
         fromResourceName={this.props.resourceCard.conceptSet.name}
         fromCdrVersionId={this.props.resourceCard.cdrVersionId}
         resourceType={this.resourceType}

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -178,8 +178,9 @@ export const NotebookResourceCard = fp.flow(
       {this.state.showCopyNotebookModal &&
       <CopyModal
         fromWorkspaceNamespace={this.props.resource.workspaceNamespace}
-        fromWorkspaceName={this.props.resource.workspaceFirecloudName}
+        fromWorkspaceFCName={this.props.resource.workspaceFirecloudName}
         fromResourceName={dropNotebookFileSuffix(this.props.resource.notebook.name)}
+        fromCdrVersionId={this.props.resource.cdrVersionId}
         resourceType={this.resourceType}
         onClose={() => this.setState({showCopyNotebookModal: false})}
         onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -178,7 +178,7 @@ export const NotebookResourceCard = fp.flow(
       {this.state.showCopyNotebookModal &&
       <CopyModal
         fromWorkspaceNamespace={this.props.resource.workspaceNamespace}
-        fromWorkspaceFCName={this.props.resource.workspaceFirecloudName}
+        fromWorkspaceFirecloudName={this.props.resource.workspaceFirecloudName}
         fromResourceName={dropNotebookFileSuffix(this.props.resource.notebook.name)}
         fromCdrVersionId={this.props.resource.cdrVersionId}
         resourceType={this.resourceType}

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -372,8 +372,9 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
           </Modal>}
           {copying && <CopyModal
             fromWorkspaceNamespace={workspace.namespace}
-            fromWorkspaceName={workspace.id}
+            fromWorkspaceFCName={workspace.id}
             fromResourceName={conceptSet.name}
+            fromCdrVersionId={workspace.cdrVersionId}
             resourceType={ResourceType.CONCEPTSET}
             onClose={() => this.setState({copying: false})}
             onCopy={() => this.onCopy()}

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -372,7 +372,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
           </Modal>}
           {copying && <CopyModal
             fromWorkspaceNamespace={workspace.namespace}
-            fromWorkspaceFCName={workspace.id}
+            fromWorkspaceFirecloudName={workspace.id}
             fromResourceName={conceptSet.name}
             fromCdrVersionId={workspace.cdrVersionId}
             resourceType={ResourceType.CONCEPTSET}


### PR DESCRIPTION
Description:

Progress toward RW-5560 and RW-5561, and a useful feature in itself: in the copy-to-workspace Modal, group the destination Workspaces by CDR Version, with the compatible CDR Version first.

TODO (will include in final RW-5560/1 PR):
* unit tests
* e2e tests

![grouped by cdr](https://user-images.githubusercontent.com/2701406/94279306-e89ba080-ff19-11ea-8c39-5b4b580d597b.gif)





---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
