### PR TITLE
[RW-5708][risk=no] CircleCI optimization command for skipping non-e2e jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,10 @@ commands:
               fi
             fi
           name: "Halt job if no code changes detected in << parameters.dir_name >> directory on non-master branch"
+
+  e2e_test_changes:
+    description: ""
+    steps:
       - run:
           command: |
             if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
@@ -677,7 +681,9 @@ workflows:
     jobs:
       # Always run basic test/lint/compilation (open PRs, master merge).
       # Note: by default tags are not picked up.
-      - api-local-test
+      - api-local-test:
+          pre-steps:
+            - e2e_test_changes
       - api-unit-test
       - ui-unit-test
       - api-bigquery-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
           name: Halt job if no code changed
 
   ensure_branch_has_changes:
-    description: Halt job and succeed early if no code changes in << parameters.dir_name >> directory on non-master branch
+    description: "Halt job and succeed early if no code changes in << parameters.dir_name >> directory on non-master branch"
     parameters:
       dir_name:
         type: enum
@@ -133,13 +133,29 @@ commands:
     steps:
       - run:
           command: |
-            if [ ${CIRCLE_BRANCH} != "" ] &&
-              [ ${CIRCLE_BRANCH} != "master" ] &&
-              [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep << parameters.dir_name >>/ | wc -l | xargs) == 0 ]; then
-                echo "No relevant changes in << parameters.dir_name >> directory on non-master branch. halting job."
+            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
+              if [ $(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- << parameters.dir_name >> | wc -l | xargs) == 0 ]; then
+                echo "No code changes in << parameters.dir_name >> directory on non-master branch. halting job."
                 circleci step halt
+              fi
             fi
-          name: Halt job and succeed early if no code changes in << parameters.dir_name >> directory on non-master branch
+          name: "Halt job if no code changes detected in << parameters.dir_name >> directory on non-master branch"
+      - run:
+          command: |
+            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
+              # Count total number of files changed.
+              CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | wc -l | xargs)
+              # Number of chagned files in e2e/ dir.
+              E2E_CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e | wc -l | xargs)
+              # Compare two counts
+              if [ $E2E_CHANGED_COUNT > 0 ]; then
+                if [ $E2E_CHANGED_COUNT == CHANGED_COUNT ]; then
+                  echo "No changes in application code. halting job."
+                  circleci step halt
+                fi
+              fi
+            fi
+          name: "Halt non-e2e job if changed files in PR contain only Puppeteer e2e tests in e2e directory"
 
   install_ui_dependencies:
     description: "workbench/ui: yarn install, save and restore cache"
@@ -331,24 +347,6 @@ commands:
           name: "Halt job if not a pull request"
           command: bash .circleci/pr-skip-ci.sh
 
-  halt_on_e2e_changes:
-    steps:
-      - run:
-          name: "Halt non-e2e job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
-          command: |
-            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
-              # Count total number of files changed.
-              CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | wc -l | xargs)
-              # Number of chagned files in e2e/ dir.
-              E2E_CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e | wc -l | xargs)
-              # Compare two counts
-              if [ $E2E_CHANGED_COUNT > 0 ]; then
-                if [ $E2E_CHANGED_COUNT == CHANGED_COUNT ]; then
-                  echo "No changes in application code. Stop job now."
-                  circleci step halt
-                fi
-              fi
-            fi
 
 # -------------------------
 #        JOBS
@@ -359,7 +357,6 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -446,7 +443,8 @@ jobs:
       <<: *java_env
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
+      - ensure_branch_has_changes:
+          dir_name: "api"
       - activate_service_account_credential
       - start_local_api
       - run:
@@ -485,7 +483,6 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
       - manage_api_cache:
           restore: true
       - run:
@@ -497,7 +494,6 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -516,7 +512,6 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -533,7 +528,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout_init_git
-      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "ui"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,24 @@ commands:
           name: "Halt job if not a pull request"
           command: bash .circleci/pr-skip-ci.sh
 
+  halt_on_e2e_changes:
+    steps:
+      - run:
+          name: "Halt non-e2e job if changed files in PR contain only Puppeteer e2e tests in e2e dir"
+          command: |
+            if [ ${CIRCLE_BRANCH} != "" ] && [ ${CIRCLE_BRANCH} != "master" ]; then
+              # Count total number of files changed.
+              CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | wc -l | xargs)
+              # Number of chagned files in e2e/ dir.
+              E2E_CHANGED_COUNT=$(git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) -- e2e | wc -l | xargs)
+              # Compare two counts
+              if [ $E2E_CHANGED_COUNT > 0 ]; then
+                if [ $E2E_CHANGED_COUNT == CHANGED_COUNT ]; then
+                  echo "No changes in application code. Stop job now."
+                  circleci step halt
+                fi
+              fi
+            fi
 
 # -------------------------
 #        JOBS
@@ -341,6 +359,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -427,6 +446,7 @@ jobs:
       <<: *java_env
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - activate_service_account_credential
       - start_local_api
       - run:
@@ -465,6 +485,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - manage_api_cache:
           restore: true
       - run:
@@ -476,6 +497,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -494,6 +516,7 @@ jobs:
     <<: *java_defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "api"
       - manage_api_cache:
@@ -510,6 +533,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout_init_git
+      - halt_on_e2e_changes
       - ensure_branch_has_changes:
           dir_name: "ui"
       - run:

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -132,7 +132,7 @@ export default class WorkspaceCard extends CardBase {
     const [elemt] = await this.asElementHandle().$x(`.//*[${WorkspaceCardSelector.cardNameXpath}]`);
     const name = await getPropValue<string>(elemt, 'textContent');
     await Promise.all([
-      this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']}),
+      this.page.waitForNavigation({waitUntil: ['load', 'domcontentloaded', 'networkidle0']}),
       elemt.click(),
     ]);
     if (waitForDataPage) {


### PR DESCRIPTION
For Puppeteer tests changes pull requests, they don't require non-e2e jobs to run at all because no application code has been changed.