### PR TITLE
condition to halt non-e2e jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,9 +337,9 @@ commands:
       - run:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
-          
+
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
+              ALL_CHANGES=$(readarray -t arr2 < <(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})))
               echo $ALL_CHANGES
 
               echo "</br>"
@@ -696,13 +696,7 @@ workflows:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
       - api-local-test
-      # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only.
-      - puppeteer-e2e-test:
-          filters: *filter_only_pr_branch
-          env_name: "local"
-          parallel_num: 2
-          optional_steps:
-            - e2e_presubmit_check
+     
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ commands:
           command: |
 
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=($(readarray -t arr2 < <(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))))
+              ALL_CHANGES=($(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})))
               echo $ALL_CHANGES
 
               echo "</br>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,8 +339,9 @@ commands:
           command: |
 
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=($(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})))
-              echo $ALL_CHANGES
+              ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
+              CHANGES=($ALL_CHANGES)
+              echo $CHANGES
 
               echo "</br>"
               E2E_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e)
@@ -349,7 +350,7 @@ commands:
               # Compare list length of two lists
 
               if [ -n "$E2E_CHANGES" ]; then
-                if [ "${#ALL_CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
+                if [ "${#CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
                   echo "No changes in application code. Stop job now."
                   circleci step halt
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,26 +337,17 @@ commands:
       - run:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
-
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
+              # Count total number of files changed.
               CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | wc -l | xargs)
-              echo $CHANGED_COUNT
-
-              echo "</br>"
+              # Number of chagned files in e2e/ dir.
               E2E_CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e | wc -l | xargs)
-              echo $E2E_CHANGED_COUNT
-
-              # Compare list length of two lists
-
+              # Compare two counts
               if [ $E2E_CHANGED_COUNT > 0 ]; then
                 if [ $E2E_CHANGED_COUNT == CHANGED_COUNT ]; then
                   echo "No changes in application code. Stop job now."
                   circleci step halt
-                else
-                  echo "continue"
                 fi
-              else
-                echo "E2E_CHANGES is no"
               fi
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ commands:
       - run:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
+            IFS=$'\n'
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
               ALL_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH}))
               E2E_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH} -- e2e))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,8 +338,8 @@ commands:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=$(git diff --name-only origin/master...${CIRCLE_BRANCH})
-              E2E_CHANGES=$(git diff --name-only origin/master...${CIRCLE_BRANCH} -- e2e)
+              ALL_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH}))
+              E2E_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH} -- e2e))
 
               echo $ALL_CHANGES
               echo ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,8 +339,8 @@ commands:
           command: |
             IFS=$'\n'
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH}))
-              E2E_CHANGES=($(git diff --name-only origin/master...${CIRCLE_BRANCH} -- e2e))
+              ALL_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})) )
+              E2E_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e) )
 
               echo $ALL_CHANGES
               echo ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,18 +339,17 @@ commands:
           command: |
 
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
-              CHANGES=$(echo $ALL_CHANGES | cut -d " " -f 1-)
-              echo $CHANGES
+              CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | wc -l | xargs)
+              echo $CHANGED_COUNT
 
               echo "</br>"
-              E2E_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e)
-              echo $E2E_CHANGES
+              E2E_CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e | wc -l | xargs)
+              echo $E2E_CHANGED_COUNT
 
               # Compare list length of two lists
 
-              if [ -n "$E2E_CHANGES" ]; then
-                if [ "${#CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
+              if [ $E2E_CHANGED_COUNT > 0 ]; then
+                if [ $E2E_CHANGED_COUNT == CHANGED_COUNT ]; then
                   echo "No changes in application code. Stop job now."
                   circleci step halt
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ anchors:
     branches:
       ignore: master
 
+
 # -------------------------
 #   COMMANDS
 # Refers to https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
@@ -331,6 +332,26 @@ commands:
           name: "Halt job if not a pull request"
           command: bash .circleci/pr-skip-ci.sh
 
+  halt_on_e2e_changes:
+    steps:
+      - run:
+          name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
+          command: |
+            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
+              ALL_CHANGES=$(git diff --name-only master...${CIRCLE_BRANCH})
+              E2E_CHANGES=$(git diff --name-only master...${CIRCLE_BRANCH} -- e2e)
+
+              echo ALL_CHANGES
+              echo ""
+              echo E2E_CHANGES
+
+              # Compare list length of two lists
+              if [ "${#ALL_CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
+                echo "No changes in application code. Stop job now."
+                circleci step halt
+              fi
+            fi
+
 
 # -------------------------
 #        JOBS
@@ -341,6 +362,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -427,6 +449,7 @@ jobs:
       <<: *java_env
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - activate_service_account_credential
       - start_local_api
       - run:
@@ -440,6 +463,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       # Note: most of the time spent here appears to be in Gradle / App Engine
       # deployment. We tried more aggressively caching outputs via Circle
       # workspaces, but that seemed to have a negligible effect on speed. It's
@@ -465,6 +489,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - manage_api_cache:
           restore: true
       - run:
@@ -476,6 +501,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -494,6 +520,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -510,6 +537,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "ui"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,16 +340,23 @@ commands:
             IFS=$'\n'
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
               ALL_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})) )
-              E2E_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e) )
-
               echo $ALL_CHANGES
-              echo ""
+
+              echo "</br>"
+              E2E_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e) )
               echo $E2E_CHANGES
 
               # Compare list length of two lists
-              if [ "${#ALL_CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
-                echo "No changes in application code. Stop job now."
-                circleci step halt
+
+              if [ -n "$E2E_CHANGES" ]; then
+                if [ "${#ALL_CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then
+                  echo "No changes in application code. Stop job now."
+                  circleci step halt
+                else
+                  echo "continue"
+                fi
+              else
+                echo "E2E_CHANGES is no"
               fi
             fi
 
@@ -689,19 +696,6 @@ workflows:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
       - api-local-test
-      - api-unit-test
-      - ui-unit-test
-      - api-bigquery-test
-      - api-integration-test
-      # Run deployment to "test" on master merges.
-      - api-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - api-unit-test
-      - ui-deploy-to-test:
-          filters: *filter_only_master_branch
-          requires:
-            - ui-unit-test
       # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only.
       - puppeteer-e2e-test:
           filters: *filter_only_pr_branch
@@ -709,15 +703,7 @@ workflows:
           parallel_num: 2
           optional_steps:
             - e2e_presubmit_check
-      # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully.
-      - puppeteer-e2e-test:
-          parallel_num: 4
-          env_name: "test"
-          filters: *filter_only_master_branch
-          requires:
-            - api-deploy-to-test
-            - ui-deploy-to-test
-
+      
   deploy-staging:
     jobs:
       - api-local-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ commands:
           command: |
 
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=$(readarray -t arr2 < <(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})))
+              ALL_CHANGES=($(readarray -t arr2 < <(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))))
               echo $ALL_CHANGES
 
               echo "</br>"
@@ -696,7 +696,7 @@ workflows:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
       - api-local-test
-     
+
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ commands:
       - run:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
-            IFS=$'\n'
+          
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
               ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
               echo $ALL_CHANGES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ commands:
 
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
               ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
-              CHANGES=($ALL_CHANGES)
+              CHANGES=$(echo $ALL_CHANGES | cut -d " " -f 1-)
               echo $CHANGES
 
               echo "</br>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,12 +338,12 @@ commands:
           name: "Halt job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=$(git diff --name-only master...${CIRCLE_BRANCH})
-              E2E_CHANGES=$(git diff --name-only master...${CIRCLE_BRANCH} -- e2e)
+              ALL_CHANGES=$(git diff --name-only origin/master...${CIRCLE_BRANCH})
+              E2E_CHANGES=$(git diff --name-only origin/master...${CIRCLE_BRANCH} -- e2e)
 
-              echo ALL_CHANGES
+              echo $ALL_CHANGES
               echo ""
-              echo E2E_CHANGES
+              echo $E2E_CHANGES
 
               # Compare list length of two lists
               if [ "${#ALL_CHANGES[@]}" -eq "${#E2E_CHANGES[@]}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,11 +339,11 @@ commands:
           command: |
             IFS=$'\n'
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              ALL_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH})) )
+              ALL_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}))
               echo $ALL_CHANGES
 
               echo "</br>"
-              E2E_CHANGES=( $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e) )
+              E2E_CHANGES=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e)
               echo $E2E_CHANGES
 
               # Compare list length of two lists
@@ -703,7 +703,7 @@ workflows:
           parallel_num: 2
           optional_steps:
             - e2e_presubmit_check
-      
+
   deploy-staging:
     jobs:
       - api-local-test:

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -10,7 +10,7 @@ describe('Clone workspace', () => {
   beforeEach(async () => {
     await signIn(page);
   });
-
+  // todo
   /**
    * Test:
    * - Find an existing workspace. Create a new workspace if none exists.


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
