### PR TITLE
[RW-4848][risk=low] Add flag to use GCE by default instead of Dataproc

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -114,7 +114,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -111,7 +111,8 @@
     "enableConceptSetSearchV2": false,
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
-    "enableCustomRuntimes": false
+    "enableCustomRuntimes": false,
+    "enableGceAsNotebookRuntimeDefault": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -48,6 +48,8 @@ public class ConfigController implements ConfigApiDelegate {
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
             .enableCOPESurvey(config.featureFlags.enableCOPESurvey)
             .enableCustomRuntimes(config.featureFlags.enableCustomRuntimes)
+            .enableGceAsNotebookRuntimeDefault(
+                config.featureFlags.enableGceAsNotebookRuntimeDefault)
             .runtimeImages(
                 Stream.concat(
                         config.firecloud.runtimeImages.dataproc.stream()

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -268,6 +268,8 @@ public class WorkbenchConfig {
     public boolean enableCOPESurvey;
     // Whether users should be able to customize notebook runtime settings.
     public boolean enableCustomRuntimes;
+    // Whether Leonardo notebooks runtimes should default to GCE (instead of Dataproc).
+    public boolean enableGceAsNotebookRuntimeDefault;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.leonardo.LeonardoRetryHandler;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.api.ServiceInfoApi;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
+import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
@@ -136,6 +137,16 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         request.setRuntimeConfig(
             leonardoMapper.toLeonardoMachineConfig(runtime.getDataprocConfig()));
       }
+    } else if (workbenchConfigProvider.get().featureFlags.enableGceAsNotebookRuntimeDefault) {
+      request.setRuntimeConfig(
+          new LeonardoGceConfig()
+              .cloudService(LeonardoGceConfig.CloudServiceEnum.GCE)
+              .diskSize(
+                  Optional.ofNullable(clusterOverride.masterDiskSize)
+                      .orElse(config.firecloud.notebookRuntimeDefaultDiskSizeGb))
+              .machineType(
+                  Optional.ofNullable(clusterOverride.machineType)
+                      .orElse(config.firecloud.notebookRuntimeDefaultMachineType)));
     } else {
       request.setRuntimeConfig(
           new LeonardoMachineConfig()

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -33,8 +33,8 @@ public interface LeonardoMapper {
   BiMap<RuntimeConfigurationType, String> RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
       ImmutableBiMap.of(
           RuntimeConfigurationType.USEROVERRIDE, "user-override",
-          RuntimeConfigurationType.GENERALANALYSIS, "general-analysis",
-          RuntimeConfigurationType.HAILGENOMICANALYSIS, "hail-genomic-analysis");
+          RuntimeConfigurationType.GENERALANALYSIS, "preset-general-analysis",
+          RuntimeConfigurationType.HAILGENOMICANALYSIS, "preset-hail-genomic-analysis");
 
   DataprocConfig toDataprocConfig(LeonardoMachineConfig leonardoMachineConfig);
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -33,8 +33,8 @@ public interface LeonardoMapper {
   BiMap<RuntimeConfigurationType, String> RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP =
       ImmutableBiMap.of(
           RuntimeConfigurationType.USEROVERRIDE, "user-override",
-          RuntimeConfigurationType.DEFAULTGCE, "default-gce",
-          RuntimeConfigurationType.DEFAULTDATAPROC, "default-dataproc");
+          RuntimeConfigurationType.GENERALANALYSIS, "general-analysis",
+          RuntimeConfigurationType.HAILGENOMICANALYSIS, "hail-genomic-analysis");
 
   DataprocConfig toDataprocConfig(LeonardoMachineConfig leonardoMachineConfig);
 
@@ -98,7 +98,7 @@ public interface LeonardoMapper {
     if (runtimeLabels == null || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
       // If there's no label, fall back onto the old behavior where every Runtime was created with a
       // default Dataproc config
-      runtime.setConfigurationType(RuntimeConfigurationType.DEFAULTDATAPROC);
+      runtime.setConfigurationType(RuntimeConfigurationType.HAILGENOMICANALYSIS);
     } else {
       runtime.setConfigurationType(
           RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3937,6 +3937,10 @@ definitions:
         type: boolean
         default: false
         description: Whether user should be able to customize notebook runtime settings.
+      enableGceAsNotebookRuntimeDefault:
+        type: boolean
+        default: false
+        description: Whether the notebook runtime should default to GCE (vs Dataproc).
       runtimeImages:
         type: array
         items:
@@ -5422,6 +5426,10 @@ definitions:
     type: string
     enum:
       - UserOverride
+      - GeneralAnalysis
+      - HailGenomicAnalysis
+      # Deprecated.
+      # TODO(calbach): Remove after next release.
       - DefaultGce
       - DefaultDataproc
   Runtime:

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -391,8 +391,8 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_defaultLabel_dataproc() throws ApiException {
-    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default-dataproc"));
+  public void testGetRuntime_defaultLabel_hail() throws ApiException {
+    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "preset-hail-genomic-analysis"));
 
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime);
@@ -402,8 +402,8 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_defaultLabel_gce() throws ApiException {
-    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "default-gce"));
+  public void testGetRuntime_defaultLabel_generalAnalysis() throws ApiException {
+    testLeoRuntime.setLabels(ImmutableMap.of("all-of-us-config", "preset-general-analysis"));
 
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime);
@@ -928,7 +928,7 @@ public class RuntimeControllerTest {
     Runtime capturedRuntimeConfig = new Runtime();
     leonardoMapper.mapRuntimeConfig(
         capturedRuntimeConfig, createRuntimeRequestCaptor.getValue().getRuntimeConfig());
-    assertThat(capturedRuntimeConfig.getGceConfig())
+    assertThat(capturedRuntimeConfig.getDataprocConfig())
         .isEqualTo(
             new DataprocConfig()
                 .masterMachineType(config.firecloud.notebookRuntimeDefaultMachineType)
@@ -960,7 +960,7 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testCreateRuntime_defaultLabel_dataproc() throws ApiException {
+  public void testCreateRuntime_defaultLabel_hail() throws ApiException {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
@@ -976,11 +976,11 @@ public class RuntimeControllerTest {
 
     LeonardoCreateRuntimeRequest createRuntimeRequest = createRuntimeRequestCaptor.getValue();
     assertThat(((Map<String, String>) createRuntimeRequest.getLabels()).get("all-of-us-config"))
-        .isEqualTo("default-dataproc");
+        .isEqualTo("preset-hail-genomic-analysis");
   }
 
   @Test
-  public void testCreateRuntime_defaultLabel_gce() throws ApiException {
+  public void testCreateRuntime_defaultLabel_generalAnalysis() throws ApiException {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());
     stubGetWorkspace(WORKSPACE_NS, WORKSPACE_ID, "test");
@@ -996,7 +996,7 @@ public class RuntimeControllerTest {
 
     LeonardoCreateRuntimeRequest createRuntimeRequest = createRuntimeRequestCaptor.getValue();
     assertThat(((Map<String, String>) createRuntimeRequest.getLabels()).get("all-of-us-config"))
-        .isEqualTo("default-gce");
+        .isEqualTo("preset-general-analysis");
   }
 
   @Test

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -27,7 +27,7 @@ const baseRuntime: Runtime = {
   status: RuntimeStatus.Running,
   createdDate: '08/08/2018',
   toolDockerImage: 'docker',
-  configurationType: RuntimeConfigurationType.DefaultDataproc
+  configurationType: RuntimeConfigurationType.GeneralAnalysis
 };
 
 const workspaceNamespace = 'aou-rw-12345';

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -1,6 +1,7 @@
 import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import {isAbortError, reportError} from 'app/utils/errors';
+import {runtimePresets} from 'app/utils/runtime-presets';
 import {Runtime, RuntimeConfigurationType, RuntimeStatus} from 'generated/fetch';
 import {serverConfigStore} from './navigation';
 import {
@@ -192,11 +193,7 @@ export class LeoRuntimeInitializer {
     let runtime: Runtime;
     if (serverConfigStore.getValue().enableCustomRuntimes) {
       // TODO(RW-3418): allow custom runtimes, maybe plumb default through serverConfigStore?
-      runtime = {
-        dataprocConfig: {
-          masterMachineType: 'n1-standard-4'
-        }
-      };
+      runtime = {...runtimePresets.generalAnalysis.runtimeTemplate};
     } else {
       runtime = {configurationType: RuntimeConfigurationType.DefaultDataproc};
     }

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -2,7 +2,7 @@ import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import {isAbortError, reportError} from 'app/utils/errors';
 import {runtimePresets} from 'app/utils/runtime-presets';
-import {Runtime, RuntimeConfigurationType, RuntimeStatus} from 'generated/fetch';
+import {Runtime, RuntimeStatus} from 'generated/fetch';
 import {serverConfigStore} from './navigation';
 import {
   markRuntimeOperationCompleteForWorkspace,
@@ -191,11 +191,10 @@ export class LeoRuntimeInitializer {
     }
     const aborter = new AbortController();
     let runtime: Runtime;
-    if (serverConfigStore.getValue().enableCustomRuntimes) {
-      // TODO(RW-3418): allow custom runtimes, maybe plumb default through serverConfigStore?
+    if (serverConfigStore.getValue().enableGceAsNotebookRuntimeDefault) {
       runtime = {...runtimePresets.generalAnalysis.runtimeTemplate};
     } else {
-      runtime = {configurationType: RuntimeConfigurationType.DefaultDataproc};
+      runtime = {...runtimePresets.legacyGeneralAnalysis.runtimeTemplate};
     }
     const promise = runtimeApi().createRuntime(this.workspaceNamespace,
       runtime,

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,0 +1,28 @@
+import {RuntimeConfigurationType} from 'generated/fetch';
+
+export const runtimePresets = {
+  generalAnalysis: {
+    displayName: 'General Analysis',
+    runtimeTemplate: {
+      configurationType: RuntimeConfigurationType.DefaultGce,
+      // TODO(RW-4848): Switch this to GCE.
+      // TODO: Support specifying toolDockerImage here.
+      dataprocConfig: {
+        masterMachineType: 'n1-standard-4',
+        masterDiskSize: 50
+      }
+    }
+  },
+  hailAnalysis: {
+    displayName: 'Hail Genomics Analysis',
+    runtimeTemplate: {
+      configurationType: RuntimeConfigurationType.DefaultDataproc,
+      dataprocConfig: {
+        masterMachineType: 'n1-standard-4',
+        masterDiskSize: 50,
+        numberOfWorkers: 3
+        // Take the Leo defaults here, currently 100GB disk and n1-standard-4
+      }
+    }
+  }
+};

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,22 +1,32 @@
 import {RuntimeConfigurationType} from 'generated/fetch';
 
 export const runtimePresets = {
-  generalAnalysis: {
-    displayName: 'General Analysis',
+  // TODO(RW-5658): Remove this preset.
+  legacyGeneralAnalysis: {
+    displayName: 'General Analysis (Legacy)',
     runtimeTemplate: {
-      configurationType: RuntimeConfigurationType.DefaultGce,
-      // TODO(RW-4848): Switch this to GCE.
-      // TODO: Support specifying toolDockerImage here.
+      configurationType: RuntimeConfigurationType.GeneralAnalysis,
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
         masterDiskSize: 50
       }
     }
   },
+  generalAnalysis: {
+    displayName: 'General Analysis',
+    runtimeTemplate: {
+      configurationType: RuntimeConfigurationType.GeneralAnalysis,
+      // TODO: Support specifying toolDockerImage here.
+      gceConfig: {
+        machineType: 'n1-standard-4',
+        bootDiskSize: 50
+      }
+    }
+  },
   hailAnalysis: {
     displayName: 'Hail Genomics Analysis',
     runtimeTemplate: {
-      configurationType: RuntimeConfigurationType.DefaultDataproc,
+      configurationType: RuntimeConfigurationType.HailGenomicAnalysis,
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
         masterDiskSize: 50,

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -18,7 +18,7 @@ export class RuntimeApiStub extends RuntimeApi {
       status: RuntimeStatus.Running,
       createdDate: '08/08/2018',
       toolDockerImage: 'broadinstitute/terra-jupyter-aou:1.0.999',
-      configurationType: RuntimeConfigurationType.DefaultDataproc,
+      configurationType: RuntimeConfigurationType.GeneralAnalysis,
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
         masterDiskSize: 80,


### PR DESCRIPTION
Notes:
- Add new module of runtime presets which will be used to power the create page and preset dropdown
- We expect to launch this ahead of `enableCustomRuntimes`, but I've implemented it such that we should be able to enable them in either order.
- Renames the preset options to better match upcoming mocks:
  - DefaultGce -> GeneralAnalysis
  - DefaultDataproc -> HailGenomicAnalysis
