### PR TITLE
[RW-5681][risk=no] Refactor Puppeteer job in CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,9 +611,9 @@ jobs:
       parallel_num:
         type: integer
         default: 1
-      require_local_ui:
-        type: boolean
-        default: false
+      optional_steps:
+        type: steps
+        default: [ ]
     <<: *defaults
     environment:
       <<: *e2e_env
@@ -625,19 +625,24 @@ jobs:
     parallelism: << parameters.parallel_num >>
     steps:
       - checkout_init_git
-      - when:
-          # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment.
-          condition: << parameters.require_local_ui >>
-          steps:
-            - skip_e2e_commit
-            - run:
-                name: Halt job if not a pull request
-                command: bash .circleci/pr-skip-ci.sh
-            - halt_if_code_unchanged
-            - start_local_ui
+      - steps: << parameters.optional_steps >>
       - run_e2e_test:
           env_name: << parameters.env_name >>
 
+  # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment.
+  puppeteer-e2e-local-ui:
+    steps:
+      - puppeteer-e2e-test:
+          env_name: "local"
+          parallel_num: 2
+          optional_steps:
+            steps:
+              - skip_e2e_commit
+              - halt_if_code_unchanged
+              - run:
+                  name: Halt job if not a pull request
+                  command: bash .circleci/pr-skip-ci.sh
+              - start_local_ui
 
 workflows:
   build-test-deploy:
@@ -659,11 +664,8 @@ workflows:
           requires:
             - ui-unit-test
       # Run Puppeteer tests against local UI server for PR commits only.
-      - puppeteer-e2e-test:
+      - puppeteer-e2e-local-ui:
           filters: *filter_only_pr_branch
-          require_local_ui: true
-          parallel_num: 2
-          env_name: "local"
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,14 +298,21 @@ commands:
           name: Wait for local UI server to start
           command: dockerize -wait tcp://localhost:4200 -timeout 4m
 
-  e2e_skip_commit:
-    description: "Halt job if commit message contains 'SKIP E2E'"
+  store_commit_message:
     steps:
       - run:
-          name: "Halt job if commit message contains 'SKIP E2E'"
+          name: "Store Git commit message in an environment variable"
           command: |
             echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
             source $BASH_ENV
+
+  e2e_skip:
+    description: "Halt job if commit message contains 'SKIP E2E'"
+    steps:
+      - store_commit_message
+      - run:
+          name: "Halt job if commit message contains 'SKIP E2E'"
+          command: |
             echo "Git commit message: $COMMIT_MESSAGE"
             # Double comma is called "Parameter Expansion" in Bash version 4+. It converts string to lowercase letters.
             if [[ "${COMMIT_MESSAGE,,}" == *"skip e2e"* ]]; then
@@ -313,10 +320,9 @@ commands:
               circleci step halt
             fi
 
-
   e2e_presubmit_check:
     steps:
-      - e2e_skip_commit
+      - e2e_skip
       - halt_if_code_unchanged
       - run:
           name: "Halt job if not a pull request"
@@ -636,6 +642,12 @@ jobs:
     steps:
       - checkout_init_git
       - steps: << parameters.optional_steps >>
+      - when:
+          # Deploy local UI server then run Puppeteer tests against "local UI" + "test API" environment.
+          condition:
+            equal: [ "local", << parameters.env_name >>]
+          steps:
+            - start_local_ui
       - run_e2e_test:
           env_name: << parameters.env_name >>
 
@@ -666,7 +678,6 @@ workflows:
           parallel_num: 2
           optional_steps:
             - e2e_presubmit_check
-            - start_local_ui
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,7 +643,6 @@ jobs:
       - checkout_init_git
       - steps: << parameters.optional_steps >>
       - when:
-          # Deploy local UI server then run Puppeteer tests against "local UI" + "test API" environment.
           condition:
             equal: [ "local", << parameters.env_name >>]
           steps:
@@ -671,7 +670,7 @@ workflows:
           filters: *filter_only_master_branch
           requires:
             - ui-unit-test
-      # Deploy local ui server then run Puppeteer tests against "local ui" + "test api" environment for PR commits only.
+      # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only.
       - puppeteer-e2e-test:
           filters: *filter_only_pr_branch
           env_name: "local"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,13 +313,14 @@ commands:
               circleci step halt
             fi
 
+
   e2e_presubmit_check:
     steps:
       - e2e_skip_commit
       - halt_if_code_unchanged
       - run:
-        name: "Halt job if not a pull request"
-        command: bash .circleci/pr-skip-ci.sh
+          name: "Halt job if not a pull request"
+          command: bash .circleci/pr-skip-ci.sh
 
 
 # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,9 +665,8 @@ workflows:
           env_name: "local"
           parallel_num: 2
           optional_steps:
-            steps:
-              - e2e_presubmit_check
-              - start_local_ui
+            - e2e_presubmit_check
+            - start_local_ui
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,12 @@ anchors:
       # Workbench release tag format example: v5-3-rc1
       only: /^v[0-9]+-[0-9]+-rc[0-9]+$/
 
+  # Job runs for PR branches only
+  filter_only_pr_branch: &filter_only_pr_branch
+    tags:
+      ignore: /.*/
+    branches:
+      ignore: master
 
 # -------------------------
 #   COMMANDS
@@ -213,6 +219,7 @@ commands:
         enum: ["local", "test", "staging"]
     steps:
       - install_e2e_dependencies
+      - browser-tools/install-browser-tools
       - run:
           name: Update test user environment variables
           command: |
@@ -291,6 +298,20 @@ commands:
           name: Wait for local UI server to start
           command: dockerize -wait tcp://localhost:4200 -timeout 4m
 
+  skip_e2e_commit:
+    description: "Halt job if commit message contains 'SKIP E2E'"
+    steps:
+      - run:
+          name: "Halt job if commit message contains 'SKIP E2E'"
+          command: |
+            echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
+            source $BASH_ENV
+            echo "Git commit message: $COMMIT_MESSAGE"
+
+            if [[ "${COMMIT_MESSAGE,,}" == *"skip e2e"* ]]; then
+              echo "Halting e2e test."
+              circleci step halt
+            fi
 
 # -------------------------
 #        JOBS
@@ -574,14 +595,14 @@ jobs:
       - manage_api_cache:
           save: true
 
-  # Run Puppeteer e2e UI tests on deployed "test" or "staging" environment.
+  # Run Puppeteer e2e UI tests on deployed "local", "test" or "staging" environment.
   puppeteer-e2e-test:
     parameters:
       env_name:
-        description: The target environment for run Puppeteer tests. Must be one of "test", "staging".
+        description: The target environment for run Puppeteer tests. Must be one of "test", "staging", "local".
         default: "test"
         type: enum
-        enum: ["test", "staging"]
+        enum: ["test", "staging", "local"]
       test_mode:
         description: Switching between "nightly-integration" and normal "integration" test mode.
         default: "integration"
@@ -590,6 +611,9 @@ jobs:
       parallel_num:
         type: integer
         default: 1
+      require_local_ui:
+        type: boolean
+        default: false
     <<: *defaults
     environment:
       <<: *e2e_env
@@ -601,31 +625,19 @@ jobs:
     parallelism: << parameters.parallel_num >>
     steps:
       - checkout_init_git
-      - browser-tools/install-browser-tools
+      - when:
+          # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment.
+          condition: << parameters.require_local_ui >>
+          steps:
+            - skip_e2e_commit
+            - run:
+                name: Halt job if not a pull request
+                command: bash .circleci/pr-skip-ci.sh
+            - halt_if_code_unchanged
+            - start_local_ui
       - run_e2e_test:
           env_name: << parameters.env_name >>
 
-  # Deploy UI local server then run Puppeteer tests against "local ui" + "test api" environment.
-  puppeteer-e2e-local-ui:
-    <<: *defaults
-    environment:
-      <<: *e2e_env
-      WORKBENCH_ENV: local
-      CI: true
-      NODE_ENV: development
-    resource_class: medium+
-    working_directory: ~/workbench
-    parallelism: 2
-    steps:
-      - checkout_init_git
-      - run:
-          name: Halt job if not a pull request
-          command: bash .circleci/pr-skip-ci.sh
-      - halt_if_code_unchanged
-      - browser-tools/install-browser-tools
-      - start_local_ui
-      - run_e2e_test:
-          env_name: local
 
 workflows:
   build-test-deploy:
@@ -637,7 +649,6 @@ workflows:
       - ui-unit-test
       - api-bigquery-test
       - api-integration-test
-      - puppeteer-e2e-local-ui
       # Run deployment to "test" on master merges.
       - api-deploy-to-test:
           filters: *filter_only_master_branch
@@ -647,9 +658,16 @@ workflows:
           filters: *filter_only_master_branch
           requires:
             - ui-unit-test
+      # Run Puppeteer tests against local UI server for PR commits only.
+      - puppeteer-e2e-test:
+          filters: *filter_only_pr_branch
+          require_local_ui: true
+          parallel_num: 2
+          env_name: "local"
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4
+          env_name: "test"
           filters: *filter_only_master_branch
           requires:
             - api-deploy-to-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,7 +659,7 @@ workflows:
           filters: *filter_only_master_branch
           requires:
             - ui-unit-test
-      # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment for PR commits only.
+      # Deploy local ui server then run Puppeteer tests against "local ui" + "test api" environment for PR commits only.
       - puppeteer-e2e-test:
           filters: *filter_only_pr_branch
           env_name: "local"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ commands:
           name: Wait for local UI server to start
           command: dockerize -wait tcp://localhost:4200 -timeout 4m
 
-  skip_e2e_commit:
+  e2e_skip_commit:
     description: "Halt job if commit message contains 'SKIP E2E'"
     steps:
       - run:
@@ -307,11 +307,20 @@ commands:
             echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
             source $BASH_ENV
             echo "Git commit message: $COMMIT_MESSAGE"
-
+            # Double comma is called "Parameter Expansion" in Bash version 4+. It converts string to lowercase letters.
             if [[ "${COMMIT_MESSAGE,,}" == *"skip e2e"* ]]; then
               echo "Halting e2e test."
               circleci step halt
             fi
+
+  e2e_presubmit_check:
+    steps:
+      - e2e_skip_commit
+      - halt_if_code_unchanged
+      - run:
+        name: "Halt job if not a pull request"
+        command: bash .circleci/pr-skip-ci.sh
+
 
 # -------------------------
 #        JOBS
@@ -629,20 +638,6 @@ jobs:
       - run_e2e_test:
           env_name: << parameters.env_name >>
 
-  # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment.
-  puppeteer-e2e-local-ui:
-    steps:
-      - puppeteer-e2e-test:
-          env_name: "local"
-          parallel_num: 2
-          optional_steps:
-            steps:
-              - skip_e2e_commit
-              - halt_if_code_unchanged
-              - run:
-                  name: Halt job if not a pull request
-                  command: bash .circleci/pr-skip-ci.sh
-              - start_local_ui
 
 workflows:
   build-test-deploy:
@@ -663,9 +658,15 @@ workflows:
           filters: *filter_only_master_branch
           requires:
             - ui-unit-test
-      # Run Puppeteer tests against local UI server for PR commits only.
-      - puppeteer-e2e-local-ui:
+      # Deploy local UI server then run Puppeteer tests against "local ui" + "test api" environment for PR commits only.
+      - puppeteer-e2e-test:
           filters: *filter_only_pr_branch
+          env_name: "local"
+          parallel_num: 2
+          optional_steps:
+            steps:
+              - e2e_presubmit_check
+              - start_local_ui
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
       - puppeteer-e2e-test:
           parallel_num: 4


### PR DESCRIPTION
If "SKIP E2E" string (case-insensitive) is present in a PR commit message, CircleCI will not run `puppeteer-e2e-test` job.

Halted job screenshot:
![Screen Shot 2020-09-30 at 3 12 07 PM](https://user-images.githubusercontent.com/35533885/94729209-5c311980-032f-11eb-92a5-7b6840b738f7.png)

Continued job screenshot:
![Screen Shot 2020-09-30 at 3 14 36 PM](https://user-images.githubusercontent.com/35533885/94729482-ba5dfc80-032f-11eb-91b6-b8a8160428a8.png)


Also, single `puppeteer-e2e-test` job to run for PR commits and master branch merge.