### PR TITLE
[RW-5098][risk=low] Switch from Welder image -> registry

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -116,7 +116,8 @@ public class WorkbenchConfig {
     // The docker image that we use for our jupyter images
     public String jupyterDockerImage;
     // The docker image that we use for our welder images
-    public String welderDockerImage;
+    // TODO(RW-5098): Remove after next release.
+    @Deprecated public String welderDockerImage;
     // Base URL for the Shibboleth API server, e.g.
     // https://profile-dot-broad-shibboleth-prod.appspot.com
     // See RW-4257 for more details on Terra's Shibboleth-specific API.

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.leonardo.LeonardoRetryHandler;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.api.ServiceInfoApi;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
+import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest.WelderRegistryEnum;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
@@ -127,7 +128,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
             .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
             .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
-            .welderDockerImage(workbenchConfigProvider.get().firecloud.welderDockerImage)
+            // Note: DockerHub must be used over GCR here, since VPC-SC restricts
+            // pulling external images via GCR (since it counts as GCS traffic).
+            .welderRegistry(WelderRegistryEnum.DOCKERHUB)
             .customEnvironmentVariables(customEnvironmentVariables);
 
     if (workbenchConfigProvider.get().featureFlags.enableCustomRuntimes) {


### PR DESCRIPTION
Use new Leo API to let Leo pick the latest prod Welder image for us, instead of having us update a specific hash. This is a new capability they implemented for us a few months back.

Flag can be removed with the following release.