### PR TITLE
[RW-5700][risk=no] Puppeteer Take screenshot and save page content

### DIFF
--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -79,7 +79,7 @@ export default class Modal extends Container {
   }
 
   async waitUntilClose(): Promise<void> {
-    await this.page.waitForXPath(this.xpath, {hidden: true});
+    await this.page.waitForXPath(this.xpath, {hidden: true, timeout: 30000});
   }
 
   async waitUntilVisible(): Promise<ElementHandle> {

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -1,7 +1,6 @@
 import {Page} from 'puppeteer';
 import {PageUrl} from 'app/text-labels';
 import BasePage from 'app/page/base-page';
-import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
 import {getPropValue} from 'utils/element-utils';
 
 const signedInIndicator = 'app-signed-in';
@@ -32,15 +31,9 @@ export default abstract class AuthenticatedPage extends BasePage {
    * Wait until current page is loaded and without spinners spinning.
    */
   async waitForLoad(): Promise<this> {
-    try {
-      await this.isSignedIn();
-      await this.isLoaded();
-      return this;
-    } catch (err) {
-      await savePageToFile(this.page);
-      await takeScreenshot(this.page);
-      throw (err);
-    }
+    await this.isSignedIn();
+    await this.isLoaded();
+    return this;
   }
 
   /**

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -18,7 +18,7 @@ export default abstract class AuthenticatedPage extends BasePage {
   }
 
   protected async isSignedIn(): Promise<boolean> {
-    return this.page.waitForSelector(signedInIndicator)
+    return this.page.waitForSelector(signedInIndicator, {timeout: 30000})
       .then( (elemt) => elemt.asElement() !== null);
   }
 
@@ -33,10 +33,8 @@ export default abstract class AuthenticatedPage extends BasePage {
    */
   async waitForLoad(): Promise<this> {
     try {
-      await Promise.all([
-        this.isSignedIn(),
-        this.isLoaded(),
-      ]);
+      await this.isSignedIn();
+      await this.isLoaded();
       return this;
     } catch (err) {
       await savePageToFile(this.page);

--- a/e2e/app/page/cohort-actions-page.ts
+++ b/e2e/app/page/cohort-actions-page.ts
@@ -24,9 +24,9 @@ export default class CohortActionsPage extends AuthenticatedPage {
         this.getCreateDatasetButton().then(elemt => elemt.asElementHandle()),
       ]);
       return true;
-    } catch (e) {
-      console.log(`CohortActionsPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`CohortActionsPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/cohort-actions-page.ts
+++ b/e2e/app/page/cohort-actions-page.ts
@@ -15,19 +15,16 @@ export default class CohortActionsPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-        this.getCreateAnotherCohortButton().then(elemt => elemt.asElementHandle()),
-        this.getCreateReviewSetsButton().then(elemt => elemt.asElementHandle()),
-        this.getCreateDatasetButton().then(elemt => elemt.asElementHandle()),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`CohortActionsPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    await Promise.all([
+      this.getCreateAnotherCohortButton().then(elemt => elemt.asElementHandle()),
+      this.getCreateReviewSetsButton().then(elemt => elemt.asElementHandle()),
+      this.getCreateDatasetButton().then(elemt => elemt.asElementHandle()),
+    ]);
+    return true;
   }
 
   async clickCreateDatasetButton(): Promise<DatasetBuildPage> {

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -34,9 +34,9 @@ export default class CohortBuildPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.log(`CohortBuildPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`CohortBuildPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -28,16 +28,11 @@ export default class CohortBuildPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`CohortBuildPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   /**

--- a/e2e/app/page/cohort-participant-detail-page.ts
+++ b/e2e/app/page/cohort-participant-detail-page.ts
@@ -20,9 +20,9 @@ export default class CohortParticipantDetailPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.log(`CohortParticipantDetailPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`CohortParticipantDetailPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/cohort-participant-detail-page.ts
+++ b/e2e/app/page/cohort-participant-detail-page.ts
@@ -14,16 +14,11 @@ export default class CohortParticipantDetailPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`CohortParticipantDetailPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   async getBackToReviewSetButton(): Promise<Button> {

--- a/e2e/app/page/cohort-review-modal.ts
+++ b/e2e/app/page/cohort-review-modal.ts
@@ -14,16 +14,11 @@ export default class CohortReviewModal extends Modal {
 
   async isLoaded(): Promise<boolean> {
     const titleXpath = `${this.getXpath()}/div[normalize-space()="${title}"]`;
-    try {
-      await Promise.all([
-        waitForText(this.page, titleXpath),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (e) {
-      console.log(`CohortReviewModal isLoaded() encountered ${e}`);
-      return false;
-    }
+    await Promise.all([
+      waitForText(this.page, titleXpath),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   async fillInNumberOfPartcipants(numOfparticipants: number): Promise<void> {

--- a/e2e/app/page/cohort-review-page.ts
+++ b/e2e/app/page/cohort-review-page.ts
@@ -23,9 +23,9 @@ export default class CohortReviewPage extends AuthenticatedPage {
         this.getDataTable().exists(),
       ]);
       return true;
-    } catch (e) {
-      console.log(`CohortReviewPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`CohortReviewPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/cohort-review-page.ts
+++ b/e2e/app/page/cohort-review-page.ts
@@ -16,17 +16,12 @@ export default class CohortReviewPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-        this.getDataTable().exists(),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`CohortReviewPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    await this.getDataTable().exists();
+    return true;
   }
 
   getDataTable(): DataTable {

--- a/e2e/app/page/cohort-search-page.ts
+++ b/e2e/app/page/cohort-search-page.ts
@@ -79,7 +79,8 @@ export default class CohortSearchPage extends AuthenticatedPage {
       ]);
       return true;
     } catch (err) {
-      throw new Error(`CohortSearchPage isLoaded() encountered error.\n ${err}`);
+      console.error(`CohortSearchPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/cohort-search-page.ts
+++ b/e2e/app/page/cohort-search-page.ts
@@ -71,17 +71,12 @@ export default class CohortSearchPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        this.page.waitForXPath('//*[@id="cohort-search-container"]', {visible: true}),
-        this.page.waitForXPath('//*[@role="button"]/img[@alt="Go back"]', {visible: true}),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`CohortSearchPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      this.page.waitForXPath('//*[@id="cohort-search-container"]', {visible: true}),
+      this.page.waitForXPath('//*[@role="button"]/img[@alt="Go back"]', {visible: true})
+    ]);
+    await waitWhileLoading(this.page);
+    return true;
   }
 
 

--- a/e2e/app/page/conceptset-actions-page.ts
+++ b/e2e/app/page/conceptset-actions-page.ts
@@ -19,18 +19,15 @@ export default class ConceptsetActionsPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-        this.getCreateAnotherConceptSetButton(),
-        this.getCreateDatasetButton(),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`ConceptsetActionsPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    await Promise.all([
+      this.getCreateAnotherConceptSetButton(),
+      this.getCreateDatasetButton()
+    ]);
+    return true;
   }
 
   async clickCreateAnotherConceptSetButton(): Promise<void> {

--- a/e2e/app/page/conceptset-actions-page.ts
+++ b/e2e/app/page/conceptset-actions-page.ts
@@ -27,9 +27,9 @@ export default class ConceptsetActionsPage extends AuthenticatedPage {
         this.getCreateDatasetButton(),
       ]);
       return true;
-    } catch (e) {
-      console.log(`ConceptsetActionsPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`ConceptsetActionsPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -27,9 +27,9 @@ export default class ConceptsetPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.log(`ConceptsetPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`ConceptsetPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -21,16 +21,11 @@ export default class ConceptsetPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`ConceptsetPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   async openCopyToWorkspaceModal(conceptName: string): Promise<CopyModal> {

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -17,18 +17,13 @@ export default class ConceptsetSearchPage extends AuthenticatedPage{
   }
 
   async isLoaded(): Promise<boolean> {
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
     const searchTextbox = this.getSearchTextbox();
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        searchTextbox.waitForXPath(),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`ConceptsetSearchPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await searchTextbox.waitForXPath();
+    return true;
   }
 
   async saveConcept(saveOption?: SaveOption, existingConceptName?: string): Promise<string> {

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -25,9 +25,9 @@ export default class ConceptsetSearchPage extends AuthenticatedPage{
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.error(`ConceptsetSearchPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`ConceptsetSearchPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -83,16 +83,12 @@ export default class CreateAccountPage extends BasePage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForText(this.page, 'Please read through the entire agreement to continue'),
-        this.page.waitForXPath('//*[@data-test-id="account-creation-tos"]', {visible: true}),
-      ])
-      return true;
-    } catch (err) {
-      console.log(`CreateAccountPage isLoaded() encountered ${err}`);
-      return false;
-    }
+    await Promise.all([
+      waitForText(this.page, 'Please read through the entire agreement to continue'),
+      this.page.waitForXPath('//*[@data-test-id="account-creation-tos"]', {visible: true}),
+    ]);
+    await waitWhileLoading(this.page);
+    return true;
   }
 
   async getSubmitButton(): Promise<Button> {

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -22,16 +22,11 @@ enum LabelAlias {
 export default class DatasetBuildPage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`DatasetBuildPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   async clickAddCohortsButton(): Promise<CohortBuildPage> {

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -28,9 +28,9 @@ export default class DatasetBuildPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.log(`DatasetBuildPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`DatasetBuildPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/featured-workspaces-page.ts
+++ b/e2e/app/page/featured-workspaces-page.ts
@@ -13,17 +13,12 @@ export default class FeaturedWorkspacesPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitForText(this.page, PageHeader),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`FeaturedWorkspacesPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitForText(this.page, PageHeader),
+      waitWhileLoading(this.page)
+    ]);
+    return true;
   }
 
 }

--- a/e2e/app/page/featured-workspaces-page.ts
+++ b/e2e/app/page/featured-workspaces-page.ts
@@ -20,9 +20,9 @@ export default class FeaturedWorkspacesPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.log(`FeaturedWorkspacesPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`FeaturedWorkspacesPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -35,8 +35,8 @@ export default class HomePage extends AuthenticatedPage {
       ]);
       return true;
     } catch (err) {
-      console.log(`HomePage isLoaded() encountered ${err}`);
-      return false;
+      console.error(`HomePage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -21,23 +21,20 @@ export default class HomePage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        // Look for "See All Workspacess" link.
-        this.getSeeAllWorkspacesLink().then( (element) => element.asElementHandle()),
-        // Look for either a workspace card or msg.
-        Promise.race([
-          this.page.waitForXPath('//*[@data-test-id="workspace-card"]', {visible: true}),
-          this.page.waitForXPath('//text()[contains(., "Create your first workspace")]', {visible: true}),
-        ]),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`HomePage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    await Promise.all([
+      // Look for "See All Workspacess" link.
+      this.getSeeAllWorkspacesLink().then( (element) => element.asElementHandle()),
+      // Look for either a workspace card or msg.
+      Promise.race([
+        this.page.waitForXPath('//*[@data-test-id="workspace-card"]', {visible: true}),
+        this.page.waitForXPath('//text()[contains(., "Create your first workspace")]', {visible: true}),
+      ])
+    ]);
+    return true;
   }
 
   async getCreateNewWorkspaceLink(): Promise<ClrIconLink> {

--- a/e2e/app/page/notebook-download-modal.ts
+++ b/e2e/app/page/notebook-download-modal.ts
@@ -21,11 +21,10 @@ export default class NotebookDownloadModal {
   async waitForLoad(): Promise<this> {
     try {
       await this.waitUntilVisible();
-    } catch (e) {
+    } catch (err) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);
-      const title = await this.page.title();
-      throw new Error(`"${title}" modal waitForLoad() encountered ${e}`);
+      throw err;
     }
     return this;
   }

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -49,9 +49,9 @@ export default class NotebookPage extends AuthenticatedPage {
       await waitForDocumentTitle(this.page, this.documentTitle);
       await this.waitForKernelIdle();
       return true;
-    } catch (e) {
-      console.error(`NotebookPage isLoaded() encountered ${e}`);
-      return false;
+    } catch (err) {
+      console.error(`NotebookPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -45,14 +45,9 @@ export default class NotebookPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await waitForDocumentTitle(this.page, this.documentTitle);
-      await this.waitForKernelIdle();
-      return true;
-    } catch (err) {
-      console.error(`NotebookPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await waitForDocumentTitle(this.page, this.documentTitle);
+    await this.waitForKernelIdle();
+    return true;
   }
 
   /**

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -18,17 +18,12 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        this.page.waitForXPath(Selector.editButton),
-        this.page.waitForXPath(Selector.playgroundButton),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`NotebookPreviewPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await waitWhileLoading(this.page);
+    await Promise.all([
+      this.page.waitForXPath(Selector.editButton),
+      this.page.waitForXPath(Selector.playgroundButton)
+    ]);
+    return true;
   }
 
   /**

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -25,9 +25,9 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
         waitWhileLoading(this.page),
       ]);
       return true;
-    } catch (e) {
-      console.error(`NotebookPreviewPage isLoaded() encountered ${e}`);
-      throw new Error(e);
+    } catch (err) {
+      console.error(`NotebookPreviewPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -51,8 +51,8 @@ export default class ProfilePage extends AuthenticatedPage {
       ]);
       return true;
     } catch (err) {
-      console.log(`ProfilePage isLoaded() encountered ${err}`);
-      return false;
+      console.error(`ProfilePage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -43,17 +43,12 @@ export default class ProfilePage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForUrl(this.page, '/profile'),
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`ProfilePage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForUrl(this.page, '/profile'),
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    return true;
   }
 
   async getFirstNameInput(): Promise<Textbox> {

--- a/e2e/app/page/user-admin-page.ts
+++ b/e2e/app/page/user-admin-page.ts
@@ -19,8 +19,8 @@ export default class UserAdminPage extends AuthenticatedPage {
       ]);
       return true;
     } catch (err) {
-      console.log(`UserAdminPage isLoaded() encountered ${err}`);
-      return false;
+      console.error(`UserAdminPage isLoaded() encountered ${err}`);
+      throw err;
     }
   }
 

--- a/e2e/app/page/user-admin-page.ts
+++ b/e2e/app/page/user-admin-page.ts
@@ -12,16 +12,11 @@ export default class UserAdminPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.error(`UserAdminPage isLoaded() encountered ${err}`);
-      throw err;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
 

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -16,16 +16,11 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.log(`WorkspaceAboutPage isLoaded() encountered ${err}`);
-      return false;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    return true;
   }
 
   async findUserInCollaboratorList(username: string): Promise<WorkspaceAccessLevel> {

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -19,16 +19,11 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.log(`WorkspaceAnalysisPage isLoaded() encountered ${err}`);
-      return false;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page),
+    ]);
+    return true;
   }
 
   /**

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -156,7 +156,6 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     await waitWhileLoading(this.page);
 
     console.log(`Deleted ${resourceType} "${resourceName}"`);
-    await this.waitForLoad();
     return modalTextContent;
   }
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -25,17 +25,12 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        this.imgDiagramLoaded(),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (e) {
-      console.log(`DataPage isLoaded() encountered ${e}`);
-      return false;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    await this.imgDiagramLoaded();
+    return true;
   }
 
   async imgDiagramLoaded(): Promise<ElementHandle[]> {

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -228,21 +228,18 @@ export default class WorkspaceEditPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
     const selectXpath = buildXPath(FIELD.billingAccountSelect.textOption);
     const select = new Select(this.page, selectXpath);
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        this.getWorkspaceNameTextbox(),
-        select.asElementHandle(),
-        this.getCreateWorkspaceButton(),
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.log(`WorkspaceEditPage isLoaded() encountered ${err}`);
-      return false;
-    }
+    await Promise.all([
+      this.getWorkspaceNameTextbox(),
+      select.asElementHandle(),
+      this.getCreateWorkspaceButton()
+    ]);
+    return true;
   }
 
   /**

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -28,18 +28,15 @@ export default class WorkspacesPage extends WorkspaceEditPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    try {
-      await Promise.all([
-        waitForDocumentTitle(this.page, PageTitle),
-        this.page.waitForXPath('//a[text()="Workspaces"]', {visible: true}),
-        this.page.waitForXPath('//h3[normalize-space(text())="Workspaces"]', {visible: true}),  // Texts above Filter By Select
-        waitWhileLoading(this.page),
-      ]);
-      return true;
-    } catch (err) {
-      console.log(`WorkspacesPage isLoaded() encountered ${err}`);
-      return false;
-    }
+    await Promise.all([
+      waitForDocumentTitle(this.page, PageTitle),
+      waitWhileLoading(this.page)
+    ]);
+    await Promise.all([
+      this.page.waitForXPath('//a[text()="Workspaces"]', {visible: true}),
+      this.page.waitForXPath('//h3[normalize-space(text())="Workspaces"]', {visible: true})  // Texts above Filter By Select
+    ]);
+    return true;
   }
 
 

--- a/e2e/puppeteer-custom-environment.ts
+++ b/e2e/puppeteer-custom-environment.ts
@@ -17,32 +17,28 @@ class PuppeteerCustomEnvironment extends PuppeteerEnvironment {
   // Take a screenshot right after failure
   async handleTestEvent(event, state) {
     if (event.name === 'test_fn_failure') {
+      const testParentName = state.currentlyRunningTest.parent.name.replace(/\W/g, '-');
+      const testName = state.currentlyRunningTest.name.replace(/\W/g, '-');
 
-        console.log(`event.name = ${event.name}`);
+      const screenshotDir = `logs/screenshot/${testParentName}`;
+      const htmlDir = `logs/html/${testParentName}`;
+      await fs.ensureDir(screenshotDir);
+      await fs.ensureDir(htmlDir);
 
-        const testParentName = state.currentlyRunningTest.parent.name.replace(/\W/g, '-');
-        const testName = state.currentlyRunningTest.name.replace(/\W/g, '-');
+      const timestamp = new Date().getTime();
+      console.error(`Failed test:  "${testParentName}/${testName}"`);
 
-        const screenshotDir = `logs/screenshot/${testParentName}`;
-        const htmlDir = `logs/html/${testParentName}`;
-        await fs.ensureDir(screenshotDir);
-        await fs.ensureDir(htmlDir);
+      const screenshotFile = `${screenshotDir}/${testName}_${timestamp}.png`;
+      await this.takeScreenshot(screenshotFile);
 
-        console.error(`Failed test:  "${testParentName}/${testName}"`);
-
-        const timestamp = new Date().getTime();
-
-        const screenshotFile = `${screenshotDir}/${testName}_${timestamp}.png`;
-        await this.takeScreenshot(screenshotFile);
-
-        const htmlFile = `${htmlDir}/${testName}_${timestamp}.html`;
-        await this.savePageToFile(htmlFile);
+      const htmlFile = `${htmlDir}/${testName}_${timestamp}.html`;
+      await this.savePageToFile(htmlFile);
     }
   }
 
   async takeScreenshot(filePath) {
     await this.global.page.screenshot({path: filePath, fullPage: true});
-    console.info(`Saved screenshot ${filePath}`);
+    console.info(`Saved screenshot: ${filePath}`);
   }
 
   async savePageToFile(htmlFile) {
@@ -53,7 +49,7 @@ class PuppeteerCustomEnvironment extends PuppeteerEnvironment {
           console.error(`Failed to save html file. ` + error);
           reject(false);
         } else {
-          console.info('Saved html file ' + htmlFile);
+          console.info('Saved html file: ' + htmlFile);
           resolve(true);
         }
       })

--- a/e2e/puppeteer-custom-environment.ts
+++ b/e2e/puppeteer-custom-environment.ts
@@ -15,32 +15,37 @@ class PuppeteerCustomEnvironment extends PuppeteerEnvironment {
   }
 
   // Take a screenshot right after failure
-  async handleTestEvent(event) {
-    switch (event.name) {
-      case 'test_done':
-        if (event.test.errors.length > 0) {
-          console.error(`handleTestEvent case: ${event.name}`);
-          console.error(`Failed test:  "${event.test.name}"`);
-          const testName = event.test.name.replace(/\W/g, '-');
-          const screenshotDir = 'logs/screenshot';
-          await fs.ensureDir(screenshotDir);
-          const timestamp = new Date().getTime();
-          const screenshotFileName = `${screenshotDir}/${testName}_${timestamp}.png`;
-          await this.global.page.screenshot({path: screenshotFileName, fullPage: true});
-          console.error(`Saved screenshot ${screenshotFileName}`);
-          const htmlFileName = `${testName}_${timestamp}.html`;
-          await this.savePageToFile(htmlFileName);
-        }
-        break;
-      default:
-        break;
+  async handleTestEvent(event, state) {
+    if (event.name === 'test_fn_failure') {
+
+        console.log(`event.name = ${event.name}`);
+
+        const testParentName = state.currentlyRunningTest.parent.name.replace(/\W/g, '-');
+        const testName = state.currentlyRunningTest.name.replace(/\W/g, '-');
+
+        const screenshotDir = `logs/screenshot/${testParentName}`;
+        const htmlDir = `logs/html/${testParentName}`;
+        await fs.ensureDir(screenshotDir);
+        await fs.ensureDir(htmlDir);
+
+        console.error(`Failed test:  "${testParentName}/${testName}"`);
+
+        const timestamp = new Date().getTime();
+
+        const screenshotFile = `${screenshotDir}/${testName}_${timestamp}.png`;
+        await this.takeScreenshot(screenshotFile);
+
+        const htmlFile = `${htmlDir}/${testName}_${timestamp}.html`;
+        await this.savePageToFile(htmlFile);
     }
   }
 
-  async savePageToFile(fileName) {
-    const logDir = 'logs/html';
-    await fs.ensureDir(logDir);
-    const htmlFile = `${logDir}/${fileName}`;
+  async takeScreenshot(filePath) {
+    await this.global.page.screenshot({path: filePath, fullPage: true});
+    console.info(`Saved screenshot ${filePath}`);
+  }
+
+  async savePageToFile(htmlFile) {
     const htmlContent = await this.global.page.content();
     return new Promise((resolve, reject) => {
       fs.writeFile(htmlFile, htmlContent, 'utf8', error => {
@@ -48,7 +53,7 @@ class PuppeteerCustomEnvironment extends PuppeteerEnvironment {
           console.error(`Failed to save html file. ` + error);
           reject(false);
         } else {
-          console.log('Saved html file ' + htmlFile);
+          console.info('Saved html file ' + htmlFile);
           resolve(true);
         }
       })

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -24,7 +24,7 @@ export async function waitForUrl(page: Page, urlSubstr: string): Promise<boolean
     }, {}, urlSubstr);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
-    console.error(`Wait for URL contains "${urlSubstr}" failed. ${e}`);
+    console.error(`waitForUrl contains "${urlSubstr}" failed. ${e}`);
     throw e;
   }
 }
@@ -42,7 +42,7 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     }, {timeout: 30000}, titleSubstr);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
-    console.error(`Wait for document title contains "${titleSubstr}" failed. ${e}`);
+    console.error(`waitForDocumentTitle contains "${titleSubstr}" failed. ${e}`);
     throw e;
   }
 }
@@ -136,7 +136,7 @@ export async function waitForVisible(page: Page, cssSelector: string): Promise<b
     await jsHandle.jsonValue();
     return true;
   } catch (e) {
-    console.error(`Wait for element matching CSS="${cssSelector}" visible failed. ${e}`);
+    console.error(`waitForVisible CSS="${cssSelector}" failed. ${e}`);
     throw e;
   }
 }
@@ -155,7 +155,7 @@ export async function waitForHidden(page: Page, cssSelector: string): Promise<bo
     }, {}, cssSelector);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
-    console.error(`Wait for element matching CSS="${cssSelector}" hidden. ${e}`);
+    console.error(`waitForHidden CSS="${cssSelector}" failed. ${e}`);
     throw e;
   }
 }


### PR DESCRIPTION
Fixed blank screenshot and page content `.html` file.

Example: (note: file size is no longer 0 KB)
![Screen Shot 2020-10-06 at 8 54 39 PM](https://user-images.githubusercontent.com/35533885/95275331-31a2fd00-0816-11eb-86a6-2b296c9b8674.png)

Code refactoring that allow `handleTestEvent` function to take screenshot and save page contents when error thrown:
- Removed `try...catch` in `isLoaded` function.
- Removed `try...catch` in `waitForLoad` function.