### PR TITLE
[risk=no] Notebook environment checks should fail when the variables are not found

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -175,14 +175,16 @@ export default class NotebookPage extends AuthenticatedPage {
    */
   async runCodeCell(cellIndex: number, opts: { code?: string, codeFile?: string, timeOut?: number } = {}): Promise<string> {
     const cell = cellIndex === -1 ? await this.findLastCell() : await this.findCell(cellIndex);
-    const cellInput = await cell.focus();
+    const inputCell = await cell.focus();
+    let codeToRun;
     if (opts.code !== undefined) {
-      await cellInput.type(opts.code);
+      codeToRun = opts.code;
     } else if (opts.codeFile !== undefined) {
-      const code = fs.readFileSync(opts.codeFile, 'utf8');
-      await cellInput.type(code);
+      codeToRun = fs.readFileSync(opts.codeFile, 'ascii');
     }
-    await cellInput.dispose();
+
+    await inputCell.type(codeToRun);
+    await inputCell.dispose();
     await this.run();
     const {timeOut = 120000} = opts;
     await this.waitForKernelIdle(timeOut);

--- a/e2e/resources/python-code/import-os.py
+++ b/e2e/resources/python-code/import-os.py
@@ -1,15 +1,6 @@
 import sys
 import os
 
-# This is what I want to do, but there's a bug preventing it: RW-5740
-# def print_env_var_or_fail(var):
-#   val = os.getenv(var)
-#
-#   if not val:
-#     raise ValueError
-#
-#   print(val)
-
 print(sys.version)
 print(sys.executable)
 

--- a/e2e/resources/python-code/import-os.py
+++ b/e2e/resources/python-code/import-os.py
@@ -1,13 +1,25 @@
 import sys
 import os
 
+# This is what I want to do, but there's a bug preventing it: RW-5740
+# def print_env_var_or_fail(var):
+#   val = os.getenv(var)
+#
+#   if not val:
+#     raise ValueError
+#
+#   print(val)
+
 print(sys.version)
 print(sys.executable)
-print(os.getenv('OWNER_EMAIL'))
-print(os.getenv('WORKSPACE_CDR'))
-print(os.getenv('WORKSPACE_NAMESPACE'))
-print(os.getenv('GOOGLE_PROJECT')) # same as WORKSPACE_NAMESPACE
-print(os.getenv('CLUSTER_NAME'))
-print(os.getenv('WORKSPACE_BUCKET'))
+
+# use environ[val] instead of getenv(val) to raise an exception when missing
+# this would fail: print(os.environ['NOTHING'])
+print(os.environ['OWNER_EMAIL'])
+print(os.environ['WORKSPACE_CDR'])
+print(os.environ['WORKSPACE_NAMESPACE'])
+print(os.environ['GOOGLE_PROJECT']) # same as WORKSPACE_NAMESPACE
+print(os.environ['CLUSTER_NAME'])
+print(os.environ['WORKSPACE_BUCKET'])
 
 print('success')

--- a/e2e/resources/r-code/sys-print.R
+++ b/e2e/resources/r-code/sys-print.R
@@ -1,7 +1,19 @@
-print(Sys.getenv('OWNER_EMAIL'))
-print(Sys.getenv('WORKSPACE_CDR'))
-print(Sys.getenv('WORKSPACE_NAMESPACE'))
-print(Sys.getenv('GOOGLE_PROJECT')) # same as WORKSPACE_NAMESPACE
-print(Sys.getenv('CLUSTER_NAME'))
-print(Sys.getenv('WORKSPACE_BUCKET'))
-print('success',quote=FALSE)
+print_env_var <- function(var) {
+    value <- Sys.getenv(var, unset=NA)
+    print(value)
+    return(value)
+}
+
+vars <- c('OWNER_EMAIL',
+          'WORKSPACE_CDR',
+          'WORKSPACE_NAMESPACE',
+          'GOOGLE_PROJECT', # same as WORKSPACE_NAMESPACE
+          'CLUSTER_NAME',
+          'WORKSPACE_BUCKET')
+
+vals <- sapply(vars, print_env_var)
+
+# only print success if all env vars are present
+if (!anyNA(vals)) {
+    print('success',quote=FALSE)
+}

--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -33,10 +33,12 @@ describe('Jupyter notebook tests in Python language', () => {
     expect(kernelName).toBe('Python 3');
 
     const cell1OutputText = await notebook.runCodeCell(1, {codeFile: 'resources/python-code/import-os.py'});
-    expect(cell1OutputText).toContain('success');
+    // toContain() is not a strong enough check: error text also includes "success" because it's in the code
+    expect(cell1OutputText.endsWith('success')).toBeTruthy();
 
     const cell2OutputText = await notebook.runCodeCell(2, {codeFile: 'resources/python-code/import-libs.py'});
-    expect(cell2OutputText).toContain('success');
+    // toContain() is not a strong enough check: error text also includes "success" because it's in the code
+    expect(cell2OutputText.endsWith('success')).toBeTruthy();
 
     await notebook.runCodeCell(3, {codeFile: 'resources/python-code/simple-pyplot.py'});
 

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -1,9 +1,7 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
-import fs from 'fs';
 import {makeRandomName} from 'utils/str-utils';
 import {findWorkspace, signIn} from 'utils/test-utils';
-import {CellType} from 'app/page/notebook-cell';
 
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
 jest.setTimeout(20 * 60 * 1000);
@@ -27,28 +25,20 @@ describe('Jupyter notebook tests in R language', () => {
 
     // Run math function in Code cell [1].
     let cellIndex = 1;
-    const code1Output = await notebook.runCodeCell(cellIndex, {codeFile: 'resources/r-code/calculate-max.R'});
+    const code1Output = await notebook.runCodeCell(cellIndex,
+        {codeFile: 'resources/r-code/calculate-max.R', markdownWorkaround: true});
     expect(code1Output).toEqual('[1] 20');
 
     // Print sys environment details in Code cell [2].
     cellIndex = 2;
-    const code2Output = await notebook.runCodeCell(cellIndex, {codeFile: 'resources/r-code/sys-print.R'});
+    const code2Output = await notebook.runCodeCell(cellIndex,
+        {codeFile: 'resources/r-code/sys-print.R', markdownWorkaround: true});
     expect(code2Output).toContain('success');
 
     // Import R libs in Code cell [3].
     cellIndex = 3;
-    const rCodeSnippet = fs.readFileSync('resources/r-code/import-libs.R', 'utf8');
-    // In Code cell, autoCloseBrackets is true as default and it screws up the R code when Puppeteer types code line by line.
-    // Worksaround: Type code in Markdown cell, then change to Code cell to run.
-    const codeCell = await notebook.findCell(cellIndex);
-    await codeCell.focus();
-    await notebook.changeToMarkdownCell();
-    const markdownCell = await notebook.findCell(cellIndex, CellType.Markdown);
-    const markdownCellInput = await markdownCell.focus();
-    await markdownCellInput.type(rCodeSnippet);
-    await notebook.changeToCodeCell();
-
-    const cell3Output = await notebook.runCodeCell(cellIndex, {timeOut: 5 * 60 * 1000});
+    const cell3Output = await notebook.runCodeCell(cellIndex,
+        {codeFile: 'resources/r-code/import-libs.R', markdownWorkaround: true, timeOut: 5 * 60 * 1000});
     expect(cell3Output).toContain('success');
 
     // Delete R notebook


### PR DESCRIPTION
Description:

Adding a nonexistent variable to the notebook checks in Python and R caused failures in neither test.  This PR updates both tests so that they do fail when required environment variables are missing. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
