### PR TITLE
enable reporting cron  in all  envs

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -109,7 +109,7 @@
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
     "enableConceptSetSearchV2": false,
-    "enableReportingUploadCron": false,
+    "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -109,7 +109,7 @@
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
     "enableConceptSetSearchV2": false,
-    "enableReportingUploadCron": false,
+    "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -109,7 +109,7 @@
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
     "enableConceptSetSearchV2": false,
-    "enableReportingUploadCron": false,
+    "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -109,7 +109,7 @@
     "enableResearchPurposePrompt": false,
     "enableCohortBuilderV2": false,
     "enableConceptSetSearchV2": false,
-    "enableReportingUploadCron": false,
+    "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false
   },


### PR DESCRIPTION
Enable the feature flag guarding the reporting cron in all environments. Risk to user data or functionality is basically zero, as this feature is read-only w/r/t our system and only writes to the  configured BigQuery dataset.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
