### PR TITLE
[RW-5652][risk=no] Quick Perf test with no SQL join

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -86,6 +86,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   // Manual modification should be avoided if possible as this is a one-time generation
   // and does not run on every build and updates must be merged manually for now.
 
+  // FIXME: join is temporarily disabled for perf testing
   @Query(
       "SELECT\n"
           + "  u.aboutYou,\n"
@@ -116,14 +117,13 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
           + "  u.twoFactorAuthCompletionTime,\n"
           + "  u.userId,\n"
           + "  u.username,\n"
-          + "  a.city,\n"
-          + "  a.country,\n"
-          + "  a.state,\n"
-          + "  a.streetAddress1,\n"
-          + "  a.streetAddress2,\n"
-          + "  a.zipCode\n"
+          + "  'San Antonio' AS city,\n"
+          + "  'USA' AS country,\n"
+          + "  'TX' AS state,\n"
+          + "  '111 Cactus Dr.' AS streetAddress1,\n"
+          + "  '# 333'  AS streetAddress2,\n"
+          + "  '11111-2222' AS zipCode\n"
           + "FROM DbUser u\n"
-          + "  LEFT OUTER JOIN FETCH DbAddress AS a ON u.userId = a.user.userId\n"
           + "  ORDER BY u.userId")
   List<ProjectedReportingUser> getReportingUsers();
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -28,11 +28,11 @@ public class UserDaoTest {
   private static final Timestamp NOW = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
   private static final Timestamp BETA_ACCESS_REQUEST_TIME =
       Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
-  private static final String STREET_ADDRESS_1 = "101 Main St";
-  private static final String STREET_ADDRESS_2 = "# 202";
-  private static final String CITY = "New Braunfels";
+  private static final String STREET_ADDRESS_1 = "111 Cactus Dr.";
+  private static final String STREET_ADDRESS_2 = "# 333";
+  private static final String CITY = "San Antonio";
   private static final String STATE = "TX";
-  private static final String COUNTRY = "US";
+  private static final String COUNTRY = "USA";
 
   @Autowired private UserDao userDao;
 


### PR DESCRIPTION
Assumption at this point is that the explosion in query/projection/proxy time & memory is due to lots of lazy fetches. To see if this  is plausible, I want to  see the timing when I have no JOINs at all. To do this, I've simply returned fixed values for the address fields instead of joining on the address table.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
