### PR TITLE
[RW-5558][risk=no] Make footer for Attributes & Modifiers sidebar sticky

### DIFF
--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -126,23 +126,38 @@ const styles = reactStyles({
   },
 });
 
-export const CalculateFooter = (props) => {
-  return <FlexRowWrap style={styles.countPreview}>
-     <div style={styles.resultsContainer}>
-     <Button id='attributes-calculate'
-       type='secondaryLight'
-    disabled={props.disabled}
-    style={{...styles.calculateButton, ...(props.disabled ? {borderColor: colorWithWhiteness(colors.dark, 0.6)} : {})}}
-    onClick={() => props.calculate()}>
-    {props.calculating && <Spinner size={16} style={styles.spinner}/>} Calculate
-    </Button>
-    </div>
-    <div style={styles.resultsContainer}>
-      <div style={{fontWeight: 600}}>Number of Participants:
-        <span> {props.count === null ? '--' : props.count.toLocaleString()} </span>
+export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating, count, disableAdd = false, disableCalculate}) => {
+  return <React.Fragment>
+    <FlexRowWrap style={styles.countPreview}>
+      <div style={styles.resultsContainer}>
+        <Button id='attributes-calculate'
+          type='secondaryLight'
+          disabled={disableCalculate}
+          style={{...styles.calculateButton, ...(disableCalculate ? {borderColor: colorWithWhiteness(colors.dark, 0.6)} : {})}}
+          onClick={() => calculateFn()}>
+          {calculating && <Spinner size={16} style={styles.spinner}/>} Calculate
+        </Button>
       </div>
-    </div>
-  </FlexRowWrap>;
+      <div style={styles.resultsContainer}>
+        <div style={{fontWeight: 600}}>Number of Participants:
+          <span> {count === null ? '--' : count.toLocaleString()} </span>
+        </div>
+      </div>
+    </FlexRowWrap>
+    <FlexRowWrap style={{flexDirection: 'row-reverse', marginTop: '0.5rem'}}>
+      <Button type='primary'
+              disabled={disableAdd}
+              style={styles.addButton}
+              onClick={() => addFn()}>
+        {addButtonText}
+      </Button>
+      <Button type='link'
+              style={{color: colors.primary, marginRight: '0.75rem'}}
+              onClick={() => close()}>
+        BACK
+      </Button>
+    </FlexRowWrap>
+  </React.Fragment>;
 };
 
 const optionUtil = {
@@ -595,20 +610,15 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
               </div>
             </React.Fragment>}
           </div>}
-          <CalculateFooter disabled={disableCalculate} calculating={calculating} calculate={() => this.requestPreview()} count={count}/>
-          <FlexRowWrap style={{flexDirection: 'row-reverse', marginTop: '2rem'}}>
-            <Button type='primary'
-                    disabled={disableAdd}
-                    style={styles.addButton}
-                    onClick={() => this.addParameterToSearchItem()}>
-              ADD THIS
-            </Button>
-            <Button type='link'
-                    style={{color: colors.primary, marginRight: '0.75rem'}}
-                    onClick={() => close()}>
-              BACK
-            </Button>
-          </FlexRowWrap>
+          <div style={{background: colorWithWhiteness(colors.primary, .87), bottom: 0, position: 'sticky'}}>
+            <CalculateFooter addButtonText='ADD THIS'
+                             addFn={() => this.addParameterToSearchItem()}
+                             calculateFn={() => this.requestPreview()}
+                             calculating={calculating}
+                             count={count}
+                             disableAdd={disableAdd}
+                             disableCalculate={disableCalculate}/>
+          </div>
         </div>
       );
     }

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -126,7 +126,7 @@ const styles = reactStyles({
   },
 });
 
-export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating, count, disableAdd, disableCalculate}) => {
+export const CalculateFooter = ({addButtonText, addFn, backFn, calculateFn, calculating, count, disableAdd, disableCalculate}) => {
   return <div style={{background: colorWithWhiteness(colors.primary, .87), bottom: 0, position: 'sticky'}}>
     <FlexRowWrap style={styles.countPreview}>
       <div style={styles.resultsContainer}>
@@ -153,7 +153,7 @@ export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating,
       </Button>
       <Button type='link'
               style={{color: colors.primary, marginRight: '0.75rem'}}
-              onClick={() => close()}>
+              onClick={() => backFn()}>
         BACK
       </Button>
     </FlexRowWrap>
@@ -612,6 +612,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
           </div>}
           <CalculateFooter addButtonText='ADD THIS'
                            addFn={() => this.addParameterToSearchItem()}
+                           backFn={() => close()}
                            calculateFn={() => this.requestPreview()}
                            calculating={calculating}
                            count={count}

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -126,8 +126,8 @@ const styles = reactStyles({
   },
 });
 
-export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating, count, disableAdd = false, disableCalculate}) => {
-  return <React.Fragment>
+export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating, count, disableAdd, disableCalculate}) => {
+  return <div style={{background: colorWithWhiteness(colors.primary, .87), bottom: 0, position: 'sticky'}}>
     <FlexRowWrap style={styles.countPreview}>
       <div style={styles.resultsContainer}>
         <Button id='attributes-calculate'
@@ -157,7 +157,7 @@ export const CalculateFooter = ({addButtonText, addFn, calculateFn, calculating,
         BACK
       </Button>
     </FlexRowWrap>
-  </React.Fragment>;
+  </div>;
 };
 
 const optionUtil = {
@@ -610,15 +610,13 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
               </div>
             </React.Fragment>}
           </div>}
-          <div style={{background: colorWithWhiteness(colors.primary, .87), bottom: 0, position: 'sticky'}}>
-            <CalculateFooter addButtonText='ADD THIS'
-                             addFn={() => this.addParameterToSearchItem()}
-                             calculateFn={() => this.requestPreview()}
-                             calculating={calculating}
-                             count={count}
-                             disableAdd={disableAdd}
-                             disableCalculate={disableCalculate}/>
-          </div>
+          <CalculateFooter addButtonText='ADD THIS'
+                           addFn={() => this.addParameterToSearchItem()}
+                           calculateFn={() => this.requestPreview()}
+                           calculating={calculating}
+                           count={count}
+                           disableAdd={disableAdd}
+                           disableCalculate={disableCalculate}/>
         </div>
       );
     }

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -126,14 +126,28 @@ const styles = reactStyles({
   },
 });
 
-export const CalculateFooter = ({addButtonText, addFn, backFn, calculateFn, calculating, count, disableAdd, disableCalculate}) => {
+interface CalculateFooterProps {
+  addButtonText: string;
+  addFn: () => void;
+  backFn: () => void;
+  calculateFn: () => void;
+  calculating: boolean;
+  count: number;
+  disableAdd: boolean;
+  disableCalculate: boolean;
+}
+
+export const CalculateFooter = (props: CalculateFooterProps) => {
+  const {addButtonText, addFn, backFn, calculateFn, calculating, count, disableAdd, disableCalculate} = props;
   return <div style={{background: colorWithWhiteness(colors.primary, .87), bottom: 0, position: 'sticky'}}>
     <FlexRowWrap style={styles.countPreview}>
       <div style={styles.resultsContainer}>
         <Button id='attributes-calculate'
           type='secondaryLight'
           disabled={disableCalculate}
-          style={{...styles.calculateButton, ...(disableCalculate ? {borderColor: colorWithWhiteness(colors.dark, 0.6)} : {})}}
+          style={disableCalculate
+            ? {...styles.calculateButton, borderColor: colorWithWhiteness(colors.dark, 0.6)}
+            : styles.calculateButton}
           onClick={() => calculateFn()}>
           {calculating && <Spinner size={16} style={styles.spinner}/>} Calculate
         </Button>

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -13,7 +13,7 @@ import {DatePicker, NumberInput} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
-import colors from 'app/styles/colors';
+import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentCohortSearchContext, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortSearchContextStore, serverConfigStore} from 'app/utils/navigation';
@@ -533,6 +533,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
                            calculateFn={() => this.props.closeModifiers()}
                            calculating={calculating}
                            count={count}
+                           disableAdd={formErrors.length > 0 || formUntouched}
                            disableCalculate={disableCalculate}/>
         </div>
       </div>;

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -528,20 +528,12 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
               </div>;
             })
           }
-          <CalculateFooter disabled={disableCalculate} calculating={calculating}
-                           calculate={() => this.calculate()} count={count}/>
-          <FlexRowWrap style={{flexDirection: 'row-reverse', marginTop: '2rem'}}>
-            <Button type='primary'
-                    style={styles.addButton}
-                    onClick={() => this.updateMods()}>
-              APPLY MODIFIERS
-            </Button>
-            <Button type='link'
-                    style={{color: colors.primary, marginRight: '0.5rem'}}
-                    onClick={() => this.props.closeModifiers()}>
-              BACK
-            </Button>
-          </FlexRowWrap>
+          <CalculateFooter addButtonText='APPLY MODIFIERS'
+                           addFn={() => this.updateMods()}
+                           calculateFn={() => this.props.closeModifiers()}
+                           calculating={calculating}
+                           count={count}
+                           disableCalculate={disableCalculate}/>
         </div>
       </div>;
     }

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -528,7 +528,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
           <CalculateFooter addButtonText='APPLY MODIFIERS'
                            addFn={() => this.updateMods()}
                            backFn={() => this.props.closeModifiers()}
-                           calculateFn={() => this.props.closeModifiers()}
+                           calculateFn={() => this.calculate()}
                            calculating={calculating}
                            count={count}
                            disableAdd={formErrors.length > 0 || formUntouched}

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -6,14 +6,11 @@ import * as React from 'react';
 import {CalculateFooter} from 'app/cohort-search/attributes-page-v2/attributes-page-v2.component';
 import {encountersStore} from 'app/cohort-search/search-state.service';
 import {domainToTitle, mapParameter} from 'app/cohort-search/utils';
-import {Button} from 'app/components/buttons';
-import {FlexRowWrap} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import {DatePicker, NumberInput} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
-import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentCohortSearchContext, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortSearchContextStore, serverConfigStore} from 'app/utils/navigation';
@@ -530,6 +527,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
           }
           <CalculateFooter addButtonText='APPLY MODIFIERS'
                            addFn={() => this.updateMods()}
+                           backFn={() => this.props.closeModifiers()}
                            calculateFn={() => this.props.closeModifiers()}
                            calculating={calculating}
                            count={count}

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -471,7 +471,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
               </Button>
             </FlexRowWrap>
           </React.Fragment>}
-          {showModifiersSlide && <ModifierPage selections={criteria}
+          {showModifiersSlide && !attributesSelection && <ModifierPage selections={criteria}
                                                closeModifiers={() => {
                                                  this.setState({showModifiersSlide: false});
                                                  this.checkCriteriaChanges();


### PR DESCRIPTION
Make the footer with the Calculate, Back and Add/Apply buttons fixed at the bottom of the Attributes & Modifiers sidebars

Top of sidebar content:
<img width="561" alt="Screen Shot 2020-09-28 at 9 54 04 AM" src="https://user-images.githubusercontent.com/40036095/94452095-c81b5280-0174-11eb-88f4-618d07d6b798.png">

Scrolled to the bottom:
<img width="548" alt="Screen Shot 2020-09-28 at 9 54 12 AM" src="https://user-images.githubusercontent.com/40036095/94452096-c8b3e900-0174-11eb-8a97-72364150200f.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
