### PR TITLE
[RW-3389] [RW-4125] [risk=no] Speed up user admin table load time & refresh the UI

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -544,7 +544,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<UserListResponse> getAllUsers() {
-    return ResponseEntity.ok(new UserListResponse().profileList(profileService.listAllProfiles()));
+    return ResponseEntity.ok(new UserListResponse().users(profileService.listAllProfiles()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -544,7 +544,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<AdminUserListResponse> getAllUsers() {
-    return ResponseEntity.ok(new AdminUserListResponse().users(profileService.listAllProfiles()));
+    return ResponseEntity.ok(new AdminUserListResponse().users(profileService.getAdminTableUsers()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -544,7 +544,8 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<AdminUserListResponse> getAllUsers() {
-    return ResponseEntity.ok(new AdminUserListResponse().users(profileService.getAdminTableUsers()));
+    return ResponseEntity.ok(
+        new AdminUserListResponse().users(profileService.getAdminTableUsers()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -45,6 +45,7 @@ import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.AccountPropertyUpdate;
 import org.pmiops.workbench.model.Address;
+import org.pmiops.workbench.model.AdminUserListResponse;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.BillingProjectStatus;
 import org.pmiops.workbench.model.CreateAccountRequest;
@@ -58,7 +59,6 @@ import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.ResendWelcomeEmailRequest;
 import org.pmiops.workbench.model.UpdateContactEmailRequest;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
-import org.pmiops.workbench.model.UserListResponse;
 import org.pmiops.workbench.model.UsernameTakenResponse;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.moodle.ApiException;
@@ -543,8 +543,8 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<UserListResponse> getAllUsers() {
-    return ResponseEntity.ok(new UserListResponse().users(profileService.listAllProfiles()));
+  public ResponseEntity<AdminUserListResponse> getAllUsers() {
+    return ResponseEntity.ok(new AdminUserListResponse().users(profileService.listAllProfiles()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -74,22 +74,27 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
     Long getUserCount();
   }
 
+  // Note: setter methods are included only where necessary for testing. See ProfileServiceTest.
   interface DbAdminTableUser {
     Long getUserId();
+    void setUserId(Long userId);
 
     String getUsername();
 
     Short getDataAccessLevel();
 
     Boolean getDisabled();
+    void setDisabled(Boolean disabled);
 
     String getGivenName();
 
     String getFamilyName();
 
     String getContactEmail();
+    void setContactEmail(String contactEmail);
 
     String getInstitutionName();
+    void setInstitutionName(String institutionName);
 
     Timestamp getFirstRegistrationCompletionTime();
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -77,6 +77,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   // Note: setter methods are included only where necessary for testing. See ProfileServiceTest.
   interface DbAdminTableUser {
     Long getUserId();
+
     void setUserId(Long userId);
 
     String getUsername();
@@ -84,6 +85,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
     Short getDataAccessLevel();
 
     Boolean getDisabled();
+
     void setDisabled(Boolean disabled);
 
     String getGivenName();
@@ -91,9 +93,11 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
     String getFamilyName();
 
     String getContactEmail();
+
     void setContactEmail(String contactEmail);
 
     String getInstitutionName();
+
     void setInstitutionName(String institutionName);
 
     Timestamp getFirstRegistrationCompletionTime();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import org.pmiops.workbench.db.model.DbUser;
@@ -72,4 +73,70 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Long getUserCount();
   }
+
+  interface DbAdminTableUser {
+    Long getUserId();
+
+    String getUsername();
+
+    Short getDataAccessLevel();
+
+    Boolean getDisabled();
+
+    String getGivenName();
+
+    String getFamilyName();
+
+    String getContactEmail();
+
+    String getInstitutionName();
+
+    Timestamp getFirstRegistrationCompletionTime();
+
+    Timestamp getFirstSignInTime();
+
+    Timestamp getCreationTime();
+
+    Timestamp getDataUseAgreementBypassTime();
+
+    Timestamp getDataUseAgreementCompletionTime();
+
+    Timestamp getComplianceTrainingBypassTime();
+
+    Timestamp getComplianceTrainingCompletionTime();
+
+    Timestamp getBetaAccessBypassTime();
+
+    Timestamp getEmailVerificationBypassTime();
+
+    Timestamp getEmailVerificationCompletionTime();
+
+    Timestamp getEraCommonsBypassTime();
+
+    Timestamp getEraCommonsCompletionTime();
+
+    Timestamp getIdVerificationBypassTime();
+
+    Timestamp getIdVerificationCompletionTime();
+
+    Timestamp getTwoFactorAuthBypassTime();
+
+    Timestamp getTwoFactorAuthCompletionTime();
+  }
+
+  @Query(
+      "SELECT u.userId, u.username, u.dataAccessLevel, u.disabled, u.givenName, u.familyName, "
+          + "u.contactEmail, i.displayName AS institutionName, "
+          + "u.firstRegistrationCompletionTime, u.creationTime, u.firstSignInTime, "
+          + "u.dataUseAgreementBypassTime, u.dataUseAgreementCompletionTime, "
+          + "u.complianceTrainingBypassTime, u.complianceTrainingCompletionTime, "
+          + "u.betaAccessBypassTime, "
+          + "u.emailVerificationBypassTime, u.emailVerificationCompletionTime, "
+          + "u.eraCommonsBypassTime, u.eraCommonsCompletionTime, "
+          + "u.idVerificationBypassTime, u.idVerificationCompletionTime, "
+          + "u.twoFactorAuthBypassTime, u.twoFactorAuthCompletionTime "
+          + "FROM DbUser u "
+          + "LEFT JOIN DbVerifiedInstitutionalAffiliation AS a ON u.userId = a.user.userId "
+          + "LEFT JOIN DbInstitution AS i ON i.institutionId = a.institution.institutionId")
+  List<DbAdminTableUser> getAdminTableUsers();
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -2,9 +2,11 @@ package org.pmiops.workbench.profile;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
+import org.pmiops.workbench.model.AdminTableUser;
 import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -32,6 +34,8 @@ public interface ProfileMapper {
       DbUserTermsOfService latestTermsOfService,
       Double freeTierUsage,
       Double freeTierDollarQuota);
+
+  AdminTableUser adminViewToModel(UserDao.DbAdminTableUser dbUser);
 
   @Mapping(target = "authoritiesEnum", ignore = true) // derived property
   @Mapping(target = "billingProjectRetries", ignore = true) // I don't think we actually use this

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -455,7 +455,7 @@ public class ProfileService {
     validateProfileForCorrectness(dummyProfile, profile);
   }
 
-  public List<AdminTableUser> listAllProfiles() {
+  public List<AdminTableUser> getAdminTableUsers() {
     return userDao.getAdminTableUsers().stream()
         .map(dbUser -> profileMapper.adminViewToModel(dbUser))
         .collect(ImmutableList.toImmutableList());

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5096,6 +5096,77 @@ definitions:
       jwt:
         type: string
         description: the encoded/signed JWT
+  AdminTableUser:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+      username:
+        type: string
+      dataAccessLevel:
+        "$ref": "#/definitions/DataAccessLevel"
+      givenName:
+        type: string
+      familyName:
+        type: string
+      disabled:
+        type: boolean
+        default: false
+      contactEmail:
+        type: string
+      institutionName:
+        description: Verified institution name
+        type: string
+      firstRegistrationCompletionTime:
+        type: integer
+        format: int64
+      firstSignInTime:
+        type: integer
+        format: int64
+      creationTime:
+        type: integer
+        format: int64
+      idVerificationBypassTime:
+        type: integer
+        format: int64
+      idVerificationCompletionTime:
+        type: integer
+        format: int64
+      twoFactorAuthBypassTime:
+        type: integer
+        format: int64
+      twoFactorAuthCompletionTime:
+        type: integer
+        format: int64
+      eraCommonsBypassTime:
+        type: integer
+        format: int64
+      eraCommonsCompletionTime:
+        type: integer
+        format: int64
+      complianceTrainingBypassTime:
+        type: integer
+        format: int64
+      complianceTrainingCompletionTime:
+        type: integer
+        format: int64
+      betaAccessBypassTime:
+        type: integer
+        format: int64
+      emailVerificationBypassTime:
+        type: integer
+        format: int64
+      emailVerificationCompletionTime:
+        type: integer
+        format: int64
+      dataUseAgreementBypassTime:
+        type: integer
+        format: int64
+      dataUseAgreementCompletionTime:
+        type: integer
+        format: int64
+
   Profile:
     type: object
     required:
@@ -5601,12 +5672,12 @@ definitions:
   UserListResponse:
     type: object
     required:
-    - profileList
+    - users
     properties:
-      profileList:
+      users:
         type: array
         items:
-          "$ref": "#/definitions/Profile"
+          "$ref": "#/definitions/AdminTableUser"
   UpdateUserDisabledRequest:
     type: object
     required:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1250,7 +1250,7 @@ paths:
         200:
           description: A list of users
           schema:
-            "$ref": "#/definitions/UserListResponse"
+            "$ref": "#/definitions/AdminUserListResponse"
         403:
           description: User doesn't have the ACCESS_CONTROL_ADMIN authority
           schema:
@@ -5669,7 +5669,7 @@ definitions:
       accessLevel:
         "$ref": "#/definitions/WorkspaceAccessLevel"
 
-  UserListResponse:
+  AdminUserListResponse:
     type: object
     required:
     - users

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -550,9 +550,7 @@ public class ProfileServiceTest {
 
   @Test
   public void testGetAdminTableUsers_noUsers() {
-    doReturn(ImmutableList.of())
-        .when(userDao)
-        .getAdminTableUsers();
+    doReturn(ImmutableList.of()).when(userDao).getAdminTableUsers();
 
     final List<AdminTableUser> profiles = profileService.getAdminTableUsers();
     assertThat(profiles).isEmpty();
@@ -580,9 +578,7 @@ public class ProfileServiceTest {
     user3.setDisabled(true);
     user3.setInstitutionName("University 3");
 
-    doReturn(ImmutableList.of(user1, user2, user3))
-      .when(userDao)
-      .getAdminTableUsers();
+    doReturn(ImmutableList.of(user1, user2, user3)).when(userDao).getAdminTableUsers();
 
     final List<AdminTableUser> adminTableUsers = profileService.getAdminTableUsers();
     assertThat(adminTableUsers).hasSize(3);

--- a/ui/src/app/pages/admin/admin-user-bypass.spec.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.spec.tsx
@@ -1,12 +1,12 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 import {AdminUserBypass} from './admin-user-bypass';
-import {Profile} from 'generated/fetch';
+import {AdminTableUser} from 'generated/fetch';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {serverConfigStore} from 'app/utils/navigation';
 
 describe('AdminUserBypassSpec', () => {
-  let props: {profile: Profile};
+  let props: {user: AdminTableUser};
 
   const component = () => {
     return mount(<AdminUserBypass {...props}/>);
@@ -21,7 +21,7 @@ describe('AdminUserBypassSpec', () => {
       enableEraCommons: true,
     });
     props = {
-      profile: ProfileStubVariables.PROFILE_STUB
+      user: ProfileStubVariables.ADMIN_TABLE_USER_STUB
     };
   });
 

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -7,7 +7,7 @@ import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {serverConfigStore} from 'app/utils/navigation';
-import {AccessModule, Profile} from 'generated/fetch';
+import {AccessModule, AdminTableUser} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
@@ -22,20 +22,24 @@ const styles = reactStyles({
   }
 });
 
+interface Props {
+  user: AdminTableUser;
+}
+
 export class AdminUserBypass extends React.Component<
-    { profile: Profile},
+    Props,
     { initialModules: AccessModule[], selectedModules: AccessModule[],
       open: boolean} > {
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
-    const {profile} = props;
+    const {user} = props;
     const initialModules = [
-      ...(profile.betaAccessBypassTime ? [AccessModule.BETAACCESS] : []),
-      ...(profile.complianceTrainingBypassTime ? [AccessModule.COMPLIANCETRAINING] : []),
-      ...(profile.dataUseAgreementBypassTime ? [AccessModule.DATAUSEAGREEMENT] : []),
-      ...(profile.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
-      ...(profile.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
+      ...(user.betaAccessBypassTime ? [AccessModule.BETAACCESS] : []),
+      ...(user.complianceTrainingBypassTime ? [AccessModule.COMPLIANCETRAINING] : []),
+      ...(user.dataUseAgreementBypassTime ? [AccessModule.DATAUSEAGREEMENT] : []),
+      ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
+      ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
     ];
     this.state = {
       open: false,
@@ -51,11 +55,11 @@ export class AdminUserBypass extends React.Component<
 
   save() {
     const {initialModules, selectedModules} = this.state;
-    const {profile} = this.props;
+    const {user} = this.props;
     const changedModules = fp.xor(initialModules, selectedModules);
     changedModules.forEach(async module => {
       await profileApi()
-        .bypassAccessRequirement(profile.userId,
+        .bypassAccessRequirement(user.userId,
           {isBypassed: selectedModules.includes(module), moduleName: module});
     });
 
@@ -123,7 +127,7 @@ export class AdminUserBypass extends React.Component<
                         disabled={!this.hasEdited()}/>
           </div>
         </FlexColumn>}>
-      <Button type='secondaryLight' data-test-id='bypass-popup'>
+      <Button type='secondaryLight' data-test-id='bypass-popup' style={{height: '40px'}}>
         <ClrIcon shape={open ? 'caret down' : 'caret right'} size={19}
                  style={{color: colors.accent, marginRight: '1px', cursor: 'pointer'}}/>
         Bypass

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -199,7 +199,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
                style={{marginBottom: '.5em', width: '300px'}}
                type='text'
                placeholder='Search'
-               onChange={e => this.setState({filter: e.target.value})}
+               onChange={fp.debounce(300, e => this.setState({filter: e.target.value}))}
         />
         <DataTable value={this.convertProfilesToFields(users)}
                    paginator={true}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -47,9 +47,10 @@ interface Props {
 }
 
 interface State {
-  users: AdminTableUser[];
   contentLoaded: boolean;
+  filter: string;
   loading: boolean;
+  users: AdminTableUser[];
 }
 
 /**
@@ -62,9 +63,10 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
   constructor(props) {
     super(props);
     this.state = {
-      users: [],
       contentLoaded: false,
+      filter: '',
       loading: false,
+      users: [],
     };
   }
 
@@ -160,13 +162,16 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
       dataUseAgreement: this.getAccessModuleString(user, 'dataUseAgreement'),
       eraCommons: this.getAccessModuleString(user, 'eraCommons'),
       firstRegistrationCompletionTime: moment.unix(user.firstRegistrationCompletionTime / 1000).format('lll'),
+      firstRegistrationCompletionTimestamp: user.firstRegistrationCompletionTime,
       firstSignInTime: moment.unix(user.firstSignInTime / 1000).format('lll'),
+      firstSignInTimetsamp: user.firstSignInTime,
       institutionName: user.institutionName,
       name: <a
         href={`/admin/users/${usernameWithoutDomain(user.username)}`}
         target='_blank'>
         {user.familyName + ', ' + user.givenName}
       </a>,
+      nameText: user.familyName + ' ' + user.givenName,
       status: user.disabled ? 'Disabled' : 'Active',
       twoFactorAuth: this.getAccessModuleString(user, 'twoFactorAuth'),
       username: user.username,
@@ -176,25 +181,46 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
     }));
   }
 
+  filter(query: string) {
+
+  }
+
   render() {
-    const {contentLoaded, loading, users} = this.state;
+    const {contentLoaded, filter, loading, users} = this.state;
     return <div style={{position: 'relative'}}>
       <h2>User Admin Table</h2>
-      {loading && <SpinnerOverlay opacity={0.6} />}
-      {contentLoaded ?
+      {loading &&
+        <SpinnerOverlay opacity={0.6}
+                        overrideStylesOverlay={{alignItems: 'flex-start', marginTop: '2rem'}}/>
+      }
+      {!contentLoaded && <div>Loading user profiles...</div>}
+      {contentLoaded && <div>
+        <input data-test-id='search'
+               style={{marginBottom: '.5em', width: '300px'}}
+               type='text'
+               placeholder='Search'
+               onChange={e => this.setState({filter: e.target.value})}
+        />
         <DataTable value={this.convertProfilesToFields(users)}
+                   paginator={true}
+                   rows={100}
                    frozenWidth='200px'
+                   globalFilter={filter}
                    scrollable
                    style={styles.tableStyle}>
           <Column field='name'
                   bodyStyle={{...styles.colStyle}}
+                  filterField={'nameText'}
+                  filterMatchMode={'contains'}
                   frozen={true}
                   header='Name'
                   headerStyle={{...styles.colStyle, width: '200px'}}
                   sortable={true}
+                  sortField={'nameText'}
           />
           <Column field='status'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='Status'
                   headerStyle={{...styles.colStyle, width: '80px'}}
           />
@@ -202,11 +228,15 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
                   bodyStyle={{...styles.colStyle}}
                   header='Institution'
                   headerStyle={{...styles.colStyle, width: '180px'}}
+                  sortable={true}
           />
           <Column field='firstRegistrationCompletionTime'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='Registration date'
                   headerStyle={{...styles.colStyle, width: '180px'}}
+                  sortable={true}
+                  sortField={'firstRegistrationCompletionTimestamp'}
           />
           <Column field='username'
                   bodyStyle={{...styles.colStyle}}
@@ -222,50 +252,57 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
           />
           <Column field='userLockout'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='User Lockout'
                   headerStyle={{...styles.colStyle, width: '150px'}}
           />
           <Column field='firstSignInTime'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='First Sign-in'
                   headerStyle={{...styles.colStyle, width: '180px'}}
+                  sortable={true}
+                  sortField={'firstSignInTimestamp'}
           />
           <Column field='twoFactorAuth'
-                  bodyStyle={{...styles.colStyle}}
+                  bodyStyle={{...styles.colStyle, textAlign: 'center'}}
+                  excludeGlobalFilter={true}
                   header='2FA'
                   headerStyle={{...styles.colStyle, width: '80px'}}
           />
           <Column field='complianceTraining'
-                  bodyStyle={{...styles.colStyle}}
+                  bodyStyle={{...styles.colStyle, textAlign: 'center'}}
+                  excludeGlobalFilter={true}
                   header='Training'
                   headerStyle={{...styles.colStyle, width: '80px'}}
           />
           <Column field='eraCommons'
-                  bodyStyle={{...styles.colStyle}}
+                  bodyStyle={{...styles.colStyle, textAlign: 'center'}}
+                  excludeGlobalFilter={true}
                   header='eRA Commons'
                   headerStyle={{...styles.colStyle, width: '80px'}}
           />
           <Column field='dataUseAgreement'
-                  bodyStyle={{...styles.colStyle}}
+                  bodyStyle={{...styles.colStyle, textAlign: 'center'}}
+                  excludeGlobalFilter={true}
                   header='DUCC'
                   headerStyle={{...styles.colStyle, width: '80px'}}
           />
           <Column field='bypass'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='Bypass'
                   headerStyle={{...styles.colStyle, width: '150px'}}
           />
           <Column field='audit'
                   bodyStyle={{...styles.colStyle}}
+                  excludeGlobalFilter={true}
                   header='Audit'
                   headerStyle={{width: '60px'}}
           />
-        </DataTable> :
-        <div>
-          Loading user profiles...
-          <SpinnerOverlay
-            overrideStylesOverlay={{alignItems: 'flex-start', marginTop: '2rem'}}/>
-        </div>}
+        </DataTable>
+      </div>
+      }
     </div>;
   }
 

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -136,11 +136,11 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
     return a.familyName.localeCompare(b.familyName);
   }
 
-  convertDate(date): string {
-    return new Date(date).toString().split(' ').slice(1, 5).join(' ');
-  }
-
-  getAccessModuleString(user: AdminTableUser, key: string): (string|React.ReactElement) {
+  /**
+   * Returns the appropriate cell contents (icon plus tooltip) for an access module cell
+   * in the table.
+   */
+  accessModuleCellContents(user: AdminTableUser, key: string): (string|React.ReactElement) {
     const completionTime = user[key + 'CompletionTime'];
     const bypassTime = user[key + 'BypassTime'];
 
@@ -159,6 +159,17 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
     }
   }
 
+  /**
+   * Returns a formatted timestamp, or an empty string if the timestamp is zero or null.
+   */
+  formattedTimestampOrEmptyString(timestampSecs: (number|null)): string {
+    if (timestampSecs) {
+      return moment.unix(timestampSecs / 1000).format('lll');
+    } else {
+      return '';
+    }
+  }
+
   convertProfilesToFields(users: AdminTableUser[]) {
     return users.map(user => ({
       audit: <a
@@ -166,14 +177,16 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
         target='_blank'>
         link
       </a>,
-      bypass: <AdminUserBypass user={{...user}}/>,
-      complianceTraining: this.getAccessModuleString(user, 'complianceTraining'),
+      bypass: <AdminUserBypass
+        user={{...user}}
+        onBypassModuleUpdate={() => this.loadProfiles()}/>,
+      complianceTraining: this.accessModuleCellContents(user, 'complianceTraining'),
       contactEmail: user.contactEmail,
-      dataUseAgreement: this.getAccessModuleString(user, 'dataUseAgreement'),
-      eraCommons: this.getAccessModuleString(user, 'eraCommons'),
-      firstRegistrationCompletionTime: moment.unix(user.firstRegistrationCompletionTime / 1000).format('lll'),
+      dataUseAgreement: this.accessModuleCellContents(user, 'dataUseAgreement'),
+      eraCommons: this.accessModuleCellContents(user, 'eraCommons'),
+      firstRegistrationCompletionTime: this.formattedTimestampOrEmptyString(user.firstRegistrationCompletionTime),
       firstRegistrationCompletionTimestamp: user.firstRegistrationCompletionTime,
-      firstSignInTime: moment.unix(user.firstSignInTime / 1000).format('lll'),
+      firstSignInTime: this.formattedTimestampOrEmptyString(user.firstSignInTime),
       firstSignInTimetsamp: user.firstSignInTime,
       institutionName: user.institutionName,
       name: <a
@@ -183,7 +196,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
       </a>,
       nameText: user.familyName + ' ' + user.givenName,
       status: user.disabled ? 'Disabled' : 'Active',
-      twoFactorAuth: this.getAccessModuleString(user, 'twoFactorAuth'),
+      twoFactorAuth: this.accessModuleCellContents(user, 'twoFactorAuth'),
       username: user.username,
       userLockout: <LockoutButton disabled={false}
         profileDisabled={user.disabled}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -187,7 +187,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
       firstRegistrationCompletionTime: this.formattedTimestampOrEmptyString(user.firstRegistrationCompletionTime),
       firstRegistrationCompletionTimestamp: user.firstRegistrationCompletionTime,
       firstSignInTime: this.formattedTimestampOrEmptyString(user.firstSignInTime),
-      firstSignInTimetsamp: user.firstSignInTime,
+      firstSignInTimestamp: user.firstSignInTime,
       institutionName: user.institutionName,
       name: <a
         href={`/admin/users/${usernameWithoutDomain(user.username)}`}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -202,11 +202,12 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
                onChange={fp.debounce(300, e => this.setState({filter: e.target.value}))}
         />
         <DataTable value={this.convertProfilesToFields(users)}
-                   paginator={true}
-                   rows={100}
                    frozenWidth='200px'
                    globalFilter={filter}
+                   paginator={true}
+                   rows={50}
                    scrollable
+                   sortField={'firstRegistrationCompletionTimestamp'}
                    style={styles.tableStyle}>
           <Column field='name'
                   bodyStyle={{...styles.colStyle}}

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -1,6 +1,6 @@
 import {
   AccessBypassRequest,
-  AccessModule, CreateAccountRequest,
+  AccessModule, AdminTableUser, CreateAccountRequest,
   DataAccessLevel,
   InstitutionalRole,
   InvitationVerificationRequest,
@@ -46,6 +46,7 @@ export class ProfileStubVariables {
       institutionalRoleEnum: InstitutionalRole.FELLOW
     }
   };
+  static ADMIN_TABLE_USER_STUB = <AdminTableUser>{...ProfileStubVariables.PROFILE_STUB};
 }
 
 // TODO: Port functionality from ProfileServiceStub as needed.

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -1,6 +1,8 @@
 import {
   AccessBypassRequest,
-  AccessModule, AdminTableUser, CreateAccountRequest,
+  AccessModule,
+  AdminTableUser,
+  CreateAccountRequest,
   DataAccessLevel,
   InstitutionalRole,
   InvitationVerificationRequest,


### PR DESCRIPTION
This PR makes two major changes to the user admin table:

1. Swap a projection interface in for the existing entity-based DAO calls to improve performance. SQL debugging shows that a single SQL query is now being executed, instead of previously 2-3 queries per user. This should speed up SQL execution time by a significant factor. Executing against the test database, it now takes ~10-15 secs to load (instead of 40-60 secs).

2. Revamp the UI to come closer to Lou's original mocks, including a horizontally-scrollable table with a fixed first column. To prevent extreme UI slow-down with many users, we limit the rows-on-screen to 50 and add client-side filtering. IMO this feels pretty snappy now.

and one bugfix:

- Fix the UserBypass component (it was copying values from props to state only on construction, so when the row was re-rendered with a new user, the component wasn't updated as needed).

I kept the "disable" and "bypass" buttons for now to try and maintain existing functionality, though I think we'll be much better off moving all user-modifying actions into the single-user admin page rather than the table. We should work with the user admins to finalize a plan.

Screenshot:

<img width="800" alt="admin-ui-screenshot" src="https://user-images.githubusercontent.com/51842/94924749-1a69b580-048c-11eb-8482-1c1b487d8042.png">
