### PR TITLE
disable compile warnings for untyped client result

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -83,18 +83,20 @@ public interface LeonardoMapper {
   @AfterMapping
   default void getRuntimeAfterMapper(
       @MappingTarget Runtime runtime, LeonardoGetRuntimeResponse leonardoGetRuntimeResponse) {
-    mapLabels(runtime, (Map<String, String>) leonardoGetRuntimeResponse.getLabels());
+    mapLabels(runtime, leonardoGetRuntimeResponse.getLabels());
     mapRuntimeConfig(runtime, leonardoGetRuntimeResponse.getRuntimeConfig());
   }
 
   @AfterMapping
   default void listRuntimeAfterMapper(
       @MappingTarget Runtime runtime, LeonardoListRuntimeResponse leonardoListRuntimeResponse) {
-    mapLabels(runtime, (Map<String, String>) leonardoListRuntimeResponse.getLabels());
+    mapLabels(runtime, leonardoListRuntimeResponse.getLabels());
     mapRuntimeConfig(runtime, leonardoListRuntimeResponse.getRuntimeConfig());
   }
 
-  default void mapLabels(Runtime runtime, Map<String, String> runtimeLabels) {
+  default void mapLabels(Runtime runtime, Object runtimeLabelsObj) {
+    @SuppressWarnings("unchecked")
+    final Map<String, String> runtimeLabels = (Map<String, String>) runtimeLabelsObj;
     if (runtimeLabels == null || runtimeLabels.get(RUNTIME_LABEL_AOU_CONFIG) == null) {
       // If there's no label, fall back onto the old behavior where every Runtime was created with a
       // default Dataproc config


### PR DESCRIPTION
The Leonardo  client for some reason returns a  Object that has to be downcast into a `Map<String, String>`. Make a wrapper method to do this and locally disable the unchecked warning.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
