### PR TITLE
[risk=no] e2e: Rename incorrect instances of "Concept" to ConceptSet

### DIFF
--- a/e2e/app/page/conceptset-actions-page.ts
+++ b/e2e/app/page/conceptset-actions-page.ts
@@ -6,13 +6,13 @@ import {LinkText} from 'app/text-labels';
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import Link from 'app/element/link';
 import AuthenticatedPage from './authenticated-page';
-import ConceptsetPage from './conceptset-page';
-import ConceptsetSearchPage from './conceptset-search-page';
+import ConceptSetPage from './conceptset-page';
+import ConceptSetSearchPage from './conceptset-search-page';
 import DatasetBuildPage from './dataset-build-page';
 
 const PageTitle = 'Concept Set Actions';
 
-export default class ConceptsetActionsPage extends AuthenticatedPage {
+export default class ConceptSetActionsPage extends AuthenticatedPage {
 
   constructor(page: Page) {
     super(page);
@@ -50,12 +50,12 @@ export default class ConceptsetActionsPage extends AuthenticatedPage {
     return Button.findByName(this.page, {name: LinkText.CreateDataset});
   }
 
-  async openConceptSet(conceptName: string): Promise<ConceptsetPage> {
+  async openConceptSet(conceptName: string): Promise<ConceptSetPage> {
     const link = new Link(this.page, `//a[text()="${conceptName}"]`);
     await link.click();
-    const conceptsetPage = new ConceptsetPage(this.page);
-    await conceptsetPage.waitForLoad();
-    return conceptsetPage;
+    const conceptSetPage = new ConceptSetPage(this.page);
+    await conceptSetPage.waitForLoad();
+    return conceptSetPage;
   }
 
   /**
@@ -63,13 +63,13 @@ export default class ConceptsetActionsPage extends AuthenticatedPage {
    * Click Domain card.
    * @param {Domain} domain
    */
-  async openConceptSearch(domain: Domain): Promise<ConceptsetSearchPage> {
+  async openConceptSearch(domain: Domain): Promise<ConceptSetSearchPage> {
     await this.clickCreateAnotherConceptSetButton();
 
     const procedures = await ConceptDomainCard.findDomainCard(this.page, domain);
     await procedures.clickSelectConceptButton();
 
-    const conceptSearchPage = new ConceptsetSearchPage(this.page);
+    const conceptSearchPage = new ConceptSetSearchPage(this.page);
     await conceptSearchPage.waitForLoad();
     return conceptSearchPage;
   }

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -14,7 +14,7 @@ import CopyModal from 'app/component/copy-modal';
 
 const PageTitle = 'Concept Set';
 
-export default class ConceptsetPage extends AuthenticatedPage {
+export default class ConceptSetPage extends AuthenticatedPage {
 
   constructor(page: Page) {
     super(page);
@@ -28,8 +28,8 @@ export default class ConceptsetPage extends AuthenticatedPage {
     return true;
   }
 
-  async openCopyToWorkspaceModal(conceptName: string): Promise<CopyModal> {
-    await this.getSnowmanMenu(conceptName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
+  async openCopyToWorkspaceModal(conceptSetName: string): Promise<CopyModal> {
+    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
     return new CopyModal(this.page);
   }
 
@@ -42,7 +42,7 @@ export default class ConceptsetPage extends AuthenticatedPage {
     return new SnowmanMenu(this.page);
   }
 
-  async getConceptName(): Promise<string> {
+  async getConceptSetName(): Promise<string> {
     const xpath = `//*[@data-test-id="concept-set-title"]`;
     const title = await this.page.waitForXPath(xpath, {visible: true});
     return getPropValue<string>(title, 'innerText');

--- a/e2e/app/page/conceptset-save-modal.ts
+++ b/e2e/app/page/conceptset-save-modal.ts
@@ -27,7 +27,7 @@ export default class ConceptsetSaveModal extends Modal {
    * @param {SaveOption} saveOption
    * @return {string} Concept name.
    */
-  async fillOutSaveModal(saveOption: SaveOption = SaveOption.CreateNewSet, existingConceptName: string = '0'): Promise<string> {
+  async fillOutSaveModal(saveOption: SaveOption = SaveOption.CreateNewSet, existingConceptSetName: string = '0'): Promise<string> {
     const createNewSetRadioButton = await RadioButton.findByName(this.page, {name: saveOption}, this);
     await createNewSetRadioButton.select();
 
@@ -43,7 +43,7 @@ export default class ConceptsetSaveModal extends Modal {
       const descriptionTextarea = await Textarea.findByName(this.page, {containsText: 'Description'}, this);
       await descriptionTextarea.type(faker.lorem.words());
     } else {
-      const [selectedValue] = await this.page.select('[data-test-id="add-to-existing"] select', existingConceptName);
+      const [selectedValue] = await this.page.select('[data-test-id="add-to-existing"] select', existingConceptSetName);
       const elem = await this.page.waitForSelector(`[data-test-id="add-to-existing"] select option[value="${selectedValue}"]`);
       conceptName = await getPropValue<string>(elem, 'textContent');
     }

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -6,11 +6,11 @@ import DataTable from 'app/component/data-table';
 import Button from 'app/element/button';
 import {getPropValue, waitUntilChanged} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
-import ConceptsetSaveModal, {SaveOption} from './conceptset-save-modal';
+import ConceptSetSaveModal, {SaveOption} from './conceptset-save-modal';
 
 const PageTitle = 'Search Concepts';
 
-export default class ConceptsetSearchPage extends AuthenticatedPage{
+export default class ConceptSetSearchPage extends AuthenticatedPage{
 
   constructor(page: Page) {
     super(page);
@@ -26,9 +26,9 @@ export default class ConceptsetSearchPage extends AuthenticatedPage{
     return true;
   }
 
-  async saveConcept(saveOption?: SaveOption, existingConceptName?: string): Promise<string> {
-    const modal = new ConceptsetSaveModal(this.page);
-    return modal.fillOutSaveModal(saveOption, existingConceptName);
+  async saveConceptSet(saveOption?: SaveOption, existingConceptSetName?: string): Promise<string> {
+    const modal = new ConceptSetSaveModal(this.page);
+    return modal.fillOutSaveModal(saveOption, existingConceptSetName);
   }
 
   async getAddToSetButton(): Promise<Button> {

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -8,7 +8,7 @@ import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
 import AuthenticatedPage from './authenticated-page';
 import CohortBuildPage from './cohort-build-page';
-import ConceptsetSearchPage from './conceptset-search-page';
+import ConceptSetSearchPage from './conceptset-search-page';
 import DatasetSaveModal from './dataset-save-modal';
 
 const PageTitle = 'Dataset Page';
@@ -56,10 +56,10 @@ export default class DatasetBuildPage extends AuthenticatedPage {
   /**
    * Click Add Concept Sets button, opened the Concept Sets page.
    */
-  async clickAddConceptSetsButton(): Promise<ConceptsetSearchPage> {
+  async clickAddConceptSetsButton(): Promise<ConceptSetSearchPage> {
     const addConceptSetsButton = await ClrIconLink.findByName(this.page, {name: LabelAlias.SelectConceptSets, ancestorLevel: 3, iconShape: 'plus-circle'});
     await addConceptSetsButton.clickAndWait();
-    const conceptPage = new ConceptsetSearchPage(this.page);
+    const conceptPage = new ConceptSetSearchPage(this.page);
     await conceptPage.waitForLoad();
     return conceptPage;
   }

--- a/e2e/app/page/dataset-build-page.ts
+++ b/e2e/app/page/dataset-build-page.ts
@@ -59,9 +59,9 @@ export default class DatasetBuildPage extends AuthenticatedPage {
   async clickAddConceptSetsButton(): Promise<ConceptSetSearchPage> {
     const addConceptSetsButton = await ClrIconLink.findByName(this.page, {name: LabelAlias.SelectConceptSets, ancestorLevel: 3, iconShape: 'plus-circle'});
     await addConceptSetsButton.clickAndWait();
-    const conceptPage = new ConceptSetSearchPage(this.page);
-    await conceptPage.waitForLoad();
-    return conceptPage;
+    const conceptSetSearchPage = new ConceptSetSearchPage(this.page);
+    await conceptSetSearchPage.waitForLoad();
+    return conceptSetSearchPage;
   }
 
   /**

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -3,7 +3,7 @@ import Modal from 'app/component/modal';
 import Link from 'app/element/link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import {Option, LinkText, ResourceCard} from 'app/text-labels';
+import {LinkText, Option, ResourceCard} from 'app/text-labels';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
 import {Page} from 'puppeteer';
@@ -12,6 +12,8 @@ import {waitForAttributeEquality} from 'utils/waits-utils';
 import SnowmanMenu from 'app/component/snowman-menu';
 import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
+
+export const UseFreeCredits = 'Use All of Us free credits';
 
 export enum TabLabels {
   Data = 'Data',

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -10,7 +10,7 @@ import {waitForDocumentTitle} from 'utils/waits-utils';
 import CohortActionsPage from './cohort-actions-page';
 import CohortBuildPage from './cohort-build-page';
 import {Visits} from './cohort-search-page';
-import ConceptsetSearchPage from './conceptset-search-page';
+import ConceptSetSearchPage from './conceptset-search-page';
 import DatasetBuildPage from './dataset-build-page';
 import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
@@ -111,7 +111,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    * Click Domain card.
    * @param {Domain} domain
    */
-  async openConceptSearch(domain: Domain): Promise<ConceptsetSearchPage> {
+  async openConceptSearch(domain: Domain): Promise<ConceptSetSearchPage> {
     // Click Add Datasets button.
     const datasetBuildPage = await this.clickAddDatasetButton();
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -111,18 +111,18 @@ export default class WorkspaceDataPage extends WorkspaceBase {
    * Click Domain card.
    * @param {Domain} domain
    */
-  async openConceptSearch(domain: Domain): Promise<ConceptSetSearchPage> {
+  async openConceptSetSearch(domain: Domain): Promise<ConceptSetSearchPage> {
     // Click Add Datasets button.
     const datasetBuildPage = await this.clickAddDatasetButton();
 
     // Click Add Concept Sets button.
-    const conceptSearchPage = await datasetBuildPage.clickAddConceptSetsButton();
+    const conceptSetSearchPage = await datasetBuildPage.clickAddConceptSetsButton();
 
     // Add Concept Set in domain.
     const procedures = await ConceptDomainCard.findDomainCard(this.page, domain);
     await procedures.clickSelectConceptButton();
 
-    return conceptSearchPage;
+    return conceptSetSearchPage;
   }
 
   /**

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -10,7 +10,7 @@ import {waitWhileLoading} from 'utils/test-utils';
 import {waitForDocumentTitle} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
 import {LinkText} from 'app/text-labels';
-import WorkspaceBase from './workspace-base';
+import WorkspaceBase, {UseFreeCredits} from './workspace-base';
 import {config} from 'resources/workbench-config';
 
 const faker = require('faker/locale/en_US');
@@ -327,7 +327,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * Select Billing Account
    * @param {string} billingAccount
    */
-  async selectBillingAccount(billingAccount: string = 'Use All of Us free credits') {
+  async selectBillingAccount(billingAccount: string = UseFreeCredits) {
     const billingAccountSelect = await Select.findByName(this.page, FIELD.billingAccountSelect.textOption);
     await billingAccountSelect.selectOption(billingAccount);
   }

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -9,6 +9,7 @@ import {waitForDocumentTitle, waitForText} from 'utils/waits-utils';
 import ReactSelect from 'app/element/react-select';
 import WorkspaceDataPage from './workspace-data-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
+import {UseFreeCredits} from './workspace-base';
 
 const faker = require('faker/locale/en_US');
 export const PageTitle = 'View Workspace';
@@ -72,12 +73,12 @@ export default class WorkspacesPage extends WorkspaceEditPage {
    */
   async createWorkspace(
      workspaceName: string,
-     billingAccount: string = 'Use All of Us free credits',
+     billingAccount: string = UseFreeCredits,
      reviewRequest: boolean = false): Promise<string[]> {
 
     const editPage = await this.clickCreateNewWorkspace();
     // wait for Billing Account default selected value
-    await waitForText(this.page, 'Use All of Us free credits');
+    await waitForText(this.page, UseFreeCredits);
 
     await (await editPage.getWorkspaceNameTextbox()).type(workspaceName);
     await (await editPage.getWorkspaceNameTextbox()).pressTab();

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -1,6 +1,6 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard from 'app/component/data-resource-card';
-import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
+import ConceptSetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
@@ -26,7 +26,7 @@ describe('Create Concept Sets from Domains', () => {
     const datasetBuildPage = await dataPage.clickAddDatasetButton();
 
     // Click Add Concept Sets button.
-    const conceptPage = await datasetBuildPage.clickAddConceptSetsButton();
+    const conceptSetPage = await datasetBuildPage.clickAddConceptSetsButton();
 
     // Start: Add a Concept in Conditions domain
     const conditionDomainCard = await ConceptDomainCard.findDomainCard(page, Domain.Conditions);
@@ -47,30 +47,30 @@ describe('Create Concept Sets from Domains', () => {
     const conditionName = 'Essential hypertension';
 
     // Search by Code.
-    await conceptPage.searchConcepts(conditionCode);
-    const rowCells = await conceptPage.dataTableSelectRow();
+    await conceptSetPage.searchConcepts(conditionCode);
+    const rowCells = await conceptSetPage.dataTableSelectRow();
     // Verify condition name from search result
     expect(rowCells.name).toBe(conditionName);
 
-    await conceptPage.clickAddToSetButton();
+    await conceptSetPage.clickAddToSetButton();
 
     // Save
-    const conceptName = await conceptPage.saveConcept();
+    const conceptSetName = await conceptSetPage.saveConceptSet();
 
     // Verify Concept Set created successfully.
     const successMessage = `Concept Set Saved Successfully`;
     const isSuccess = await waitForText(page, successMessage);
     expect(isSuccess).toBe(true);
 
-    const linkExists = await waitForText(page, conceptName);
+    const linkExists = await waitForText(page, conceptSetName);
     expect(linkExists).toBe(true);
-    console.log(`Created Concept Set "${conceptName}"`);
+    console.log(`Created Concept Set "${conceptSetName}"`);
 
     // Delete Concept Set
     await dataPage.openConceptSetsSubtab();
 
-    const modalTextContent = await dataPage.deleteResource(conceptName, ResourceCard.ConceptSet);
-    expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptName}?`);
+    const modalTextContent = await dataPage.deleteResource(conceptSetName, ResourceCard.ConceptSet);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Concept Set: ${conceptSetName}?`);
   });
 
   /**
@@ -116,11 +116,11 @@ describe('Create Concept Sets from Domains', () => {
     await conceptSearchPage.clickAddToSetButton();
 
     // Save
-    const conceptName1 = await conceptSearchPage.saveConcept();
+    const conceptName1 = await conceptSearchPage.saveConceptSet();
     console.log(`Created Concept Set "${conceptName1}"`);
 
     // Start: Create new Concept Set 2
-    const conceptActionPage = new ConceptsetActionsPage(page);
+    const conceptActionPage = new ConceptSetActionsPage(page);
     await conceptActionPage.clickCreateAnotherConceptSetButton();
 
     // Add new Concept in Measurements domain
@@ -137,7 +137,7 @@ describe('Create Concept Sets from Domains', () => {
     await conceptSearchPage.clickAddToSetButton();
 
     // Save
-    const conceptName2 = await conceptSearchPage.saveConcept();
+    const conceptName2 = await conceptSearchPage.saveConceptSet();
     console.log(`Created Concept Set "${conceptName2}"`);
 
     // Create new Dataset with two new Concept Sets

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -116,8 +116,8 @@ describe('Create Concept Sets from Domains', () => {
     await conceptSearchPage.clickAddToSetButton();
 
     // Save
-    const conceptName1 = await conceptSearchPage.saveConceptSet();
-    console.log(`Created Concept Set "${conceptName1}"`);
+    const conceptSet1 = await conceptSearchPage.saveConceptSet();
+    console.log(`Created Concept Set "${conceptSet1}"`);
 
     // Start: Create new Concept Set 2
     const conceptActionPage = new ConceptSetActionsPage(page);
@@ -137,13 +137,13 @@ describe('Create Concept Sets from Domains', () => {
     await conceptSearchPage.clickAddToSetButton();
 
     // Save
-    const conceptName2 = await conceptSearchPage.saveConceptSet();
-    console.log(`Created Concept Set "${conceptName2}"`);
+    const conceptSet2 = await conceptSearchPage.saveConceptSet();
+    console.log(`Created Concept Set "${conceptSet2}"`);
 
     // Create new Dataset with two new Concept Sets
     await conceptActionPage.clickCreateDatasetButton();
     await datasetBuildPage.selectCohorts(['All Participants']);
-    await datasetBuildPage.selectConceptSets([conceptName1, conceptName2]);
+    await datasetBuildPage.selectConceptSets([conceptSet1, conceptSet2]);
     const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
     const datasetName = await saveModal.saveDataset();
 
@@ -161,8 +161,8 @@ describe('Create Concept Sets from Domains', () => {
     // Delete Concept Set.
     await dataPage.openConceptSetsSubtab();
 
-    await dataPage.deleteResource(conceptName1, ResourceCard.ConceptSet);
-    await dataPage.deleteResource(conceptName2, ResourceCard.ConceptSet);
+    await dataPage.deleteResource(conceptSet1, ResourceCard.ConceptSet);
+    await dataPage.deleteResource(conceptSet2, ResourceCard.ConceptSet);
   });
 
 });

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -27,7 +27,7 @@ describe('Editing and rename Concept Set', () => {
     const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
-    let conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
+    let conceptSearchPage = await dataPage.openConceptSetSearch(Domain.Procedures);
 
     // Select first two rows.
     const row1 = await conceptSearchPage.dataTableSelectRow(1, 1);

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -1,6 +1,6 @@
 import {Domain} from 'app/component/concept-domain-card';
 import Link from 'app/element/link';
-import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
+import ConceptSetActionsPage from 'app/page/conceptset-actions-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {ResourceCard} from 'app/text-labels';
@@ -49,12 +49,12 @@ describe('Editing and rename Concept Set', () => {
     expect(addButtonLabel).toBe('Add (2) to set');
 
     // Save new Concept Set.
-    const conceptName = await conceptSearchPage.saveConcept(SaveOption.CreateNewSet);
-    console.log(`Created Concept Set: "${conceptName}"`);
+    const conceptSetName = await conceptSearchPage.saveConceptSet(SaveOption.CreateNewSet);
+    console.log(`Created Concept Set: "${conceptSetName}"`);
 
     // Add another Concept in Procedures domain.
-    const conceptsetActionPage = new ConceptsetActionsPage(page);
-    conceptSearchPage = await conceptsetActionPage.openConceptSearch(Domain.Procedures);
+    const conceptSetActionsPage = new ConceptSetActionsPage(page);
+    conceptSearchPage = await conceptSetActionsPage.openConceptSearch(Domain.Procedures);
 
     // Search in Procedures domain
     const searchWords = 'Screening for disorder';
@@ -68,21 +68,21 @@ describe('Editing and rename Concept Set', () => {
     expect(addButtonLabel).toBe('Add (1) to set');
 
     // Save to Existing Set: Only one Concept set and it is the new Concept Set created earlier in same workspace.
-    const existingConceptName = await conceptSearchPage.saveConcept(SaveOption.ChooseExistingSet);
-    expect(existingConceptName).toBe(conceptName);
-    console.log(`Added new Concept to existing Concept Set "${conceptName}"`);
+    const existingConceptSetName = await conceptSearchPage.saveConceptSet(SaveOption.ChooseExistingSet);
+    expect(existingConceptSetName).toBe(conceptSetName);
+    console.log(`Added new Concept to existing Concept Set "${conceptSetName}"`);
 
     // Concept Set saved. Click Concept Set link. Land on Concept Set page.
-    const conceptsetPage = await conceptsetActionPage.openConceptSet(conceptName);
+    const conceptSetPage = await conceptSetActionsPage.openConceptSet(conceptSetName);
 
     // Verify Concept Set name is displayed.
-    const value = await conceptsetPage.getConceptName();
-    expect(value).toBe(conceptName);
+    const value = await conceptSetPage.getConceptSetName();
+    expect(value).toBe(conceptSetName);
 
     // Edit Concept name and description.
     const newName = makeRandomName();
-    await conceptsetPage.edit(newName, makeString(20));
-    console.log(`Renamed Concept Set: "${conceptName}" to "${newName}"`);
+    await conceptSetPage.edit(newName, makeString(20));
+    console.log(`Renamed Concept Set: "${conceptSetName}" to "${newName}"`);
 
     // Navigate to workspace Data page, then delete Concept Set
     await (new Link(page, `//a[text()="${workspaceName}"]`)).click();

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -1,8 +1,8 @@
 import {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceCard from 'app/component/workspace-card';
-import ConceptsetActionsPage from 'app/page/conceptset-actions-page';
-import ConceptsetPage from 'app/page/conceptset-page';
+import ConceptSetActionsPage from 'app/page/conceptset-actions-page';
+import ConceptSetPage from 'app/page/conceptset-page';
 import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText, ResourceCard} from 'app/text-labels';
@@ -42,24 +42,24 @@ describe('Copy Concept Set to another workspace', () => {
     const addButtonLabel = await conceptSearchPage.clickAddToSetButton();
     // Table pagination displays 20 rows. If this changes, then update the check below.
     expect(addButtonLabel).toBe('Add (20) to set');
-    const conceptName = await conceptSearchPage.saveConcept(SaveOption.CreateNewSet);
-    console.log(`Created Concept Set: "${conceptName}"`);
+    const conceptSetName = await conceptSearchPage.saveConceptSet(SaveOption.CreateNewSet);
+    console.log(`Created Concept Set: "${conceptSetName}"`);
     // Click on link to open Concept Set page.
-    const conceptsetActionPage = new ConceptsetActionsPage(page);
-    await conceptsetActionPage.openConceptSet(conceptName);
+    const conceptSetActionsPage = new ConceptSetActionsPage(page);
+    await conceptSetActionsPage.openConceptSet(conceptSetName);
 
     // Concept Set page is open.
-    const conceptsetPage = new ConceptsetPage(page);
-    await conceptsetPage.waitForLoad();
+    const conceptSetPage = new ConceptSetPage(page);
+    await conceptSetPage.waitForLoad();
 
     // Copy Concept Set to another workspace with new Concept name.
     const conceptSetCopyName = makeRandomName();
 
-    const conceptCopyModal = await conceptsetPage.openCopyToWorkspaceModal(conceptName);
-    await conceptCopyModal.copyToAnotherWorkspace(destWorkspace, conceptSetCopyName);
+    const conceptSetCopyModal = await conceptSetPage.openCopyToWorkspaceModal(conceptSetName);
+    await conceptSetCopyModal.copyToAnotherWorkspace(destWorkspace, conceptSetCopyName);
 
     // Click "Go to Copied Concept Set" button.
-    await conceptCopyModal.waitForButton(LinkText.GoToCopiedConceptSet).then(butn => butn.click());
+    await conceptSetCopyModal.waitForButton(LinkText.GoToCopiedConceptSet).then(butn => butn.click());
 
     await dataPage.waitForLoad();
 
@@ -71,7 +71,7 @@ describe('Copy Concept Set to another workspace', () => {
     const exists = await resourceCard.cardExists(conceptSetCopyName, ResourceCard.ConceptSet);
     expect(exists).toBe(true);
 
-    console.log(`Copied Concept Set: "${conceptName} from workspace: "${srcWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${destWorkspace}"`)
+    console.log(`Copied Concept Set: "${conceptSetName} from workspace: "${srcWorkspace}" to Concept Set: "${conceptSetCopyName}" in another workspace: "${destWorkspace}"`)
 
     // Delete Concept Set in destWorkspace.
     await dataPage.deleteResource(conceptSetCopyName, ResourceCard.ConceptSet);

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -37,7 +37,7 @@ describe('Copy Concept Set to another workspace', () => {
     await dataPage.openConceptSetsSubtab();
 
     // Create new Concept Set
-    const conceptSearchPage = await dataPage.openConceptSearch(Domain.Procedures);
+    const conceptSearchPage = await dataPage.openConceptSetSearch(Domain.Procedures);
     await conceptSearchPage.dataTableSelectAllRows();
     const addButtonLabel = await conceptSearchPage.clickAddToSetButton();
     // Table pagination displays 20 rows. If this changes, then update the check below.

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -5,6 +5,7 @@ import {signIn, performActions} from 'utils/test-utils';
 import Button from 'app/element/button';
 import * as testData from 'resources/data/workspace-data';
 import {makeWorkspaceName} from 'utils/str-utils';
+import {UseFreeCredits} from 'app/page/workspace-base';
 
 describe('Creating new workspaces', () => {
 
@@ -42,7 +43,7 @@ describe('Creating new workspaces', () => {
     await workspacesPage.selectCdrVersion();
 
     // select Billing Account
-    await workspacesPage.selectBillingAccount('Use All of Us free credits');
+    await workspacesPage.selectBillingAccount(UseFreeCredits);
 
     // fill out question #1 - What is the primary purpose of your project?
     await workspacesPage.expandResearchPurposeGroup(true); // First, expand accordion: "Research purpose"


### PR DESCRIPTION
Description:

Also:
* Capitalize `conceptset` to `conceptSet`
* New constant `UseFreeCredits` for the Free Credits Billing Account selection value

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
