### PR TITLE
[RW-5652][RISK=NO] upgrade GAE  instance class on test env

### DIFF
--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -23,3 +23,4 @@ WORKBENCH_ENV=local
 # GAE_*_INSTANCES variables are substituted into the API appengine-web.xml
 GAE_MIN_IDLE_INSTANCES=1
 GAE_MAX_INSTANCES=10
+GAE_INSTANCE_CLASS=F1

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -71,7 +71,7 @@ ENVIRONMENTS = {
     :config_json => "config_perf.json",
     :cdr_versions_json => "cdr_versions_perf.json",
     :featured_workspaces_json => "featured_workspaces_perf.json",
-    :gae_vars => make_gae_vars(20, 20, 'all-of-us-rw-perf')
+    :gae_vars => make_gae_vars(20, 20)
   },
   "all-of-us-rw-stable" => {
     :env_name => "stable",

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -26,13 +26,13 @@ SERVICES = %W{servicemanagement.googleapis.com storage-component.googleapis.com 
               clouderrorreporting.googleapis.com bigquery-json.googleapis.com}
 DRY_RUN_CMD = %W{echo [DRY_RUN]}
 
-def make_gae_vars(min, max)
+def make_gae_vars(min_idle_instances = 0, max_instances = 10, instance_class = 'F1')
   {
-    "GAE_MIN_IDLE_INSTANCES" => min.to_s,
-    "GAE_MAX_INSTANCES" => max.to_s
+    "GAE_MIN_IDLE_INSTANCES" => min_idle_instances.to_s,
+    "GAE_MAX_INSTANCES" => max_instances.to_s,
+    'GAE_INSTANCE_CLASS' => instance_class
   }
 end
-TEST_GAE_VARS = make_gae_vars(0, 10)
 
 # TODO: Make environment/project flags consistent across commands, consider
 # using a environment keywords as dict keys here, e.g. :test, :staging, etc.
@@ -44,7 +44,7 @@ ENVIRONMENTS = {
     :config_json => "config_local.json",
     :cdr_versions_json => "cdr_versions_local.json",
     :featured_workspaces_json => "featured_workspaces_local.json",
-    :gae_vars => TEST_GAE_VARS
+    :gae_vars => make_gae_vars
   },
   "all-of-us-workbench-test" => {
     :env_name => "test",
@@ -53,7 +53,7 @@ ENVIRONMENTS = {
     :config_json => "config_test.json",
     :cdr_versions_json => "cdr_versions_test.json",
     :featured_workspaces_json => "featured_workspaces_test.json",
-    :gae_vars => TEST_GAE_VARS
+    :gae_vars => make_gae_vars(0, 10, 'F4_1G')
   },
   "all-of-us-rw-staging" => {
     :env_name => "staging",
@@ -62,7 +62,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_versions_json => "cdr_versions_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => TEST_GAE_VARS
+    :gae_vars => make_gae_vars
   },
   "all-of-us-rw-perf" => {
     :env_name => "perf",
@@ -71,7 +71,7 @@ ENVIRONMENTS = {
     :config_json => "config_perf.json",
     :cdr_versions_json => "cdr_versions_perf.json",
     :featured_workspaces_json => "featured_workspaces_perf.json",
-    :gae_vars => make_gae_vars(20, 20)
+    :gae_vars => make_gae_vars(20, 20, 'all-of-us-rw-perf')
   },
   "all-of-us-rw-stable" => {
     :env_name => "stable",
@@ -80,7 +80,7 @@ ENVIRONMENTS = {
     :config_json => "config_stable.json",
     :cdr_versions_json => "cdr_versions_stable.json",
     :featured_workspaces_json => "featured_workspaces_stable.json",
-    :gae_vars => TEST_GAE_VARS
+    :gae_vars => make_gae_vars
   },
   "all-of-us-rw-preprod" => {
     :env_name => "preprod",
@@ -89,7 +89,7 @@ ENVIRONMENTS = {
     :config_json => "config_preprod.json",
     :cdr_versions_json => "cdr_versions_preprod.json",
     :featured_workspaces_json => "featured_workspaces_preprod.json",
-    :gae_vars => TEST_GAE_VARS
+    :gae_vars => make_gae_vars
   },
   "all-of-us-rw-prod" => {
     :env_name => "prod",

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -86,7 +86,6 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   // Manual modification should be avoided if possible as this is a one-time generation
   // and does not run on every build and updates must be merged manually for now.
 
-  // FIXME: join is temporarily disabled for perf testing
   @Query(
       "SELECT\n"
           + "  u.aboutYou,\n"
@@ -117,13 +116,14 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
           + "  u.twoFactorAuthCompletionTime,\n"
           + "  u.userId,\n"
           + "  u.username,\n"
-          + "  'San Antonio' AS city,\n"
-          + "  'USA' AS country,\n"
-          + "  'TX' AS state,\n"
-          + "  '111 Cactus Dr.' AS streetAddress1,\n"
-          + "  '# 333'  AS streetAddress2,\n"
-          + "  '11111-2222' AS zipCode\n"
+          + "  a.city,\n"
+          + "  a.country,\n"
+          + "  a.state,\n"
+          + "  a.streetAddress1,\n"
+          + "  a.streetAddress2,\n"
+          + "  a.zipCode\n"
           + "FROM DbUser u\n"
+          + "  LEFT OUTER JOIN FETCH DbAddress AS a ON u.userId = a.user.userId\n"
           + "  ORDER BY u.userId")
   List<ProjectedReportingUser> getReportingUsers();
 }

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -48,5 +48,6 @@
   <automatic-scaling>
     <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
+    <instance-class>${GAE_INSTANCE_CLASS}</instance-class>
   </automatic-scaling>
 </appengine-web-app>

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -28,11 +28,11 @@ public class UserDaoTest {
   private static final Timestamp NOW = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
   private static final Timestamp BETA_ACCESS_REQUEST_TIME =
       Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
-  private static final String STREET_ADDRESS_1 = "111 Cactus Dr.";
-  private static final String STREET_ADDRESS_2 = "# 333";
-  private static final String CITY = "San Antonio";
+  private static final String STREET_ADDRESS_1 = "101 Main St";
+  private static final String STREET_ADDRESS_2 = "# 202";
+  private static final String CITY = "New Braunfels";
   private static final String STATE = "TX";
-  private static final String COUNTRY = "USA";
+  private static final String COUNTRY = "US";
 
   @Autowired private UserDao userDao;
 


### PR DESCRIPTION
The available memory for F1  instance class on AppEngine is  256 MB.  The reporting implementation currently loads all the needed snapshot  data into memory at  once, which pushes and frequently exceeds this limit on test.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
