### PR TITLE
[no ticket][risk=no] Puppeteer Simplify openSubtab function in Data page

### DIFF
--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -38,11 +38,10 @@ export default abstract class AuthenticatedPage extends BasePage {
         this.isLoaded(),
       ]);
       return this;
-    } catch (e) {
+    } catch (err) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);
-      const title = await this.page.title();
-      throw new Error(`"${title}" page waitForLoad() encountered ${e}.`);
+      throw (err);
     }
   }
 

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -10,6 +10,7 @@ import {Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/test-utils';
 import {waitForAttributeEquality} from 'utils/waits-utils';
 import SnowmanMenu from 'app/component/snowman-menu';
+import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
 
 export enum TabLabels {
@@ -57,32 +58,32 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Click Datasets subtab in Data page.
    * @param opts
    */
-  async openDatasetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabels.Datasets, opts);
+  async openDatasetsSubtab(): Promise<void> {
+    return this.openDataPage().then(() => this.openTab(TabLabels.Datasets, {waitPageChange: false}));
   }
 
   /**
    * Click Cohorts subtab in Data page.
    * @param opts
    */
-  async openCohortsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabels.Cohorts, opts);
+  async openCohortsSubtab(): Promise<void> {
+    return this.openDataPage().then(() => this.openTab(TabLabels.Cohorts, {waitPageChange: false}));
   }
 
   /**
    * Click Cohorts Reviews subtab in Data page.
    * @param opts
    */
-  async openCohortReviewsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabels.CohortReviews, opts);
+  async openCohortReviewsSubtab(): Promise<void> {
+    return this.openDataPage().then(() => this.openTab(TabLabels.CohortReviews, {waitPageChange: false}));
   }
 
   /**
    * Click Concept Sets subtab in Data page.
    * @param opts
    */
-  async openConceptSetsSubtab(opts: {waitPageChange?: boolean} = {}): Promise<void> {
-    return this.openTab(TabLabels.ConceptSets, opts);
+  async openConceptSetsSubtab(): Promise<void> {
+    return this.openDataPage().then(() => this.openTab(TabLabels.ConceptSets, {waitPageChange: false}));
   }
 
   /**
@@ -94,6 +95,10 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     const { waitPageChange = true } = opts;
     const selector = buildXPath({name: pageTabName, type: ElementType.Tab});
     const tab = new Link(this.page, selector);
+    const isSelected = await getPropValue<boolean>(await tab.asElementHandle(), 'ariaSelected');
+    if (isSelected === true) {
+      return; // Tab is already open.
+    }
     waitPageChange ? await tab.clickAndWait() : await tab.click();
     await tab.dispose();
     return waitWhileLoading(this.page);

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -78,8 +78,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async findCohortCard(cohortName?: string): Promise<DataResourceCard> {
-    await this.openDataPage();
-    await this.openCohortsSubtab({waitPageChange: false});
+    await this.openCohortsSubtab();
     if (cohortName === undefined) {
       // if cohort name isn't specified, find any existing cohort.
       return DataResourceCard.findAnyCard(this.page);
@@ -142,6 +141,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async createNotebook(notebookName: string, lang: Language = Language.Python): Promise<NotebookPage> {
     await this.openAnalysisPage();
     const analysisPage = new WorkspaceAnalysisPage(this.page);
+    await analysisPage.waitForLoad();
     return analysisPage.createNotebook(notebookName, lang);
   }
 

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -89,8 +89,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
     const cohortActionsPage = new CohortActionsPage(page);
     await cohortActionsPage.waitForLoad();
 
-    await dataPage.openDataPage();
-    await dataPage.openCohortsSubtab({waitPageChange: false});
+    await dataPage.openCohortsSubtab();
 
     // Rename cohort.
     const newCohortName = makeRandomName();

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -87,8 +87,7 @@ describe('Cohort review tests', () => {
     await cohortBuildPage.waitForLoad();
 
     // Land on the Data Page & click the Cohort Reviews SubTab
-    await dataPage.openDataPage();
-    await dataPage.openCohortReviewsSubtab({waitPageChange: false});
+    await dataPage.openCohortReviewsSubtab();
 
     // Rename Cohort Review 
     const newCohortReviewName = makeRandomName();

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -67,8 +67,7 @@ describe('Create Concept Sets from Domains', () => {
     console.log(`Created Concept Set "${conceptName}"`);
 
     // Delete Concept Set
-    await dataPage.openDataPage();
-    await dataPage.openConceptSetsSubtab({waitPageChange: false});
+    await dataPage.openConceptSetsSubtab();
 
     const modalTextContent = await dataPage.deleteResource(conceptName, ResourceCard.ConceptSet);
     expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
@@ -149,8 +148,7 @@ describe('Create Concept Sets from Domains', () => {
     const datasetName = await saveModal.saveDataset();
 
     // Verify Dataset created successful.
-    await dataPage.openDataPage();
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
@@ -161,7 +159,7 @@ describe('Create Concept Sets from Domains', () => {
     expect(textContent).toContain(`Are you sure you want to delete Dataset: ${datasetName}?`);
 
     // Delete Concept Set.
-    await dataPage.openConceptSetsSubtab({waitPageChange: false});
+    await dataPage.openConceptSetsSubtab();
 
     await dataPage.deleteResource(conceptName1, ResourceCard.ConceptSet);
     await dataPage.deleteResource(conceptName2, ResourceCard.ConceptSet);

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -87,7 +87,7 @@ describe('Editing and rename Concept Set', () => {
     // Navigate to workspace Data page, then delete Concept Set
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();
     await dataPage.waitForLoad();
-    await dataPage.openConceptSetsSubtab({waitPageChange: false});
+    await dataPage.openConceptSetsSubtab();
     await dataPage.deleteResource(newName, ResourceCard.ConceptSet);
   });
 

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -33,7 +33,7 @@ describe('Copy Concept Set to another workspace', () => {
     await workspace2.clickWorkspaceName();
     // Open Concept Sets tab.
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openConceptSetsSubtab({waitPageChange: false});
+    await dataPage.openConceptSetsSubtab();
 
     // Create new Concept Set
     const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -63,7 +63,7 @@ describe('Dataset test', () => {
     let datasetName = await saveModal.saveDataset({exportToNotebook: false});
 
     // Verify create successful.
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
 
     const resourceCard = new DataResourceCard(page);
     const dataSetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
@@ -81,7 +81,7 @@ describe('Dataset test', () => {
     datasetName = await saveModal.saveDataset({exportToNotebook: false}, true);
     await dataPage.waitForLoad();
 
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
     await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
   });
 

--- a/e2e/tests/datasets/dataset-rename.spec.ts
+++ b/e2e/tests/datasets/dataset-rename.spec.ts
@@ -40,7 +40,7 @@ describe('Dataset test', () => {
     const newDatasetName = makeRandomName();
     await dataPage.renameResource(datasetName, newDatasetName, ResourceCard.Dataset);
 
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
 
     // Verify rename successful
     const newDatasetExists = await resourceCard.cardExists(newDatasetName, ResourceCard.Dataset);

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -69,8 +69,7 @@ describe('Create Dataset', () => {
     expect(newCardsCount).toBe(origCardsCount - 1);
 
     // Delete Dataset.
-    await dataPage.openDataPage();
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
 
     await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
   });
@@ -116,8 +115,7 @@ describe('Create Dataset', () => {
     await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
 
     // Delete Dataset
-    await analysisPage.openDataPage();
-    await analysisPage.openDatasetsSubtab({waitPageChange: false});
+    await analysisPage.openDatasetsSubtab();
     await analysisPage.deleteResource(datasetName, ResourceCard.Dataset);
   });
 

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -85,14 +85,13 @@ describe('Create Dataset', () => {
     await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
 
     // Delete Dataset
-    await dataPage.openDataPage();
-    await dataPage.openDatasetsSubtab({waitPageChange: false});
+    await dataPage.openDatasetsSubtab();
 
     const datasetDeleteDialogText = await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
     expect(datasetDeleteDialogText).toContain(`Are you sure you want to delete Dataset: ${newDatasetName}?`);
 
     // Delete Cohort
-    await dataPage.openCohortsSubtab({waitPageChange: false});
+    await dataPage.openCohortsSubtab();
 
     const cohortDeleteDialogText = await dataPage.deleteResource(newCohortName, ResourceCard.Cohort);
     expect(cohortDeleteDialogText).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -39,7 +39,7 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     const jsHandle = await page.waitForFunction(t => {
       const actualTitle = document.title;
       return actualTitle.includes(t);
-    }, {}, titleSubstr);
+    }, {timeout: 30000}, titleSubstr);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
     console.error(`Wait for document title contains "${titleSubstr}" failed. ${e}`);

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -112,7 +112,7 @@ export async function waitForPropertyExists(page: Page, xpathSelector: string, p
     return true;
   } catch (err) {
     console.error(`Failed waiting element (XPath="${xpathSelector}") property: ${propertyName} exists. ${err}`);
-    throw new Error(err);
+    throw (err);
   }
 }
 


### PR DESCRIPTION
Small improvement in openTab functions:
- If tab is already open (ariaSelected == true), then click on element is skipped.
- If open sub-tab in Data page, users do not have to remember to open Data tab first.