### PR TITLE
[RW-5516][risk=no] update dataset builder BQ sql

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -181,7 +181,6 @@ public class DataSetController implements DataSetApiDelegate {
       String workspaceNamespace, String workspaceId, DataSetPreviewRequest dataSetPreviewRequest) {
     workspaceService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    DataSetPreviewResponse previewQueryResponse = new DataSetPreviewResponse();
     List<DataSetPreviewValueList> valuePreviewList = new ArrayList<>();
 
     QueryJobConfiguration previewBigQueryJobConfig =
@@ -213,10 +212,10 @@ public class DataSetController implements DataSetApiDelegate {
           valuePreviewList,
           Comparator.comparing(item -> dataSetPreviewRequest.getValues().indexOf(item.getValue())));
     }
-
-    previewQueryResponse.setDomain(dataSetPreviewRequest.getDomain());
-    previewQueryResponse.setValues(valuePreviewList);
-    return ResponseEntity.ok(previewQueryResponse);
+    return ResponseEntity.ok(
+        new DataSetPreviewResponse()
+            .domain(dataSetPreviewRequest.getDomain())
+            .values(valuePreviewList));
   }
 
   @VisibleForTesting

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -46,7 +46,7 @@ public enum BigQueryDataSetTableInfo {
   DRUG(
       Domain.DRUG,
       "ds_drug_exposure",
-      " (drug_concept_id in (select distinct ca.descendant_id\n"
+      " drug_concept_id in (select distinct ca.descendant_id\n"
           + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
           + "join (select distinct c.concept_id\n"
           + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
@@ -56,7 +56,7 @@ public enum BigQueryDataSetTableInfo {
           + "and concept_id in unnest(@conceptIds)\n"
           + ") a\n"
           + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)\n"
-          + ") b on (ca.ancestor_id = b.concept_id)))",
+          + ") b on (ca.ancestor_id = b.concept_id))",
       " (drug_concept_id in unnest(@conceptIds) or drug_source_concept_id in unnest(@conceptIds))"),
   MEASUREMENT(
       Domain.MEASUREMENT,
@@ -79,7 +79,7 @@ public enum BigQueryDataSetTableInfo {
   OBSERVATION(
       Domain.OBSERVATION,
       "ds_observation",
-      " (observation_concept_id in unnest(@conceptIds) or observation_source_concept_id in unnest(@conceptIds))",
+      " observation_concept_id in unnest(@conceptIds)",
       " (observation_concept_id in unnest(@conceptIds) or observation_source_concept_id in unnest(@conceptIds))");
 
   private final Domain domain;

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -21,7 +21,8 @@ public enum BigQueryDataSetTableInfo {
           + "where concept_id in unnest(@conceptIds)\n"
           + "and domain_id = 'CONDITION'\n"
           + "and is_standard = 0) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))"),
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))",
+      " (condition_concept_id in unnest(@conceptIds) or condition_source_concept_id in unnest(@conceptIds))"),
   PROCEDURE(
       Domain.PROCEDURE,
       "ds_procedure_occurrence",
@@ -40,7 +41,8 @@ public enum BigQueryDataSetTableInfo {
           + "where concept_id in unnest(@conceptIds)\n"
           + "and domain_id = 'PROCEDURE'\n"
           + "and is_standard = 0) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))"),
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))",
+      " (procedure_concept_id in unnest(@conceptIds) or procedure_source_concept_id in unnest(@conceptIds))"),
   DRUG(
       Domain.DRUG,
       "ds_drug_exposure",
@@ -54,7 +56,8 @@ public enum BigQueryDataSetTableInfo {
           + "and concept_id in unnest(@conceptIds)\n"
           + ") a\n"
           + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)\n"
-          + ") b on (ca.ancestor_id = b.concept_id)))"),
+          + ") b on (ca.ancestor_id = b.concept_id)))",
+      " (drug_concept_id in unnest(@conceptIds) or drug_source_concept_id in unnest(@conceptIds))"),
   MEASUREMENT(
       Domain.MEASUREMENT,
       "ds_measurement",
@@ -65,22 +68,31 @@ public enum BigQueryDataSetTableInfo {
           + "where concept_id in unnest(@conceptIds)\n"
           + "and domain_id = 'MEASUREMENT'\n"
           + "and is_standard = 1) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id))"),
-  SURVEY(Domain.SURVEY, "ds_survey", " question_concept_id in unnest(@conceptIds)"),
-  PERSON(Domain.PERSON, "ds_person", null),
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id))",
+      " (measurement_concept_id in unnest(@conceptIds) or measurement_source_concept_id in unnest(@conceptIds))"),
+  SURVEY(
+      Domain.SURVEY,
+      "ds_survey",
+      " question_concept_id in unnest(@conceptIds)",
+      " question_concept_id in unnest(@conceptIds)"),
+  PERSON(Domain.PERSON, "ds_person", null, null),
   OBSERVATION(
       Domain.OBSERVATION,
       "ds_observation",
+      " (observation_concept_id in unnest(@conceptIds) or observation_source_concept_id in unnest(@conceptIds))",
       " (observation_concept_id in unnest(@conceptIds) or observation_source_concept_id in unnest(@conceptIds))");
 
   private final Domain domain;
   private final String tableName;
   private final String conceptIdIn;
+  private final String conceptIdInOld;
 
-  BigQueryDataSetTableInfo(Domain domain, String tableName, String conceptIdIn) {
+  BigQueryDataSetTableInfo(
+      Domain domain, String tableName, String conceptIdIn, String conceptIdInOld) {
     this.domain = domain;
     this.tableName = tableName;
     this.conceptIdIn = conceptIdIn;
+    this.conceptIdInOld = conceptIdInOld;
   }
 
   public static String getTableName(Domain domain) {
@@ -96,6 +108,15 @@ public enum BigQueryDataSetTableInfo {
     for (BigQueryDataSetTableInfo info : values()) {
       if (info.domain.equals(domain)) {
         return info.conceptIdIn;
+      }
+    }
+    return null;
+  }
+
+  public static String getConceptIdInOld(Domain domain) {
+    for (BigQueryDataSetTableInfo info : values()) {
+      if (info.domain.equals(domain)) {
+        return info.conceptIdInOld;
       }
     }
     return null;

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -6,14 +6,66 @@ public enum BigQueryDataSetTableInfo {
   CONDITION(
       Domain.CONDITION,
       "ds_condition_occurrence",
-      " (condition_concept_id in unnest(@conceptIds) or condition_source_concept_id in unnest(@conceptIds))"),
+      " (condition_concept_id in (select concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(id as string)  as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
+          + "where concept_id in unnest(@conceptIds)\n"
+          + "and domain_id = 'CONDITION'\n"
+          + "and is_standard = 1) a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id))\n "
+          + "or condition_source_concept_id in(select concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(id as string)  as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
+          + "where concept_id in unnest(@conceptIds)\n"
+          + "and domain_id = 'CONDITION'\n"
+          + "and is_standard = 0) a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))"),
   PROCEDURE(
       Domain.PROCEDURE,
       "ds_procedure_occurrence",
-      " (procedure_concept_id in unnest(@conceptIds) or procedure_source_concept_id in unnest(@conceptIds))"),
-  DRUG(Domain.DRUG, "ds_drug_exposure", " (drug_concept_id in unnest(@conceptIds))"),
+      " (procedure_concept_id in (select concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(id as string)  as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
+          + "where concept_id in unnest(@conceptIds)\n"
+          + "and domain_id = 'PROCEDURE'\n"
+          + "and is_standard = 1) a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id))\n "
+          + "or procedure_source_concept_id in (select concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(id as string)  as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
+          + "where concept_id in unnest(@conceptIds)\n"
+          + "and domain_id = 'PROCEDURE'\n"
+          + "and is_standard = 0) a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)))"),
+  DRUG(
+      Domain.DRUG,
+      "ds_drug_exposure",
+      " (drug_concept_id in (select distinct ca.descendant_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
+          + "join (select distinct c.concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(cr.id as string) as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
+          + "where domain_id = 'DRUG'\n"
+          + "and concept_id in unnest(@conceptIds)\n"
+          + ") a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id)\n"
+          + ") b on (ca.ancestor_id = b.concept_id)))"),
   MEASUREMENT(
-      Domain.MEASUREMENT, "ds_measurement", " (measurement_concept_id in unnest(@conceptIds))"),
+      Domain.MEASUREMENT,
+      "ds_measurement",
+      " measurement_concept_id in (select concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(id as string)  as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
+          + "where concept_id in unnest(@conceptIds)\n"
+          + "and domain_id = 'MEASUREMENT'\n"
+          + "and is_standard = 1) a\n"
+          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%') or c.path = a.id))"),
   SURVEY(Domain.SURVEY, "ds_survey", " question_concept_id in unnest(@conceptIds)"),
   PERSON(Domain.PERSON, "ds_person", null),
   OBSERVATION(

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -11,14 +11,9 @@ public enum BigQueryDataSetTableInfo {
       Domain.PROCEDURE,
       "ds_procedure_occurrence",
       " (procedure_concept_id in unnest(@conceptIds) or procedure_source_concept_id in unnest(@conceptIds))"),
-  DRUG(
-      Domain.DRUG,
-      "ds_drug_exposure",
-      " (drug_concept_id in unnest(@conceptIds) or drug_source_concept_id in unnest(@conceptIds))"),
+  DRUG(Domain.DRUG, "ds_drug_exposure", " (drug_concept_id in unnest(@conceptIds))"),
   MEASUREMENT(
-      Domain.MEASUREMENT,
-      "ds_measurement",
-      " (measurement_concept_id in unnest(@conceptIds) or measurement_source_concept_id in unnest(@conceptIds))"),
+      Domain.MEASUREMENT, "ds_measurement", " (measurement_concept_id in unnest(@conceptIds))"),
   SURVEY(Domain.SURVEY, "ds_survey", " question_concept_id in unnest(@conceptIds)"),
   PERSON(Domain.PERSON, "ds_person", null),
   OBSERVATION(

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -122,6 +122,13 @@ public class DataSetServiceTest {
     Clock clock() {
       return CLOCK;
     }
+
+    @Bean
+    WorkbenchConfig workbenchConfig() {
+      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
+      workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
+      return workbenchConfig;
+    }
   }
 
   @Before

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Provider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +43,7 @@ import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetServiceImpl;
 import org.pmiops.workbench.dataset.DataSetServiceImpl.QueryAndParameters;
 import org.pmiops.workbench.dataset.mapper.DataSetMapper;
@@ -96,6 +98,7 @@ public class DataSetServiceTest {
   @Autowired private DataSetDao dataSetDao;
   @Autowired private DSLinkingDao dsLinkingDao;
   @Autowired private DataSetMapper dataSetMapper;
+  @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @MockBean private BigQueryService mockBigQueryService;
   @MockBean private CohortDao mockCohortDao;
@@ -135,7 +138,8 @@ public class DataSetServiceTest {
             dataSetDao,
             dsLinkingDao,
             dataSetMapper,
-            CLOCK);
+            CLOCK,
+            workbenchConfigProvider);
 
     final DbCohort cohort = buildSimpleCohort();
     when(cohortDao.findCohortByNameAndWorkspaceId(anyString(), anyLong())).thenReturn(cohort);


### PR DESCRIPTION
This PR addresses the need to change dataset BQ sql generation to account for CB nuances.

- BigQueryDataSetTableInfo - added the new BQ sql to the conceptIdIn property
- DataSetServiceImpl - using feature flag to call the proper conceptIdIn method
- Updated corresponding test cases