### PR TITLE
[risk=no] Move machine type / disk defaults to client side

### DIFF
--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -1,6 +1,7 @@
 import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import {isAbortError, reportError} from 'app/utils/errors';
+import {runtimePresets} from 'app/utils/runtime-presets';
 import {Runtime, RuntimeConfigurationType, RuntimeStatus} from 'generated/fetch';
 import {serverConfigStore} from './navigation';
 import {
@@ -192,11 +193,7 @@ export class LeoRuntimeInitializer {
     let runtime: Runtime;
     if (serverConfigStore.getValue().enableCustomRuntimes) {
       // TODO(RW-3418): allow custom runtimes, maybe plumb default through serverConfigStore?
-      runtime = {
-        dataprocConfig: {
-          masterMachineType: 'n1-standard-4'
-        }
-      };
+      runtime = {...runtimePresets.generalAnalysis.runtimeTemplate};
     } else {
       runtime = {configurationType: RuntimeConfigurationType.DefaultDataproc};
     }

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,0 +1,28 @@
+import {RuntimeConfigurationType} from 'generated/fetch';
+
+export const runtimePresets = {
+  generalAnalysis: {
+    displayName: 'General Analysis',
+    runtimeTemplate: {
+      configurationType: RuntimeConfigurationType.DefaultGce,
+      // TODO(RW-4848): Switch this to GCE.
+      // TODO: Support specifying toolDockerImage here.
+      dataprocConfig: {
+        masterMachineType: 'n1-standard-4',
+        masterDiskSize: 50
+      }
+    }
+  },
+  hailAnalysis: {
+    displayName: 'Hail Genomics Analysis',
+    runtimeTemplate: {
+      configurationType: RuntimeConfigurationType.DefaultDataproc,
+      dataprocConfig: {
+        masterMachineType: 'n1-standard-4',
+        masterDiskSize: 50,
+        numberOfWorkers: 3
+        // Take the Leo defaults here, currently 100GB disk and n1-standard-4
+      }
+    }
+  }
+};


### PR DESCRIPTION
Add runtime presets, start using them from the client side. This fixes runtime creation when the `enableCustomRuntimes` flag is enabled.

Note:
- This affects existing code, and effectively nullifies our workbenchConfig.notebookRuntime* values