### PR TITLE
[no ticket][risk=no] CI e2e job change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # https://circleci.com/orbs/registry/
 orbs:
-  browser-tools: circleci/browser-tools@1.0.0
+  browser-tools: circleci/browser-tools@1.0.1
 
 # -------------------------
 #   PARAMETERS
@@ -601,8 +601,7 @@ jobs:
     parallelism: << parameters.parallel_num >>
     steps:
       - checkout_init_git
-      - browser-tools/install-browser-tools:
-          firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
+      - browser-tools/install-browser-tools
       - run_e2e_test:
           env_name: << parameters.env_name >>
 
@@ -623,9 +622,7 @@ jobs:
           name: Halt job if not a pull request
           command: bash .circleci/pr-skip-ci.sh
       - halt_if_code_unchanged
-      - browser-tools/install-browser-tools:
-          firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
-          background: true
+      - browser-tools/install-browser-tools
       - start_local_ui
       - run_e2e_test:
           env_name: local
@@ -634,7 +631,7 @@ workflows:
   build-test-deploy:
     jobs:
       - puppeteer-e2e-local-ui
-      
+
   deploy-staging:
     jobs:
       - api-local-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,28 +632,28 @@ workflows:
     jobs:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
-      #- api-local-test
-      #- api-unit-test
-      #- ui-unit-test
-      #- api-bigquery-test
-      #- api-integration-test
-      #- puppeteer-e2e-local-ui
+      - api-local-test
+      - api-unit-test
+      - ui-unit-test
+      - api-bigquery-test
+      - api-integration-test
+      - puppeteer-e2e-local-ui
       # Run deployment to "test" on master merges.
-      #- api-deploy-to-test:
-          #filters: *filter_only_master_branch
-          #requires:
-            #- api-unit-test
-      #- ui-deploy-to-test:
-          #filters: *filter_only_master_branch
-          #requires:
-            #- ui-unit-test
+      - api-deploy-to-test:
+          filters: *filter_only_master_branch
+          requires:
+            - api-unit-test
+      - ui-deploy-to-test:
+          filters: *filter_only_master_branch
+          requires:
+            - ui-unit-test
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4
-          # filters: *filter_only_master_branch
-          # requires:
-            # - api-deploy-to-test
-            # - ui-deploy-to-test
+          filters: *filter_only_master_branch
+          requires:
+            - api-deploy-to-test
+            - ui-deploy-to-test
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,14 +639,14 @@ workflows:
       #- api-integration-test
       #- puppeteer-e2e-local-ui
       # Run deployment to "test" on master merges.
-      - api-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - api-unit-test
-      - ui-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - ui-unit-test
+      #- api-deploy-to-test:
+          #filters: *filter_only_master_branch
+          #requires:
+            #- api-unit-test
+      #- ui-deploy-to-test:
+          #filters: *filter_only_master_branch
+          #requires:
+            #- ui-unit-test
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,7 +630,30 @@ jobs:
 workflows:
   build-test-deploy:
     jobs:
-      - puppeteer-e2e-local-ui
+      # Always run basic test/lint/compilation (open PRs, master merge).
+      # Note: by default tags are not picked up.
+      #- api-local-test
+      #- api-unit-test
+      #- ui-unit-test
+      #- api-bigquery-test
+      #- api-integration-test
+      #- puppeteer-e2e-local-ui
+      # Run deployment to "test" on master merges.
+      - api-deploy-to-test:
+          filters: *filter_only_master_branch
+          requires:
+            - api-unit-test
+      - ui-deploy-to-test:
+          filters: *filter_only_master_branch
+          requires:
+            - ui-unit-test
+      # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
+      - puppeteer-e2e-test:
+          parallel_num: 4
+          # filters: *filter_only_master_branch
+          # requires:
+            # - api-deploy-to-test
+            # - ui-deploy-to-test
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -625,6 +625,7 @@ jobs:
       - halt_if_code_unchanged
       - browser-tools/install-browser-tools:
           firefox-version: "78.0" # https://github.com/CircleCI-Public/browser-tools-orb/issues/14
+          background: true
       - start_local_ui
       - run_e2e_test:
           env_name: local
@@ -632,31 +633,8 @@ jobs:
 workflows:
   build-test-deploy:
     jobs:
-      # Always run basic test/lint/compilation (open PRs, master merge).
-      # Note: by default tags are not picked up.
-      - api-local-test
-      - api-unit-test
-      - ui-unit-test
-      - api-bigquery-test
-      - api-integration-test
       - puppeteer-e2e-local-ui
-      # Run deployment to "test" on master merges.
-      - api-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - api-unit-test
-      - ui-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - ui-unit-test
-      # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
-      - puppeteer-e2e-test:
-          parallel_num: 4
-          filters: *filter_only_master_branch
-          requires:
-            - api-deploy-to-test
-            - ui-deploy-to-test
-
+      
   deploy-staging:
     jobs:
       - api-local-test:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,7 @@
     "test-local:debug": "cross-env WORKBENCH_ENV=local PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=2",
     "test-staging": "cross-env WORKBENCH_ENV=staging jest --maxWorkers=3",
     "test-staging:debug": "cross-env WORKBENCH_ENV=staging PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=1",
-    "test:ci": "jest --ci --maxWorkers=2",
+    "test:ci": "jest --ci --maxWorkers=3",
     "test:ci:debug": "jest --ci --debug --maxWorkers=1 --bail 1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",


### PR DESCRIPTION
Firefox install bug was resolved.
Set `maxWorkers=3` seems to work just fine for single CI run and the e2e job completed quicker. Issue may arise if too many CI jobs running concurrently that put too much load on API & UI servers.
`puppeteer-e2e-local-ui` job took under 20 minutes. https://app.circleci.com/pipelines/github/all-of-us/workbench/4314/workflows/0c778cf9-6bc8-47c8-98c4-f4868a10c571/jobs/101540
`puppeteer-e2e-test` job took under 10 minutes. https://app.circleci.com/pipelines/github/all-of-us/workbench/4317/workflows/7bba18e4-dd0e-4447-9ce1-3dbf2ec4cea9/jobs/101551