### PR TITLE
[no ticket][risk=no] Puppeteer fix a flaky test

### DIFF
--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -24,11 +24,10 @@ export default class Modal extends Container {
     try {
       await this.waitUntilVisible();
       await waitWhileLoading(this.page);
-    } catch (e) {
+    } catch (err) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);
-      const title = await this.page.title();
-      throw new Error(`"${title}" modal waitForLoad() encountered ${e}`);
+      throw err;
     }
     return this;
   }

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -8,6 +8,7 @@ import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
 import {LinkText} from 'app/text-labels';
 import {getPropValue} from 'utils/element-utils';
 import * as fp from 'lodash/fp';
+import {waitWhileLoading} from 'utils/test-utils';
 
 const Selector = {
   defaultDialog: '//*[@role="dialog"]',
@@ -22,6 +23,7 @@ export default class Modal extends Container {
   async waitForLoad(): Promise<this> {
     try {
       await this.waitUntilVisible();
+      await waitWhileLoading(this.page);
     } catch (e) {
       await savePageToFile(this.page);
       await takeScreenshot(this.page);

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -30,7 +30,9 @@ export default class ConceptSetPage extends AuthenticatedPage {
 
   async openCopyToWorkspaceModal(conceptSetName: string): Promise<CopyModal> {
     await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
-    return new CopyModal(this.page);
+    const modal = new CopyModal(this.page);
+    await modal.waitForLoad();
+    return modal;
   }
 
   /**


### PR DESCRIPTION
`conceptsets/copy-to-workspace.spec.ts` is flaky. `Copy to Workspace` modal was not ready after open.

https://app.circleci.com/pipelines/github/all-of-us/workbench/4813/workflows/5e96ba37-155a-434f-b9b8-7c58772867f8/jobs/104053/steps
```
FAIL  tests/conceptsets/copy-to-workspace.spec.ts (603.205 s)
  Copy Concept Set to another workspace
    ✕ Workspace OWNER can copy Concept Set (312864 ms)

  ● Copy Concept Set to another workspace › Workspace OWNER can copy Concept Set

    TimeoutError: waiting for XPath "(//*[@role="dialog"]//label | //*[@role="dialog"]//*)[contains(text(), "Destination") or contains(@aria-label, "Destination") or contains(@placeholder, "Destination")]/ancestor::node()[1]//input[@type="text"]" failed: timeout 10000ms exceeded

      34 |     if (this.element !== undefined) return this.element.asElement();
      35 |     try {
    > 36 |       return this.page.waitForXPath(this.xpath, waitOptions).then(elemt => this.element = elemt.asElement());
         |                        ^
      37 |     } catch (err) {
      38 |       console.error(`waitForXpath('${this.xpath}') encountered ${err}`);
      39 |       // Debugging pause

      at new WaitTask (node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:394:34)
      at DOMWorld._waitForSelectorOrXPath (node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:326:26)
      at DOMWorld.waitForXPath (node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:312:21)
      at Frame.waitForXPath (node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:825:51)
      at Page.waitForXPath (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:1218:33)
      at Textbox.waitForXPath (app/element/base-element.ts:36:24)
      at Textbox.asElementHandle (app/element/base-element.ts:340:17)
      at Textbox.click (app/element/base-element.ts:144:17)
      at CopyModal.copyToAnotherWorkspace (app/component/copy-modal.ts:30:28)
      at Object.<anonymous> (tests/conceptsets/copy-to-workspace.spec.ts:59:5)
```
