### PR TITLE
[RW-5272][RISK=low] Terraform config for reporting for each environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,9 +527,15 @@ flexible [queries](api/docs/action-audit-queries.md). Read more about its design
 implementation in this [document](api/docs/action-audit.md).
 
 ### Reporting System
-To supporrt analytics, we have a reporting pipeline that exports data to a BigQuery dataset.
+To support analytics, we have a reporting pipeline that exports data to a BigQuery dataset.
 The main source of documentation is the [design document (internal)](https://docs.google.com/document/d/1EKGApPC55X-KTHwVsv_saBQty4m-HCP2Kd5o6JHKDnQ/edit?usp=sharing).
 Some [codegen utilities](./api/reporting/schemas/REPORTING-SCHEMA-TOOLS.md) exist to assist
 with keeping types for all phases of the pipeline consistent.
 
 Queries and views of interest in the BigQuery  dataset(s) are described [here](api/reporting/queries/REPORTING-QUERIES.md).
+
+#### Teraform
+The Reporting system is also our testbench for Terraform-managed process. Notes and pointers from this
+initial project are in this [quickstart guide](ops/terraform/TERRAFORM-QUICKSTART.md).
+It's expected that we'll also use Terraform to manage monitoring and alerting configurations, log
+configs, and VPC configurations under the upcoming Multiple Tier project.

--- a/ops/terraform/.gitignore
+++ b/ops/terraform/.gitignore
@@ -1,0 +1,3 @@
+**/*.backup
+**/*.tfstate
+**/.terraform/*

--- a/ops/terraform/AOU_RW_MODULE_WALKTHROUGH.md
+++ b/ops/terraform/AOU_RW_MODULE_WALKTHROUGH.md
@@ -1,0 +1,276 @@
+# AoU Researcher Workbench Module  Walkthrough
+## 0. Module Structure
+The state associated with the current deployment  consists of
+one `root` module for each environment, in separate directories
+
+In  order to deploy a full (or partial) environment we need to declare what modules are used and to supply
+values to all unbound declared variables. The environment module is  unioned with the modules in the
+`source` statement.
+
+The overall source structure looks like the following. Note that 
+Terraform will collect all `.tf` files in a referenced directory,
+so the calling module will need to specify values for the chilid
+modules' `variable` blocks that don't have defaults.
+
+```text
+/repos/workbench/ops/terraform/
+├── AOU_RW_MODULE_WALKTHROUGH.md
+├── TERRAFORM-QUICKSTART.md
+├── environments
+│   ├── local
+│   ├── scratch
+│   │   ├── SCRATCH-ENVIRONMENT.md
+│   │   ├── scratch.tf
+│   │   ├── terraform.tfstate
+│   │   ├── terraform.tfstate.backup
+│   │   └── terraform.tfstate.yet.another.backup
+│   └── test
+└── modules
+    └── aou-rw-reporting
+        ├── providers.tf
+        ├── reporting.tf
+        ├── schemas
+        │   ├── cohort.json
+        │   ├── institution.json
+        │   ├── user.json
+        │   └── workspace.json
+        ├── variables.tf
+        └── views
+            ├── latest_cohorts.sql
+            ├── latest_institutions.sql
+            ├── latest_users.sql
+            ├── latest_workspaces.sql
+            └── table_count_vs_time.sql
+```
+The `modules` directory contains independent, reusable modules foor
+subsystems that are 
+* logical to deploy and configure operationally,
+* don't depend on each other (at least for exported modules) and
+* can be used by AoU or potentially another organization interested in deploying a copy
+of all or part of our system.
+
+## Prerequisites
+### 1. Get Terraform
+Install Terraform using the directinos at [TERRAFORM-QUICKSTART.md]
+### 2. Change to the `environments/scratch directory` `get` and `init`
+The environment for this outline is `scratch`, which exists in a target environment
+of your choice. 
+### 3. Assign Values to Input Variables
+
+The following public variable declarations are representative of those
+specified in `modules/reporting/variables.tf` and elsewhere. The description
+string shows when interactively running from the command line without all the
+vars cominig in from a `-var-file` argument.
+```hcl-terraform
+variable credentials_file {
+  description = "Location of service account credentials JSON file."
+  type        = string
+}
+
+variable aou_env {
+  description = "Short name (all lowercase) of All of Us Workbench deployed environments, e.g. local, test, staging, prod."
+  type        = string
+}
+
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}
+```
+Create a `scratch_tutorrial.tfvars` file outside of this repository. This file should
+look contain values for the following [input variables](https://www.terraform.io/docs/configuration/variables.html) that will be different
+for different organizations and environments.
+
+```hcl-terraform
+aou_env = "scratch" # Name of environment we're creating or attaching to. Needs to match directory name
+project_id = "my-qa-project" # Should not be prod
+reporting_dataset_id = "firstname_lastname_scratch_0" # BigQuery  dataset id
+```
+
+The credentials file should point to a JSON key file generated
+by Google Cloud IAM (at least on lower environments). The only required
+permission is `BigQuery Data Owner` Neither the credentials nor
+the `.tfvars` file itself should be checked into public source control.
+
+It's sometimes helpful to assign the full path to this `.tfvars` to an environment variable,
+as it will need to e provided for most commands. There are several other ways to do this, 
+but the advantage for us is separating the reusable stuff from the AoU-instance-specific
+values.
+```shell script
+$ SCRATCH_TFVARS=/rerpos/workbench-devops/terraform/scratch.tfvars
+```
+
+### 4. Initialize Terraform
+Run [`terraform init`](https://www.terraform.io/docs/commands/init.html) to initialize the current directory (which should be 
+`api/terraform/environrments/scratch` if working from this repo. It should also be possible
+work from a directory completely sepaated from source control. It's just 
+a bit harder to refer to the module definitions.
+
+If `init` was successful, the following message should print something like the following
+like following:
+```
+Initializing modules...
+
+Initializing the backend...
+
+Initializing provider plugins...
+- Using previously-installed hashicorp/google v3.5.0
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+After successfully `init`, while the backend, plugins, and modules are now in a reasonably good state,
+but certain expensive operations are deferred for performance. Look at the `terraform.tfstate` file
+in the run directory to confirming nothing is of intererst there:
+```json
+{
+  "version": 4,
+  "terraform_version": "0.13.0",
+  "serial": 24,
+  "lineage": "d9d8e034-fad0-03ff-df40-86bdd7a43128",
+  "outputs": {},
+  "resources": []
+}
+```
+ 
+### 5. Build a Plan
+Terraform creates a plan of action based on the difference between its view of the state
+of all the resources, and what's stated in the file.
+
+Run like
+```
+terraform plan -var-file=$SCRATCH_TFVARS
+```
+The output for me looks like [this](doc/plan_output.txt). You should see a couple of key things:
+*  A dataset, several tables, and some views will be created. Searching for "will be created" is an easy way to
+see this.
+* All the variables are expanded in the state file, so treat this file as Eyes Only.
+* The summary line should show `Plan: 10 to add, 0 to change, 0 to destroy.`
+
+The `plan` command doesn't edit actual resources, but is important for understanding Terraform's marching
+orders.
+
+### 6. Apply the Plan
+Use the `apply` command to make the chagnes necessary. It will ask you for a `yes` confirmation beofre proceeding.
+In the sase of the reporting module, creating the dataset then immediately crerating tabales may mean
+that we need to run one more time. Luckily, `apply` is idempotent for this case and there's no harm.
+
+Once everything is applied, rerunning `tf plan` will show that nothing is left to do:
+```
+$ tf plan -lock=false -var-file=$SCRATCH_TFVARS
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+module.aou_rw_scratch_env.module.reporting.google_bigquery_dataset.main: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_cohorts"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/latest_cohorts]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["institution"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/institution]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["table_count_vs_time"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/table_count_vs_time]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_institutions"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/latest_institutions]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_users"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/latest_users]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["cohort"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/cohort]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_workspaces"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/latest_workspaces]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["user"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/user]
+module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["workspace"]: Refreshing state... [id=projects/all-of-us-workbench-test/datasets/jaycarlton_terraform_tmp_2/tables/workspace]
+
+------------------------------------------------------------------------
+
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.
+```
+
+### 7. Selectively removing state
+If it's necessary to detach one or more online resources from the local Terraform state (as if it has
+never been created or imported), use the `terraform state rm` command. The general pattern is
+`terraform remove tfitem_id cloud_id`. For example, let's say I've decided I no longer want the view
+named `latest_workspaces` to be included in the state file.
+
+### 8. Handy State commands
+The [state command](https://www.terraform.io/docs/commands/state/index.html) is one of the more powerful ones to use, and lets you avoid interacting directly with `.tfstate`
+files.
+#### Import
+Working with resources tha already exist requires `terraform import` command. This seems unintuitive,
+but the sample `tarraform state list` output shows what's expected. Third party modules should show
+the expected syntx. For [importing a BigQuery dataset](https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html#import)
+from the `scratch` environment to the `local` environment, simply do;
+
+```shell script
+terraform import -var-file=$TFVARS_LOCAL \
+    module.local.module.reporting.google_bigquery_dataset.main \
+    reporting_local
+``` 
+The output should look like this if successful. There are several failure modes involving directory structure,
+module path, and differing asset ID configurations for different providers. 
+
+```
+terraform import -var-file=$TFVARS_LOCAL module.local.module.reporting.google_bigquery_dataset.main reporting_local
+module.local.module.reporting.google_bigquery_dataset.main: Importing from ID "reporting_local"...
+module.local.module.reporting.google_bigquery_dataset.main: Import prepared!
+  Prepared google_bigquery_dataset for import
+module.local.module.reporting.google_bigquery_dataset.main: Refreshing state... [id=projects/my-project/datasets/reporting_local]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+`tf state` should now show that we are managing the resource:
+```shell script
+tf state list
+module.local.module.reporting.google_bigquery_dataset.main
+```
+
+```shell script
+
+terraform import -var-file=$TFVARS_LOCAL module.local.module.reporting.google_bigquery_table.main[\"cohort\"] \projects/all-of-us-workbench-test/datasets/reporting_local/tables/cohort
+terraform import -var-file=$TFVARS_LOCAL module.local.module.reporting.google_bigquery_table.view[\"latest_users\"]  projects/all-of-us-workbench-test/datasets/reporting_local/tables/latest_users
+```
+is an example of importing a table. remember that equation marks must be escaped.
+
+```shell script
+$ tf state list
+module.local.module.reporting.google_bigquery_dataset.main
+module.local.module.reporting.google_bigquery_table.main["cohort"]
+```
+None of the `teraform state` commands accept variable values, as those have already been interpolated
+during a `plan` or `apply` operation.
+
+**NOTE** While Terraform is managing the dataset, it's not yet managing any data in it directly.
+Running `tf plan` at this point will indicate that, while the dataset is controlled, the tables and
+views in it are not. It's probalby not a good idea to `terraform destory` imported resources that
+contain other resources you care about; always study the `plan` output carefully.
+#### `state list`
+`terraform state list` lists all modules and resources under management for the current module. It's
+especially handy when trying to find the desired module path string for `import` if you're reusing a
+oonfiguration for another environment or system.
+#### `state show`
+terraform show is a more detailed listing for a given item in the state tree. The comm
+```
+terraform state show module.local.module.reporting.google_bigquery_dataset.main
+```
+
+#### `state pull`
+To show the active state file (by default named `terraform.tfstate`), simply do
+ ```terraform state pull | jq```.
+The `jq` command makes the JSON colorized, though it already has a nice structure.
+
+I don't know why you'd use `terraform push`, which applies state that's externalized as JSON somehow.
+Likely an advanced feature.
+
+#### `state rm`
+The opposite of `state import`, the `state rm` subcommand removes a tracked resource from the
+Terraform state file. Some uses for this are for repairing configurations, spliting them up,
+or allowing someone else to experiment with changes on a deployed artifact before bringing it
+back under control. Happily, this command does not `destroy` objects when removing them.

--- a/ops/terraform/TERRAFORM_QUICKSTART.md
+++ b/ops/terraform/TERRAFORM_QUICKSTART.md
@@ -1,0 +1,218 @@
+# Terraform Quickstart
+The [official documentation](https://www.terraform.io/) for Terraform
+is quite readable and exposes the functionality and assumptions at a good pace.
+In particular, I found the [Get Started - Google Cloud](https://learn.hashicorp.com/collections/terraform/gcp-get-started) guide to  be very helpful. 
+
+It's worth making an alias for terraform and putting it in your `.bash_profile` or other shell init file, as
+it's difficult to spell `terraform` correctly when caffeinated.
+```shell script
+alias tf='terraform'
+```
+The above tip also serves as a warning and non-apology that I'm going to forget to spell out the
+command name repeatedly below.
+
+## Installation
+For the work so far, I've used the [Terraform CLI](https://www.terraform.io/docs/cli-index.html), which has the  advantage of not costing
+money or requiring an email registration. On the mac, `brew inistall terraform` is pretty much all it takes. 
+
+Terraform works by keeping state  on the local filesystem for evaluating diffs and staging changes. Primary files for users to author
+and check in to source control are:
+* main.tf - listing providers and specifying Terraform version  and other global options
+* <subsystem_name>.tf - list of resources and their properties and dependencies. This file can reference any other .tf flies in the local directory.
+* variables.tf - any string, numeric, or map variables to be provided to the script.
+* external text files - useful files with text input, such as BigQuery table schema JSON files
+
+Output files provided Terraform (and not checked in to source control) include
+* tfstate files - a record of the current known state of resources under Terraform's control.
+
+## Organization
+Terraform configuration settings are reusable for all environments (after bvinding environment-specific
+variables in `.tfvars` files). The reuse is provided by Terraform
+## Running
+If you have a small change to make to a resource under Terraform's management, in the simplest case the workflow is
+* Run `terraform init` to initialize the providers
+* Run `terraform state list` to list all  artifacts currently known and managed by Terraform within
+the scope of the `.tf` files in the current directory.
+* Run `terraform show` to view the current  state of the (managed) world, and check any errors.
+* change the setting in the tf file (such as reporting.tf). 
+* Run `terraform plan` to see the execution plan. This can be saved with the `-out` argument in
+situations where it's important to apply exactly the planned changes. Otherwise, new changes to the
+environment might be picked up in the `apply` step, giving possibly significantly different behaviors
+than were expected based on the `plan` output.
+* Run `terraform apply` to execute the plan and apply the changes. You'll need  to type "yes" to
+ proceed with the changes (or use `-auto-approve` in a non-interactive workflow.)
+* Check in changes to the terraform file.
+
+## Managing Ownership
+### Importing resources
+Frequently, resources to be managed already exist. By default, Terraform will try to re-create them
+if they're added to a configuration and fail because the name or r other unique identifier is already  in use.
+Using `terraform import` allows the existing resource to be included
+in the `tfstate` file as if Terraform created it from scratch. 
+
+### Removing items from Terraform
+Occasionally, it's desirable to remove a resource form Terraform state. This can be helpful when reorganizing
+resources or `tf` files. The `terraform state rm` command accomplishes this, and moves those resources
+into a state where Terraform doesn't know  it either created or owned them. The
+[official](https://www.terraform.io/docs/commands/state/rm.html) do are pretty good for this.
+
+## Good Practices
+### Formatting
+A builtin linter is available with the `terraform fmt` command. It spaces assignments in clever ways
+that would be difficult to maintain by hand, but that are easy to read. It's easy to set up in IntelliJ
+by installing the FileWitchers plugin and adding a Terraform Format action. Runs fast,too.
+
+### Labels
+It's handy to have a human-readable label called `managedByTerraform` and set it to `true` for all TF artifacts.
+It's possible to set up default labels and things for this.
+### Local Variables
+Using a `locals` bock allows you to assign values (computed once) to variables to be used elsewhere. This
+is especially useful for nested map lookups: 
+```hcl-terraform
+locals {
+  project = var.aou_env_info[var.aou_env]["project"]
+  dataset = var.aou_env_info[var.aou_env]["dataset"]
+}
+```
+
+Later, simply reference the value by `dataset_id = local.dataset`. Note that these "local" variables
+are available to other `.tf` files, but apparently, since things are all initialized at once and immutable,
+it doesn't really matter whether you define them in `chicken.tf` or `egg.tf`. It just works as long
+as both files are part of the same logical configuration.
+
+It's useful in some cases to specify `default` values for the resources in use, but it's advisable to
+force the user to specify certain fundamental things (such as the AoU environment) every time in order
+to avoid migrating the wrong environment prematurely (such as removing artifacts that code running on
+that environment expects to be there).
+
+### Starting with a scratch state collection
+It's much faster to work Terraform-created artifacts, properties, etc, than to attach to existing infrastructure.
+For this purpose, it can be handy to add new BigQuery datasets just for the development of the configuration,
+capture resource and module identifiers for import, and then tear down the temporary artifacts with `terraform destroy`.
+
+### Use Modules
+[Modules](https://www.terraform.io/docs/configuration/modules.html) are the basis of reuse,
+encapsulation, and separation of concerns in Terraform. Frequently, the provider (such as Google
+Cloud Platform) has already written handy base modules that provide reasonable
+defaults, logical arrangement of resources, and convenient output variable declarations.
+
+### Separate Private Vars from Community-use Settings
+Names of artifacts, deployments (such as test and staging), service accounts, or other pseudo-secrets
+should be kept separate from the primary module definitions outlining behavior. For example, looking
+at the reporting project, we have:
+* public: table schemas, names, and clustering/partitioning settings
+* public: view queries (with dataset and project names abstracted out)
+* private: names of AoU environments (currently exposed in several places publicly, but of no legitimate
+use to the general public)
+* private: BigQuery dataset names. We have a simple convention of naming it after the environment,
+but this isn't a contract enforced by our application code or the Terraform configurations.
+
+Why do we include the environment name in the dataset name (as opposed to just calling it `reporting`) in every
+environment? Firstly, we have two environments that share a GCP project, so we would have a name clash.
+More fundamentally, though, is that it would be too easy to apply a query to a dataset in the wrong environment
+if it simply referred to `reporting.workspace` instead of `reporting_prod.workspace`, as the BigQuery
+console lets you mix datasets from multiple environments as long as you have the required credentials. In most
+cases, I'd argue against such inconsistent resource naming.
+
+### Don't fear the `tfstate` file
+Despite the scary name, the contents of `tfstate` are in JSON, and largely readable. You can operate
+on it with utilities such as `jq`
+
+```shell script
+$ jq '.resources[0].instances[0].attributes.friendly_name' terraform.tfstate
+"Workbench Scratch Environment Reporting Data"
+```
+
+I'd keep any operations read-only whenever possible, but I have a feeling one of the keys to mastering
+Terraform will be understanding the `tfstate` file.
+## Gotchas
+## A Terra by any other name
+[Terra](https://terra.bio/) and [Terraform](https://www.terraform.io/) are different things, and for
+the most part going to one organization for help with the other's platform will result in bemusement
+at best. Good luck differentiating them on your resume.
+
+### Mis-configuring a tfstate file
+The file really shouldn't be checked into source contol, because
+it's not safe to have multiple developers working with it. It's too easy to getinito an inconsistent view of the world.
+
+However, that doesn't mean it's safe to lost track of the tfstate JSON file altogether.
+When working with multiple people, a shared   online backend  with locking is really
+required.
+
+### Using two terminals in the same terraform root module working directory.
+Frequent error messages about the lock file and how you can use `lock=fale` but should really never
+do so. It's basically that two processes think they own something in `.terraform/`. So don't do that.
+
+### Using `terraform state show` with `for-each` or an array-declared value.
+When creating many items of hte same type at the same level/scope, it's useful to use arrays or 
+`for-each`. However, the syntax for `tf state show` is trickier because you need to pass a double-quoted
+string index from the command line.
+
+Given the following output of `terraform state list`:
+```
+$ tf state list
+module.bigquery_dataset.google_bigquery_dataset.main
+module.bigquery_dataset.google_bigquery_table.main["cohort"]
+module.bigquery_dataset.google_bigquery_table.main["user"]
+module.bigquery_dataset.google_bigquery_table.main["workspace"]
+module.bigquery_dataset.google_bigquery_table.view["latest_users"]
+```
+The naive approach gives you this [cryptic error message](https://github.com/hashicorp/terraform/pull/22395).
+```
+$ tf state show module.bigquery_dataset.google_bigquery_table.main["cohort"]
+Error parsing instance address: module.bigquery_dataset.google_bigquery_table.main[cohort]
+
+This command requires that the address references one specific instance.
+To view the available instances, use "terraform state list". Please modify 
+the address to reference a specific instance.
+
+```
+The approach that seems to work in Bash is
+```
+ terraform state show ¨
+```
+
+### Cloud not quite ready to use newly created resource
+When creating a new BigQuery dataset with tables and views
+all at once, I once  run into an issue where the new  table
+wasn't  ready for a view creation yet. The error message was
+```
+Error: googleapi: Error 404: Not found: Table my-project:my_dataset.user, notFound
+
+  on .terraform/modules/aou_rw_reporting/main.tf line 76, in resource "google_bigquery_table" "view":
+  76: resource "google_bigquery_table" "view" {
+```
+
+Re-running `terraform apply` fixed this.
+### Renaming  files and  directories
+It's really easy to refactor yourself into a corner by renaming modules or directories in their paths.
+If you see this  error,  it  probably means you've moved something in the local filesystem  that  the
+cached state was depending on.
+```
+Error: Module not found
+
+The module address
+"/repos/workbench/ops/terraform/modules/aou-rw-reporting/"
+could not be resolved.
+
+If you intended this as a path relative to the current module, use
+"/repos/workbench/ops/terraform/modules/aou-rw-reporting/"
+instead. The "./" prefix indicates that the address is a relative filesystem
+path.
+```
+So the last chance to rename things  relatively is just before you've created them and people are depending on them in prod.
+It not really easy to rework your tf  files after deployment. (Another good reason for a scratch project).
+
+### Running in wrong terminal window
+If things get created on the wrong cloud, that's not good. I was really confused when I tried running
+the AWS tutorial tf file. `tf destroy`  is cathartic in such situations. I'm not  even sure it's OK to use  two
+terminals in the same root module at once.
+
+### Using new BigQuery resources
+The BigQuery console UI frequently doesn't list all of the new datasets for several minutes, so using
+`bq show` is helpful if you want to see things  "with  your own eyes after tf operation".
+
+### Yes Man
+If you "yes" out of habit but `terraform apply` or `destroy` bailed out earlier than the prompt,
+you see a string of `y`s in  your terminia. I nearly filed a bug for this, but then realized the `yes`
+command with no argument does that for all time (at least, so far...).

--- a/ops/terraform/modules/workbench/README.md
+++ b/ops/terraform/modules/workbench/README.md
@@ -1,0 +1,24 @@
+# Workbench Child Modules
+The module directories here represent individually deployable subsystems, 
+microservices, or other functional units. It's easy enough to put all buckets, say,
+in a `gcs` module, but that wouldn't really let us operate on an individual components's bucket.
+
+Following is a broad outline fo each child module. If you feel irritated that you can't see, for example,
+all dashboards in one place, you can still go to the Console or use `gcloud`.
+
+## Reporting
+The state for reporting is currently the BigQuery dataset and its tables and views. In the future,
+it makes sense to add j
+* Reporting-specific metrics
+* Notifications on the system
+* Reporting-specific logs, specific logs
+* Data blocks for views (maybe)
+
+## Backend Database (future)
+This resource is inherently cross-functional, so we can just put
+* The application DB 
+* backup settings
+This will take advantage of the `google_sql_database_instance` resource.
+
+Schema migrations work via `Ruby->Gradle->Liquibase->MySql->🚂` 
+Maybe it needs a `Terraform` caboose. It looks like there's not currently a Liquibase provider.

--- a/ops/terraform/modules/workbench/WORKBENCH-MODULE.md
+++ b/ops/terraform/modules/workbench/WORKBENCH-MODULE.md
@@ -1,0 +1,63 @@
+
+# Workbench Module
+The module directories here represent individually deployable subsystems, 
+microservices, or other functional units. It's easy enough to put all buckets, say,
+in a `gcs` module, but that wouldn't really let us operate on an individual components's bucket.
+
+Following is a broad outline fo each child module. If you feel irritated that you can't see, for example,
+all dashboards in one place, you can still go to the Console or use `gcloud`.
+
+A somewhat forward-looking plan for that would look like
+
+# Workbench Module Development Plan
+The Workbench is the topmost parent module in the AoU Workbench
+Application configuration. It depends on several modules for individual
+subsystems.
+
+After creating a valid Terraform configuration we're  not finished,
+as we need to make sure we don't step on other tools or automatioin.
+For example, items that  pertain to cloud resources will need to move
+out of the workbench JSON config system.
+
+I have automation already for stackdriver setting that fetches all of theiir configurations
+and plan to migrate it to Terraform.
+
+## Reporting
+The state for reporting is currently the BigQuery dataset and its tables and views.
+Highlights
+* Reporting-specific metrics with the `google_logging_metric` [resource](https://www.terraform.io/docs/providers/google/r/logging_metric.html)
+and others
+* Notifications on the system
+* Reporting-specific logs, specific logs
+* Data blocks for views (maybe)
+
+## Backend Database (future)
+This resource is inherently cross-functional, so we can just put
+* The application DB 
+* backup settings
+This will take advantage of the `google_sql_database_instance` resource.
+
+Schema migrations work via `Ruby->Gradle->Liquibase->MySql->�`  
+Maybe it needs a `Terraform` caboose. It looks like there's not currently a Liquibase provider.
+
+## Workbench to RDR Pipeline
+Instantiate [google_cloud_tasks_queue](https://www.terraform.io/docs/providers/google/r/cloud_tasks_queue.html) resource
+resouorces as necessary.
+
+## API Server
+* AppEngine versions, instances, logs, etc. Isn't just named
+App Engine, since that's the resource that gets crated.
+
+## Action Audit
+This module maps to 
+* Stackdriver logs for each environment. (It will nedd to
+ move from the applicatioin JSON config likely.)
+
+## Tiers and Egress Detection
+There is a [sumo logic provider](https://www.sumologic.com/blog/terraform-provider-hosted/) for Terraform, which is very good
+news. It looks really svelte.
+
+We will also want to control the VPC flow logs,
+perimeters, etc, but it  won't be  in this `workbench` module,
+because Terra-not-form owns the organization and needs to do
+cration manually for now.

--- a/ops/terraform/modules/workbench/main.tf
+++ b/ops/terraform/modules/workbench/main.tf
@@ -1,0 +1,19 @@
+
+// Module for creating an instance of the scratch AoU RW Environment
+module "reporting" {
+  source = "./modules/reporting"
+
+  # reporting
+  aou_env              = var.aou_env
+  reporting_dataset_id = var.reporting_dataset_id
+
+  # provider
+  project_id = var.project_id
+}
+
+# Stackdriver Alerting
+module "monitoring" {
+  source                    = "./modules/monitoring"
+  project_id                = var.project_id
+  notification_channel_info = var.notification_channel_info
+}

--- a/ops/terraform/modules/workbench/modules/monitoring/main.tf
+++ b/ops/terraform/modules/workbench/modules/monitoring/main.tf
@@ -1,0 +1,6 @@
+
+module "notification_channels" {
+  source                    = "./modules/notification_channels"
+  notification_channel_info = var.notification_channel_info
+  project_id                = var.project_id
+}

--- a/ops/terraform/modules/workbench/modules/monitoring/modules/notification_channels/main.tf
+++ b/ops/terraform/modules/workbench/modules/monitoring/modules/notification_channels/main.tf
@@ -1,0 +1,10 @@
+# All notification channels for Stackdriver alerts (all subsystems).
+resource "google_monitoring_notification_channel" "channel" {
+  for_each = var.notification_channel_info
+
+  description  = each.value.description
+  display_name = each.value.display_name
+  labels       = each.value.labels
+  project      = each.value.project_id
+  type         = each.value.type
+}

--- a/ops/terraform/modules/workbench/modules/monitoring/modules/notification_channels/variables.tf
+++ b/ops/terraform/modules/workbench/modules/monitoring/modules/notification_channels/variables.tf
@@ -1,0 +1,43 @@
+
+
+variable "notification_channel_info" {
+  description = <<EOF
+I want to use an  array  of objects,  but  as of v0.13, only
+sets of strings or  single objects are supported. Next best thing is
+a map where the keys are unique, short names for the instances. It's
+possible to name them anonymously like _0, _1, etc, but I found it helpful
+to use recognizable tokens.
+{
+    email_channel_1 = {
+      display_name = "An email channel"
+      type         = "email" # email or
+      project_id   = "my-project-id" # belt and suspenders
+      labels = {
+        email_address = "a@b.co"
+      }
+    },
+    slack_random = {
+      display_name = "Slack Random Channel"
+      type         = "slack"
+      project_id   = "my-project-id" # belt and suspenders
+      labels = {
+        channel_name = "#random"
+        auth_token = "my_token"
+      }
+    }
+EOF
+
+  type = map(
+    object({
+      display_name = string
+      type         = string
+      labels       = map(string)
+      description  = string
+      project_id   = string
+  }))
+}
+
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}

--- a/ops/terraform/modules/workbench/modules/monitoring/variables.tf
+++ b/ops/terraform/modules/workbench/modules/monitoring/variables.tf
@@ -1,0 +1,43 @@
+
+
+variable "notification_channel_info" {
+  description = <<EOF
+I want to use an  array  of objects,  but  as of v0.13, only
+sets of strings or  single objects are supported. Next best thing is
+a map where the keys are unique, short names for the instances. It's
+possible to name them anonymously like _0, _1, etc, but I found it helpful
+to use recognizable tokens.
+{
+    email_channel_1 = {
+      display_name = "An email channel"
+      type         = "email" # email or
+      project_id   = "my-project-id" # belt and suspenders
+      labels = {
+        email_address = "a@b.co"
+      }
+    },
+    slack_random = {
+      display_name = "Slack Random Channel"
+      type         = "slack"
+      project_id   = "my-project-id" # belt and suspenders
+      labels = {
+        channel_name = "#random"
+        auth_token = "my_token"
+      }
+    }
+EOF
+
+  type = map(
+    object({
+      display_name = string
+      type         = string
+      labels       = map(string)
+      description  = string
+      project_id   = string
+  }))
+}
+
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}

--- a/ops/terraform/modules/workbench/modules/reporting/assets/schemas/cohort.json
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/schemas/cohort.json
@@ -6,7 +6,7 @@
   },
   {
     "name": "cohort_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "Unique ID of this cohort in the application DB. Should be unique within each snapshot."
   },
   {
@@ -16,8 +16,8 @@
   },
   {
     "name": "creator_id",
-    "type": "INT64",
-    "description": "User ID of cohort crerator. Should be a foreign key into the user table."
+    "type": "INTEGER",
+    "description": "User ID of cohort creator. Should be a foreign key into the user table."
   },
   {
     "name": "criteria",
@@ -41,7 +41,7 @@
   },
   {
     "name": "workspace_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "Application workspace ID of the workspace containing this cohort. Should be a foreign\nkey into the workspace table."
   }
 ]

--- a/ops/terraform/modules/workbench/modules/reporting/assets/schemas/institution.json
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/schemas/institution.json
@@ -16,7 +16,7 @@
   },
   {
     "name": "institution_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "Unique PK for institution table in  application DB. Note that in foreign key relationships,\nthe short_name is typically used in place of this identifier."
   },
   {

--- a/ops/terraform/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -106,7 +106,7 @@
   },
   {
     "name": "free_tier_credits_limit_dollars_override",
-    "type": "FLOAT64",
+    "type": "FLOAT",
     "description": "Override value for the default free tier spending limit (USD)."
   },
   {
@@ -174,19 +174,19 @@
     "type": "STRING",
     "description": "Up to 10-digit zip code for use residence."
   },
-   {
-     "name": "institution_id",
-     "type": "INTEGER",
-     "description": "Foreign key into institution table. Each user is only affiliated\nwith a single institution."
-   },
-   {
-     "name": "institutional_role_enum",
-     "type": "STRING",
-     "description": "Description of the user's role at the institution they are\naffiliated with. Selected from a list of predefined values. If \"other\", see institutional_role_other_text\nfor custom description."
-   },
-   {
-     "name": "institutional_role_other_text",
-     "type": "STRING",
-     "description": "If the institutional_role_enum is \"other\", custom description\nof this user's role in the institution."
-   }
+  {
+    "name": "institution_id",
+    "type": "INTEGER",
+    "description": "Foreign key into institution table. Each user is only affiliated\nwith a single institution."
+  },
+  {
+    "name": "institutional_role_enum",
+    "type": "STRING",
+    "description": "Description of the user's role at the institution they are\naffiliated with. Selected from a list of predefined values. If \"other\", see institutional_role_other_text\nfor custom description."
+  },
+  {
+    "name": "institutional_role_other_text",
+    "type": "STRING",
+    "description": "If the institutional_role_enum is \"other\", custom description\nof this user's role in the institution."
+  }
 ]

--- a/ops/terraform/modules/workbench/modules/reporting/assets/schemas/workspace.json
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/schemas/workspace.json
@@ -16,7 +16,7 @@
   },
   {
     "name": "cdr_version_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "Foreign key into CDR table."
   },
   {
@@ -26,7 +26,7 @@
   },
   {
     "name": "creator_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "User ID of user who initially created this workspace."
   },
   {
@@ -51,7 +51,7 @@
   },
   {
     "name": "needs_rp_review_prompt",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "If true, the owner of the workspace will be asked to review the Research purpose."
   },
   {
@@ -117,7 +117,7 @@
   {
     "name": "rp_intended_study",
     "type": "STRING",
-    "description": ""
+    "description": "Intended field of study for this research"
   },
   {
     "name": "rp_methods_development",
@@ -127,7 +127,7 @@
   {
     "name": "rp_other_population_details",
     "type": "STRING",
-    "description": ""
+    "description": "If studying a specific population categorized as Other, user's description of that population."
   },
   {
     "name": "rp_other_purpose",
@@ -147,7 +147,7 @@
   {
     "name": "rp_reason_for_all_of_us",
     "type": "STRING",
-    "description": ""
+    "description": "Why All of Us was chosen for the research in this workspace."
   },
   {
     "name": "rp_review_requested",
@@ -171,7 +171,7 @@
   },
   {
     "name": "workspace_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "description": "Primary key of the workspace table in Workrbench application database. Along with\nsnapshot_timestamp, serves as a pseudo-primary key for this table."
   }
 ]

--- a/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_cohorts.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_cohorts.sql
@@ -1,0 +1,13 @@
+-- All cohorts from the most recent snapshot
+SELECT
+    c.*
+FROM
+    `${project}`.${dataset}.cohort c
+WHERE
+        c.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+ORDER BY
+    c.cohort_id;

--- a/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_institutions.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_institutions.sql
@@ -1,0 +1,14 @@
+-- All institutions from the most recent snapshot. Some may not  have
+-- users associated with them.
+SELECT
+    i.*
+FROM
+    `${project}`.${dataset}.institution i
+WHERE
+        i.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+ORDER BY
+    i.institution_id;

--- a/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_users.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_users.sql
@@ -1,0 +1,12 @@
+SELECT
+    u.*
+FROM
+    `${project}`.${dataset}.user u
+WHERE
+        u.snapshot_timestamp = (
+        SELECT
+            MAX(u2.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u2)
+ORDER BY
+    u.username;

--- a/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_workspaces.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/views/latest_workspaces.sql
@@ -1,0 +1,13 @@
+SELECT
+    w.*
+FROM
+    `${project}`.${dataset}.workspace w
+WHERE
+    w.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+
+ORDER BY
+    w.workspace_id;

--- a/ops/terraform/modules/workbench/modules/reporting/assets/views/table_count_vs_time.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/assets/views/table_count_vs_time.sql
@@ -1,0 +1,39 @@
+-- simple count of each table over time. Demonstrates time series
+-- aggregation across snapshots. Note that if the user table is missing a timestamp,
+-- we consider it a bad snapshot, but any other table will return zero rows.
+SELECT
+    TIMESTAMP_MILLIS(u.snapshot_timestamp) AS snapshot,
+    (
+        SELECT
+            COUNT(u_inner.user_id)
+        FROM
+            `${project}`.${dataset}.user u_inner
+        WHERE
+                u_inner.snapshot_timestamp = u.snapshot_timestamp) AS user_count,
+    (
+        SELECT
+            COUNT(w.workspace_id)
+        FROM
+            `${project}`.${dataset}.workspace w
+        WHERE
+                w.snapshot_timestamp = u.snapshot_timestamp) AS workspace_count,
+    (
+        SELECT
+            COUNT(c.cohort_id)
+        FROM
+            `${project}`.${dataset}.cohort c
+        WHERE
+                c.snapshot_timestamp = u.snapshot_timestamp) AS cohort_count,
+    (
+        SELECT
+            COUNT(institution_id)
+        FROM
+            `${project}`.${dataset}.institution i
+        WHERE
+                i.snapshot_timestamp = u.snapshot_timestamp) AS institution_count
+FROM
+    `${project}`.${dataset}.user u
+GROUP BY
+    u.snapshot_timestamp
+ORDER BY
+    u.snapshot_timestamp;

--- a/ops/terraform/modules/workbench/modules/reporting/main.tf
+++ b/ops/terraform/modules/workbench/modules/reporting/main.tf
@@ -1,0 +1,106 @@
+locals {
+  #
+  # Tables
+  #
+
+  # Description attribute for each table. If absent, no description is set (null).
+  table_to_description = {
+    cohort      = "Workbench Cohorts, including Uncompressed JSON Criteria"
+    user        = "All Workbench users at each snapshot, including disabled or incompletely registered accounts."
+    institution = "Institutions represented by workbench users in an official affiliation"
+    workspace   = "Workbench Workspaces (Active Only). Includes all user-supplied data about the research being conducted in each workspace."
+  }
+
+  # Values that don't ever change set for this dataset.
+  TABLE_CONSTANTS = {
+    time_partitioning = null
+    expiration_time   = null
+    clustering        = []
+    labels = {
+      terraform_managed = "true"
+    }
+  }
+
+  TABLE_SCHEMA_SUFFIX = ".json"
+  #  The module path is in a hidden directory under the running directory of the calling module, but
+  # our view files and schemas for BigQuery are in whatever directory this file is located, and apparently
+  # don't get loaded into that dir by default.
+  table_schema_filenames = fileset(pathexpand("${path.module}/assets/schemas"), "*.json")
+  // fileset() doesn't have an option to output full paths, so we need to re-expand them
+  table_schema_paths = [for file_name in local.table_schema_filenames : pathexpand("${path.module}/assets/schemas/${file_name}")]
+
+  # Build a vector of objects, one for each table
+  table_inputs = [for full_path in local.table_schema_paths : {
+    schema = full_path
+    # TODO(jaycarlton) I do not yet see a way around doing the replacement twice, as it's not possible
+    #   to refer to other values in the same object when defining it.
+    table_id    = replace(basename(full_path), local.TABLE_SCHEMA_SUFFIX, "")
+    description = lookup(local.table_to_description, replace(basename(full_path), local.TABLE_SCHEMA_SUFFIX, ""), null)
+  }]
+
+  # Merge calculated inputs with the ones we use every time.
+  tables = [for table_input in local.table_inputs :
+    merge(table_input, local.TABLE_CONSTANTS)
+  ]
+
+  #
+  # Views
+  #
+  VIEW_CONSTANTS = {
+    # Reporting Subsystem always uses Standard SQL Syntax
+    use_legacy_sql = false,
+    labels = {
+      terraform_managed = "true"
+    }
+  }
+  QUERY_TEMPLATE_SUFFIX = ".sql"
+  # Local filenames for view templates. Returns something like ["latest_users.sql", "users_by_id.sql"]
+  view_query_template_filenames = fileset("${path.module}/assets/views", "*.sql")
+  # expanded to fully qualified path, e.g. ["/repos/workbench/terraform/modules/reporting/views/latest_users.sql", ...]
+  //  view_query_template_paths = [for file_name in local.view_query_template_filenames : pathexpand("./reporting/views/${file_name}")]
+  view_query_template_paths = [for file_name in local.view_query_template_filenames : pathexpand("${path.module}/assets/views/${file_name}")]
+
+  # Create views for each .sql file in the views directory. There is no Terraform
+  # dependency from the view to the table(s) it queries, and I  don't believe the SQL is even checked
+  # for accuracy prior to creation on the BQ side.
+  views = [for view_query_template_path in local.view_query_template_paths :
+    merge({
+      view_id = replace(basename(view_query_template_path), local.QUERY_TEMPLATE_SUFFIX, ""),
+      query = templatefile(view_query_template_path, {
+        project = var.project_id
+        dataset = var.reporting_dataset_id
+      })
+  }, local.VIEW_CONSTANTS)]
+
+}
+
+# All BigQuery assets for Reporting subsystem
+module "main" {
+  source     = "terraform-google-modules/bigquery/google"
+  version    = "~> 4.3"
+  dataset_id = var.reporting_dataset_id
+  project_id = var.project_id
+  location   = "US"
+
+  # Note: friendly_name is discovered in plan and apply steps, but can't be
+  # entered here. Maybe they're just not exposed by the dataset module but the resources are looking
+  # for them?
+  dataset_name = "Workbench ${title(var.aou_env)} Environment Reporting Data" # exposed as friendly_name in plan
+  description  = "Daily output of relational tables and time series views for analysis. Views are provided for general ad-hoc analysis."
+
+  tables = local.tables
+
+  # Note that, when creating this module fom the ground up, it's common to see an error like
+  # `Error: googleapi: Error 404: Not found: Table my-project:my_dataset.my_table, notFound`. It seems
+  # to be a momentary issue due to the dataset's existence not yet being observable to the table/view
+  # create API. So far, it's always worked on a re-run.
+  # TODO(jaycarlton) see if there's a way to put a retry on this. I'm not convinced that will work
+  #   outside of a resource context (and inside a third-party module).
+  views = local.views
+
+  dataset_labels = {
+    subsystem         = "reporting"
+    terraform_managed = "true"
+    aou_env           = var.aou_env
+  }
+}

--- a/ops/terraform/modules/workbench/modules/reporting/variables.tf
+++ b/ops/terraform/modules/workbench/modules/reporting/variables.tf
@@ -1,0 +1,14 @@
+variable aou_env {
+  description = "Short name (all lowercase) of All of Us Workbench deployed environments, e.g. local, test, staging, prod."
+  type        = string
+}
+
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}
+
+variable reporting_dataset_id {
+  description = "BigQuery dataset for workbench reporting data."
+  type        = string
+}

--- a/ops/terraform/modules/workbench/modules/reporting/views/latest_cohorts.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/views/latest_cohorts.sql
@@ -1,0 +1,13 @@
+-- All cohorts from the most recent snapshot
+SELECT
+    c.*
+FROM
+    `${project}`.${dataset}.cohort c
+WHERE
+        c.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+ORDER BY
+    c.cohort_id;

--- a/ops/terraform/modules/workbench/modules/reporting/views/latest_institutions.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/views/latest_institutions.sql
@@ -1,0 +1,14 @@
+-- All institutions from the most recent snapshot. Some may not  have
+-- users associated with them.
+SELECT
+    i.*
+FROM
+    `${project}`.${dataset}.institution i
+WHERE
+        i.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+ORDER BY
+    i.institution_id;

--- a/ops/terraform/modules/workbench/modules/reporting/views/latest_users.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/views/latest_users.sql
@@ -1,0 +1,12 @@
+SELECT
+    u.*
+FROM
+    `${project}`.${dataset}.user u
+WHERE
+        u.snapshot_timestamp = (
+        SELECT
+            MAX(u2.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u2)
+ORDER BY
+    u.username;

--- a/ops/terraform/modules/workbench/modules/reporting/views/latest_workspaces.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/views/latest_workspaces.sql
@@ -1,0 +1,13 @@
+SELECT
+    w.*
+FROM
+    `${project}`.${dataset}.workspace w
+WHERE
+    w.snapshot_timestamp = (
+        SELECT
+            MAX(u.snapshot_timestamp)
+        FROM
+            `${project}`.${dataset}.user u)
+
+ORDER BY
+    w.workspace_id;

--- a/ops/terraform/modules/workbench/modules/reporting/views/table_count_vs_time.sql
+++ b/ops/terraform/modules/workbench/modules/reporting/views/table_count_vs_time.sql
@@ -1,0 +1,39 @@
+-- simple count of each table over time. Demonstrates time series
+-- aggregation across snapshots. Note that if the user table is missing a timestamp,
+-- we consider it a bad snapshot, but any other table will return zero rows.
+SELECT
+    TIMESTAMP_MILLIS(u.snapshot_timestamp) AS snapshot,
+    (
+        SELECT
+            COUNT(u_inner.user_id)
+        FROM
+            `${project}`.${dataset}.user u_inner
+        WHERE
+                u_inner.snapshot_timestamp = u.snapshot_timestamp) AS user_count,
+    (
+        SELECT
+            COUNT(w.workspace_id)
+        FROM
+            `${project}`.${dataset}.workspace w
+        WHERE
+                w.snapshot_timestamp = u.snapshot_timestamp) AS workspace_count,
+    (
+        SELECT
+            COUNT(c.cohort_id)
+        FROM
+            `${project}`.${dataset}.cohort c
+        WHERE
+                c.snapshot_timestamp = u.snapshot_timestamp) AS cohort_count,
+    (
+        SELECT
+            COUNT(institution_id)
+        FROM
+            `${project}`.${dataset}.institution i
+        WHERE
+                i.snapshot_timestamp = u.snapshot_timestamp) AS institution_count
+FROM
+    `${project}`.${dataset}.user u
+GROUP BY
+    u.snapshot_timestamp
+ORDER BY
+    u.snapshot_timestamp;

--- a/ops/terraform/modules/workbench/providers.tf
+++ b/ops/terraform/modules/workbench/providers.tf
@@ -1,0 +1,19 @@
+// See https://www.terraform.io/docs/configuration/providers.html
+// Child modules receive their provider configurations from the root module.
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {
+  version = "3.5.0"
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+  # Rather than provide a credentials_file value, we should
+  # use Application-default credentials.
+  # https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+}

--- a/ops/terraform/modules/workbench/variables.tf
+++ b/ops/terraform/modules/workbench/variables.tf
@@ -1,0 +1,74 @@
+#
+# Provider Variables
+#
+variable aou_env {
+  description = "Short name (all lowercase) of All of Us Workbench deployed environments, e.g. local, test, staging, prod."
+  type        = string
+}
+
+#
+# Provider Variables
+#
+
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable reporting_dataset_id {
+  description = "BigQuery dataset for workbench reporting data."
+  type        = string
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-central1-c"
+}
+
+# TODO(jaycarlton) codegen this top-level variables as the union
+#   of all modules' variables files.
+# List of objects whose values correspond to the google_monitoring_notification_channel
+# structure
+variable "notification_channels" {
+  description = "Email address and Friendly Descriptions for Email Notification Channels"
+  default = [{
+    display_name = "Anonymous  Notification Channel"
+    type         = "" # email or
+    labels = {
+      email = ""
+    }
+  }]
+}
+
+variable "notification_channel_info" {
+  description = <<EOF
+I want to use an  array  of objects,  but  as of v0.13, only
+sets of strings or  single objects are supported.l Hence I'm
+passing dummy keys as  the outermost entries, named _0, _1, etc.
+TODO(jaycarlton) move to collection of objects wen that's an  actual thing.
+{
+    _0 = {
+      display_name = "An email channel"
+      type         = "email" # email or
+      labels = {
+        email = ""
+      }
+    },
+    _1 = {
+      display_name = "Slack Random Channel"
+      type         = "slack"
+      labels = {
+        channel = "#random"
+      }
+    }
+EOF
+
+  type = map(any)
+}


### PR DESCRIPTION
Define a new Terraform module `aou_rw_reporting` that can be reuses  by any GCP project to set up our BigQuery stuff.
Built out an initial directory structure with a `modules` directory for high-level reusable sybsystem modules like `reporting`, `alerting`, `tiers`, etc.

I got pretty close to the level of reusability I wanted, but had a hard time pointing to a portable implementation directory relative to the module's source path and not the run dir. This will break as soon as someone else tries to use this, or some other envifronment.

In order to avoid stepping on the "local" BQ environment (and to have something I could tear down), I created another pseudo-environment called `scratch`. I'd love a new GCP project for that, since it's really handy for experiments to be able to tear everything down.

There's a README that needs some polishing, but I think I'm starting to get my head around it all.


At the end of running this, you should  be able to see a list of configured state with `state list`
```
/usr/local/bin/terraform state list
module.aou_rw_scratch_env.module.reporting.google_bigquery_dataset.main
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["cohort"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["institution"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["user"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.main["workspace"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_cohorts"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_institutions"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_users"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["latest_workspaces"]
module.aou_rw_scratch_env.module.reporting.google_bigquery_table.view["table_count_vs_time"]

Process finished with exit code 0
```

Lots more notes int he markdown files, but highlights are:
* a reliable way to launch a new environment with a specified module (reporting in this case)
* Relatively painless import process, once you learn a couple of gotchas
* we'll be needing a remote backend so we don't have to have state files in a locking repo of some sort
* It's a great way to break our deployment structure down, share with other groups, etc
* Really good tutorials and pretty decent StackOverflow juice.

---

**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
