### PR TITLE
[RW-5599][risk=no] Update counts for cards on Concept Search homepage

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -108,7 +108,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
     "enableCohortBuilderV2": true,
-    "enableConceptSetSearchV2": false,
+    "enableConceptSetSearchV2": true,
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
     "enableCustomRuntimes": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -108,7 +108,7 @@
     "useNewShibbolethService": true,
     "enableResearchPurposePrompt": true,
     "enableCohortBuilderV2": true,
-    "enableConceptSetSearchV2": false,
+    "enableConceptSetSearchV2": true,
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
     "enableCustomRuntimes": false,

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -28,6 +28,8 @@ import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DataFiltersResponse;
 import org.pmiops.workbench.model.DemoChartInfoListResponse;
+import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.DomainCount;
 import org.pmiops.workbench.model.DomainInfoResponse;
 import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.GenderOrSexType;
@@ -35,6 +37,7 @@ import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.SearchRequest;
+import org.pmiops.workbench.model.SurveyCount;
 import org.pmiops.workbench.model.SurveyVersionListResponse;
 import org.pmiops.workbench.model.SurveysResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,7 +72,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findCriteriaAutoComplete(
       Long cdrVersionId, String domain, String term, String type, Boolean standard, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomain(domain);
+    validateDomainType(domain);
     validateType(type);
     validateTerm(term);
     return ResponseEntity.ok(
@@ -127,7 +130,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListWithCountResponse> findCriteriaByDomainAndSearchTerm(
       Long cdrVersionId, String domain, String term, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomain(domain);
+    validateDomainType(domain);
     validateTerm(term);
     return ResponseEntity.ok(
         cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, limit));
@@ -153,7 +156,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findStandardCriteriaByDomainAndConceptId(
       Long cdrVersionId, String domain, Long conceptId) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomain(domain);
+    validateDomainType(domain);
     return ResponseEntity.ok(
         new CriteriaListResponse()
             .items(
@@ -187,11 +190,23 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   }
 
   @Override
-  public ResponseEntity<DomainInfoResponse> findDomainInfos(Long cdrVersionId, String term) {
+  public ResponseEntity<DomainCount> findDomainCount(
+      Long cdrVersionId, String domain, String term) {
     cdrVersionService.setCdrVersion(cdrVersionId);
+    validateDomain(domain);
     validateTerm(term);
+    Long count = cohortBuilderService.findDomainCount(domain, term);
     return ResponseEntity.ok(
-        new DomainInfoResponse().items(cohortBuilderService.findDomainInfos(term)));
+        new DomainCount()
+            .conceptCount(count == null ? 0 : count)
+            .domain(Domain.valueOf(domain))
+            .name(domain));
+  }
+
+  @Override
+  public ResponseEntity<DomainInfoResponse> findDomainInfos(Long cdrVersionId) {
+    return ResponseEntity.ok(
+        new DomainInfoResponse().items(cohortBuilderService.findDomainInfos()));
   }
 
   @Override
@@ -207,7 +222,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findCriteriaBy(
       Long cdrVersionId, String domain, String type, Boolean standard, Long parentId) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomain(domain);
+    validateDomainType(domain);
     validateType(type);
     return ResponseEntity.ok(
         new CriteriaListResponse()
@@ -221,10 +236,16 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   }
 
   @Override
-  public ResponseEntity<SurveysResponse> findSurveyModules(Long cdrVersionId, String term) {
+  public ResponseEntity<SurveyCount> findSurveyCount(Long cdrVersionId, String name, String term) {
     cdrVersionService.setCdrVersion(cdrVersionId);
+    Long surveyCount = cohortBuilderService.findSurveyCount(name, term);
     return ResponseEntity.ok(
-        new SurveysResponse().items(cohortBuilderService.findSurveyModules(term)));
+        new SurveyCount().conceptCount(surveyCount == null ? 0 : surveyCount).name(name));
+  }
+
+  @Override
+  public ResponseEntity<SurveysResponse> findSurveyModules(Long cdrVersionId) {
+    return ResponseEntity.ok(new SurveysResponse().items(cohortBuilderService.findSurveyModules()));
   }
 
   @Override
@@ -266,8 +287,16 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
         || allParams.stream().anyMatch(sp -> CriteriaSubType.BP.toString().equals(sp.getSubtype()));
   }
 
-  private void validateDomain(String domain) {
+  private void validateDomainType(String domain) {
     Arrays.stream(DomainType.values())
+        .filter(domainType -> domainType.toString().equalsIgnoreCase(domain))
+        .findFirst()
+        .orElseThrow(
+            () -> new BadRequestException(String.format(BAD_REQUEST_MESSAGE, "domain", domain)));
+  }
+
+  private void validateDomain(String domain) {
+    Arrays.stream(Domain.values())
         .filter(domainType -> domainType.toString().equalsIgnoreCase(domain))
         .findFirst()
         .orElseThrow(

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -205,6 +205,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
 
   @Override
   public ResponseEntity<DomainInfoResponse> findDomainInfos(Long cdrVersionId) {
+    cdrVersionService.setCdrVersion(cdrVersionId);
     return ResponseEntity.ok(
         new DomainInfoResponse().items(cohortBuilderService.findDomainInfos()));
   }
@@ -245,6 +246,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
 
   @Override
   public ResponseEntity<SurveysResponse> findSurveyModules(Long cdrVersionId) {
+    cdrVersionService.setCdrVersion(cdrVersionId);
     return ResponseEntity.ok(new SurveysResponse().items(cohortBuilderService.findSurveyModules()));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -288,6 +288,42 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
+          "select count(*) from DbCriteria where standard IN (:standards) and match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0)")
+  Long findDomainCount(
+      @Param("term") String term,
+      @Param("domain") String domain,
+      @Param("standards") List<Boolean> standards);
+
+  @Query(
+      value =
+          "select count(*) from concept c "
+              + "where (c.count_value > 0 or c.source_count_value > 0) "
+              + "and match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against(:term in boolean mode) "
+              + "and c.vocabulary_id = 'PPI' "
+              + "and c.concept_class_id = 'Clinical Observation' "
+              + "and c.standard_concept IN ('')",
+      nativeQuery = true)
+  Long findPhysicalMeasurementCount(@Param("term") String term);
+
+  @Query(
+      value =
+          "select count from cb_criteria c "
+              + "join(select substring_index(path,'.',1) as survey_id, count(*) as count "
+              + "       from cb_criteria "
+              + "      where domain_id = 'SURVEY' "
+              + "        and subtype = 'QUESTION' "
+              + "        and concept_id in ( select concept_id "
+              + "                              from cb_criteria "
+              + "                             where domain_id = 'SURVEY' "
+              + "                               and match(full_text) against(concat(:term, '+[survey_rank1]') in boolean mode)) "
+              + "   group by survey_id) a "
+              + "on c.id = a.survey_id "
+              + "where name = :surveyName",
+      nativeQuery = true)
+  Long findSurveyCount(@Param("surveyName") String surveyName, @Param("term") String term);
+
+  @Query(
+      value =
           "select surveyId, version, itemCount from( "
               + "select distinct csv.survey_id as surveyId, csv.version as version, csa.item_count as itemCount, csv.display_order "
               + "from cb_survey_version csv "

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
@@ -21,7 +21,7 @@ public interface DomainInfoDao extends CrudRepository<DbDomainInfo, Long> {
   @Query(
       value =
           "select new DbDomainInfo(\n"
-              + "d.domain, d.domainId, d.name, d.description,\n"
+              + "d.domain, d.domainId, d.domainEnumValue, d.name, d.description,\n"
               + "d.conceptId, COUNT(*), COUNT(*), d.participantCount)\n"
               + "from DbDomainInfo d\n"
               + "join DbConcept c ON d.domainId = c.domainId\n"
@@ -43,7 +43,7 @@ public interface DomainInfoDao extends CrudRepository<DbDomainInfo, Long> {
   @Query(
       value =
           "select new DbDomainInfo(\n"
-              + "d.domain, d.domainId, d.name, d.description,\n"
+              + "d.domain, d.domainId, d.domainEnumValue, d.name, d.description,\n"
               + "d.conceptId, COUNT(*), COUNT(*), d.participantCount)\n"
               + "from DbDomainInfo d\n"
               + "join DbConcept c ON 'Measurement' = c.domainId\n"

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/SurveyModuleDao.java
@@ -7,6 +7,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface SurveyModuleDao extends CrudRepository<DbSurveyModule, Long> {
 
+  List<DbSurveyModule> findByOrderByOrderNumberAsc();
+
   List<DbSurveyModule> findByParticipantCountNotOrderByOrderNumberAsc(
       @Param("participantCount") Long participantCount);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/model/DbDomainInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/model/DbDomainInfo.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.cdr.model;
 
 import java.util.Objects;
-import java.util.function.Function;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -10,25 +9,15 @@ import javax.persistence.Transient;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.DomainInfo;
 
 @Entity
 @Table(name = "domain_info")
 public class DbDomainInfo {
 
-  public static final Function<DbDomainInfo, DomainInfo> TO_CLIENT_DOMAIN_INFO =
-      (domain) ->
-          new DomainInfo()
-              .domain(domain.getDomainEnum())
-              .name(domain.getName())
-              .description(domain.getDescription())
-              .allConceptCount(domain.getAllConceptCount())
-              .standardConceptCount(domain.getStandardConceptCount())
-              .participantCount(domain.getParticipantCount());
-
   private long conceptId;
   private short domain;
   private String domainId;
+  private String domainEnumValue;
   private String name;
   private String description;
   private long allConceptCount;
@@ -41,6 +30,7 @@ public class DbDomainInfo {
   public DbDomainInfo(
       short domain,
       String domainId,
+      String domainEnumValue,
       String name,
       String description,
       long conceptId,
@@ -50,6 +40,7 @@ public class DbDomainInfo {
     this.conceptId = conceptId;
     this.domain = domain;
     this.domainId = domainId;
+    this.domainEnumValue = domainEnumValue;
     this.name = name;
     this.description = description;
     this.allConceptCount = allConceptCount;
@@ -107,6 +98,20 @@ public class DbDomainInfo {
 
   public DbDomainInfo domainId(String domainId) {
     this.domainId = domainId;
+    return this;
+  }
+
+  @Column(name = "domain_enum")
+  public String getDomainEnumValue() {
+    return domainEnumValue;
+  }
+
+  public void setDomainEnumValue(String domainEnumValue) {
+    this.domainEnumValue = domainEnumValue;
+  }
+
+  public DbDomainInfo domainEnumValue(String domainEnumValue) {
+    this.domainEnumValue = domainEnumValue;
     return this;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -44,7 +44,9 @@ public interface CohortBuilderService {
   List<DemoChartInfo> findDemoChartInfo(
       GenderOrSexType genderOrSexType, AgeType ageType, SearchRequest request);
 
-  List<DomainInfo> findDomainInfos(String term);
+  Long findDomainCount(String domain, String term);
+
+  List<DomainInfo> findDomainInfos();
 
   List<Criteria> findDrugBrandOrIngredientByValue(String value, Integer limit);
 
@@ -63,7 +65,9 @@ public interface CohortBuilderService {
   List<String> findSortedConceptIdsByDomainIdAndType(
       String domainId, String sortColumn, String sortName);
 
-  List<SurveyModule> findSurveyModules(String term);
+  Long findSurveyCount(String name, String term);
+
+  List<SurveyModule> findSurveyModules();
 
   List<SurveyVersion> findSurveyVersionByQuestionConceptId(
       Long surveyConceptId, Long questionConceptId);

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6606,6 +6606,19 @@ definitions:
         description: number of concepts matching the search query in this domain
         type: integer
         format: int64
+  SurveyCount:
+    type: object
+    required:
+    - name
+    - conceptCount
+    properties:
+      name:
+        description: display name of the survey
+        type: string
+      conceptCount:
+        description: number of concepts matching the search query in this survey
+        type: integer
+        format: int64
   CreateReviewRequest:
     type: object
     required:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3158,33 +3158,33 @@ paths:
           schema:
             "$ref": "#/definitions/CriteriaMenuOptionsListResponse"
   "/v1/cohortbuilder/{cdrVersionId}/criteria/domaininfo":
-    parameters:
-    - "$ref": "#/parameters/cdrVersionId"
     get:
       tags:
       - cohortBuilder
-      description: 'Returns a collection of DomainInfo'
+      description: 'Returns information on the domains of data in the workspace''s
+        CDR version along with participant and concept counts'
       operationId: findDomainInfos
       parameters:
-      - in: query
-        name: term
-        type: string
-        required: true
-        description: the term to search for
+      - "$ref": "#/parameters/cdrVersionId"
       responses:
         200:
-          description: A collection of DomainInfo
+          description: information on the domains
           schema:
             "$ref": "#/definitions/DomainInfoResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/surveymodule":
+  "/v1/cohortbuilder/{cdrVersionId}/criteria/domaininfo/{domain}":
     parameters:
     - "$ref": "#/parameters/cdrVersionId"
     get:
       tags:
       - cohortBuilder
-      description: 'Returns a collection of SurveyModule'
-      operationId: findSurveyModules
+      description: 'Returns a count of term matches per domain'
+      operationId: findDomainCount
       parameters:
+      - in: path
+        name: domain
+        type: string
+        required: true
+        description: the specific type of domain
       - in: query
         name: term
         type: string
@@ -3192,9 +3192,47 @@ paths:
         description: the term to search for
       responses:
         200:
-          description: A collection of SurveyModule
+          description: A count of matching concepts in this domain
+          schema:
+            "$ref": "#/definitions/DomainCount"
+  "/v1/cohortbuilder/{cdrVersionId}/criteria/surveymodule":
+    get:
+      tags:
+      - cohortBuilder
+      description: 'Returns survey information in the workspace''s CDR version along
+        with participant and question count'
+      operationId: findSurveyModules
+      parameters:
+      - "$ref": "#/parameters/cdrVersionId"
+      responses:
+        200:
+          description: information about the surveys
           schema:
             "$ref": "#/definitions/SurveysResponse"
+  "/v1/cohortbuilder/{cdrVersionId}/criteria/surveymodule/{name}":
+    parameters:
+    - "$ref": "#/parameters/cdrVersionId"
+    get:
+      tags:
+      - cohortBuilder
+      description: 'Returns a count of term matches per survey name'
+      operationId: findSurveyCount
+      parameters:
+      - in: path
+        name: name
+        type: string
+        required: true
+        description: the name of the survey
+      - in: query
+        name: term
+        type: string
+        required: true
+        description: the term to search for
+      responses:
+        200:
+          description: A count of matching concepts per survey
+          schema:
+            "$ref": "#/definitions/SurveyCount"
   "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}/search/term":
     parameters:
     - "$ref": "#/parameters/cdrVersionId"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -123,11 +123,11 @@ public class CohortBuilderControllerTest {
                 .standardConceptCount(0)
                 .participantCount(1000));
 
-    DomainInfo domainInfo = controller.findDomainInfos(1L, "term").getBody().getItems().get(0);
+    DomainInfo domainInfo = controller.findDomainInfos(1L).getBody().getItems().get(0);
     assertEquals(domainInfo.getName(), dbDomainInfo.getName());
     assertEquals(domainInfo.getDescription(), dbDomainInfo.getDescription());
     assertEquals(domainInfo.getParticipantCount().longValue(), dbDomainInfo.getParticipantCount());
-    assertEquals(domainInfo.getAllConceptCount().longValue(), 1);
+    assertEquals(domainInfo.getAllConceptCount().longValue(), 0);
     assertEquals(domainInfo.getStandardConceptCount().longValue(), 0);
   }
 
@@ -168,8 +168,7 @@ public class CohortBuilderControllerTest {
                 .questionCount(1)
                 .participantCount(1000));
 
-    SurveyModule surveyModule =
-        controller.findSurveyModules(1L, "term").getBody().getItems().get(0);
+    SurveyModule surveyModule = controller.findSurveyModules(1L).getBody().getItems().get(0);
     assertEquals(surveyModule.getName(), dbSurveyModule.getName());
     assertEquals(surveyModule.getDescription(), dbSurveyModule.getDescription());
     assertEquals(

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -161,6 +161,7 @@ interface Props {
   hierarchy: Function;
   source: string;
   searchContext: any;
+  searchTerms: string;
   select: Function;
   selectedIds: Array<string>;
   setAttributes: Function;
@@ -174,6 +175,7 @@ interface State {
   hoverId: string;
   ingredients: any;
   loading: boolean;
+  searchTerms: string;
   standardOnly: boolean;
   sourceMatch: any;
   standardData: any;
@@ -182,7 +184,7 @@ interface State {
 
 export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
   class extends React.Component<Props, State> {
-    constructor(props: any) {
+    constructor(props: Props) {
       super(props);
       this.state = {
         cdrVersion: undefined,
@@ -191,6 +193,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
         ingredients: {},
         hoverId: undefined,
         loading: false,
+        searchTerms: props.searchTerms,
         standardOnly: false,
         sourceMatch: undefined,
         standardData: null,
@@ -198,9 +201,12 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
       };
     }
     componentDidMount(): void {
-      const {cdrVersionListResponse, workspace: {cdrVersionId}} = this.props;
+      const {cdrVersionListResponse, searchTerms, source, workspace: {cdrVersionId}} = this.props;
       const cdrVersions = cdrVersionListResponse.items;
       this.setState({cdrVersion: cdrVersions.find(cdr => cdr.cdrVersionId === cdrVersionId)});
+      if (source === 'concept' && searchTerms !== '') {
+        this.getResults(searchTerms);
+      }
     }
 
     handleInput = (event: any) => {
@@ -372,7 +378,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
 
     render() {
       const {searchContext: {domain}} = this.props;
-      const {cdrVersion, data, error, ingredients, loading, standardOnly, sourceMatch, standardData, totalCount} = this.state;
+      const {cdrVersion, data, error, ingredients, loading, searchTerms, standardOnly, sourceMatch, standardData, totalCount} = this.state;
       const showStandardOption = !standardOnly && !!standardData && standardData.length > 0;
       const displayData = standardOnly ? standardData : data;
       return <div style={{overflow: 'auto'}}>
@@ -380,8 +386,10 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
           <div style={styles.searchBar}>
             <ClrIcon shape='search' size='18'/>
             <TextInput style={styles.searchInput}
-              placeholder={`Search ${domainToTitle(domain)} by code or description`}
-              onKeyPress={this.handleInput} />
+                       value={searchTerms}
+                       placeholder={`Search ${domainToTitle(domain)} by code or description`}
+                       onChange={(e) => this.setState({searchTerms: e})}
+                       onKeyPress={this.handleInput} />
           </div>
         </div>
         <div style={{display: 'table', height: '100%', width: '100%'}}>

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -7,6 +7,7 @@ import {conceptsApi, registerApiClient} from 'app/services/swagger-fetch-clients
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {serverConfigStore} from 'app/utils/navigation';
 import {
+  CohortBuilderApi,
   ConceptsApi,
   ConceptSetsApi,
   DomainInfo,
@@ -15,6 +16,7 @@ import {
 } from 'generated/fetch';
 import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {
   ConceptsApiStub,
@@ -60,6 +62,7 @@ describe('ConceptHomepage', () => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
     registerApiClient(ConceptsApi, new ConceptsApiStub());
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
+    registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
     serverConfigStore.next({...defaultServerConfig, enableConceptSetSearchV2: false});
   });

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -134,8 +134,8 @@ interface ConceptCacheItem {
 }
 
 const DomainCard: React.FunctionComponent<{conceptDomainInfo: DomainInfo,
-  standardConceptsOnly: boolean, browseInDomain: Function}> =
-    ({conceptDomainInfo, standardConceptsOnly, browseInDomain}) => {
+  standardConceptsOnly: boolean, browseInDomain: Function, updating: boolean}> =
+    ({conceptDomainInfo, standardConceptsOnly, browseInDomain, updating}) => {
       const conceptCount = standardConceptsOnly ?
           conceptDomainInfo.standardConceptCount.toLocaleString() : conceptDomainInfo.allConceptCount.toLocaleString();
       return <DomainCardBase style={{width: 'calc(25% - 1rem)'}} data-test-id='domain-box'>
@@ -143,7 +143,9 @@ const DomainCard: React.FunctionComponent<{conceptDomainInfo: DomainInfo,
              onClick={browseInDomain}
              data-test-id='domain-box-name'>{conceptDomainInfo.name}</Clickable>
         <div style={styles.conceptText}>
-          <span style={{fontSize: 30}}>{conceptCount.toLocaleString()}</span> concepts in this domain. <p/>
+          {updating ? <Spinner size={42}/> : <React.Fragment>
+            <span style={{fontSize: 30}}>{conceptCount.toLocaleString()}</span> concepts in this domain. <p/>
+          </React.Fragment>}
           <div><b>{conceptDomainInfo.participantCount.toLocaleString()}</b> participants in domain.</div>
         </div>
         <Clickable style={styles.domainBoxLink}
@@ -151,14 +153,16 @@ const DomainCard: React.FunctionComponent<{conceptDomainInfo: DomainInfo,
       </DomainCardBase>;
     };
 
-const SurveyCard: React.FunctionComponent<{survey: SurveyModule, browseSurvey: Function}> =
-    ({survey, browseSurvey}) => {
+const SurveyCard: React.FunctionComponent<{survey: SurveyModule, browseSurvey: Function, updating: boolean}> =
+    ({survey, browseSurvey, updating}) => {
       return <DomainCardBase style={{maxHeight: 'auto', width: 'calc(25% - 1rem)'}}>
         <Clickable style={styles.domainBoxHeader}
           onClick={browseSurvey}
           data-test-id='survey-box-name'>{survey.name}</Clickable>
         <div style={styles.conceptText}>
-          <span style={{fontSize: 30}}>{survey.questionCount.toLocaleString()}</span> survey questions with
+          {updating ? <Spinner size={42}/> : <React.Fragment>
+            <span style={{fontSize: 30}}>{survey.questionCount.toLocaleString()}</span> survey questions with
+          </React.Fragment>}
           <div><b>{survey.participantCount.toLocaleString()}</b> participants</div>
         </div>
         <div style={{...styles.conceptText, height: '3.5rem'}}>
@@ -220,6 +224,8 @@ interface State {
   domainErrors: Domain[];
   // True if the getDomainInfo call fails
   domainInfoError: boolean;
+  // List of domains loading updated counts for domain cards
+  domainsLoading: Array<Domain>;
   // List of error messages to display if the search input is invalid
   inputErrors: Array<string>;
   // If concept metadata is still being gathered for any domain
@@ -244,6 +250,8 @@ interface State {
   surveyAddModalOpen: boolean;
   // True if the getSurveyInfo call fails
   surveyInfoError: boolean;
+  // List of surveys loading updated counts for survey cards
+  surveysLoading: Array<string>;
   workspacePermissions: WorkspacePermissions;
 }
 
@@ -269,6 +277,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
         currentSearchString: '',
         domainErrors: [],
         domainInfoError: false,
+        domainsLoading: [],
         inputErrors: [],
         loadingDomains: true,
         countsLoading: false,
@@ -278,9 +287,10 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
         selectedSurvey: '',
         selectedSurveyQuestions: [],
         showSearchError: false,
-        standardConceptsOnly: true,
+        standardConceptsOnly: !this.isConceptSetFlagEnable(),
         surveyAddModalOpen: false,
         surveyInfoError: false,
+        surveysLoading: [],
         workspacePermissions: new WorkspacePermissions(props.workspace),
       };
     }
@@ -298,8 +308,8 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
     }
 
     async loadDomainsAndSurveys() {
-      const {namespace, id} = this.props.workspace;
-      const getDomainInfo = conceptsApi().getDomainInfo(namespace, id)
+      const {cdrVersionId} = this.props.workspace;
+      const getDomainInfo = cohortBuilderApi().findDomainInfos(+cdrVersionId)
         .then(conceptDomainInfo => {
           let conceptsCache: ConceptCacheItem[] = conceptDomainInfo.items.map((domain) => ({
             domain: domain.domain,
@@ -330,7 +340,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
           this.setState({domainInfoError: true});
           console.error(e);
         });
-      const getSurveyInfo = conceptsApi().getSurveyInfo(namespace, id)
+      const getSurveyInfo = cohortBuilderApi().findSurveyModules(+cdrVersionId)
         .then(surveysInfo => this.setState({conceptSurveysList: surveysInfo.items}))
         .catch((e) => {
           this.setState({surveyInfoError: true});
@@ -343,13 +353,29 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
 
     async updateCardCounts() {
       const {cdrVersionId} = this.props.workspace;
-      const {currentInputString} = this.state;
-      this.setState({loadingDomains: true});
-      const [domains, surveys] = await Promise.all([
-        cohortBuilderApi().findDomainInfos(+cdrVersionId, currentInputString),
-        cohortBuilderApi().findSurveyModules(+cdrVersionId, currentInputString),
-      ]);
-      this.setState({conceptDomainList: domains.items, conceptSurveysList: surveys.items, loadingDomains: false});
+      const {conceptDomainList, conceptSurveysList, currentInputString} = this.state;
+      this.setState({
+        domainsLoading: conceptDomainList.map(domain => domain.domain),
+        surveysLoading: conceptSurveysList.map(survey => survey.name),
+      });
+      const promises = [];
+      conceptDomainList.forEach(conceptDomain => {
+        promises.push(cohortBuilderApi().findDomainCount(+cdrVersionId, conceptDomain.domain.toString(), currentInputString)
+          .then(domainCount => {
+            conceptDomain.allConceptCount = domainCount.conceptCount;
+            this.setState({domainsLoading: this.state.domainsLoading.filter(domain => domain !== conceptDomain.domain)});
+          })
+        );
+      });
+      conceptSurveysList.forEach(conceptSurvey => {
+        promises.push(cohortBuilderApi().findSurveyCount(+cdrVersionId, conceptSurvey.name, currentInputString)
+          .then(surveyCount => {
+            conceptSurvey.questionCount = surveyCount.conceptCount;
+            this.setState({surveysLoading: this.state.surveysLoading.filter(survey => survey !== conceptSurvey.name)});
+          }));
+      });
+      await Promise.all(promises);
+      this.setState({conceptDomainList, conceptSurveysList});
     }
 
     browseDomainFromQueryParams() {
@@ -377,7 +403,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
           this.setState({inputErrors, showSearchError: false});
           if (inputErrors.length === 0) {
             this.setState({currentSearchString: currentInputString}, () => {
-              if (serverConfigStore.getValue().enableConceptSetSearchV2 && !(selectedDomain || selectedSurvey)) {
+              if (this.isConceptSetFlagEnable() && !(selectedDomain || selectedSurvey)) {
                 this.updateCardCounts();
               } else {
                 this.searchConcepts();
@@ -636,9 +662,9 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
 
     render() {
       const {activeDomainTab, browsingSurvey, conceptAddModalOpen, conceptDomainList, conceptsSavedText, conceptSurveysList,
-        currentInputString, currentSearchString, domainInfoError, inputErrors, loadingDomains, surveyInfoError,
+        currentInputString, currentSearchString, domainInfoError, domainsLoading, inputErrors, loadingDomains, surveyInfoError,
         standardConceptsOnly, showSearchError, searching, selectedDomain, selectedSurvey, selectedConceptDomainMap, selectedSurveyQuestions,
-        surveyAddModalOpen} = this.state;
+        surveyAddModalOpen, surveysLoading} = this.state;
       return <React.Fragment>
         <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
           <FlexRow>
@@ -664,13 +690,13 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
                                                         data-test-id='clear-search'>
                   <ClrIcon shape='times-circle' style={styles.clearSearchIcon}/>
               </Clickable>}
-              <CheckBox checked={standardConceptsOnly}
+              {!this.isConceptSetFlagEnable() && <CheckBox checked={standardConceptsOnly}
                         label='Standard concepts only'
                         labelStyle={{marginLeft: '0.2rem'}}
                         data-test-id='standardConceptsCheckBox'
                         style={{marginLeft: '0.5rem', height: '16px', width: '16px'}}
                         manageOwnState={false}
-                        onChange={() => this.handleCheckboxChange()}/>
+                        onChange={() => this.handleCheckboxChange()}/>}
             </div>}
             {inputErrors.map((error, e) => <AlertDanger key={e} style={styles.inputAlert}>
               <span data-test-id='input-error-alert'>{error}</span>
@@ -702,14 +728,12 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
                 {domainInfoError
                   ? this.errorMessage()
                   : conceptDomainList
-                    .filter(item => item.domain !== Domain.PHYSICALMEASUREMENT
-                      && (item.allConceptCount > 0 || item.standardConceptCount > 0))
-                    .map((domain, i) => {
-                      return <DomainCard conceptDomainInfo={domain}
-                                           standardConceptsOnly={standardConceptsOnly}
-                                           browseInDomain={() => this.browseDomain(domain)}
-                                           key={i} data-test-id='domain-box'/>;
-                    })
+                    .filter(item => item.domain !== Domain.PHYSICALMEASUREMENT && item.allConceptCount !== 0)
+                    .map((domain, i) => <DomainCard conceptDomainInfo={domain}
+                                                    standardConceptsOnly={standardConceptsOnly}
+                                                    browseInDomain={() => this.browseDomain(domain)}
+                                                    key={i} data-test-id='domain-box'
+                                                    updating={domainsLoading.includes(domain.domain)}/>)
                 }
               </div>
               <div style={styles.sectionHeader}>
@@ -720,9 +744,10 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
                   ? this.errorMessage()
                   : conceptSurveysList
                     .filter(survey => survey.questionCount > 0)
-                    .map((surveys) =>
-                      <SurveyCard survey={surveys} key={surveys.orderNumber} browseSurvey={() => this.browseSurvey(surveys.name)} />
-                    )
+                    .map((survey) => <SurveyCard survey={survey}
+                                                  key={survey.orderNumber}
+                                                  browseSurvey={() => this.browseSurvey(survey.name)}
+                                                  updating={surveysLoading.includes(survey.name)}/>)
                 }
                </div>
               {environment.enableNewConceptTabs && <React.Fragment>

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -70,6 +70,7 @@ const css = `
 
 interface Props {
   cohortContext: any;
+  conceptSearchTerms?: string;
   selectedSurvey?: string;
   source: string;
 }
@@ -93,7 +94,7 @@ export class CriteriaSearch extends React.Component<Props, State>  {
   growlTimer: NodeJS.Timer;
   subscription: Subscription;
 
-  constructor(props: any) {
+  constructor(props: Props) {
     super(props);
     this.state = {
       autocompleteSelection: undefined,
@@ -105,7 +106,7 @@ export class CriteriaSearch extends React.Component<Props, State>  {
       selectedIds: [],
       selections: [],
       selectedCriteriaList: [],
-      treeSearchTerms: '',
+      treeSearchTerms: props.source === 'concept' ? props.conceptSearchTerms : '',
       loadingSubtree: false
     };
   }
@@ -222,7 +223,7 @@ export class CriteriaSearch extends React.Component<Props, State>  {
   }
 
   render() {
-    const {cohortContext, selectedSurvey, source} = this.props;
+    const {cohortContext, conceptSearchTerms, selectedSurvey, source} = this.props;
     const {autocompleteSelection, groupSelections, hierarchyNode, loadingSubtree,
       selectedIds, treeSearchTerms, growlVisible} = this.state;
     return <div>
@@ -249,6 +250,7 @@ export class CriteriaSearch extends React.Component<Props, State>  {
           <ListSearchV2 source={source}
                         hierarchy={this.showHierarchy}
                         searchContext={cohortContext}
+                        searchTerms={conceptSearchTerms}
                         select={this.addSelection}
                         selectedIds={this.getListSearchSelectedIds()}/>
         </div>

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -11,12 +11,7 @@ import {
   DomainType,
   ParticipantDemographics, SurveyCount, SurveysResponse
 } from 'generated/fetch';
-import {
-  ConceptsApiStub,
-  ConceptStubVariables,
-  DomainStubVariables,
-  SurveyStubVariables
-} from 'testing/stubs/concepts-api-stub';
+import {DomainStubVariables, SurveyStubVariables} from 'testing/stubs/concepts-api-stub';
 
 export const cohortStub = {
   name: 'Test Cohort',

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -5,9 +5,18 @@ import {
   CriteriaListResponse, CriteriaMenuOptionsListResponse,
   CriteriaType,
   DemoChartInfoListResponse,
+  Domain,
+  DomainCount,
+  DomainInfoResponse,
   DomainType,
-  ParticipantDemographics
+  ParticipantDemographics, SurveyCount, SurveysResponse
 } from 'generated/fetch';
+import {
+  ConceptsApiStub,
+  ConceptStubVariables,
+  DomainStubVariables,
+  SurveyStubVariables
+} from 'testing/stubs/concepts-api-stub';
 
 export const cohortStub = {
   name: 'Test Cohort',
@@ -29,6 +38,17 @@ const criteriaStub = {
   domainId: DomainType[DomainType.CONDITION],
   hasAttributes: false,
   path: '0',
+};
+
+const domainCountStub = {
+  domain: Domain.CONDITION,
+  name: Domain.CONDITION.toString(),
+  conceptCount: 1
+};
+
+const surveyCountStub = {
+  name: 'The Basics',
+  conceptCount: 1
 };
 
 export class CohortBuilderServiceStub extends CohortBuilderApi {
@@ -75,5 +95,21 @@ export class CohortBuilderServiceStub extends CohortBuilderApi {
 
   findCriteriaMenuOptions(): Promise<CriteriaMenuOptionsListResponse> {
     return new Promise<CriteriaMenuOptionsListResponse>(resolve => resolve({items: []}));
+  }
+
+  findDomainInfos(): Promise<DomainInfoResponse> {
+    return new Promise<DomainInfoResponse>(resolve => resolve({items: DomainStubVariables.STUB_DOMAINS}));
+  }
+
+  findSurveyModules(): Promise<SurveysResponse> {
+    return new Promise<SurveysResponse>(resolve => resolve({items: SurveyStubVariables.STUB_SURVEYS}));
+  }
+
+  findDomainCount(): Promise<DomainCount> {
+    return new Promise<DomainCount>(resolve => resolve(domainCountStub));
+  }
+
+  findSurveyCount(): Promise<SurveyCount> {
+    return new Promise<SurveyCount>(resolve => resolve(surveyCountStub));
   }
 }


### PR DESCRIPTION
- When searching on the concept homepage, update the counts on the domain & survey cards instead of switching to the table view
- Remove 'Standard concepts only' checkbox
- Show spinners on each card when updating counts
- Filter out cards with zero counts
<img width="1182" alt="Screen Shot 2020-10-13 at 12 48 29 AM" src="https://user-images.githubusercontent.com/40036095/95820550-e09b7900-0ced-11eb-8b7f-97c08dc2cf22.png">
<img width="1178" alt="Screen Shot 2020-10-13 at 12 44 54 AM" src="https://user-images.githubusercontent.com/40036095/95820339-8a2e3a80-0ced-11eb-9f4d-b36c4e7bbc72.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
