### PR TITLE
[risk=no] Don't render the sidebar tab content unless active

### DIFF
--- a/e2e/app/component/help-sidebar.ts
+++ b/e2e/app/component/help-sidebar.ts
@@ -16,6 +16,9 @@ enum SectionSelectors {
   ModifiersForm = '//*[@id="modifiers-form"]',
   SelectionList = '//*[@id="selection-list"]',
 }
+enum TabSelectors {
+  Criteria = '//*[@data-test-id="help-sidebar-icon-criteria"]'
+}
 
 export default class HelpSidebar extends Container {
 
@@ -23,7 +26,13 @@ export default class HelpSidebar extends Container {
     super(page, xpath);
   }
 
+  async clickTabIcon(xpath: string): Promise<void> {
+    const icon = await this.page.waitForXPath(xpath, {visible: true});
+    await icon.click();
+  }
+
   async getPhysicalMeasurementParticipantResult(filterSign: FilterSign, filterValue: number): Promise<string> {
+    await this.clickTabIcon(TabSelectors.Criteria);
     await this.waitUntilSectionVisible(SectionSelectors.AttributesForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {ancestorLevel: 0}, this);

--- a/e2e/app/component/help-sidebar.ts
+++ b/e2e/app/component/help-sidebar.ts
@@ -16,9 +16,6 @@ enum SectionSelectors {
   ModifiersForm = '//*[@id="modifiers-form"]',
   SelectionList = '//*[@id="selection-list"]',
 }
-enum TabSelectors {
-  Criteria = '//*[@data-test-id="help-sidebar-icon-criteria"]'
-}
 
 export default class HelpSidebar extends Container {
 
@@ -26,13 +23,7 @@ export default class HelpSidebar extends Container {
     super(page, xpath);
   }
 
-  async clickTabIcon(xpath: string): Promise<void> {
-    const icon = await this.page.waitForXPath(xpath, {visible: true});
-    await icon.click();
-  }
-
   async getPhysicalMeasurementParticipantResult(filterSign: FilterSign, filterValue: number): Promise<string> {
-    await this.clickTabIcon(TabSelectors.Criteria);
     await this.waitUntilSectionVisible(SectionSelectors.AttributesForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {ancestorLevel: 0}, this);

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -13,7 +13,7 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCdrVersions, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
-import {attributesSelectionStore} from 'app/utils/navigation';
+import {attributesSelectionStore, setSidebarActiveIconStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {CdrVersion, CdrVersionListResponse, CriteriaType, DomainType} from 'generated/fetch';
 
@@ -247,6 +247,11 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
       this.props.select(param);
     }
 
+    setAttributes(node: any) {
+      attributesSelectionStore.next(node);
+      setSidebarActiveIconStore.next('criteria');
+    }
+
     showHierarchy = (row: any) => {
       this.trackEvent('More Info');
       this.props.hierarchy(row);
@@ -316,7 +321,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
         <td style={{...columnStyle, width: '31%', textAlign: 'left', borderLeft: 0, padding: '0 0.25rem'}}>
           {row.selectable && <div style={{...styles.selectDiv}}>
             {attributes &&
-              <ClrIcon style={styles.attrIcon} shape='slider' dir='right' size='20' onClick={() => attributesSelectionStore.next(row)}/>
+              <ClrIcon style={styles.attrIcon} shape='slider' dir='right' size='20' onClick={() => this.setAttributes(row)}/>
             }
             {selected && <ClrIcon style={styles.selectedIcon} shape='check-circle' size='20'/>}
             {unselected && <ClrIcon style={styles.selectIcon} shape='plus-circle' size='16' onClick={() => this.selectItem(row)}/>}

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -10,7 +10,13 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {highlightSearchTerm, reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
-import {attributesSelectionStore, currentCohortCriteriaStore, currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
+import {
+  attributesSelectionStore,
+  currentCohortCriteriaStore,
+  currentWorkspaceStore,
+  serverConfigStore,
+  setSidebarActiveIconStore
+} from 'app/utils/navigation';
 import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
 
 const COPE_SURVEY_ID = 1333342;
@@ -283,6 +289,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     if (serverConfigStore.getValue().enableCohortBuilderV2) {
       delete node.children;
       attributesSelectionStore.next(node);
+      setSidebarActiveIconStore.next('criteria');
     } else {
       this.props.setAttributes(node);
     }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -576,7 +576,6 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
       const displayContent = filteredContent !== undefined ? filteredContent : sidebarContent[helpContentKey];
 
       const contentStyle = (tab: string) => ({
-        display: activeIcon === tab ? 'block' : 'none',
         height: 'calc(100% - 1rem)',
         overflow: 'auto',
         padding: iconConfigs[tab].contentPadding || '0.5rem 0.5rem 5.5rem'
@@ -619,7 +618,7 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
                      alt='Close'/>
               </Clickable>
             </FlexRow>}
-            <div style={contentStyle(helpIconName(helpContentKey))}>
+            {activeIcon === helpIconName(helpContentKey) && <div style={contentStyle(helpIconName(helpContentKey))}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>{helpContentKey === NOTEBOOK_HELP_CONTENT ? 'Workspace storage' : 'Help Tips'}</h3>
               {helpContentKey !== NOTEBOOK_HELP_CONTENT &&
                 <div style={styles.textSearch}>
@@ -648,23 +647,23 @@ export const HelpSidebar = fp.flow(withCurrentWorkspace(), withUserProfile(), wi
                   </div>)
                 : <div style={{marginTop: '0.5rem'}}><em>No results found</em></div>
               }
-            </div>
-            <div style={contentStyle('runtime')}>
+            </div>}
+            {activeIcon === 'runtime' && <div style={contentStyle('runtime')}>
               {<RuntimePanel />}
-            </div>
-            <div style={contentStyle('annotations')}>
+            </div>}
+            {activeIcon === 'annotations' && <div style={contentStyle('annotations')}>
               {participant && <SidebarContent />}
-            </div>
-            <div style={contentStyle('criteria')}>
+            </div>}
+            {activeIcon === 'criteria' && <div style={contentStyle('criteria')}>
               <div style={{padding: '0.25rem 0.25rem 0rem'}}>
                 {!!currentCohortSearchContextStore.getValue() && <SelectionList back={() => setSidebarState(false)} selections={[]}/>}
               </div>
-            </div>
-            <div style={contentStyle('concept')}>
+            </div>}
+            {activeIcon === 'concept' && <div style={contentStyle('concept')}>
               <div style={{padding: '0.25rem 0.25rem 0rem'}}>
                 {!!currentConceptStore.getValue() && <ConceptListPage/>}
               </div>
-            </div>
+            </div>}
             {(iconConfigs[activeIcon] || {}).hideSidebarFooter || <div style={styles.footer}>
               <h3 style={{...styles.sectionTitle, marginTop: 0}}>Not finding what you're looking for?</h3>
               <p style={styles.contentItem}>


### PR DESCRIPTION
- This avoids hidden elements on the page, which interfere with testing
- This also avoids undesirable background loads which may be triggered by tab contents (currently, the runtime is unexpectedly being requested by a flagged off feature)

Note that switching tabs now may eliminate ephemeral state on the previously active tab. I'm not sure whether that was also the case previously. From manual testing, this didn't seem to cause any obvious issues.