### PR TITLE
[RW-5652][risk=no] use FETCH to eagerly associate address fields

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -123,7 +123,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
           + "  a.streetAddress2,\n"
           + "  a.zipCode\n"
           + "FROM DbUser u\n"
-          + "  LEFT OUTER JOIN DbAddress AS a ON u.userId = a.user.userId\n"
+          + "  LEFT OUTER JOIN FETCH DbAddress AS a ON u.userId = a.user.userId\n"
           + "  ORDER BY u.userId")
   List<ProjectedReportingUser> getReportingUsers();
 }


### PR DESCRIPTION
Projections against Entities in inherit attributes associated with joins,  such as `FetchType.LAZY`. Setting FETCH in the query itself should hopefully override this behavior, which is obviously very slow for large collections of users.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
