### PR TITLE
[RW-5684][risk=no] Enable Cloud Profiler for API server

### DIFF
--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -4,6 +4,11 @@
   <threadsafe>true</threadsafe>
   <!-- Deploy complains about this tag, bug BigQuery needs it. -->
   <application>all-of-us-workbench-test</application>
+
+  <env-variables>
+    <env-var name="GAE_PROFILER_MODE" value="cpu,heap" />
+  </env-variables>
+
   <system-properties>
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
 


### PR DESCRIPTION
As far as I can tell from the [docs](https://cloud.google.com/profiler/docs/profiling-java#starting_your_program), this line should be enough to get cloud profiler working for a Java 8 GAE app. I've turned on the 