### PR TITLE
[risk=no] Don't cache BigQuery integration test results

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -520,6 +520,8 @@ task bigQueryTest(type: Test) {
   description = 'Runs BigQery test suite.'
   testClassesDirs = sourceSets.__bigQueryTest__.output.classesDirs
   classpath = sourceSets.__bigQueryTest__.runtimeClasspath
+
+  outputs.upToDateWhen { false }
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Noticed this while looking at the flake. This matches what we have for the other integration tests.