### PR TITLE
[risk=no] Temporarily disable billing buffer cron in test

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -26,7 +26,7 @@
     "projectNamePrefix": "aou-rw-local1-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 2,
+    "bufferCapacity": 0,
     "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -26,7 +26,7 @@
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 100,
+    "bufferCapacity": 0,
     "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [


### PR DESCRIPTION
Rawls is over some quota limit, which should be restored tomorrow. Revert once confirming with cloud integrations.