### PR TITLE
[no ticket][risk=no] Puppeteer Split ConceptSet test

### DIFF
--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -8,7 +8,7 @@ import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
 
-describe('Editing and rename Concept Sets', () => {
+describe('Editing and rename Concept Set', () => {
 
   beforeEach(async () => {
     await signIn(page);
@@ -19,11 +19,11 @@ describe('Editing and rename Concept Sets', () => {
    * - Create new workspace.
    * - Create first new Concept Set in Procedure domain.
    * - Add new concept to first (existing) Concept Set.
-   * - Rename first Concept Set.
-   * - Delete first Concept Set.
+   * - Rename Concept Set.
+   * - Delete Concept Set.
    */
   test('Workspace OWNER can edit Concept Set', async () => {
-    // Create a workspace
+
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -1,17 +1,14 @@
 import {Domain} from 'app/component/concept-domain-card';
-import DataResourceCard from 'app/component/data-resource-card';
-import WorkspaceCard from 'app/component/workspace-card';
 import Link from 'app/element/link';
 import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
-import ConceptsetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {LinkText, ResourceCard} from 'app/text-labels';
+import {ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
 
-describe('Editing and Copying Concept Sets', () => {
+describe('Editing and rename Concept Sets', () => {
 
   beforeEach(async () => {
     await signIn(page);
@@ -21,9 +18,11 @@ describe('Editing and Copying Concept Sets', () => {
    * Test:
    * - Create new workspace.
    * - Create first new Concept Set in Procedure domain.
-   * - Create second new Concept Set in Procedure domain. Add to first Concept Set.
+   * - Add new concept to first (existing) Concept Set.
+   * - Rename first Concept Set.
+   * - Delete first Concept Set.
    */
-  test('Add to existing Concept Set in same workspace', async () => {
+  test('Workspace OWNER can edit Concept Set', async () => {
     // Create a workspace
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
@@ -90,66 +89,6 @@ describe('Editing and Copying Concept Sets', () => {
     await dataPage.waitForLoad();
     await dataPage.openConceptSetsSubtab({waitPageChange: false});
     await dataPage.deleteResource(newName, ResourceCard.ConceptSet);
-  });
-
-  /**
-   * Test:
-   * - Copy Concept Set from one workspace to another workspace.
-   */
-  test('Copy Concept Set to another workspace', async () => {
-
-    // Need two workspaces. workspace1 is the Copy to workspace. workspace2 is the Copy from workspace.
-    const workspace1: WorkspaceCard = await findWorkspace(page, {create: true});
-    const copyToWorkspace = await workspace1.getWorkspaceName();
-
-    const workspace2: WorkspaceCard = await findWorkspace(page, {create: true});
-    const copyFromWorkspace = await workspace2.getWorkspaceName();
-
-    // Open workspace2 Data Page.
-    await workspace2.clickWorkspaceName();
-
-    // Look for one existing Concept Set in workspace2. If none exists, create a new Concept Set.
-    const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openConceptSetsSubtab({waitPageChange: false});
-
-    // Create new Concept Set
-    const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
-    await conceptSearchPage.dataTableSelectAllRows();
-    const addButtonLabel = await conceptSearchPage.clickAddToSetButton();
-    // Table pagination displays 20 rows. If this changes, then update the check below.
-    expect(addButtonLabel).toBe('Add (20) to set');
-    const conceptName = await conceptSearchPage.saveConcept(SaveOption.CreateNewSet);
-    console.log(`Created Concept Set: "${conceptName}"`);
-    // Click on link to open Concept Set page.
-    const conceptsetActionPage = new ConceptsetActionsPage(page);
-    await conceptsetActionPage.openConceptSet(conceptName);
-
-    // Concept Set page is open.
-    const conceptsetPage = new ConceptsetPage(page);
-    await conceptsetPage.waitForLoad();
-
-    // Copy Concept Set to another workspace with new Concept name.
-    const conceptSetCopyName = makeRandomName();
-
-    const conceptCopyModal = await conceptsetPage.openCopyToWorkspaceModal(conceptName);
-    await conceptCopyModal.copyToAnotherWorkspace(copyToWorkspace, conceptSetCopyName);
-
-    await conceptCopyModal.waitForButton(LinkText.GoToCopiedConceptSet).then(butn => butn.click());
-
-    // Verify GoTo works
-    await dataPage.waitForLoad();
-
-    const url = page.url();
-    expect(url).toContain(copyToWorkspace.replace(/-/g, ''));
-
-    const resourceCard = new DataResourceCard(page);
-    const exists = await resourceCard.cardExists(conceptSetCopyName, ResourceCard.ConceptSet);
-    expect(exists).toBe(true);
-
-    console.log(`Copied Concept Set: "${conceptName} from workspace: "${copyFromWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${copyToWorkspace}"`)
-
-    // Delete Concept Sets
-    await dataPage.deleteResource(conceptSetCopyName, ResourceCard.ConceptSet);
   });
 
 

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -10,7 +10,7 @@ import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
 
 
-describe('Workspace OWNER can copy Concept Sets to another workspace', () => {
+describe('Copy Concept Set to another workspace', () => {
 
   beforeEach(async () => {
     await signIn(page);
@@ -20,7 +20,7 @@ describe('Workspace OWNER can copy Concept Sets to another workspace', () => {
    * Test:
    * - Copy Concept Set from one workspace to another workspace.
    */
-  test('Copy Concept Set', async () => {
+  test('Workspace OWNER can copy Concept Set', async () => {
 
     // Need two workspaces. workspace1 is the Copy to workspace. workspace2 is the Copy from workspace.
     const workspace1: WorkspaceCard = await findWorkspace(page, {create: true});

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -1,0 +1,80 @@
+import {Domain} from 'app/component/concept-domain-card';
+import DataResourceCard from 'app/component/data-resource-card';
+import WorkspaceCard from 'app/component/workspace-card';
+import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
+import ConceptsetPage from 'app/page/conceptset-page';
+import {SaveOption} from 'app/page/conceptset-save-modal';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {LinkText, ResourceCard} from 'app/text-labels';
+import {makeRandomName} from 'utils/str-utils';
+import {findWorkspace, signIn} from 'utils/test-utils';
+
+
+describe('Workspace OWNER can copy Concept Sets to another workspace', () => {
+
+  beforeEach(async () => {
+    await signIn(page);
+  });
+
+  /**
+   * Test:
+   * - Copy Concept Set from one workspace to another workspace.
+   */
+  test('Copy Concept Set', async () => {
+
+    // Need two workspaces. workspace1 is the Copy to workspace. workspace2 is the Copy from workspace.
+    const workspace1: WorkspaceCard = await findWorkspace(page, {create: true});
+    const copyToWorkspace = await workspace1.getWorkspaceName();
+
+    const workspace2: WorkspaceCard = await findWorkspace(page, {create: true});
+    const copyFromWorkspace = await workspace2.getWorkspaceName();
+
+    // Open workspace2 Data Page.
+    await workspace2.clickWorkspaceName();
+    // Open Concept Sets tab.
+    const dataPage = new WorkspaceDataPage(page);
+    await dataPage.openConceptSetsSubtab({waitPageChange: false});
+
+    // Create new Concept Set
+    const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
+    await conceptSearchPage.dataTableSelectAllRows();
+    const addButtonLabel = await conceptSearchPage.clickAddToSetButton();
+    // Table pagination displays 20 rows. If this changes, then update the check below.
+    expect(addButtonLabel).toBe('Add (20) to set');
+    const conceptName = await conceptSearchPage.saveConcept(SaveOption.CreateNewSet);
+    console.log(`Created Concept Set: "${conceptName}"`);
+    // Click on link to open Concept Set page.
+    const conceptsetActionPage = new ConceptsetActionsPage(page);
+    await conceptsetActionPage.openConceptSet(conceptName);
+
+    // Concept Set page is open.
+    const conceptsetPage = new ConceptsetPage(page);
+    await conceptsetPage.waitForLoad();
+
+    // Copy Concept Set to another workspace with new Concept name.
+    const conceptSetCopyName = makeRandomName();
+
+    const conceptCopyModal = await conceptsetPage.openCopyToWorkspaceModal(conceptName);
+    await conceptCopyModal.copyToAnotherWorkspace(copyToWorkspace, conceptSetCopyName);
+
+    // Click "Go to Copied Concept Set" button.
+    await conceptCopyModal.waitForButton(LinkText.GoToCopiedConceptSet).then(butn => butn.click());
+
+    await dataPage.waitForLoad();
+
+    // Verify copyToWorkspace is open.
+    const url = page.url();
+    expect(url).toContain(copyToWorkspace.replace(/-/g, ''));
+
+    const resourceCard = new DataResourceCard(page);
+    const exists = await resourceCard.cardExists(conceptSetCopyName, ResourceCard.ConceptSet);
+    expect(exists).toBe(true);
+
+    console.log(`Copied Concept Set: "${conceptName} from workspace: "${copyFromWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${copyToWorkspace}"`)
+
+    // Delete Concept Set in copyToWorkspace.
+    await dataPage.deleteResource(conceptSetCopyName, ResourceCard.ConceptSet);
+  });
+
+
+});


### PR DESCRIPTION
Break up `conceptset-edit.spec.ts` by concept set feature. One is for editing & rename. Other is for Copy-to-another-workspace.
Test code is not changed.