### PR TITLE
[risk=low] Upgrade jackson, databind, and json-patch to address snyk vulns

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,8 +10,8 @@ buildscript {
     ELASTICSEARCH_VERSION = '6.8.3'
     GAE_VERSION = '1.9.64'
     GSON_VERSION = '2.8.5'
-    JACKSON_DATABIND_VERSION = '2.10.1'
-    JACKSON_VERSION = '2.10.1'
+    JACKSON_DATABIND_VERSION = '2.11.3'
+    JACKSON_VERSION = '2.11.3'
     JODA_VERSION = '2.10'
     KOTLIN_VERSION = '1.3.50'
     MAPSTRUCT_VERSION = '1.3.1.Final'
@@ -373,7 +373,7 @@ dependencies {
   compile "com.fasterxml.jackson.core:jackson-databind:$project.ext.JACKSON_DATABIND_VERSION"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$project.ext.JACKSON_VERSION"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:$project.ext.JACKSON_VERSION"
-  compile "com.github.fge:json-patch:1.9"
+  compile "com.github.java-json-tools:json-patch:1.13"
   compile "com.github.rholder:guava-retrying:2.0.0"
   compile "org.javers:javers-core:5.10.1"
   compile "com.google.api-client:google-api-client-appengine:1.30.0"


### PR DESCRIPTION
Description:

Not sure if these are actual vulns or mis-diagnoses by Snyk, because running `./project.rb gradle dependencies --configuration compile` indicates that the vulnerable versions of jackson-databind are actually shadowed by updated versions.  Still, this should at least clean up the Snyk output, enabling us to see the real problems.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
