### PR TITLE
[RW-5652][risk=no] Fix mapping cardinality

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -112,7 +112,7 @@ public class DbUser {
   private Timestamp lastModifiedTime;
   private Timestamp twoFactorAuthBypassTime;
   private DbDemographicSurvey demographicSurvey;
-  private Set<DbAddress> addresses;
+  private Set<DbAddress> addresses = new HashSet<>();
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -697,6 +697,14 @@ public class DbUser {
     this.professionalUrl = professionalUrl;
   }
 
+  /**
+   * The mapping from user:address is logically 1:1 in the app, but is modeled as 1:many in the DB.
+   * As a workaround until we're ready to correrct the constraint in the schema, I've added a
+   * binding to a Set to allow multiple addresses to be stored and also exposed a transient setter
+   * and getter for a single address.
+   *
+   * @return
+   */
   @OneToMany(
       cascade = CascadeType.ALL,
       orphanRemoval = true,
@@ -710,7 +718,14 @@ public class DbUser {
     this.addresses = address;
   }
 
+  /**
+   * This set may be initially null, but if this method is called with a null parameter, we set it
+   * to empty.
+   *
+   * @param address
+   */
   @Transient
+  @Nullable
   public void setAddress(DbAddress address) {
     if (address != null) {
       setAddresses(Collections.singleton(address));

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -62,5 +62,6 @@ public interface ProfileMapper {
       target = "moodleId",
       ignore = true) // handled by UserService.syncComplianceTraining[V1|V2]
   @Mapping(target = "version", ignore = true)
+  @Mapping(target = "addresses", ignore = true)
   DbUser profileToDbUser(Profile profile);
 }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -198,14 +198,17 @@ public class RdrExportServiceImpl implements RdrExportService {
       researcher.setEmail(dbUser.getContactEmail());
     }
 
-    if (dbUser.getAddress() != null) {
-      researcher.setStreetAddress1(dbUser.getAddress().getStreetAddress1());
-      researcher.setStreetAddress2(dbUser.getAddress().getStreetAddress2());
-      researcher.setCity(dbUser.getAddress().getCity());
-      researcher.setState(dbUser.getAddress().getState());
-      researcher.setCountry(dbUser.getAddress().getCountry());
-      researcher.setZipCode(dbUser.getAddress().getZipCode());
-    }
+    Optional.ofNullable(dbUser.getAddress())
+        .ifPresent(
+            a -> {
+              researcher.setStreetAddress1(a.getStreetAddress1());
+              researcher.setStreetAddress2(a.getStreetAddress2());
+              researcher.setCity(a.getCity());
+              researcher.setState(a.getState());
+              researcher.setCountry(a.getCountry());
+              researcher.setZipCode(a.getZipCode());
+            });
+
     DbDemographicSurvey dbDemographicSurvey = dbUser.getDemographicSurvey();
     if (null != dbDemographicSurvey) {
       researcher.setDisability(

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -168,7 +168,7 @@ public class UserDaoTest {
     final DbAddress address = ReportingTestUtils.createDbAddress();
     DbUser user = ReportingTestUtils.createDbUser();
     assertThat(user.getAddress()).isNull();
-    assertThat(user.getAddresses()).isNull(); // no ctor
+    assertThat(user.getAddresses()).isEmpty();
     user.setAddress(address);
     address.setUser(user);
     user = userDao.save(user);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -15,6 +15,7 @@ import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.testconfig.ReportingTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -124,7 +125,7 @@ public class UserDaoTest {
       user.setBetaAccessRequestTime(BETA_ACCESS_REQUEST_TIME);
       final DbAddress address = stubAddress();
       address.setUser(user);
-      user.setAddress(address); // ?
+      user.setAddress(address);
       user.setDisabled(isDisabled);
       if (isBetaBypassed) {
         user.setBetaAccessBypassTime(NOW);
@@ -159,5 +160,21 @@ public class UserDaoTest {
     assertThat(user.getCity()).isEqualTo(CITY);
     assertThat(user.getState()).isEqualTo(STATE);
     assertThat(user.getCountry()).isEqualTo(COUNTRY);
+  }
+
+  @Test
+  public void testAddressWorkaround() {
+
+    final DbAddress address = ReportingTestUtils.createDbAddress();
+    DbUser user = ReportingTestUtils.createDbUser();
+    assertThat(user.getAddress()).isNull();
+    assertThat(user.getAddresses()).isNull(); // no ctor
+    user.setAddress(address);
+    address.setUser(user);
+    user = userDao.save(user);
+
+    assertThat(user.getAddress()).isEqualTo(address);
+    assertThat(user.getAddress().getUser()).isEqualTo(user);
+    assertThat(user.getAddresses()).hasSize(1);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import org.pmiops.workbench.db.dao.projection.ProjectedReportingCohort;
 import org.pmiops.workbench.db.dao.projection.ProjectedReportingUser;
 import org.pmiops.workbench.db.dao.projection.ProjectedReportingWorkspace;
+import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbStorageEnums;
@@ -146,9 +147,7 @@ public class ReportingTestUtils {
   public static final Timestamp COHORT__LAST_MODIFIED_TIME =
       Timestamp.from(Instant.parse("2015-05-10T00:00:00.00Z"));
   public static final String COHORT__NAME = "foo_6";
-  public static final String COHORT__TYPE = "foo_7";
-  public static final Short COHORT__VERSION = 8;
-  public static final Long COHORT__WORKSPACE_ID = 9L;
+  public static final Long COHORT__WORKSPACE_ID = 7L;
 
   public static void assertDtoUserFields(ReportingUser user) {
     assertThat(user.getAboutYou()).isEqualTo(USER__ABOUT_YOU);
@@ -558,8 +557,6 @@ public class ReportingTestUtils {
     doReturn(COHORT__DESCRIPTION).when(mockCohort).getDescription();
     doReturn(COHORT__LAST_MODIFIED_TIME).when(mockCohort).getLastModifiedTime();
     doReturn(COHORT__NAME).when(mockCohort).getName();
-    doReturn(COHORT__TYPE).when(mockCohort).getType();
-    doReturn(COHORT__VERSION).when(mockCohort).getVersion();
     doReturn(COHORT__WORKSPACE_ID).when(mockCohort).getWorkspaceId();
     return mockCohort;
   }
@@ -576,8 +573,6 @@ public class ReportingTestUtils {
     assertThat(cohort.getDescription()).isEqualTo(COHORT__DESCRIPTION);
     assertTimeApprox(cohort.getLastModifiedTime(), COHORT__LAST_MODIFIED_TIME);
     assertThat(cohort.getName()).isEqualTo(COHORT__NAME);
-    assertThat(cohort.getType()).isEqualTo(COHORT__TYPE);
-    assertThat(cohort.getVersion()).isEqualTo(COHORT__VERSION);
     assertThat(cohort.getWorkspaceId()).isEqualTo(expectedWorkspaceId);
   }
 
@@ -589,8 +584,6 @@ public class ReportingTestUtils {
     assertThat(cohort.getDescription()).isEqualTo(COHORT__DESCRIPTION);
     assertTimeApprox(cohort.getLastModifiedTime(), COHORT__LAST_MODIFIED_TIME);
     assertThat(cohort.getName()).isEqualTo(COHORT__NAME);
-    assertThat(cohort.getType()).isEqualTo(COHORT__TYPE);
-    assertThat(cohort.getVersion()).isEqualTo(COHORT__VERSION);
     assertThat(cohort.getWorkspaceId()).isEqualTo(COHORT__WORKSPACE_ID);
   }
 
@@ -603,8 +596,6 @@ public class ReportingTestUtils {
         .description(COHORT__DESCRIPTION)
         .lastModifiedTime(offsetDateTimeUtc(COHORT__LAST_MODIFIED_TIME))
         .name(COHORT__NAME)
-        .type(COHORT__TYPE)
-        .version(COHORT__VERSION.intValue()) // manual fixup
         .workspaceId(COHORT__WORKSPACE_ID);
   }
 
@@ -617,8 +608,6 @@ public class ReportingTestUtils {
     cohort.setDescription(COHORT__DESCRIPTION);
     cohort.setLastModifiedTime(COHORT__LAST_MODIFIED_TIME);
     cohort.setName(COHORT__NAME);
-    cohort.setType(COHORT__TYPE);
-    cohort.setVersion(COHORT__VERSION);
     cohort.setWorkspaceId(dbWorkspace.getWorkspaceId());
     return cohort;
   }
@@ -636,5 +625,16 @@ public class ReportingTestUtils {
     return (reportingSnapshot.getCohorts().isEmpty() ? 0 : 1)
         + (reportingSnapshot.getUsers().isEmpty() ? 0 : 1)
         + (reportingSnapshot.getWorkspaces().isEmpty() ? 0 : 1);
+  }
+
+  public static DbAddress createDbAddress() {
+    final DbAddress address = new DbAddress();
+    address.setCity(USER__CITY);
+    address.setCountry(USER__COUNTRY);
+    address.setState(USER__STATE);
+    address.setStreetAddress1(USER__STREET_ADDRESS_1);
+    address.setStreetAddress2(USER__STREET_ADDRESS_2);
+    address.setZipCode(USER__ZIP_CODE);
+    return address;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -147,7 +147,9 @@ public class ReportingTestUtils {
   public static final Timestamp COHORT__LAST_MODIFIED_TIME =
       Timestamp.from(Instant.parse("2015-05-10T00:00:00.00Z"));
   public static final String COHORT__NAME = "foo_6";
-  public static final Long COHORT__WORKSPACE_ID = 7L;
+  public static final String COHORT__TYPE = "foo_7";
+  public static final Short COHORT__VERSION = 8;
+  public static final Long COHORT__WORKSPACE_ID = 9L;
 
   public static void assertDtoUserFields(ReportingUser user) {
     assertThat(user.getAboutYou()).isEqualTo(USER__ABOUT_YOU);
@@ -557,6 +559,8 @@ public class ReportingTestUtils {
     doReturn(COHORT__DESCRIPTION).when(mockCohort).getDescription();
     doReturn(COHORT__LAST_MODIFIED_TIME).when(mockCohort).getLastModifiedTime();
     doReturn(COHORT__NAME).when(mockCohort).getName();
+    doReturn(COHORT__TYPE).when(mockCohort).getType();
+    doReturn(COHORT__VERSION).when(mockCohort).getVersion();
     doReturn(COHORT__WORKSPACE_ID).when(mockCohort).getWorkspaceId();
     return mockCohort;
   }
@@ -573,6 +577,8 @@ public class ReportingTestUtils {
     assertThat(cohort.getDescription()).isEqualTo(COHORT__DESCRIPTION);
     assertTimeApprox(cohort.getLastModifiedTime(), COHORT__LAST_MODIFIED_TIME);
     assertThat(cohort.getName()).isEqualTo(COHORT__NAME);
+    assertThat(cohort.getType()).isEqualTo(COHORT__TYPE);
+    assertThat(cohort.getVersion()).isEqualTo(COHORT__VERSION);
     assertThat(cohort.getWorkspaceId()).isEqualTo(expectedWorkspaceId);
   }
 
@@ -584,6 +590,8 @@ public class ReportingTestUtils {
     assertThat(cohort.getDescription()).isEqualTo(COHORT__DESCRIPTION);
     assertTimeApprox(cohort.getLastModifiedTime(), COHORT__LAST_MODIFIED_TIME);
     assertThat(cohort.getName()).isEqualTo(COHORT__NAME);
+    assertThat(cohort.getType()).isEqualTo(COHORT__TYPE);
+    assertThat(cohort.getVersion()).isEqualTo(COHORT__VERSION);
     assertThat(cohort.getWorkspaceId()).isEqualTo(COHORT__WORKSPACE_ID);
   }
 
@@ -596,6 +604,8 @@ public class ReportingTestUtils {
         .description(COHORT__DESCRIPTION)
         .lastModifiedTime(offsetDateTimeUtc(COHORT__LAST_MODIFIED_TIME))
         .name(COHORT__NAME)
+        .type(COHORT__TYPE)
+        .version(COHORT__VERSION.intValue()) // manual fixup
         .workspaceId(COHORT__WORKSPACE_ID);
   }
 
@@ -608,6 +618,8 @@ public class ReportingTestUtils {
     cohort.setDescription(COHORT__DESCRIPTION);
     cohort.setLastModifiedTime(COHORT__LAST_MODIFIED_TIME);
     cohort.setName(COHORT__NAME);
+    cohort.setType(COHORT__TYPE);
+    cohort.setVersion(COHORT__VERSION);
     cohort.setWorkspaceId(dbWorkspace.getWorkspaceId());
     return cohort;
   }


### PR DESCRIPTION
Since setting FETCH by itself didn't work, I believe  fixing an issue in the mapping of the entity class to the DbAddress entity is the next logical thing to try.

Each user may technically (accorrding to the DB schema) have many addresses.  However, the application only recognizes it as a 1:1 mapping. Instead of doing a migration just yet to make the `user_id` unique in the `address` table, I'm adding transient methods to set  and retrieve a single address and adding a mapping to a `Set<DbAddress>` in the entity. This fixes the IDE warning about the mapping cardinality; hopefully it will help with proxy management too.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
